### PR TITLE
(MOT-4407) feat(shell): add reconnectable multi-terminal PTY workspace

### DIFF
--- a/.github/workflows/shell-e2e.yml
+++ b/.github/workflows/shell-e2e.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     paths:
       - 'shell/**'
+      - 'console/**'
+      - 'packages/console-ui/**'
+      - 'pnpm-lock.yaml'
       - '.github/workflows/shell-e2e.yml'
   workflow_dispatch:
     inputs:
@@ -94,8 +97,95 @@ jobs:
             shell/tests/e2e/reports/
           retention-days: 7
 
+  terminal:
+    name: Browser terminal
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.source_sha || github.sha }}
+
+      - name: Rewrite SSH to HTTPS for public deps
+        run: git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.97.1
+
+      - name: Cache cargo registry & builds
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            shell
+            console
+
+      - name: Install Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Install terminal prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y tmux zsh
+          npm install --global @anthropic-ai/claude-code
+
+      - name: Install iii engine (latest from main)
+        run: |
+          curl -fsSL --retry 3 --retry-connrefused --retry-delay 5 \
+            https://install.iii.dev/iii/main/install.sh | sh
+          {
+            echo "$HOME/.local/bin"
+            echo "$HOME/.iii/bin"
+          } >> "$GITHUB_PATH"
+          export PATH="$HOME/.local/bin:$HOME/.iii/bin:$PATH"
+          echo "III_BIN=$(command -v iii)" >> "$GITHUB_ENV"
+          iii --version
+
+      - name: Install UI dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build shell and console UIs
+        run: |
+          pnpm --dir shell/ui build
+          pnpm --dir console/web build
+
+      - name: Build shell and console workers
+        run: |
+          cargo build --locked --release --manifest-path shell/Cargo.toml
+          cargo build --locked --release --manifest-path console/Cargo.toml
+
+      - name: Install Playwright Chromium
+        working-directory: console/web
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Typecheck Console E2E tests
+        working-directory: console/web
+        run: pnpm typecheck:e2e
+
+      - name: Run shell terminal Playwright scenario
+        working-directory: console/web
+        env:
+          CONSOLE_BIN: ${{ github.workspace }}/console/target/release/console
+          CONSOLE_E2E_ARTIFACTS_DIR: ${{ github.workspace }}/target/console-e2e
+          SHELL_BIN: ${{ github.workspace }}/shell/target/release/shell
+        run: pnpm test:e2e:shell
+
+      - name: Upload browser evidence on failure
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: shell-terminal-e2e
+          path: target/console-e2e/
+          retention-days: 7
+
   evidence:
-    needs: e2e
+    needs: [e2e, terminal]
     if: github.event_name == 'workflow_dispatch' && always()
     runs-on: ubuntu-latest
     steps:
@@ -103,7 +193,8 @@ jobs:
         with: { ref: "${{ github.sha }}" }
       - run: |
           subject=$(jq -cn --arg source_sha '${{ inputs.source_sha }}' '{source_sha:$source_sha}')
-          checks=$(jq -cn --arg status '${{ needs.e2e.result }}' '[{name:"shell_e2e",status:$status}]')
+          checks=$(jq -cn --arg harness '${{ needs.e2e.result }}' --arg terminal '${{ needs.terminal.result }}' \
+            '[{name:"shell_e2e",status:$harness},{name:"shell_terminal_e2e",status:$terminal}]')
           python3 .github/scripts/release_control_contract.py write-result --kind test --repository '${{ github.repository }}' \
             --operation-id '${{ inputs.operation_id }}' --step-id '${{ inputs.step_id }}' --run-id '${{ github.run_id }}' \
             --run-attempt '${{ github.run_attempt }}' --workflow shell-e2e.yml --event '${{ github.event_name }}' --sha '${{ github.sha }}' \

--- a/console/web/e2e/shell-terminal-stack.ts
+++ b/console/web/e2e/shell-terminal-stack.ts
@@ -1,0 +1,256 @@
+import { type ChildProcess, spawn } from 'node:child_process'
+import { constants } from 'node:fs'
+import { access, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { connect, createServer } from 'node:net'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { setTimeout as delay } from 'node:timers/promises'
+import { test as base, expect } from '@playwright/test'
+
+export interface ShellStack {
+  consoleUrl: string
+  engineUrl: string
+  root: string
+  createTmuxSocket(): string
+}
+
+interface ShellFixtures {
+  shellStack: ShellStack
+}
+
+interface ProcessLog {
+  label: string
+  text: string
+}
+
+const MAX_PROCESS_LOG_BYTES = 256 * 1024
+
+function required(name: string): string {
+  const value = process.env[name]
+  if (!value) throw new Error(`${name} is required for shell terminal E2E`)
+  return value
+}
+
+async function reservePort(): Promise<number> {
+  const server = createServer()
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  const address = server.address()
+  if (!address || typeof address === 'string') {
+    server.close()
+    throw new Error('failed to reserve loopback port')
+  }
+  const port = address.port
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve())),
+  )
+  return port
+}
+
+function childExit(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null)
+    return Promise.resolve()
+  return new Promise((resolve) => child.once('exit', () => resolve()))
+}
+
+async function waitForTcp(
+  port: number,
+  children: ChildProcess[],
+  timeoutMs = 30_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const exited = children.find(
+      (child) => child.exitCode !== null || child.signalCode !== null,
+    )
+    if (exited)
+      throw new Error('isolated shell stack process exited before ready')
+    const ready = await new Promise<boolean>((resolve) => {
+      const socket = connect({ host: '127.0.0.1', port })
+      socket.once('connect', () => {
+        socket.destroy()
+        resolve(true)
+      })
+      socket.once('error', () => {
+        socket.destroy()
+        resolve(false)
+      })
+    })
+    if (ready) return
+    await delay(100)
+  }
+  throw new Error(`timed out waiting for TCP 127.0.0.1:${port}`)
+}
+
+async function waitForHttp(
+  url: string,
+  children: ChildProcess[],
+  timeoutMs = 30_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const exited = children.find(
+      (child) => child.exitCode !== null || child.signalCode !== null,
+    )
+    if (exited)
+      throw new Error('isolated shell stack process exited before ready')
+    try {
+      const response = await fetch(url)
+      if (response.ok) return
+    } catch {
+      await delay(100)
+      continue
+    }
+    await delay(100)
+  }
+  throw new Error(`timed out waiting for ${url}`)
+}
+
+async function stopChildren(children: ChildProcess[]): Promise<void> {
+  for (const child of [...children].reverse()) {
+    if (child.exitCode === null && child.signalCode === null)
+      child.kill('SIGTERM')
+  }
+  await Promise.all(
+    children.map(async (child) => {
+      if (child.exitCode !== null || child.signalCode !== null) return
+      const exited = childExit(child)
+      const graceful = await Promise.race([
+        exited.then(() => true),
+        delay(5_000).then(() => false),
+      ])
+      if (!graceful && child.exitCode === null && child.signalCode === null) {
+        child.kill('SIGKILL')
+        await exited
+      }
+    }),
+  )
+}
+
+async function killTmuxServer(socket: string, tmuxRoot: string): Promise<void> {
+  const child = spawn('tmux', ['-L', socket, 'kill-server'], {
+    env: { ...process.env, TMUX_TMPDIR: tmuxRoot },
+    stdio: 'ignore',
+  })
+  await childExit(child)
+}
+
+export const test = base.extend<ShellFixtures>({
+  shellStack: async ({ browserName: _browserName }, use, testInfo) => {
+    const root = await mkdtemp(path.join(tmpdir(), 'shell-terminal-e2e-'))
+    const runRoot = path.join(root, 'workspace')
+    const tmuxRoot = await mkdtemp('/tmp/t8-tmux-')
+    const zshRoot = path.join(root, 'zsh')
+    const zshPath = '/bin/zsh'
+    await access(zshPath, constants.X_OK)
+    await mkdir(runRoot, { recursive: true })
+    await mkdir(zshRoot, { recursive: true })
+    await writeFile(path.join(zshRoot, '.zshrc'), "PROMPT='iii-e2e% '\n")
+    const enginePort = await reservePort()
+    const consolePort = await reservePort()
+    const engineConfig = path.join(root, 'engine.yaml')
+    const consoleConfig = path.join(root, 'console.yaml')
+    const shellConfig = path.join(root, 'shell.yaml')
+    await writeFile(
+      engineConfig,
+      `workers:\n  - name: iii-worker-manager\n    config:\n      host: 127.0.0.1\n      port: ${enginePort}\n  - name: iii-observability\n`,
+    )
+    await writeFile(consoleConfig, `http_port: ${consolePort}\n`)
+    await writeFile(
+      shellConfig,
+      `working_dir: ${JSON.stringify(runRoot)}\nenv:\n  inherit: true\nfs:\n  host_roots:\n    - ${JSON.stringify(runRoot)}\n  allow_unjailed: false\n`,
+    )
+
+    const engineUrl = `ws://127.0.0.1:${enginePort}`
+    const consoleUrl = `http://127.0.0.1:${consolePort}`
+    const children: ChildProcess[] = []
+    const logs: ProcessLog[] = []
+    const tmuxSockets = new Set<string>()
+    const spawnChild = (
+      label: string,
+      command: string,
+      args: string[],
+      env: NodeJS.ProcessEnv = process.env,
+    ) => {
+      const log = { label, text: '' }
+      const child = spawn(command, args, {
+        cwd: runRoot,
+        env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+      const capture = (chunk: Buffer | string) => {
+        log.text = `${log.text}${chunk.toString()}`.slice(
+          -MAX_PROCESS_LOG_BYTES,
+        )
+      }
+      child.stdout?.on('data', capture)
+      child.stderr?.on('data', capture)
+      children.push(child)
+      logs.push(log)
+      return child
+    }
+
+    try {
+      spawnChild('engine', required('III_BIN'), [
+        '--no-update-check',
+        '-c',
+        engineConfig,
+      ])
+      await waitForTcp(enginePort, children)
+      spawnChild(
+        'console',
+        required('CONSOLE_BIN'),
+        ['--config', consoleConfig, '--http-port', String(consolePort)],
+        { ...process.env, III_URL: engineUrl },
+      )
+      await waitForHttp(consoleUrl, children)
+      const shellEnv: NodeJS.ProcessEnv = {
+        ...process.env,
+        III_URL: engineUrl,
+        SHELL: zshPath,
+        TMUX_TMPDIR: tmuxRoot,
+        ZDOTDIR: zshRoot,
+      }
+      delete shellEnv.III_SHELL_UI_WATCH
+      delete shellEnv.TMUX
+      delete shellEnv.TMUX_PANE
+      spawnChild(
+        'shell',
+        required('SHELL_BIN'),
+        ['--config', shellConfig],
+        shellEnv,
+      )
+      await waitForHttp(`${consoleUrl}/ui/shell/page.js`, children)
+
+      await use({
+        consoleUrl,
+        engineUrl,
+        root: runRoot,
+        createTmuxSocket() {
+          const socket = `t8-${Math.random().toString(36).slice(2, 8)}`
+          tmuxSockets.add(socket)
+          return socket
+        },
+      })
+    } finally {
+      await stopChildren(children)
+      for (const socket of tmuxSockets) {
+        await killTmuxServer(socket, tmuxRoot)
+      }
+      if (testInfo.status !== testInfo.expectedStatus) {
+        for (const log of logs) {
+          await testInfo.attach(`${log.label}-log`, {
+            body: log.text,
+            contentType: 'text/plain',
+          })
+        }
+      }
+      await rm(root, { recursive: true, force: true })
+      await rm(tmuxRoot, { recursive: true, force: true })
+    }
+  },
+})
+
+export { expect }

--- a/console/web/e2e/shell-terminal.spec.ts
+++ b/console/web/e2e/shell-terminal.spec.ts
@@ -1,0 +1,447 @@
+import type { Locator, Page, TestInfo } from '@playwright/test'
+import { registerWorker } from 'iii-browser-sdk'
+import { expect, test } from './shell-terminal-stack'
+
+async function openShell(page: Page, consoleUrl: string): Promise<void> {
+  await page.goto(`${consoleUrl}/#/ext/shell`, { waitUntil: 'networkidle' })
+  const shellTabs = page.getByRole('tab', { name: /^shell(?: close shell)?$/ })
+  if ((await shellTabs.count()) === 0) {
+    await page.getByRole('button', { name: 'new tab', exact: true }).click()
+    await page
+      .getByRole('option', { name: /shell Interactive shell sessions/ })
+      .click()
+  } else {
+    await shellTabs.last().click()
+  }
+  const open = page.getByRole('button', { name: 'Open terminal', exact: true })
+  await open.click()
+  await expect(page.locator('.shui-terminal-state').first()).toHaveText('ready')
+}
+
+async function runInPane(
+  page: Page,
+  pane: Locator,
+  command: string,
+): Promise<void> {
+  await pane.locator('.xterm-helper-textarea').focus()
+  await page.keyboard.type(command, { delay: 1 })
+  await page.keyboard.press('Enter')
+}
+
+function markerFromText(text: string, prefix: string): string | null {
+  const match = text.match(
+    new RegExp(`${prefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}([^\\s]+)`),
+  )
+  return match?.[1] ?? null
+}
+
+async function markerValue(pane: Locator, prefix: string): Promise<string> {
+  await expect
+    .poll(async () =>
+      markerFromText(await pane.locator('.xterm-rows').innerText(), prefix),
+    )
+    .not.toBeNull()
+  const value = markerFromText(
+    await pane.locator('.xterm-rows').innerText(),
+    prefix,
+  )
+  if (value === null) throw new Error(`terminal marker ${prefix} was not found`)
+  return value
+}
+
+async function captureEvidence(
+  page: Page,
+  testInfo: TestInfo,
+  name: string,
+): Promise<void> {
+  const outputPath = testInfo.outputPath(`${name}.png`)
+  await page.screenshot({ path: outputPath })
+  await testInfo.attach(name, { path: outputPath, contentType: 'image/png' })
+}
+
+test('runs multi-terminal PTYs, replay, tmux, Claude, and cleanup', async ({
+  page,
+  shellStack,
+}, testInfo) => {
+  const consoleErrors: string[] = []
+  const failedRequests: string[] = []
+  const badResponses: string[] = []
+  page.on('console', (message) => {
+    if (message.type() === 'error') consoleErrors.push(message.text())
+  })
+  page.on('requestfailed', (request) => {
+    failedRequests.push(
+      `${request.method()} ${request.url()}: ${request.failure()?.errorText ?? 'failed'}`,
+    )
+  })
+  page.on('response', (response) => {
+    if (response.status() >= 400 && !response.url().endsWith('/favicon.ico')) {
+      badResponses.push(`${response.status()} ${response.url()}`)
+    }
+  })
+
+  await openShell(page, shellStack.consoleUrl)
+  await page.getByRole('button', { name: 'Dock terminal on right' }).click()
+  await expect(page.locator('.shui-terminal-panel')).toHaveAttribute(
+    'data-terminal-dock',
+    'right',
+  )
+  await expect(
+    page.getByRole('separator', { name: 'Resize right terminal' }),
+  ).toBeVisible()
+  await page
+    .getByRole('button', { name: 'Open terminal as an editor tab' })
+    .click()
+  await expect(page.locator('.shui-terminal-panel')).toHaveAttribute(
+    'data-terminal-dock',
+    'editor',
+  )
+  await captureEvidence(page, testInfo, 'task8-docking')
+  await page.getByRole('button', { name: 'Dock terminal at bottom' }).click()
+  await expect(page.locator('.shui-terminal-panel')).toHaveAttribute(
+    'data-terminal-dock',
+    'bottom',
+  )
+  const terminalResize = page.getByRole('separator', {
+    name: 'Resize bottom terminal',
+  })
+  const terminalResizeBox = await terminalResize.boundingBox()
+  if (!terminalResizeBox)
+    throw new Error('terminal resize handle has no bounds')
+  await page.mouse.move(
+    terminalResizeBox.x + terminalResizeBox.width / 2,
+    terminalResizeBox.y + terminalResizeBox.height / 2,
+  )
+  await page.mouse.down()
+  await page.mouse.move(
+    terminalResizeBox.x + terminalResizeBox.width / 2,
+    terminalResizeBox.y + terminalResizeBox.height / 2 - 220,
+  )
+  await page.mouse.up()
+  await page.getByRole('button', { name: 'New terminal' }).click()
+  await expect(page.locator('.shui-terminal-state')).toHaveText(['ready'])
+  await page.getByRole('button', { name: 'Split down' }).click()
+  await expect(page.locator('[data-terminal-pane-id]')).toHaveCount(2)
+  await expect(page.locator('.shui-terminal-state')).toHaveText([
+    'ready',
+    'ready',
+  ])
+  await page.getByRole('button', { name: 'Split right' }).first().click()
+  await expect(page.locator('[data-terminal-pane-id]')).toHaveCount(3)
+  await expect(page.locator('.shui-terminal-state')).toHaveText([
+    'ready',
+    'ready',
+    'ready',
+  ])
+
+  let panes = page.locator('[data-terminal-pane-id]')
+  for (let index = 0; index < 3; index += 1) {
+    await expect(panes.nth(index).locator('.xterm-rows')).toContainText(
+      'iii-e2e',
+    )
+  }
+  for (let index = 0; index < 3; index += 1) {
+    const pane = panes.nth(index)
+    await runInPane(
+      page,
+      pane,
+      `sleep 0.2; printf '%s%s%s\\n' '__PANE_' '${index}' '__'; sleep 0.2`,
+    )
+    await expect(pane.locator('.xterm-rows')).toContainText(`__PANE_${index}__`)
+  }
+  await captureEvidence(page, testInfo, 'task8-tabs-splits')
+
+  const terminalTabs = page.getByRole('tab', { name: /^zsh [12]$/ })
+  await expect(terminalTabs).toHaveCount(2)
+  await terminalTabs.first().click()
+  await expect(page.locator('.shui-terminal-state')).toHaveText(['ready'])
+  let tabPane = page.locator('[data-terminal-pane-id]').first()
+  await expect(tabPane.locator('.xterm-rows')).toContainText('iii-e2e')
+  await runInPane(
+    page,
+    tabPane,
+    `printf '%s%s%s\\n' '__TAB_ONE_PID_' 'BEFORE__:' "$$"; sleep 0.2`,
+  )
+  const tabOnePid = await markerValue(tabPane, '__TAB_ONE_PID_BEFORE__:')
+
+  await terminalTabs.last().click()
+  await expect(page.locator('.shui-terminal-state')).toHaveText([
+    'ready',
+    'ready',
+    'ready',
+  ])
+  panes = page.locator('[data-terminal-pane-id]')
+  await expect(panes.first().locator('.xterm-rows')).toContainText('__PANE_0__')
+  await runInPane(
+    page,
+    panes.first(),
+    `printf '%s%s%s\\n' '__TAB_TWO_PID_' 'BEFORE__:' "$$"; sleep 0.2`,
+  )
+  const tabTwoPid = await markerValue(panes.first(), '__TAB_TWO_PID_BEFORE__:')
+
+  await terminalTabs.first().click()
+  await expect(page.locator('.shui-terminal-state')).toHaveText(['ready'])
+  tabPane = page.locator('[data-terminal-pane-id]').first()
+  await expect(tabPane.locator('.xterm-rows')).toContainText(
+    '__TAB_ONE_PID_BEFORE__',
+  )
+  await runInPane(
+    page,
+    tabPane,
+    `printf '%s%s%s\\n' '__TAB_ONE_PID_' 'AFTER__:' "$$"; sleep 0.2`,
+  )
+  expect(await markerValue(tabPane, '__TAB_ONE_PID_AFTER__:')).toBe(tabOnePid)
+
+  await terminalTabs.last().click()
+  await expect(page.locator('.shui-terminal-state')).toHaveText([
+    'ready',
+    'ready',
+    'ready',
+  ])
+  panes = page.locator('[data-terminal-pane-id]')
+  await runInPane(
+    page,
+    panes.first(),
+    `printf '%s%s%s\\n' '__TAB_TWO_PID_' 'AFTER__:' "$$"; sleep 0.2`,
+  )
+  expect(await markerValue(panes.first(), '__TAB_TWO_PID_AFTER__:')).toBe(
+    tabTwoPid,
+  )
+
+  const resizedPane = panes.first()
+  await runInPane(
+    page,
+    resizedPane,
+    `stty size | awk '{print "__SIZE_" "BEFORE__:" $1 "x" $2}'`,
+  )
+  const sizeBefore = await markerValue(resizedPane, '__SIZE_BEFORE__:')
+  const separator = page
+    .locator('[role="separator"][aria-orientation="vertical"]')
+    .first()
+  const separatorBox = await separator.boundingBox()
+  if (!separatorBox) throw new Error('terminal split separator has no bounds')
+  await page.mouse.move(
+    separatorBox.x + separatorBox.width / 2,
+    separatorBox.y + separatorBox.height / 2,
+  )
+  await page.mouse.down()
+  await page.mouse.move(
+    separatorBox.x + separatorBox.width / 2 + 80,
+    separatorBox.y + separatorBox.height / 2,
+  )
+  await page.mouse.up()
+  await runInPane(
+    page,
+    resizedPane,
+    `stty size | awk '{print "__SIZE_" "AFTER__:" $1 "x" $2}'`,
+  )
+  expect(await markerValue(resizedPane, '__SIZE_AFTER__:')).not.toBe(sizeBefore)
+
+  await runInPane(
+    page,
+    resizedPane,
+    `for i in {1..120}; do printf '%s%03d\\n' '__SCROLL_LINE__:' "$i"; done; sleep 0.5; printf '%s%s%d\\n' '__SCROLL_' 'DONE__:' 120; sleep 0.2`,
+  )
+  await expect(resizedPane.locator('.xterm-rows')).toContainText(
+    '__SCROLL_DONE__:120',
+  )
+  await resizedPane.locator('.xterm').hover()
+  await page.mouse.wheel(0, -2400)
+  const jump = resizedPane.getByRole('button', {
+    name: 'Jump to latest output',
+  })
+  await expect(jump).toBeVisible()
+  await captureEvidence(page, testInfo, 'task8-jump-paused')
+  await jump.click()
+  await expect(jump).toBeHidden()
+  await captureEvidence(page, testInfo, 'task8-jump-latest')
+
+  await runInPane(
+    page,
+    resizedPane,
+    `printf '%s%s%s\\n' '__PID_' 'BEFORE__:' "$$"; sleep 0.2`,
+  )
+  const pidBefore = await markerValue(resizedPane, '__PID_BEFORE__:')
+  await page.waitForTimeout(800)
+  await runInPane(
+    page,
+    resizedPane,
+    `sh -c 'sleep 1; printf "%s%s\\n" "__REPLAY_" "OK__"' &`,
+  )
+  await page.waitForTimeout(100)
+  await page.reload({ waitUntil: 'networkidle' })
+  await page
+    .getByRole('tab', { name: /^shell(?: close shell)?$/ })
+    .last()
+    .click()
+  await expect(page.locator('[data-terminal-pane-id]')).toHaveCount(3)
+  await expect(page.locator('.shui-terminal-state')).toHaveText([
+    'ready',
+    'ready',
+    'ready',
+  ])
+  panes = page.locator('[data-terminal-pane-id]')
+  const reloadedPane = panes.first()
+  await expect(reloadedPane.locator('.xterm-rows')).toContainText(
+    '__REPLAY_OK__',
+  )
+  await runInPane(
+    page,
+    reloadedPane,
+    `printf '%s%s%s\\n' '__PID_' 'AFTER__:' "$$"; sleep 0.2`,
+  )
+  expect(await markerValue(reloadedPane, '__PID_AFTER__:')).toBe(pidBefore)
+  const replayText = await reloadedPane.locator('.xterm-rows').innerText()
+  expect(replayText.match(/__REPLAY_OK__/g)).toHaveLength(1)
+  await captureEvidence(page, testInfo, 'task8-reload-replay')
+
+  const tmuxSocket = shellStack.createTmuxSocket()
+  const tmux = `tmux -L ${tmuxSocket}`
+  await runInPane(
+    page,
+    reloadedPane,
+    `${tmux} new-session -s terminal-acceptance`,
+  )
+  await page.waitForTimeout(500)
+  await page.keyboard.press('Control+b')
+  await page.keyboard.insertText('%')
+  await page.waitForTimeout(300)
+  await page.keyboard.type(`printf '%s%s\\n' '__TMUX_' 'RIGHT__'; sleep 0.2`, {
+    delay: 1,
+  })
+  await page.keyboard.press('Enter')
+  await page.waitForTimeout(300)
+  await page.keyboard.press('Control+b')
+  await page.keyboard.insertText('o')
+  await page.waitForTimeout(200)
+  await page.keyboard.type(`printf '%s%s\\n' '__TMUX_' 'LEFT__'; sleep 0.2`, {
+    delay: 1,
+  })
+  await page.keyboard.press('Enter')
+  await page.waitForTimeout(300)
+  await expect(reloadedPane.locator('.xterm-rows')).toContainText(
+    '__TMUX_LEFT__',
+  )
+  await expect(reloadedPane.locator('.xterm-rows')).toContainText(
+    '__TMUX_RIGHT__',
+  )
+  await captureEvidence(page, testInfo, 'task8-tmux-attached')
+  await page.keyboard.press('Control+b')
+  await page.keyboard.insertText('d')
+  await runInPane(
+    page,
+    reloadedPane,
+    `${tmux} capture-pane -pt terminal-acceptance:0.0; ${tmux} capture-pane -pt terminal-acceptance:0.1; sleep 0.2`,
+  )
+  await runInPane(
+    page,
+    reloadedPane,
+    `${tmux} attach-session -t terminal-acceptance`,
+  )
+  await page.waitForTimeout(300)
+  await page.keyboard.type(
+    `printf '%s%s\\n' '__TMUX_' 'REATTACHED__'; sleep 0.2`,
+    {
+      delay: 1,
+    },
+  )
+  await page.keyboard.press('Enter')
+  await page.waitForTimeout(300)
+  await expect(reloadedPane.locator('.xterm-rows')).toContainText(
+    '__TMUX_REATTACHED__',
+  )
+  await page.keyboard.press('Control+b')
+  await page.keyboard.insertText('d')
+  await runInPane(
+    page,
+    reloadedPane,
+    `${tmux} capture-pane -pt terminal-acceptance:0.0; ${tmux} capture-pane -pt terminal-acceptance:0.1; ${tmux} kill-server`,
+  )
+
+  await runInPane(
+    page,
+    reloadedPane,
+    `claude --version >/tmp/iii-claude-version 2>&1; code=$?; printf '%s%s%d\\n' '__CLAUDE_' 'EXIT__:' "$code"; sed -n '1p' /tmp/iii-claude-version`,
+  )
+  expect(await markerValue(reloadedPane, '__CLAUDE_EXIT__:')).toBe('0')
+
+  const closingPane = panes.last()
+  const closingPaneId = await closingPane.getAttribute('data-terminal-pane-id')
+  if (!closingPaneId) throw new Error('closing pane has no pane ID')
+  const lease = await page.evaluate((paneId) => {
+    for (const key of Object.keys(localStorage)) {
+      if (!key.startsWith('iii::shell-ui::terminal-leases::')) continue
+      const value = localStorage.getItem(key)
+      if (!value) continue
+      const candidate = (
+        JSON.parse(value) as Array<{
+          paneId: string
+          sessionId: string
+          reconnectToken: string
+        }>
+      ).find((entry) => entry.paneId === paneId)
+      if (candidate) return candidate
+    }
+    return null
+  }, closingPaneId)
+  expect(lease).not.toBeNull()
+  await closingPane.getByRole('button', { name: 'Close terminal pane' }).click()
+  await expect(page.locator('[data-terminal-pane-id]')).toHaveCount(2)
+
+  if (!lease) throw new Error('closed pane lease was not found')
+  const probe = registerWorker(shellStack.engineUrl)
+  try {
+    const closedAttachError = await probe
+      .trigger({
+        function_id: 'shell::pty::attach',
+        payload: {
+          session_id: lease.sessionId,
+          reconnect_token: lease.reconnectToken,
+          output_function_id: `iii::shell-ui::pty-output::console-probe-${Date.now()}`,
+          cols: 80,
+          rows: 24,
+          after_sequence: 0,
+        },
+      })
+      .catch((error: unknown) => error)
+    expect(
+      closedAttachError instanceof Error
+        ? closedAttachError.message
+        : String(closedAttachError),
+    ).toContain('terminal session does not exist')
+  } finally {
+    await probe.shutdown()
+  }
+
+  const newTerminal = page.getByRole('button', { name: 'New terminal' })
+  let createdTerminals = 0
+  for (
+    let index = 0;
+    index < 20 && !(await newTerminal.isDisabled());
+    index += 1
+  ) {
+    await newTerminal.click()
+    await expect(page.locator('.shui-terminal-state')).toHaveText(['ready'])
+    createdTerminals += 1
+  }
+  expect(createdTerminals).toBe(13)
+  await expect(newTerminal).toBeDisabled()
+  await captureEvidence(page, testInfo, 'task8-session-cap')
+  await page
+    .getByRole('button', { name: 'Close disconnected terminals' })
+    .click()
+  await expect(newTerminal).toBeEnabled({ timeout: 30_000 })
+  await expect(page.locator('.shui-terminal-tab')).toHaveCount(1, {
+    timeout: 30_000,
+  })
+  for (let index = 0; index < 15; index += 1) {
+    await newTerminal.click()
+    await expect(page.locator('.shui-terminal-state')).toHaveText(['ready'])
+  }
+  await expect(newTerminal).toBeDisabled()
+  await captureEvidence(page, testInfo, 'task8-permit-refill')
+
+  expect(consoleErrors).toEqual([])
+  expect(failedRequests).toEqual([])
+  expect(badResponses).toEqual([])
+})

--- a/console/web/package.json
+++ b/console/web/package.json
@@ -16,6 +16,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
+    "test:e2e:shell": "SHELL_E2E=1 playwright test e2e/shell-terminal.spec.ts",
     "test:e2e:install": "playwright install chromium",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",

--- a/console/web/playwright.config.ts
+++ b/console/web/playwright.config.ts
@@ -7,6 +7,7 @@ const artifactsRoot =
 
 export default defineConfig({
   testDir: './e2e',
+  testIgnore: process.env.SHELL_E2E ? [] : ['shell-terminal.spec.ts'],
   fullyParallel: false,
   workers: 1,
   retries: 0,

--- a/iii-permissions.yaml
+++ b/iii-permissions.yaml
@@ -51,6 +51,8 @@ rules:
   # build-error string (e.g. a host_root path). Operators/console reach it via
   # the privileged dispatch path that bypasses this agent gate.
   - '!shell::config-status'
+  # Interactive PTY lifecycle is driven only by the console UI.
+  - '!shell::pty::*'
   - '!oauth::anthropic::login'
   - '!oauth::openai-codex::login'
   - '!run::start'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,7 +311,7 @@ importers:
         version: link:../../packages/console-ui
       '@pierre/diffs':
         specifier: ^1.2.7
-        version: 1.2.12(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 1.2.12(@shikijs/themes@4.3.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.7)
     devDependencies:
       '@types/react':
         specifier: ^19.2.14
@@ -516,10 +516,16 @@ importers:
         version: link:../../packages/console-ui
       '@pierre/trees':
         specifier: 1.0.0-beta.6
-        version: 1.0.0-beta.6(@pierre/theme@1.1.0)(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(shiki@4.3.1)
+        version: 1.0.0-beta.6(@pierre/theme@1.1.0)(@shikijs/themes@4.3.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(shiki@4.3.1)
+      '@xterm/addon-fit':
+        specifier: ^0.11.0
+        version: 0.11.0
+      '@xterm/xterm':
+        specifier: ^6.0.0
+        version: 6.0.0
       lucide-react:
         specifier: ^1.16.0
-        version: 1.25.0(react@19.2.7)
+        version: 1.25.0(react@19.2.8)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -527,9 +533,18 @@ importers:
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
       esbuild:
         specifier: ^0.25.0
         version: 0.25.12
+      react:
+        specifier: ^19.2.8
+        version: 19.2.8
+      react-dom:
+        specifier: ^19.2.8
+        version: 19.2.8(react@19.2.8)
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
@@ -2798,6 +2813,12 @@ packages:
   '@webcontainer/env@1.1.1':
     resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
 
+  '@xterm/addon-fit@0.11.0':
+    resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
+
+  '@xterm/xterm@6.0.0':
+    resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
+
   acorn-import-attributes@1.9.5:
     resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
     peerDependencies:
@@ -4063,6 +4084,11 @@ packages:
     peerDependencies:
       react: ^19.2.7
 
+  react-dom@19.2.8:
+    resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
+    peerDependencies:
+      react: ^19.2.8
+
   react-error-boundary@6.1.2:
     resolution: {integrity: sha512-3DpCr5HVdZ0caUjYE/kIHBEJN0mNP3ZCgf16c48uJ5TbWjorKVp+YG8W3XqlJ7vJAVNw6wNIImyPXmFydwmyng==}
     peerDependencies:
@@ -4109,6 +4135,10 @@ packages:
 
   react@19.2.7:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.8:
+    resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
     engines: {node: '>=0.10.0'}
 
   readdirp@3.6.0:
@@ -5422,16 +5452,16 @@ snapshots:
   '@oxc-resolver/binding-win32-x64-msvc@11.24.2':
     optional: true
 
-  '@pierre/diffs@1.2.12(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@pierre/diffs@1.2.12(@shikijs/themes@4.3.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.7)':
     dependencies:
       '@pierre/theme': 1.1.0
-      '@pierre/theming': 0.0.2(@pierre/theme@1.1.0)(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(shiki@4.3.1)
+      '@pierre/theming': 0.0.2(@pierre/theme@1.1.0)(@shikijs/themes@4.3.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.7)(shiki@4.3.1)
       '@shikijs/transformers': 4.3.1
       diff: 9.0.0
       hast-util-to-html: 9.0.5
       lru_map: 0.4.1
       react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react-dom: 19.2.8(react@19.2.8)
       shiki: 4.3.1
     transitivePeerDependencies:
       - '@shikijs/themes'
@@ -5454,20 +5484,20 @@ snapshots:
 
   '@pierre/theme@2.0.0': {}
 
-  '@pierre/theming@0.0.2(@pierre/theme@1.1.0)(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(shiki@4.3.1)':
+  '@pierre/theming@0.0.2(@pierre/theme@1.1.0)(@shikijs/themes@4.3.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.7)(shiki@4.3.1)':
     optionalDependencies:
       '@pierre/theme': 1.1.0
       '@shikijs/themes': 4.3.1
       react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react-dom: 19.2.8(react@19.2.8)
       shiki: 4.3.1
 
-  '@pierre/theming@1.0.0(@pierre/theme@1.1.0)(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(shiki@4.3.1)':
+  '@pierre/theming@1.0.0(@pierre/theme@1.1.0)(@shikijs/themes@4.3.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(shiki@4.3.1)':
     optionalDependencies:
       '@pierre/theme': 1.1.0
       '@shikijs/themes': 4.3.1
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       shiki: 4.3.1
 
   '@pierre/theming@1.0.1(@pierre/theme@2.0.0)(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(shiki@4.3.1)':
@@ -5478,13 +5508,13 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       shiki: 4.3.1
 
-  '@pierre/trees@1.0.0-beta.6(@pierre/theme@1.1.0)(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(shiki@4.3.1)':
+  '@pierre/trees@1.0.0-beta.6(@pierre/theme@1.1.0)(@shikijs/themes@4.3.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(shiki@4.3.1)':
     dependencies:
-      '@pierre/theming': 1.0.0(@pierre/theme@1.1.0)(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(shiki@4.3.1)
+      '@pierre/theming': 1.0.0(@pierre/theme@1.1.0)(@shikijs/themes@4.3.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(shiki@4.3.1)
       preact: 11.0.0-beta.0
       preact-render-to-string: 6.6.5(preact@11.0.0-beta.0)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     transitivePeerDependencies:
       - '@pierre/theme'
       - '@shikijs/themes'
@@ -6747,6 +6777,10 @@ snapshots:
 
   '@webcontainer/env@1.1.1': {}
 
+  '@xterm/addon-fit@0.11.0': {}
+
+  '@xterm/xterm@6.0.0': {}
+
   acorn-import-attributes@1.9.5(acorn@8.17.0):
     dependencies:
       acorn: 8.17.0
@@ -7566,6 +7600,10 @@ snapshots:
     dependencies:
       react: 19.2.7
 
+  lucide-react@1.25.0(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+
   lz-string@1.5.0: {}
 
   magic-string@0.30.21:
@@ -8197,6 +8235,11 @@ snapshots:
       react: 19.2.7
       scheduler: 0.27.0
 
+  react-dom@19.2.8(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+      scheduler: 0.27.0
+
   react-error-boundary@6.1.2(react@19.2.7):
     dependencies:
       react: 19.2.7
@@ -8249,6 +8292,8 @@ snapshots:
       '@types/react': 19.2.17
 
   react@19.2.7: {}
+
+  react@19.2.8: {}
 
   readdirp@3.6.0:
     dependencies:

--- a/shell/Cargo.lock
+++ b/shell/Cargo.lock
@@ -92,6 +92,12 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
@@ -148,6 +154,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
@@ -391,6 +403,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,6 +447,17 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -611,7 +640,7 @@ dependencies = [
  "serde_json",
  "syn",
  "textwrap",
- "thiserror",
+ "thiserror 2.0.18",
  "typed-builder",
 ]
 
@@ -634,7 +663,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "ignore",
  "walkdir",
 ]
@@ -947,7 +976,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
  "tracing",
@@ -978,7 +1007,7 @@ version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "inotify-sys",
  "libc",
 ]
@@ -1066,7 +1095,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "libc",
 ]
 
@@ -1146,6 +1175,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1171,7 +1212,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -1189,7 +1230,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1216,7 +1257,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1257,7 +1298,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -1286,7 +1327,7 @@ dependencies = [
  "opentelemetry",
  "percent-encoding",
  "rand",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
 ]
@@ -1351,6 +1392,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "portable-pty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix",
+ "serial2",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1394,14 +1456,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1422,7 +1484,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1434,7 +1496,7 @@ version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
  "socket2",
@@ -1614,7 +1676,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1740,7 +1802,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1843,6 +1905,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial2"
+version = "0.2.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16809bc35793b19ce4e0c53924bc0dce3937f15487997cfdaed936004180730"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1874,6 +1947,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
 name = "shell"
 version = "0.11.1"
 dependencies = [
@@ -1889,6 +1972,7 @@ dependencies = [
  "libc",
  "notify",
  "once_cell",
+ "portable-pty",
  "regex",
  "schemars",
  "serde",
@@ -1897,7 +1981,7 @@ dependencies = [
  "sha2",
  "shell-words",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2099,11 +2183,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2236,7 +2340,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -2342,7 +2446,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -2594,7 +2698,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -2927,6 +3031,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2990,7 +3103,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/shell/Cargo.toml
+++ b/shell/Cargo.toml
@@ -37,6 +37,7 @@ base64 = "0.22"
 walkdir = "2"
 globset = "0.4"
 sha2 = "0.10"
+portable-pty = "0.9.0"
 
 [dev-dependencies]
 tempfile = "3"

--- a/shell/src/lib.rs
+++ b/shell/src/lib.rs
@@ -13,6 +13,7 @@ pub mod fs;
 pub mod functions;
 pub mod jobs;
 pub mod path;
+pub mod pty;
 pub mod scode;
 pub mod target;
 pub mod telemetry;

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -17,6 +17,7 @@ mod fs;
 mod functions;
 mod jobs;
 mod path;
+mod pty;
 mod scode;
 mod target;
 mod telemetry;
@@ -412,6 +413,8 @@ async fn main() -> Result<()> {
         );
     }
 
+    let pty_manager = pty::PtyManager::new(iii.clone(), watch_resolver.clone());
+    pty::register(&iii, pty_manager.clone());
     register_workspace(&iii, &state);
 
     // fs::* keep Value handlers (preserving S210) and read the live host backend
@@ -452,6 +455,18 @@ async fn main() -> Result<()> {
     let killed = jobs::kill_running_host_jobs().await;
     if killed > 0 {
         tracing::info!(count = killed, "killed in-flight host jobs on shutdown");
+    }
+    match pty_manager.close_all().await {
+        Ok(closed) if closed > 0 => {
+            tracing::info!(
+                count = closed,
+                "closed interactive terminal sessions on shutdown"
+            );
+        }
+        Ok(_) => {}
+        Err(error) => {
+            tracing::error!(error = %error, "failed to close interactive terminal sessions");
+        }
     }
 
     iii.shutdown_async().await;

--- a/shell/src/pty.rs
+++ b/shell/src/pty.rs
@@ -1,0 +1,2090 @@
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use std::time::Duration as StdDuration;
+#[cfg(unix)]
+use std::time::Instant;
+
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use base64::Engine;
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::{IIIClient, RegisterFunction, TriggerAction};
+use portable_pty::{native_pty_system, Child, ChildKiller, CommandBuilder, MasterPty, PtySize};
+use serde::Serialize;
+#[cfg(test)]
+use tokio::sync::Notify;
+use tokio::sync::{Mutex as AsyncMutex, OwnedSemaphorePermit, RwLock, Semaphore};
+use uuid::Uuid;
+
+use crate::code::state::ResolverCell;
+
+mod output_buffer;
+mod protocol;
+mod session;
+
+#[cfg(test)]
+use output_buffer::OutputFrame;
+use output_buffer::{OutputBuffer, MAX_OUTPUT_BUFFER_BYTES};
+pub use protocol::{
+    AttachRequest, AttachResponse, CloseRequest, CloseResponse, DetachRequest, DetachResponse,
+    OpenRequest, OpenResponse, ResizeRequest, ResizeResponse, WriteRequest, WriteResponse,
+};
+use session::{SessionControl, SessionStatus};
+
+const MAX_SESSIONS: usize = 16;
+const MAX_INPUT_BYTES: usize = 64 * 1024;
+const OUTPUT_FUNCTION_PREFIX: &str = "iii::shell-ui::pty-output::console-";
+const TERMINATION_POLL_INTERVAL: StdDuration = StdDuration::from_millis(10);
+const PORTABLE_TERMINATION_WAIT: StdDuration = StdDuration::from_secs(2);
+#[cfg(unix)]
+const SIGHUP_TERMINATION_WAIT: StdDuration = StdDuration::from_millis(150);
+#[cfg(unix)]
+const SIGTERM_TERMINATION_WAIT: StdDuration = StdDuration::from_millis(250);
+#[cfg(unix)]
+const SIGKILL_TERMINATION_WAIT: StdDuration = StdDuration::from_secs(2);
+
+#[derive(Clone)]
+pub struct PtyManager {
+    iii: IIIClient,
+    resolver: ResolverCell,
+    sessions: Arc<RwLock<HashMap<String, Arc<PtySession>>>>,
+    permits: Arc<Semaphore>,
+    open_requests: Arc<AsyncMutex<HashMap<String, OpenResponse>>>,
+    shutdown: Arc<RwLock<bool>>,
+    program: Option<Arc<str>>,
+    #[cfg(test)]
+    open_pause: Option<Arc<OpenPause>>,
+}
+
+#[cfg(test)]
+struct OpenPause {
+    reached: Notify,
+    release: Notify,
+}
+
+struct PtySession {
+    control: AsyncMutex<SessionControl>,
+    lifecycle: AsyncMutex<SessionLifecycle>,
+    write_serial: AsyncMutex<()>,
+    output: Mutex<OutputBuffer>,
+    status: Mutex<SessionStatus>,
+    cwd: String,
+    #[cfg(test)]
+    pid: Option<u32>,
+    #[cfg(unix)]
+    process_group: Mutex<Option<libc::pid_t>>,
+    master: Mutex<Box<dyn MasterPty + Send>>,
+    writer: Mutex<Box<dyn Write + Send>>,
+    killer: Mutex<Box<dyn ChildKiller + Send + Sync>>,
+    permit: Mutex<Option<OwnedSemaphorePermit>>,
+}
+
+#[derive(Default)]
+struct SessionLifecycle {
+    closing: bool,
+    closed: bool,
+}
+
+struct SpawnedPty {
+    master: Box<dyn MasterPty + Send>,
+    reader: Box<dyn Read + Send>,
+    writer: Box<dyn Write + Send>,
+    child: Box<dyn Child + Send + Sync>,
+}
+
+#[derive(Debug, Serialize)]
+struct OutputEvent {
+    session_id: String,
+    sequence: Option<u64>,
+    data: Option<String>,
+    eof: bool,
+    exit_code: Option<u32>,
+    signal: Option<String>,
+    error: Option<String>,
+}
+
+impl PtyManager {
+    pub fn new(iii: IIIClient, resolver: ResolverCell) -> Self {
+        Self {
+            iii,
+            resolver,
+            sessions: Arc::new(RwLock::new(HashMap::new())),
+            permits: Arc::new(Semaphore::new(MAX_SESSIONS)),
+            open_requests: Arc::new(AsyncMutex::new(HashMap::new())),
+            shutdown: Arc::new(RwLock::new(false)),
+            program: None,
+            #[cfg(test)]
+            open_pause: None,
+        }
+    }
+
+    #[cfg(test)]
+    fn with_program(mut self, program: &str) -> Self {
+        self.program = Some(Arc::from(program));
+        self
+    }
+
+    pub async fn open(&self, req: OpenRequest) -> Result<OpenResponse, String> {
+        validate_size(req.cols, req.rows)?;
+        let caller_worker_id = require_caller(req.caller_worker_id.as_deref())?.to_string();
+        let request_key = req
+            .request_id
+            .as_deref()
+            .map(validate_request_id)
+            .transpose()?
+            .map(|request_id| format!("{caller_worker_id}:{request_id}"));
+        let mut open_requests = self.open_requests.lock().await;
+        if let Some(cached) = request_key.as_ref().and_then(|key| open_requests.get(key)) {
+            return Ok(cached.clone());
+        }
+        validate_output_function_id(&req.output_function_id)?;
+        let shutdown = self.shutdown.read().await;
+        if *shutdown {
+            return Err("terminal manager is shutting down".to_string());
+        }
+        let permit = self
+            .permits
+            .clone()
+            .try_acquire_owned()
+            .map_err(|_| format!("terminal session limit reached ({MAX_SESSIONS})"))?;
+
+        let resolver = self.resolver.read().await.clone();
+        let cwd = resolver
+            .resolve(&req.cwd)
+            .map_err(|error| format!("terminal cwd is outside the shell workspace: {error}"))?;
+        if !cwd.is_dir() {
+            return Err(format!(
+                "terminal cwd is not a directory: {}",
+                cwd.display()
+            ));
+        }
+
+        let spawn_cwd = cwd.clone();
+        let cols = req.cols;
+        let rows = req.rows;
+        let program = self.program.clone();
+        let spawned = tokio::task::spawn_blocking(move || {
+            spawn_process(&spawn_cwd, cols, rows, program.as_deref())
+        })
+        .await
+        .map_err(|error| format!("terminal spawn task failed: {error}"))?
+        .map_err(|error| format!("terminal spawn failed: {error}"))?;
+
+        let session_id = Uuid::new_v4().to_string();
+        let control = SessionControl::new(&caller_worker_id, &req.output_function_id);
+        let access_key = control.access_key().to_string();
+        let reconnect_token = control.reconnect_token().to_string();
+        let pid = spawned.child.process_id();
+        #[cfg(unix)]
+        let process_group = spawned.master.process_group_leader();
+        let killer = spawned.child.clone_killer();
+        let SpawnedPty {
+            master,
+            reader,
+            writer,
+            child,
+        } = spawned;
+        let session = Arc::new(PtySession {
+            control: AsyncMutex::new(control),
+            lifecycle: AsyncMutex::new(SessionLifecycle::default()),
+            write_serial: AsyncMutex::new(()),
+            output: Mutex::new(OutputBuffer::new(MAX_OUTPUT_BUFFER_BYTES)),
+            status: Mutex::new(SessionStatus::Attached),
+            cwd: cwd.display().to_string(),
+            #[cfg(test)]
+            pid,
+            #[cfg(unix)]
+            process_group: Mutex::new(process_group),
+            master: Mutex::new(master),
+            writer: Mutex::new(writer),
+            killer: Mutex::new(killer),
+            permit: Mutex::new(Some(permit)),
+        });
+        #[cfg(test)]
+        if let Some(pause) = &self.open_pause {
+            pause.reached.notify_one();
+            pause.release.notified().await;
+        }
+        self.sessions
+            .write()
+            .await
+            .insert(session_id.clone(), session);
+        self.spawn_output_pump(session_id.clone(), reader, child);
+
+        let response = OpenResponse {
+            session_id,
+            access_key,
+            reconnect_token,
+            pid,
+            cwd: cwd.display().to_string(),
+        };
+        if let Some(request_key) = request_key {
+            open_requests.insert(request_key, response.clone());
+        }
+        Ok(response)
+    }
+
+    pub async fn write(&self, req: WriteRequest) -> Result<WriteResponse, String> {
+        let caller_worker_id = require_caller(req.caller_worker_id.as_deref())?;
+        let data = BASE64_STANDARD
+            .decode(&req.data)
+            .map_err(|error| format!("terminal input is not valid base64: {error}"))?;
+        if data.len() > MAX_INPUT_BYTES {
+            return Err(format!("terminal input exceeds {MAX_INPUT_BYTES} bytes"));
+        }
+        let session = self.session(&req.session_id).await?;
+        {
+            let lifecycle = session.lifecycle.lock().await;
+            ensure_session_open(&lifecycle)?;
+            authenticate_session(&session, &req.access_key, caller_worker_id).await?;
+        }
+        let _write_guard = session.write_serial.lock().await;
+        {
+            let lifecycle = session.lifecycle.lock().await;
+            ensure_session_open(&lifecycle)?;
+            authenticate_session(&session, &req.access_key, caller_worker_id).await?;
+        }
+        let written = data.len();
+        let write_session = session.clone();
+        let write_result = tokio::task::spawn_blocking(move || {
+            let mut writer = write_session
+                .writer
+                .lock()
+                .map_err(|_| "terminal writer lock poisoned".to_string())?;
+            writer
+                .write_all(&data)
+                .and_then(|_| writer.flush())
+                .map_err(|error| format!("terminal input failed: {error}"))
+        })
+        .await
+        .map_err(|error| format!("terminal input task failed: {error}"))?;
+        if let Err(error) = write_result {
+            let lifecycle = session.lifecycle.lock().await;
+            ensure_session_open(&lifecycle)?;
+            return Err(error);
+        }
+        let lifecycle = session.lifecycle.lock().await;
+        ensure_session_open(&lifecycle)?;
+        Ok(WriteResponse { written })
+    }
+
+    pub async fn resize(&self, req: ResizeRequest) -> Result<ResizeResponse, String> {
+        validate_size(req.cols, req.rows)?;
+        let caller_worker_id = require_caller(req.caller_worker_id.as_deref())?;
+        let session = self.session(&req.session_id).await?;
+        let lifecycle = session.lifecycle.lock().await;
+        ensure_session_open(&lifecycle)?;
+        authenticate_session(&session, &req.access_key, caller_worker_id).await?;
+        let cols = req.cols;
+        let rows = req.rows;
+        resize_session(session.clone(), cols, rows).await?;
+        drop(lifecycle);
+        Ok(ResizeResponse { cols, rows })
+    }
+
+    pub async fn close(&self, req: CloseRequest) -> Result<CloseResponse, String> {
+        let caller_worker_id = require_caller(req.caller_worker_id.as_deref())?;
+        let session = {
+            let sessions = self.sessions.read().await;
+            sessions.get(&req.session_id).cloned()
+        };
+        let Some(session) = session else {
+            return Ok(CloseResponse { closed: false });
+        };
+        let mut lifecycle = session.lifecycle.lock().await;
+        ensure_session_open(&lifecycle)?;
+        authenticate_session(&session, &req.access_key, caller_worker_id).await?;
+        lifecycle.closing = true;
+        drop(lifecycle);
+        if let Err(error) = terminate_session(session.clone()).await {
+            reset_session_closing(&session).await;
+            return Err(error);
+        }
+        if let Err(error) = release_session_permit(&session) {
+            reset_session_closing(&session).await;
+            return Err(error);
+        }
+        {
+            let mut lifecycle = session.lifecycle.lock().await;
+            lifecycle.closing = false;
+            lifecycle.closed = true;
+        }
+        remove_session(&self.sessions, &req.session_id, &session).await;
+        self.open_requests
+            .lock()
+            .await
+            .retain(|_, response| response.session_id != req.session_id);
+        Ok(CloseResponse { closed: true })
+    }
+
+    pub async fn close_all(&self) -> Result<usize, String> {
+        let mut shutdown = self.shutdown.write().await;
+        *shutdown = true;
+        let sessions = {
+            let sessions = self.sessions.read().await;
+            sessions
+                .iter()
+                .map(|(session_id, session)| (session_id.clone(), session.clone()))
+                .collect::<Vec<_>>()
+        };
+        let mut closed = 0;
+        let mut failures = Vec::new();
+        for (session_id, session) in sessions {
+            let mut lifecycle = session.lifecycle.lock().await;
+            if lifecycle.closed {
+                continue;
+            }
+            if lifecycle.closing {
+                failures.push(format!("{session_id}: terminal session is already closing"));
+                continue;
+            }
+            lifecycle.closing = true;
+            drop(lifecycle);
+            if let Err(error) = terminate_session(session.clone()).await {
+                reset_session_closing(&session).await;
+                failures.push(format!("{session_id}: {error}"));
+                continue;
+            }
+            if let Err(error) = release_session_permit(&session) {
+                reset_session_closing(&session).await;
+                failures.push(format!("{session_id}: {error}"));
+                continue;
+            }
+            {
+                let mut lifecycle = session.lifecycle.lock().await;
+                lifecycle.closing = false;
+                lifecycle.closed = true;
+            }
+            remove_session(&self.sessions, &session_id, &session).await;
+            closed += 1;
+        }
+        if failures.is_empty() {
+            self.open_requests.lock().await.clear();
+            Ok(closed)
+        } else {
+            Err(format!(
+                "failed to close {} terminal session(s): {}",
+                failures.len(),
+                failures.join("; ")
+            ))
+        }
+    }
+
+    pub async fn detach(&self, req: DetachRequest) -> Result<DetachResponse, String> {
+        let caller_worker_id = require_caller(req.caller_worker_id.as_deref())?;
+        let session = self.session(&req.session_id).await?;
+        let lifecycle = session.lifecycle.lock().await;
+        ensure_session_open(&lifecycle)?;
+        let mut control = session.control.lock().await;
+        control.detach(&req.access_key, caller_worker_id)?;
+        let mut status = session
+            .status
+            .lock()
+            .map_err(|_| "terminal status lock poisoned".to_string())?;
+        if !matches!(*status, SessionStatus::Exited { .. }) {
+            *status = SessionStatus::Detached;
+        }
+        Ok(DetachResponse {
+            status: status.clone(),
+        })
+    }
+
+    pub async fn attach(&self, req: AttachRequest) -> Result<AttachResponse, String> {
+        validate_size(req.cols, req.rows)?;
+        validate_output_function_id(&req.output_function_id)?;
+        let caller_worker_id = require_caller(req.caller_worker_id.as_deref())?;
+        let request_id = req
+            .request_id
+            .as_deref()
+            .map(validate_request_id)
+            .transpose()?;
+        let session = self.session(&req.session_id).await?;
+        let lifecycle = session.lifecycle.lock().await;
+        ensure_session_open(&lifecycle)?;
+
+        {
+            let control = session.control.lock().await;
+            if !control.can_attach(&req.reconnect_token, request_id) {
+                return Err("terminal reconnect token is invalid".to_string());
+            }
+        }
+
+        let cols = req.cols;
+        let rows = req.rows;
+        resize_session(session.clone(), cols, rows).await?;
+
+        let mut control = session.control.lock().await;
+        if !control.can_attach(&req.reconnect_token, request_id) {
+            return Err("terminal reconnect token is invalid".to_string());
+        }
+        let replay = session
+            .output
+            .lock()
+            .map_err(|_| "terminal output lock poisoned".to_string())?
+            .frames_after(req.after_sequence);
+        let credentials = control.attach(
+            &req.reconnect_token,
+            request_id,
+            caller_worker_id,
+            &req.output_function_id,
+        )?;
+        let mut status = session
+            .status
+            .lock()
+            .map_err(|_| "terminal status lock poisoned".to_string())?;
+        if !matches!(*status, SessionStatus::Exited { .. }) {
+            *status = SessionStatus::Attached;
+        }
+        let status = status.clone();
+
+        Ok(AttachResponse {
+            access_key: credentials.access_key,
+            reconnect_token: credentials.reconnect_token,
+            frames: replay.frames,
+            truncated: replay.truncated,
+            next_sequence: replay.next_sequence,
+            cwd: session.cwd.clone(),
+            status,
+        })
+    }
+
+    async fn session(&self, session_id: &str) -> Result<Arc<PtySession>, String> {
+        let sessions = self.sessions.read().await;
+        sessions
+            .get(session_id)
+            .cloned()
+            .ok_or_else(|| "terminal session does not exist".to_string())
+    }
+
+    fn spawn_output_pump(
+        &self,
+        session_id: String,
+        mut reader: Box<dyn Read + Send>,
+        mut child: Box<dyn Child + Send + Sync>,
+    ) {
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<Result<Vec<u8>, String>>(64);
+        tokio::task::spawn_blocking(move || {
+            let mut chunk = vec![0_u8; 16 * 1024];
+            loop {
+                match reader.read(&mut chunk) {
+                    Ok(0) => break,
+                    Ok(read) => {
+                        if tx.blocking_send(Ok(chunk[..read].to_vec())).is_err() {
+                            break;
+                        }
+                    }
+                    Err(error) => {
+                        let _ = tx.blocking_send(Err(error.to_string()));
+                        break;
+                    }
+                }
+            }
+        });
+        let child_wait = tokio::task::spawn_blocking(move || child.wait());
+        let iii = self.iii.clone();
+        let sessions = self.sessions.clone();
+        tokio::spawn(async move {
+            let mut read_error = None;
+            while let Some(chunk) = rx.recv().await {
+                match chunk {
+                    Ok(data) => {
+                        let session = {
+                            let sessions = sessions.read().await;
+                            sessions.get(&session_id).cloned()
+                        };
+                        let Some(session) = session else {
+                            rx.close();
+                            break;
+                        };
+                        let frame = match session.output.lock() {
+                            Ok(mut output) => output.push(data),
+                            Err(_) => {
+                                read_error = Some("terminal output lock poisoned".to_string());
+                                break;
+                            }
+                        };
+                        if let Some((output_function_id, access_key)) =
+                            output_target(&session).await
+                        {
+                            let delivered = emit_output(
+                                &iii,
+                                &output_function_id,
+                                OutputEvent {
+                                    session_id: session_id.clone(),
+                                    sequence: Some(frame.sequence),
+                                    data: Some(frame.data),
+                                    eof: false,
+                                    exit_code: None,
+                                    signal: None,
+                                    error: None,
+                                },
+                            )
+                            .await;
+                            if !delivered {
+                                detach_failed_output(&session, &output_function_id, &access_key)
+                                    .await;
+                            }
+                        }
+                    }
+                    Err(error) => {
+                        read_error = Some(error);
+                        break;
+                    }
+                }
+            }
+            let (exit_code, signal, wait_error) = match child_wait.await {
+                Ok(Ok(status)) => (
+                    Some(status.exit_code()),
+                    status.signal().map(str::to_string),
+                    None,
+                ),
+                Ok(Err(error)) => (None, None, Some(error.to_string())),
+                Err(error) => (None, None, Some(error.to_string())),
+            };
+            let session = {
+                let sessions = sessions.read().await;
+                sessions.get(&session_id).cloned()
+            };
+            if let Some(session) = session {
+                let error = read_error.or(wait_error);
+                if let Ok(mut status) = session.status.lock() {
+                    *status = SessionStatus::Exited {
+                        exit_code,
+                        signal: signal.clone(),
+                        error: error.clone(),
+                    };
+                }
+                #[cfg(unix)]
+                clear_terminated_process_group(&session);
+                if let Some((output_function_id, access_key)) = output_target(&session).await {
+                    let delivered = emit_output(
+                        &iii,
+                        &output_function_id,
+                        OutputEvent {
+                            session_id,
+                            sequence: None,
+                            data: None,
+                            eof: true,
+                            exit_code,
+                            signal,
+                            error,
+                        },
+                    )
+                    .await;
+                    if !delivered {
+                        detach_failed_output(&session, &output_function_id, &access_key).await;
+                    }
+                }
+            }
+        });
+    }
+}
+
+async fn output_target(session: &PtySession) -> Option<(String, String)> {
+    let control = session.control.lock().await;
+    (control.status() == SessionStatus::Attached).then(|| {
+        (
+            control.output_function_id().to_string(),
+            control.access_key().to_string(),
+        )
+    })
+}
+
+async fn detach_failed_output(session: &PtySession, output_function_id: &str, access_key: &str) {
+    let detached = session
+        .control
+        .lock()
+        .await
+        .detach_output_target(output_function_id, access_key);
+    if detached {
+        if let Ok(mut status) = session.status.lock() {
+            if !matches!(*status, SessionStatus::Exited { .. }) {
+                *status = SessionStatus::Detached;
+            }
+        }
+    }
+}
+
+pub fn register(iii: &IIIClient, manager: PtyManager) {
+    {
+        let manager = manager.clone();
+        iii.register_function(
+            "shell::pty::open",
+            RegisterFunction::new_async(move |req: OpenRequest| {
+                let manager = manager.clone();
+                async move { manager.open(req).await.map_err(Error::Handler) }
+            })
+            .description("Open a persistent host PTY running the user's login shell.")
+            .metadata(serde_json::json!({ "internal": true })),
+        );
+    }
+    {
+        let manager = manager.clone();
+        iii.register_function(
+            "shell::pty::write",
+            RegisterFunction::new_async(move |req: WriteRequest| {
+                let manager = manager.clone();
+                async move { manager.write(req).await.map_err(Error::Handler) }
+            })
+            .description("Write base64-encoded keyboard input to a PTY session.")
+            .metadata(serde_json::json!({ "internal": true })),
+        );
+    }
+    {
+        let manager = manager.clone();
+        iii.register_function(
+            "shell::pty::resize",
+            RegisterFunction::new_async(move |req: ResizeRequest| {
+                let manager = manager.clone();
+                async move { manager.resize(req).await.map_err(Error::Handler) }
+            })
+            .description("Resize a PTY session in terminal columns and rows.")
+            .metadata(serde_json::json!({ "internal": true })),
+        );
+    }
+    {
+        let manager = manager.clone();
+        iii.register_function(
+            "shell::pty::detach",
+            RegisterFunction::new_async(move |req: DetachRequest| {
+                let manager = manager.clone();
+                async move { manager.detach(req).await.map_err(Error::Handler) }
+            })
+            .description("Detach a browser output target while retaining its PTY session.")
+            .metadata(serde_json::json!({ "internal": true })),
+        );
+    }
+    {
+        let manager = manager.clone();
+        iii.register_function(
+            "shell::pty::attach",
+            RegisterFunction::new_async(move |req: AttachRequest| {
+                let manager = manager.clone();
+                async move { manager.attach(req).await.map_err(Error::Handler) }
+            })
+            .description("Attach to a retained PTY session and replay buffered output.")
+            .metadata(serde_json::json!({ "internal": true })),
+        );
+    }
+    iii.register_function(
+        "shell::pty::close",
+        RegisterFunction::new_async(move |req: CloseRequest| {
+            let manager = manager.clone();
+            async move { manager.close(req).await.map_err(Error::Handler) }
+        })
+        .description("Terminate and close a PTY session.")
+        .metadata(serde_json::json!({ "internal": true })),
+    );
+}
+
+fn spawn_process(
+    cwd: &Path,
+    cols: u16,
+    rows: u16,
+    program: Option<&str>,
+) -> anyhow::Result<SpawnedPty> {
+    let pair = native_pty_system().openpty(PtySize {
+        rows,
+        cols,
+        pixel_width: 0,
+        pixel_height: 0,
+    })?;
+    let mut command = match program {
+        Some(program) => CommandBuilder::new(program),
+        None => CommandBuilder::new_default_prog(),
+    };
+    command.cwd(cwd);
+    command.env("TERM", "xterm-256color");
+    command.env("COLORTERM", "truecolor");
+    command.env("TERM_PROGRAM", "iii");
+
+    let child = pair.slave.spawn_command(command)?;
+    let reader = pair.master.try_clone_reader()?;
+    let writer = pair.master.take_writer()?;
+    drop(pair.slave);
+
+    Ok(SpawnedPty {
+        master: pair.master,
+        reader,
+        writer,
+        child,
+    })
+}
+
+fn validate_size(cols: u16, rows: u16) -> Result<(), String> {
+    if !(2..=500).contains(&cols) || !(2..=500).contains(&rows) {
+        return Err("terminal size must be between 2 and 500 columns/rows".to_string());
+    }
+    Ok(())
+}
+
+fn validate_output_function_id(function_id: &str) -> Result<(), String> {
+    let Some(browser_id) = function_id.strip_prefix(OUTPUT_FUNCTION_PREFIX) else {
+        return Err("terminal output function is not a shell UI handler".to_string());
+    };
+    if browser_id.is_empty()
+        || browser_id.len() > 128
+        || !browser_id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+    {
+        return Err("terminal output function has an invalid browser id".to_string());
+    }
+    Ok(())
+}
+
+fn require_caller(caller_worker_id: Option<&str>) -> Result<&str, String> {
+    caller_worker_id
+        .filter(|caller| !caller.is_empty())
+        .ok_or_else(|| "terminal calls require engine-stamped caller identity".to_string())
+}
+
+fn validate_request_id(request_id: &str) -> Result<&str, String> {
+    if request_id.is_empty()
+        || request_id.len() > 128
+        || !request_id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+    {
+        return Err("terminal request id is invalid".to_string());
+    }
+    Ok(request_id)
+}
+
+async fn remove_session(
+    sessions: &RwLock<HashMap<String, Arc<PtySession>>>,
+    session_id: &str,
+    expected: &Arc<PtySession>,
+) {
+    let mut sessions = sessions.write().await;
+    let matches = sessions
+        .get(session_id)
+        .is_some_and(|session| Arc::ptr_eq(session, expected));
+    if matches {
+        sessions.remove(session_id);
+    }
+}
+
+async fn terminate_session(session: Arc<PtySession>) -> Result<(), String> {
+    #[cfg(unix)]
+    {
+        let process_groups = session_process_groups(&session)?;
+        if !process_groups.is_empty() {
+            let terminate_session = session.clone();
+            return tokio::task::spawn_blocking(move || {
+                terminate_process_groups(&terminate_session, process_groups)
+            })
+            .await
+            .map_err(|error| format!("terminal close task failed: {error}"))?;
+        }
+    }
+    if session_exited(&session)? {
+        return Ok(());
+    }
+    let kill_session = session.clone();
+    let kill_result = tokio::task::spawn_blocking(move || {
+        let mut killer = kill_session
+            .killer
+            .lock()
+            .map_err(|_| "terminal killer lock poisoned".to_string())?;
+        killer
+            .kill()
+            .map_err(|error| format!("terminal close failed: {error}"))
+    })
+    .await
+    .map_err(|error| format!("terminal close task failed: {error}"))?;
+    if let Err(error) = kill_result {
+        if session_exited(&session)? {
+            return Ok(());
+        }
+        return Err(error);
+    }
+    wait_for_session_exit(&session).await
+}
+
+async fn wait_for_session_exit(session: &PtySession) -> Result<(), String> {
+    tokio::time::timeout(PORTABLE_TERMINATION_WAIT, async {
+        loop {
+            if session_exited(session)? {
+                return Ok(());
+            }
+            tokio::time::sleep(TERMINATION_POLL_INTERVAL).await;
+        }
+    })
+    .await
+    .map_err(|_| "terminal close timed out waiting for process exit".to_string())?
+}
+
+async fn reset_session_closing(session: &PtySession) {
+    let mut lifecycle = session.lifecycle.lock().await;
+    if !lifecycle.closed {
+        lifecycle.closing = false;
+    }
+}
+
+#[cfg(unix)]
+fn session_process_groups(session: &PtySession) -> Result<Vec<libc::pid_t>, String> {
+    let mut process_groups = Vec::new();
+    if let Some(process_group) = *session
+        .process_group
+        .lock()
+        .map_err(|_| "terminal process group lock poisoned".to_string())?
+    {
+        add_process_group(&mut process_groups, process_group)?;
+    }
+    let foreground = session
+        .master
+        .lock()
+        .map_err(|_| "terminal master lock poisoned".to_string())?
+        .process_group_leader();
+    if let Some(process_group) = foreground {
+        add_process_group(&mut process_groups, process_group)?;
+    }
+    Ok(process_groups)
+}
+
+#[cfg(unix)]
+fn add_process_group(
+    process_groups: &mut Vec<libc::pid_t>,
+    process_group: libc::pid_t,
+) -> Result<(), String> {
+    if process_group <= 1 {
+        return Err(format!(
+            "terminal close refused invalid process group {process_group}"
+        ));
+    }
+    let own_process_group = unsafe { libc::getpgrp() };
+    if process_group == own_process_group {
+        return Err("terminal close refused to signal the worker process group".to_string());
+    }
+    if !process_groups.contains(&process_group) {
+        process_groups.push(process_group);
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn terminate_process_groups(
+    session: &PtySession,
+    mut process_groups: Vec<libc::pid_t>,
+) -> Result<(), String> {
+    let stages = [
+        (libc::SIGHUP, SIGHUP_TERMINATION_WAIT),
+        (libc::SIGTERM, SIGTERM_TERMINATION_WAIT),
+        (libc::SIGKILL, SIGKILL_TERMINATION_WAIT),
+    ];
+    for (signal, wait) in stages {
+        for process_group in session_process_groups(session)? {
+            add_process_group(&mut process_groups, process_group)?;
+        }
+        for process_group in &process_groups {
+            signal_process_group(*process_group, signal)?;
+        }
+        if wait_for_process_groups(&process_groups, wait)? {
+            return Ok(());
+        }
+    }
+    let survivors = process_groups
+        .into_iter()
+        .filter(|process_group| process_group_exists(*process_group).unwrap_or(true))
+        .map(|process_group| process_group.to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    Err(format!(
+        "terminal close timed out waiting for process group(s) {survivors}"
+    ))
+}
+
+#[cfg(unix)]
+fn signal_process_group(process_group: libc::pid_t, signal: libc::c_int) -> Result<(), String> {
+    if unsafe { libc::kill(-process_group, signal) } == 0 {
+        return Ok(());
+    }
+    let error = std::io::Error::last_os_error();
+    if error.raw_os_error() == Some(libc::ESRCH) {
+        return Ok(());
+    }
+    Err(format!(
+        "terminal close failed to signal process group {process_group}: {error}"
+    ))
+}
+
+#[cfg(unix)]
+fn process_group_exists(process_group: libc::pid_t) -> Result<bool, String> {
+    if unsafe { libc::kill(-process_group, 0) } == 0 {
+        return Ok(true);
+    }
+    let error = std::io::Error::last_os_error();
+    match error.raw_os_error() {
+        Some(libc::ESRCH) => Ok(false),
+        Some(libc::EPERM) => Ok(true),
+        _ => Err(format!(
+            "terminal close failed to inspect process group {process_group}: {error}"
+        )),
+    }
+}
+
+#[cfg(unix)]
+fn wait_for_process_groups(
+    process_groups: &[libc::pid_t],
+    timeout: StdDuration,
+) -> Result<bool, String> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let mut any_running = false;
+        for process_group in process_groups {
+            any_running |= process_group_exists(*process_group)?;
+        }
+        if !any_running {
+            return Ok(true);
+        }
+        if Instant::now() >= deadline {
+            return Ok(false);
+        }
+        std::thread::sleep(TERMINATION_POLL_INTERVAL);
+    }
+}
+
+#[cfg(unix)]
+fn clear_terminated_process_group(session: &PtySession) {
+    let Ok(mut process_group) = session.process_group.lock() else {
+        return;
+    };
+    if process_group
+        .is_some_and(|process_group| !process_group_exists(process_group).unwrap_or(false))
+    {
+        *process_group = None;
+    }
+}
+
+async fn authenticate_session(
+    session: &PtySession,
+    access_key: &str,
+    caller_worker_id: &str,
+) -> Result<(), String> {
+    session
+        .control
+        .lock()
+        .await
+        .authenticate(access_key, caller_worker_id)
+}
+
+async fn resize_session(session: Arc<PtySession>, cols: u16, rows: u16) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || {
+        let master = session
+            .master
+            .lock()
+            .map_err(|_| "terminal master lock poisoned".to_string())?;
+        master
+            .resize(PtySize {
+                rows,
+                cols,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .map_err(|error| format!("terminal resize failed: {error}"))
+    })
+    .await
+    .map_err(|error| format!("terminal resize task failed: {error}"))??;
+    Ok(())
+}
+
+fn ensure_session_open(lifecycle: &SessionLifecycle) -> Result<(), String> {
+    if lifecycle.closing || lifecycle.closed {
+        Err("terminal session is closed".to_string())
+    } else {
+        Ok(())
+    }
+}
+
+fn session_exited(session: &PtySession) -> Result<bool, String> {
+    session
+        .status
+        .lock()
+        .map(|status| matches!(*status, SessionStatus::Exited { .. }))
+        .map_err(|_| "terminal status lock poisoned".to_string())
+}
+
+fn release_session_permit(session: &PtySession) -> Result<(), String> {
+    session
+        .permit
+        .lock()
+        .map_err(|_| "terminal permit lock poisoned".to_string())?
+        .take();
+    Ok(())
+}
+
+async fn emit_output(iii: &IIIClient, function_id: &str, event: OutputEvent) -> bool {
+    let payload = match serde_json::to_value(event) {
+        Ok(payload) => payload,
+        Err(error) => {
+            tracing::warn!(error = %error, "terminal output serialization failed");
+            return false;
+        }
+    };
+    match iii
+        .trigger(TriggerRequest {
+            function_id: function_id.to_string(),
+            payload,
+            action: Some(TriggerAction::Void),
+            timeout_ms: None,
+        })
+        .await
+    {
+        Ok(_) => true,
+        Err(error) => {
+            tracing::debug!(error = %error, "terminal output delivery failed");
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Condvar;
+    use std::time::Duration;
+
+    use crate::code::config::CoderConfig;
+    use crate::code::path::PathResolver;
+
+    use super::*;
+
+    struct HarnessOpen {
+        session_id: String,
+        access_key: String,
+        reconnect_token: String,
+    }
+
+    struct HarnessAttach {
+        access_key: String,
+        reconnect_token: String,
+        replay: Vec<OutputFrame>,
+        truncated: bool,
+        next_sequence: u64,
+        status: SessionStatus,
+    }
+
+    #[derive(Debug)]
+    struct FailingResizeMaster;
+
+    impl MasterPty for FailingResizeMaster {
+        fn resize(&self, _size: PtySize) -> anyhow::Result<()> {
+            Err(anyhow::anyhow!("forced resize failure"))
+        }
+
+        fn get_size(&self) -> anyhow::Result<PtySize> {
+            Err(anyhow::anyhow!("test master has no size"))
+        }
+
+        fn try_clone_reader(&self) -> anyhow::Result<Box<dyn Read + Send>> {
+            Err(anyhow::anyhow!("test master has no reader"))
+        }
+
+        fn take_writer(&self) -> anyhow::Result<Box<dyn Write + Send>> {
+            Err(anyhow::anyhow!("test master has no writer"))
+        }
+
+        #[cfg(unix)]
+        fn process_group_leader(&self) -> Option<libc::pid_t> {
+            None
+        }
+
+        #[cfg(unix)]
+        fn as_raw_fd(&self) -> Option<portable_pty::unix::RawFd> {
+            None
+        }
+
+        #[cfg(unix)]
+        fn tty_name(&self) -> Option<std::path::PathBuf> {
+            None
+        }
+    }
+
+    #[derive(Debug)]
+    struct FailingKiller;
+
+    impl ChildKiller for FailingKiller {
+        fn kill(&mut self) -> std::io::Result<()> {
+            Err(std::io::Error::other("forced kill failure"))
+        }
+
+        fn clone_killer(&self) -> Box<dyn ChildKiller + Send + Sync> {
+            Box::new(Self)
+        }
+    }
+
+    struct BlockingWriter {
+        entered: Option<std::sync::mpsc::Sender<()>>,
+        release: Arc<(Mutex<bool>, Condvar)>,
+    }
+
+    impl Write for BlockingWriter {
+        fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
+            if let Some(entered) = self.entered.take() {
+                let _ = entered.send(());
+            }
+            let (released, wake) = &*self.release;
+            let mut released = released.lock().unwrap();
+            while !*released {
+                released = wake.wait(released).unwrap();
+            }
+            Ok(data.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct PtyTestHarness {
+        manager: PtyManager,
+        caller_worker_id: String,
+        cwd: String,
+        output_function_id: String,
+        _workspace: tempfile::TempDir,
+    }
+
+    impl PtyTestHarness {
+        async fn new(program: &str) -> Self {
+            let workspace = tempfile::tempdir().unwrap();
+            let config = CoderConfig {
+                base_paths: vec![workspace.path().to_path_buf()],
+                ..CoderConfig::default()
+            };
+            let resolver = Arc::new(PathResolver::new(&config).unwrap());
+            let manager = PtyManager::new(
+                IIIClient::new("ws://127.0.0.1:1"),
+                Arc::new(RwLock::new(resolver)),
+            )
+            .with_program(program);
+
+            Self {
+                manager,
+                caller_worker_id: "pty-test-worker".to_string(),
+                cwd: workspace.path().display().to_string(),
+                output_function_id: format!("{OUTPUT_FUNCTION_PREFIX}{}", Uuid::new_v4()),
+                _workspace: workspace,
+            }
+        }
+
+        async fn open(&self) -> HarnessOpen {
+            let opened = self
+                .manager
+                .open(OpenRequest {
+                    request_id: None,
+                    cwd: self.cwd.clone(),
+                    cols: 80,
+                    rows: 24,
+                    output_function_id: self.output_function_id.clone(),
+                    caller_worker_id: Some(self.caller_worker_id.clone()),
+                })
+                .await
+                .unwrap();
+
+            HarnessOpen {
+                session_id: opened.session_id,
+                access_key: opened.access_key,
+                reconnect_token: opened.reconnect_token,
+            }
+        }
+
+        async fn write(&self, opened: &HarnessOpen, data: &[u8]) {
+            let session = self.manager.session(&opened.session_id).await.unwrap();
+            let next_sequence = session.output.lock().unwrap().frames_after(0).next_sequence;
+            self.manager
+                .write(WriteRequest {
+                    session_id: opened.session_id.clone(),
+                    access_key: opened.access_key.clone(),
+                    data: BASE64_STANDARD.encode(data),
+                    caller_worker_id: Some(self.caller_worker_id.clone()),
+                })
+                .await
+                .unwrap();
+            tokio::time::timeout(Duration::from_secs(5), async {
+                loop {
+                    let current = session.output.lock().unwrap().frames_after(0).next_sequence;
+                    if current > next_sequence {
+                        break;
+                    }
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+            })
+            .await
+            .expect("PTY output was buffered");
+        }
+
+        async fn wait_for_output(&self, session_id: &str, marker: &str) {
+            let session = self.manager.session(session_id).await.unwrap();
+            tokio::time::timeout(Duration::from_secs(5), async {
+                loop {
+                    let found = session
+                        .output
+                        .lock()
+                        .unwrap()
+                        .frames_after(0)
+                        .frames
+                        .iter()
+                        .any(|frame| decode_frame(frame).contains(marker));
+                    if found {
+                        break;
+                    }
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+            })
+            .await
+            .expect("expected PTY output was buffered");
+        }
+
+        async fn detach(&self, opened: &HarnessOpen) {
+            self.manager
+                .detach(DetachRequest {
+                    session_id: opened.session_id.clone(),
+                    access_key: opened.access_key.clone(),
+                    caller_worker_id: Some(self.caller_worker_id.clone()),
+                })
+                .await
+                .unwrap();
+        }
+
+        async fn attach(
+            &self,
+            session_id: &str,
+            reconnect_token: &str,
+            after_sequence: u64,
+        ) -> HarnessAttach {
+            let attached = self
+                .manager
+                .attach(AttachRequest {
+                    request_id: None,
+                    session_id: session_id.to_string(),
+                    reconnect_token: reconnect_token.to_string(),
+                    output_function_id: self.output_function_id.clone(),
+                    cols: 80,
+                    rows: 24,
+                    after_sequence,
+                    caller_worker_id: Some(self.caller_worker_id.clone()),
+                })
+                .await
+                .unwrap();
+
+            HarnessAttach {
+                access_key: attached.access_key,
+                reconnect_token: attached.reconnect_token,
+                replay: attached.frames,
+                truncated: attached.truncated,
+                next_sequence: attached.next_sequence,
+                status: attached.status,
+            }
+        }
+
+        async fn close(&self, session_id: &str, access_key: &str) -> CloseResponse {
+            self.manager
+                .close(CloseRequest {
+                    session_id: session_id.to_string(),
+                    access_key: access_key.to_string(),
+                    caller_worker_id: Some(self.caller_worker_id.clone()),
+                })
+                .await
+                .unwrap()
+        }
+
+        async fn pid(&self, session_id: &str) -> Option<u32> {
+            self.manager.session(session_id).await.unwrap().pid
+        }
+
+        async fn close_all(&self) {
+            self.manager.close_all().await.unwrap();
+            assert_eq!(self.manager.permits.available_permits(), MAX_SESSIONS);
+        }
+    }
+
+    fn decode_frame(frame: &OutputFrame) -> String {
+        String::from_utf8_lossy(&BASE64_STANDARD.decode(&frame.data).unwrap()).into_owned()
+    }
+
+    #[tokio::test]
+    async fn open_returns_usable_session_reconnect_token() {
+        let harness = PtyTestHarness::new("/bin/sh").await;
+        let opened = harness
+            .manager
+            .open(OpenRequest {
+                request_id: None,
+                cwd: harness.cwd.clone(),
+                cols: 80,
+                rows: 24,
+                output_function_id: harness.output_function_id.clone(),
+                caller_worker_id: Some(harness.caller_worker_id.clone()),
+            })
+            .await
+            .unwrap();
+        let session = harness.manager.session(&opened.session_id).await.unwrap();
+
+        assert_eq!(
+            opened.reconnect_token,
+            session.control.lock().await.reconnect_token()
+        );
+        harness
+            .manager
+            .detach(DetachRequest {
+                session_id: opened.session_id.clone(),
+                access_key: opened.access_key,
+                caller_worker_id: Some(harness.caller_worker_id.clone()),
+            })
+            .await
+            .unwrap();
+        let attached = harness
+            .attach(&opened.session_id, &opened.reconnect_token, 0)
+            .await;
+        assert!(
+            harness
+                .close(&opened.session_id, &attached.access_key)
+                .await
+                .closed
+        );
+    }
+
+    #[tokio::test]
+    async fn retried_open_request_returns_the_same_session() {
+        let harness = PtyTestHarness::new("/bin/sh").await;
+        let request_id = Uuid::new_v4().to_string();
+        let open = || OpenRequest {
+            request_id: Some(request_id.clone()),
+            cwd: harness.cwd.clone(),
+            cols: 80,
+            rows: 24,
+            output_function_id: harness.output_function_id.clone(),
+            caller_worker_id: Some(harness.caller_worker_id.clone()),
+        };
+
+        let first = harness.manager.open(open()).await.unwrap();
+        let retried = harness.manager.open(open()).await.unwrap();
+
+        assert_eq!(first.session_id, retried.session_id);
+        assert_eq!(first.access_key, retried.access_key);
+        assert_eq!(harness.manager.sessions.read().await.len(), 1);
+        harness.close(&first.session_id, &first.access_key).await;
+    }
+
+    #[tokio::test]
+    async fn retried_attach_request_returns_the_same_rotated_credentials() {
+        let harness = PtyTestHarness::new("/bin/sh").await;
+        let opened = harness.open().await;
+        harness.detach(&opened).await;
+        let request_id = Uuid::new_v4().to_string();
+        let attach = || AttachRequest {
+            request_id: Some(request_id.clone()),
+            session_id: opened.session_id.clone(),
+            reconnect_token: opened.reconnect_token.clone(),
+            output_function_id: harness.output_function_id.clone(),
+            cols: 80,
+            rows: 24,
+            after_sequence: 0,
+            caller_worker_id: Some(harness.caller_worker_id.clone()),
+        };
+
+        let first = harness.manager.attach(attach()).await.unwrap();
+        let session = harness.manager.session(&opened.session_id).await.unwrap();
+        assert!(session
+            .control
+            .lock()
+            .await
+            .detach_output_target(&harness.output_function_id, &first.access_key));
+        let retry_worker = "retry-worker";
+        let retry_output = format!("{OUTPUT_FUNCTION_PREFIX}{}", Uuid::new_v4());
+        let retried = harness
+            .manager
+            .attach(AttachRequest {
+                request_id: Some(request_id),
+                session_id: opened.session_id.clone(),
+                reconnect_token: opened.reconnect_token,
+                output_function_id: retry_output.clone(),
+                cols: 80,
+                rows: 24,
+                after_sequence: 0,
+                caller_worker_id: Some(retry_worker.to_string()),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(first.access_key, retried.access_key);
+        assert_eq!(first.reconnect_token, retried.reconnect_token);
+        let control = session.control.lock().await;
+        assert_eq!(control.status(), SessionStatus::Attached);
+        assert_eq!(control.output_function_id(), retry_output);
+        assert!(control
+            .authenticate(&retried.access_key, retry_worker)
+            .is_ok());
+        drop(control);
+        harness
+            .manager
+            .close(CloseRequest {
+                session_id: opened.session_id,
+                access_key: first.access_key,
+                caller_worker_id: Some(retry_worker.to_string()),
+            })
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn queued_write_is_rejected_after_close_wins_session_lock() {
+        let harness = PtyTestHarness::new("/bin/sh").await;
+        let opened = harness.open().await;
+        let session = harness.manager.session(&opened.session_id).await.unwrap();
+        let session_lock = session.lifecycle.lock().await;
+        let close_manager = harness.manager.clone();
+        let close_session_id = opened.session_id.clone();
+        let close_access_key = opened.access_key.clone();
+        let caller_worker_id = harness.caller_worker_id.clone();
+        let close_task = tokio::spawn(async move {
+            close_manager
+                .close(CloseRequest {
+                    session_id: close_session_id,
+                    access_key: close_access_key,
+                    caller_worker_id: Some(caller_worker_id),
+                })
+                .await
+        });
+        tokio::task::yield_now().await;
+
+        let write_manager = harness.manager.clone();
+        let write_session_id = opened.session_id;
+        let write_access_key = opened.access_key;
+        let caller_worker_id = harness.caller_worker_id.clone();
+        let write_task = tokio::spawn(async move {
+            write_manager
+                .write(WriteRequest {
+                    session_id: write_session_id,
+                    access_key: write_access_key,
+                    data: BASE64_STANDARD.encode(b"echo should-not-run\r"),
+                    caller_worker_id: Some(caller_worker_id),
+                })
+                .await
+        });
+        tokio::task::yield_now().await;
+        drop(session_lock);
+
+        assert!(close_task.await.unwrap().unwrap().closed);
+        assert_eq!(
+            write_task.await.unwrap().unwrap_err(),
+            "terminal session is closed"
+        );
+    }
+
+    #[tokio::test]
+    async fn blocked_write_does_not_prevent_close_and_close_wins() {
+        let harness = PtyTestHarness::new("/bin/sh").await;
+        let opened = harness.open().await;
+        let session = harness.manager.session(&opened.session_id).await.unwrap();
+        let (entered_tx, entered_rx) = std::sync::mpsc::channel();
+        let release = Arc::new((Mutex::new(false), Condvar::new()));
+        let original_writer = {
+            let mut writer = session.writer.lock().unwrap();
+            std::mem::replace(
+                &mut *writer,
+                Box::new(BlockingWriter {
+                    entered: Some(entered_tx),
+                    release: release.clone(),
+                }),
+            )
+        };
+        let write_manager = harness.manager.clone();
+        let write_session_id = opened.session_id.clone();
+        let write_access_key = opened.access_key.clone();
+        let caller_worker_id = harness.caller_worker_id.clone();
+        let write_task = tokio::spawn(async move {
+            write_manager
+                .write(WriteRequest {
+                    session_id: write_session_id,
+                    access_key: write_access_key,
+                    data: BASE64_STANDARD.encode(b"blocked input"),
+                    caller_worker_id: Some(caller_worker_id),
+                })
+                .await
+        });
+        tokio::task::spawn_blocking(move || {
+            entered_rx
+                .recv_timeout(Duration::from_secs(2))
+                .expect("writer entered blocking write")
+        })
+        .await
+        .unwrap();
+
+        let close = tokio::time::timeout(
+            Duration::from_secs(3),
+            harness.close(&opened.session_id, &opened.access_key),
+        )
+        .await
+        .expect("close completed while the writer remained blocked");
+        let (released, wake) = &*release;
+        *released.lock().unwrap() = true;
+        wake.notify_all();
+
+        assert!(close.closed);
+        assert_eq!(
+            write_task.await.unwrap().unwrap_err(),
+            "terminal session is closed"
+        );
+        drop(original_writer);
+    }
+
+    #[tokio::test]
+    async fn queued_attach_is_rejected_after_close_wins_session_lock() {
+        let harness = PtyTestHarness::new("/bin/sh").await;
+        let opened = harness.open().await;
+        let session = harness.manager.session(&opened.session_id).await.unwrap();
+        let session_lock = session.lifecycle.lock().await;
+        let close_manager = harness.manager.clone();
+        let close_session_id = opened.session_id.clone();
+        let close_access_key = opened.access_key;
+        let caller_worker_id = harness.caller_worker_id.clone();
+        let close_task = tokio::spawn(async move {
+            close_manager
+                .close(CloseRequest {
+                    session_id: close_session_id,
+                    access_key: close_access_key,
+                    caller_worker_id: Some(caller_worker_id),
+                })
+                .await
+        });
+        tokio::task::yield_now().await;
+
+        let attach_manager = harness.manager.clone();
+        let attach_session_id = opened.session_id;
+        let reconnect_token = opened.reconnect_token;
+        let output_function_id = harness.output_function_id.clone();
+        let caller_worker_id = harness.caller_worker_id.clone();
+        let attach_task = tokio::spawn(async move {
+            attach_manager
+                .attach(AttachRequest {
+                    request_id: None,
+                    session_id: attach_session_id,
+                    reconnect_token,
+                    output_function_id,
+                    cols: 80,
+                    rows: 24,
+                    after_sequence: 0,
+                    caller_worker_id: Some(caller_worker_id),
+                })
+                .await
+        });
+        tokio::task::yield_now().await;
+        drop(session_lock);
+
+        assert!(close_task.await.unwrap().unwrap().closed);
+        assert_eq!(
+            attach_task.await.unwrap().unwrap_err(),
+            "terminal session is closed"
+        );
+    }
+
+    #[tokio::test]
+    async fn close_all_waits_for_open_before_insertion() {
+        let mut harness = PtyTestHarness::new("/bin/sh").await;
+        let pause = Arc::new(OpenPause {
+            reached: Notify::new(),
+            release: Notify::new(),
+        });
+        harness.manager.open_pause = Some(pause.clone());
+        let open_manager = harness.manager.clone();
+        let cwd = harness.cwd.clone();
+        let output_function_id = harness.output_function_id.clone();
+        let caller_worker_id = harness.caller_worker_id.clone();
+        let open_task = tokio::spawn(async move {
+            open_manager
+                .open(OpenRequest {
+                    request_id: None,
+                    cwd,
+                    cols: 80,
+                    rows: 24,
+                    output_function_id,
+                    caller_worker_id: Some(caller_worker_id),
+                })
+                .await
+        });
+        pause.reached.notified().await;
+
+        let close_manager = harness.manager.clone();
+        let close_task = tokio::spawn(async move { close_manager.close_all().await });
+        tokio::task::yield_now().await;
+        let close_finished_before_release = close_task.is_finished();
+        pause.release.notify_one();
+        let opened = open_task.await.unwrap().unwrap();
+        let closed = close_task.await.unwrap().unwrap();
+        let survived_shutdown = harness.manager.session(&opened.session_id).await.is_ok();
+        if survived_shutdown {
+            harness.close(&opened.session_id, &opened.access_key).await;
+        }
+
+        assert!(!close_finished_before_release);
+        assert_eq!(closed, 1);
+        assert!(!survived_shutdown);
+    }
+
+    #[tokio::test]
+    async fn close_all_reports_kill_failure_without_losing_session() {
+        let harness = PtyTestHarness::new("/bin/sh").await;
+        let opened = harness.open().await;
+        let session = harness.manager.session(&opened.session_id).await.unwrap();
+        #[cfg(unix)]
+        let original_process_group = session.process_group.lock().unwrap().take();
+        #[cfg(unix)]
+        let original_master = {
+            let mut master = session.master.lock().unwrap();
+            std::mem::replace(&mut *master, Box::new(FailingResizeMaster))
+        };
+        let original_killer = {
+            let mut killer = session.killer.lock().unwrap();
+            std::mem::replace(&mut *killer, Box::new(FailingKiller))
+        };
+
+        let error = harness.manager.close_all().await.unwrap_err();
+        let survived_failure = harness.manager.session(&opened.session_id).await.is_ok();
+        let available_permits = harness.manager.permits.available_permits();
+        {
+            let mut killer = session.killer.lock().unwrap();
+            *killer = original_killer;
+        }
+        #[cfg(unix)]
+        {
+            *session.process_group.lock().unwrap() = original_process_group;
+            *session.master.lock().unwrap() = original_master;
+        }
+        let retried = harness.manager.close_all().await.unwrap();
+
+        assert!(error.contains("forced kill failure"));
+        assert!(survived_failure);
+        assert_eq!(available_permits, MAX_SESSIONS - 1);
+        assert_eq!(retried, 1);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn close_escalates_until_hup_ignoring_descendant_exits() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut harness = PtyTestHarness::new("/bin/sh").await;
+        let script = harness._workspace.path().join("ignore-hup.sh");
+        std::fs::write(
+            &script,
+            "#!/bin/sh\ntrap '' HUP TERM\nsh -c 'trap \"\" HUP TERM; while :; do sleep 1; done' &\nchild=$!\nprintf '__HUP_CHILD__:%s\\n' \"$child\"\nwhile :; do sleep 1; done\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o700)).unwrap();
+        harness.manager.program = Some(Arc::from(script.to_string_lossy().into_owned()));
+        let opened = harness.open().await;
+        harness
+            .wait_for_output(&opened.session_id, "__HUP_CHILD__:")
+            .await;
+        let session = harness.manager.session(&opened.session_id).await.unwrap();
+        let output = session
+            .output
+            .lock()
+            .unwrap()
+            .frames_after(0)
+            .frames
+            .iter()
+            .map(decode_frame)
+            .collect::<String>();
+        let child_pid = output
+            .split("__HUP_CHILD__:")
+            .nth(1)
+            .and_then(|suffix| {
+                let digits = suffix
+                    .chars()
+                    .take_while(|character| character.is_ascii_digit())
+                    .collect::<String>();
+                digits.parse::<libc::pid_t>().ok()
+            })
+            .expect("descendant pid was printed");
+        let process_group = session
+            .process_group
+            .lock()
+            .unwrap()
+            .expect("PTY process group");
+        signal_process_group(process_group, libc::SIGHUP).unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(process_exists(child_pid));
+
+        assert!(
+            tokio::time::timeout(
+                Duration::from_secs(3),
+                harness.close(&opened.session_id, &opened.access_key),
+            )
+            .await
+            .expect("close completed after escalation")
+            .closed
+        );
+        assert!(!process_exists(child_pid));
+        assert_eq!(harness.manager.permits.available_permits(), MAX_SESSIONS);
+    }
+
+    #[cfg(unix)]
+    fn process_exists(pid: libc::pid_t) -> bool {
+        if unsafe { libc::kill(pid, 0) } == 0 {
+            return true;
+        }
+        std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
+    }
+
+    #[tokio::test]
+    async fn detached_session_replays_output() {
+        let harness = PtyTestHarness::new("/bin/sh").await;
+        let opened = harness.open().await;
+        let pid = harness.pid(&opened.session_id).await;
+
+        harness.detach(&opened).await;
+        harness
+            .write(&opened, b"printf '__DETACHED_%s__\\n' OK\r")
+            .await;
+        harness
+            .wait_for_output(&opened.session_id, "__DETACHED_OK__")
+            .await;
+        let attached = harness
+            .attach(&opened.session_id, &opened.reconnect_token, 0)
+            .await;
+
+        assert_eq!(harness.pid(&opened.session_id).await, pid);
+        assert!(attached
+            .replay
+            .iter()
+            .any(|frame| decode_frame(frame).contains("__DETACHED_OK__")));
+        assert!(attached
+            .replay
+            .windows(2)
+            .all(|frames| frames[0].sequence < frames[1].sequence));
+        assert!(!attached.truncated);
+        assert_eq!(
+            attached.next_sequence,
+            attached
+                .replay
+                .last()
+                .map_or(1, |frame| frame.sequence.saturating_add(1))
+        );
+        harness.close_all().await;
+    }
+
+    #[tokio::test]
+    async fn invalid_access_key_cannot_detach_session() {
+        let harness = PtyTestHarness::new("/bin/sh").await;
+        let opened = harness.open().await;
+
+        let result = harness
+            .manager
+            .detach(DetachRequest {
+                session_id: opened.session_id,
+                access_key: "invalid".to_string(),
+                caller_worker_id: Some(harness.caller_worker_id.clone()),
+            })
+            .await;
+
+        assert_eq!(
+            result.unwrap_err(),
+            "terminal session credentials are invalid"
+        );
+        harness.close_all().await;
+    }
+
+    #[tokio::test]
+    async fn matching_delivery_failure_detaches_without_closing_session() {
+        let harness = PtyTestHarness::new("/bin/sh").await;
+        let opened = harness.open().await;
+        let pid = harness.pid(&opened.session_id).await;
+        let session = harness.manager.session(&opened.session_id).await.unwrap();
+        let (output_function_id, access_key) = output_target(&session)
+            .await
+            .expect("attached output target");
+
+        detach_failed_output(&session, &output_function_id, &access_key).await;
+
+        assert_eq!(*session.status.lock().unwrap(), SessionStatus::Detached);
+        assert_eq!(harness.pid(&opened.session_id).await, pid);
+        assert!(
+            harness
+                .close(&opened.session_id, &opened.access_key)
+                .await
+                .closed
+        );
+    }
+
+    #[tokio::test]
+    async fn reused_reconnect_token_is_rejected() {
+        let harness = PtyTestHarness::new("/bin/sh").await;
+        let opened = harness.open().await;
+        harness.detach(&opened).await;
+
+        let attached = harness
+            .attach(&opened.session_id, &opened.reconnect_token, 0)
+            .await;
+        let reused = harness
+            .manager
+            .attach(AttachRequest {
+                request_id: None,
+                session_id: opened.session_id.clone(),
+                reconnect_token: opened.reconnect_token.clone(),
+                output_function_id: harness.output_function_id.clone(),
+                cols: 80,
+                rows: 24,
+                after_sequence: 0,
+                caller_worker_id: Some(harness.caller_worker_id.clone()),
+            })
+            .await;
+
+        assert_eq!(reused.unwrap_err(), "terminal reconnect token is invalid");
+        assert_ne!(attached.access_key, opened.access_key);
+        assert_ne!(attached.reconnect_token, opened.reconnect_token);
+        assert_eq!(attached.status, SessionStatus::Attached);
+        assert!(
+            harness
+                .close(&opened.session_id, &attached.access_key)
+                .await
+                .closed
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_resize_preserves_valid_reconnect_token() {
+        let harness = PtyTestHarness::new("/bin/sh").await;
+        let opened = harness.open().await;
+        harness.detach(&opened).await;
+        let session = harness.manager.session(&opened.session_id).await.unwrap();
+        let original_master = {
+            let mut master = session.master.lock().unwrap();
+            std::mem::replace(&mut *master, Box::new(FailingResizeMaster))
+        };
+
+        let failed = harness
+            .manager
+            .attach(AttachRequest {
+                request_id: None,
+                session_id: opened.session_id.clone(),
+                reconnect_token: opened.reconnect_token.clone(),
+                output_function_id: harness.output_function_id.clone(),
+                cols: 80,
+                rows: 24,
+                after_sequence: 0,
+                caller_worker_id: Some(harness.caller_worker_id.clone()),
+            })
+            .await;
+        assert!(failed.unwrap_err().contains("forced resize failure"));
+
+        {
+            let mut master = session.master.lock().unwrap();
+            *master = original_master;
+        }
+        let attached = harness
+            .attach(&opened.session_id, &opened.reconnect_token, 0)
+            .await;
+        assert!(
+            harness
+                .close(&opened.session_id, &attached.access_key)
+                .await
+                .closed
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_attach_consumes_reconnect_token_once() {
+        let harness = PtyTestHarness::new("/bin/sh").await;
+        let opened = harness.open().await;
+        harness.detach(&opened).await;
+        let request = || AttachRequest {
+            request_id: None,
+            session_id: opened.session_id.clone(),
+            reconnect_token: opened.reconnect_token.clone(),
+            output_function_id: harness.output_function_id.clone(),
+            cols: 80,
+            rows: 24,
+            after_sequence: 0,
+            caller_worker_id: Some(harness.caller_worker_id.clone()),
+        };
+
+        let (first, second) = tokio::join!(
+            harness.manager.attach(request()),
+            harness.manager.attach(request())
+        );
+        let (attached, rejected) = match (first, second) {
+            (Ok(attached), Err(rejected)) | (Err(rejected), Ok(attached)) => (attached, rejected),
+            results => panic!("expected one successful attach, got {results:?}"),
+        };
+
+        assert_eq!(rejected, "terminal reconnect token is invalid");
+        assert!(
+            harness
+                .close(&opened.session_id, &attached.access_key)
+                .await
+                .closed
+        );
+    }
+
+    #[tokio::test]
+    async fn explicit_close_releases_detached_session_permit() {
+        let harness = PtyTestHarness::new("/bin/sh").await;
+        let opened = harness.open().await;
+        harness.detach(&opened).await;
+
+        assert_eq!(
+            harness.manager.permits.available_permits(),
+            MAX_SESSIONS - 1
+        );
+        assert!(
+            harness
+                .close(&opened.session_id, &opened.access_key)
+                .await
+                .closed
+        );
+        assert_eq!(harness.manager.permits.available_permits(), MAX_SESSIONS);
+    }
+
+    #[tokio::test]
+    async fn close_all_releases_all_session_permits() {
+        let harness = PtyTestHarness::new("/bin/sh").await;
+        for _ in 0..MAX_SESSIONS {
+            harness.open().await;
+        }
+
+        assert_eq!(harness.manager.permits.available_permits(), 0);
+        harness.close_all().await;
+    }
+
+    #[tokio::test]
+    async fn exited_session_is_retained_until_explicit_close() {
+        let harness = PtyTestHarness::new("/bin/sh").await;
+        let opened = harness.open().await;
+        harness.detach(&opened).await;
+        harness.write(&opened, b"exit\r").await;
+        let session = harness.manager.session(&opened.session_id).await.unwrap();
+
+        let status = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let status = session.status.lock().unwrap().clone();
+                if matches!(status, SessionStatus::Exited { .. }) {
+                    break status;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("PTY exit status was retained");
+
+        assert!(matches!(
+            status,
+            SessionStatus::Exited {
+                exit_code: Some(0),
+                ..
+            }
+        ));
+        assert_eq!(
+            harness.manager.permits.available_permits(),
+            MAX_SESSIONS - 1
+        );
+        let attached = harness
+            .attach(&opened.session_id, &opened.reconnect_token, 0)
+            .await;
+        assert!(matches!(
+            attached.status,
+            SessionStatus::Exited {
+                exit_code: Some(0),
+                ..
+            }
+        ));
+        assert!(
+            harness
+                .close(&opened.session_id, &attached.access_key)
+                .await
+                .closed
+        );
+        assert_eq!(harness.manager.permits.available_permits(), MAX_SESSIONS);
+    }
+
+    #[test]
+    fn interactive_shell_preserves_cwd_and_round_trips_input() {
+        let tmp = tempfile::tempdir().unwrap();
+        let expected = tmp.path().canonicalize().unwrap();
+        let mut pty = spawn_process(&expected, 80, 24, Some("/bin/sh")).unwrap();
+        pty.master
+            .resize(PtySize {
+                rows: 40,
+                cols: 120,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .unwrap();
+        let size = pty.master.get_size().unwrap();
+        assert_eq!((size.cols, size.rows), (120, 40));
+
+        let mut reader = pty.reader;
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let mut chunk = [0_u8; 4096];
+            while let Ok(read) = reader.read(&mut chunk) {
+                if read == 0 || tx.send(chunk[..read].to_vec()).is_err() {
+                    break;
+                }
+            }
+        });
+
+        write!(pty.writer, "printf '__PTY_OK__:%s\\n' \"$PWD\"\r").unwrap();
+        pty.writer.flush().unwrap();
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        let mut output = Vec::new();
+        let marker = format!("__PTY_OK__:{}", expected.display());
+        while std::time::Instant::now() < deadline {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            let chunk = rx.recv_timeout(remaining).expect("PTY produced output");
+            output.extend_from_slice(&chunk);
+            if String::from_utf8_lossy(&output).contains(&marker) {
+                break;
+            }
+        }
+        let output = String::from_utf8_lossy(&output);
+        assert!(
+            output.contains(&marker),
+            "interactive shell output: {output:?}"
+        );
+
+        write!(pty.writer, "exit\r").unwrap();
+        pty.writer.flush().unwrap();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+        while std::time::Instant::now() < deadline {
+            if pty.child.try_wait().unwrap().is_some() {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        pty.child.kill().unwrap();
+    }
+
+    #[test]
+    fn output_target_is_scoped_to_a_console_browser() {
+        let browser = Uuid::new_v4();
+        assert!(validate_output_function_id(&format!("{OUTPUT_FUNCTION_PREFIX}{browser}")).is_ok());
+        assert!(validate_output_function_id("harness::run").is_err());
+        assert!(
+            validate_output_function_id(&format!("{OUTPUT_FUNCTION_PREFIX}mep4u3o0-a1b2c3d4"))
+                .is_ok()
+        );
+        assert!(validate_output_function_id(&format!("{OUTPUT_FUNCTION_PREFIX}bad_id")).is_err());
+    }
+
+    #[test]
+    fn terminal_dimensions_are_bounded() {
+        assert!(validate_size(80, 24).is_ok());
+        assert!(validate_size(1, 24).is_err());
+        assert!(validate_size(80, 501).is_err());
+    }
+
+    #[test]
+    fn request_accepts_engine_stamped_caller_identity() {
+        let request: CloseRequest = serde_json::from_value(serde_json::json!({
+            "session_id": "session",
+            "access_key": "key",
+            "_caller_worker_id": "worker-1"
+        }))
+        .unwrap();
+        assert_eq!(request.caller_worker_id.as_deref(), Some("worker-1"));
+    }
+}

--- a/shell/src/pty/output_buffer.rs
+++ b/shell/src/pty/output_buffer.rs
@@ -1,0 +1,122 @@
+use std::collections::VecDeque;
+
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use base64::Engine;
+use schemars::JsonSchema;
+use serde::Serialize;
+
+pub const MAX_OUTPUT_BUFFER_BYTES: usize = 2 * 1024 * 1024;
+
+#[derive(Clone, Debug, Eq, JsonSchema, PartialEq, Serialize)]
+pub struct OutputFrame {
+    pub sequence: u64,
+    pub data: String,
+}
+
+#[derive(Clone, Debug, Eq, JsonSchema, PartialEq, Serialize)]
+pub struct Replay {
+    pub frames: Vec<OutputFrame>,
+    pub truncated: bool,
+    pub next_sequence: u64,
+}
+
+#[derive(Debug)]
+struct BufferedFrame {
+    frame: OutputFrame,
+    byte_len: usize,
+}
+
+#[derive(Debug)]
+pub struct OutputBuffer {
+    capacity_bytes: usize,
+    frames: VecDeque<BufferedFrame>,
+    total_bytes: usize,
+    next_sequence: u64,
+    dropped_through_sequence: u64,
+}
+
+impl OutputBuffer {
+    pub fn new(capacity_bytes: usize) -> Self {
+        Self {
+            capacity_bytes: capacity_bytes.min(MAX_OUTPUT_BUFFER_BYTES),
+            frames: VecDeque::new(),
+            total_bytes: 0,
+            next_sequence: 1,
+            dropped_through_sequence: 0,
+        }
+    }
+
+    pub fn push(&mut self, bytes: Vec<u8>) -> OutputFrame {
+        let frame = OutputFrame {
+            sequence: self.next_sequence,
+            data: BASE64_STANDARD.encode(&bytes),
+        };
+        self.next_sequence = self.next_sequence.saturating_add(1);
+        if bytes.len() > self.capacity_bytes {
+            self.dropped_through_sequence = self.dropped_through_sequence.max(frame.sequence);
+            return frame;
+        }
+
+        self.total_bytes = self.total_bytes.saturating_add(bytes.len());
+        self.frames.push_back(BufferedFrame {
+            frame: frame.clone(),
+            byte_len: bytes.len(),
+        });
+
+        while self.total_bytes > self.capacity_bytes && self.frames.len() > 1 {
+            let evicted = self.frames.pop_front().expect("buffer contains a frame");
+            self.total_bytes = self.total_bytes.saturating_sub(evicted.byte_len);
+            self.dropped_through_sequence =
+                self.dropped_through_sequence.max(evicted.frame.sequence);
+        }
+
+        frame
+    }
+
+    pub fn frames_after(&self, sequence: u64) -> Replay {
+        let truncated = sequence < self.dropped_through_sequence;
+        let frames = self
+            .frames
+            .iter()
+            .filter(|frame| frame.frame.sequence > sequence)
+            .map(|frame| frame.frame.clone())
+            .collect();
+
+        Replay {
+            frames,
+            truncated,
+            next_sequence: self.next_sequence,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OutputBuffer;
+
+    #[test]
+    fn evicts_old_frames_and_reports_truncation() {
+        let mut buffer = OutputBuffer::new(8);
+        buffer.push(vec![1, 2, 3, 4, 5]);
+        let latest = buffer.push(vec![6, 7, 8, 9, 10]);
+
+        let replay = buffer.frames_after(0);
+
+        assert!(replay.truncated);
+        assert_eq!(replay.frames, vec![latest.clone()]);
+        assert_eq!(replay.next_sequence, latest.sequence + 1);
+    }
+
+    #[test]
+    fn omits_an_oversized_frame_from_replay() {
+        let mut buffer = OutputBuffer::new(8);
+        let frame = buffer.push(vec![1; 9]);
+
+        let replay = buffer.frames_after(0);
+
+        assert!(replay.truncated);
+        assert!(replay.frames.is_empty());
+        assert_eq!(replay.next_sequence, frame.sequence + 1);
+        assert!(buffer.total_bytes <= buffer.capacity_bytes);
+    }
+}

--- a/shell/src/pty/protocol.rs
+++ b/shell/src/pty/protocol.rs
@@ -1,0 +1,113 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use super::output_buffer::OutputFrame;
+use super::session::SessionStatus;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct OpenRequest {
+    #[serde(default)]
+    pub request_id: Option<String>,
+    pub cwd: String,
+    pub cols: u16,
+    pub rows: u16,
+    pub output_function_id: String,
+    #[serde(rename = "_caller_worker_id", default)]
+    #[schemars(skip)]
+    pub caller_worker_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, JsonSchema)]
+pub struct OpenResponse {
+    pub session_id: String,
+    pub access_key: String,
+    pub reconnect_token: String,
+    pub pid: Option<u32>,
+    pub cwd: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct WriteRequest {
+    pub session_id: String,
+    pub access_key: String,
+    pub data: String,
+    #[serde(rename = "_caller_worker_id", default)]
+    #[schemars(skip)]
+    pub caller_worker_id: Option<String>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct WriteResponse {
+    pub written: usize,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ResizeRequest {
+    pub session_id: String,
+    pub access_key: String,
+    pub cols: u16,
+    pub rows: u16,
+    #[serde(rename = "_caller_worker_id", default)]
+    #[schemars(skip)]
+    pub caller_worker_id: Option<String>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ResizeResponse {
+    pub cols: u16,
+    pub rows: u16,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CloseRequest {
+    pub session_id: String,
+    pub access_key: String,
+    #[serde(rename = "_caller_worker_id", default)]
+    #[schemars(skip)]
+    pub caller_worker_id: Option<String>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct CloseResponse {
+    pub closed: bool,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct AttachRequest {
+    #[serde(default)]
+    pub request_id: Option<String>,
+    pub session_id: String,
+    pub reconnect_token: String,
+    pub output_function_id: String,
+    pub cols: u16,
+    pub rows: u16,
+    pub after_sequence: u64,
+    #[serde(rename = "_caller_worker_id", default)]
+    #[schemars(skip)]
+    pub caller_worker_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, JsonSchema)]
+pub struct AttachResponse {
+    pub access_key: String,
+    pub reconnect_token: String,
+    pub frames: Vec<OutputFrame>,
+    pub truncated: bool,
+    pub next_sequence: u64,
+    pub cwd: String,
+    pub status: SessionStatus,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DetachRequest {
+    pub session_id: String,
+    pub access_key: String,
+    #[serde(rename = "_caller_worker_id", default)]
+    #[schemars(skip)]
+    pub caller_worker_id: Option<String>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct DetachResponse {
+    pub status: SessionStatus,
+}

--- a/shell/src/pty/session.rs
+++ b/shell/src/pty/session.rs
@@ -1,0 +1,215 @@
+use schemars::JsonSchema;
+use serde::Serialize;
+use uuid::Uuid;
+
+#[derive(Clone, Debug, Eq, JsonSchema, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionStatus {
+    Attached,
+    Detached,
+    Exited {
+        exit_code: Option<u32>,
+        signal: Option<String>,
+        error: Option<String>,
+    },
+}
+
+#[derive(Clone, Debug, Eq, JsonSchema, PartialEq, Serialize)]
+pub struct SessionCredentials {
+    pub access_key: String,
+    pub reconnect_token: String,
+}
+
+#[derive(Debug)]
+pub struct SessionControl {
+    access_key: String,
+    reconnect_token: String,
+    owner_worker_id: String,
+    output_function_id: String,
+    status: SessionStatus,
+    last_attach_request_id: Option<String>,
+    last_attach_reconnect_token: Option<String>,
+}
+
+impl SessionControl {
+    pub fn new(owner_worker_id: &str, output_function_id: &str) -> Self {
+        let (access_key, reconnect_token) = new_credential_pair(new_credential);
+        Self {
+            access_key,
+            reconnect_token,
+            owner_worker_id: owner_worker_id.to_string(),
+            output_function_id: output_function_id.to_string(),
+            status: SessionStatus::Attached,
+            last_attach_request_id: None,
+            last_attach_reconnect_token: None,
+        }
+    }
+
+    pub fn authenticate(&self, access_key: &str, caller_worker_id: &str) -> Result<(), String> {
+        if self.access_key == access_key && self.owner_worker_id == caller_worker_id {
+            Ok(())
+        } else {
+            Err("terminal session credentials are invalid".to_string())
+        }
+    }
+
+    pub fn attach(
+        &mut self,
+        reconnect_token: &str,
+        request_id: Option<&str>,
+        owner_worker_id: &str,
+        output_function_id: &str,
+    ) -> Result<SessionCredentials, String> {
+        if self.is_attach_retry(reconnect_token, request_id) {
+            self.owner_worker_id = owner_worker_id.to_string();
+            self.output_function_id = output_function_id.to_string();
+            self.status = SessionStatus::Attached;
+            return Ok(SessionCredentials {
+                access_key: self.access_key.clone(),
+                reconnect_token: self.reconnect_token.clone(),
+            });
+        }
+        if self.reconnect_token != reconnect_token {
+            return Err("terminal reconnect token is invalid".to_string());
+        }
+
+        let previous_reconnect_token = reconnect_token.to_string();
+        let (access_key, reconnect_token) = new_credential_pair(new_credential);
+        self.owner_worker_id = owner_worker_id.to_string();
+        self.output_function_id = output_function_id.to_string();
+        self.access_key = access_key;
+        self.reconnect_token = reconnect_token;
+        self.status = SessionStatus::Attached;
+        self.last_attach_request_id = request_id.map(str::to_string);
+        self.last_attach_reconnect_token = Some(previous_reconnect_token);
+
+        Ok(SessionCredentials {
+            access_key: self.access_key.clone(),
+            reconnect_token: self.reconnect_token.clone(),
+        })
+    }
+
+    pub fn detach(&mut self, access_key: &str, caller_worker_id: &str) -> Result<(), String> {
+        self.authenticate(access_key, caller_worker_id)?;
+        self.status = SessionStatus::Detached;
+        Ok(())
+    }
+
+    pub fn detach_output_target(&mut self, output_function_id: &str, access_key: &str) -> bool {
+        if self.status == SessionStatus::Attached
+            && self.output_function_id == output_function_id
+            && self.access_key == access_key
+        {
+            self.status = SessionStatus::Detached;
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn access_key(&self) -> &str {
+        &self.access_key
+    }
+
+    pub fn reconnect_token(&self) -> &str {
+        &self.reconnect_token
+    }
+
+    pub fn can_attach(&self, reconnect_token: &str, request_id: Option<&str>) -> bool {
+        self.reconnect_token == reconnect_token || self.is_attach_retry(reconnect_token, request_id)
+    }
+
+    pub fn output_function_id(&self) -> &str {
+        &self.output_function_id
+    }
+
+    pub fn status(&self) -> SessionStatus {
+        self.status.clone()
+    }
+
+    fn is_attach_retry(&self, reconnect_token: &str, request_id: Option<&str>) -> bool {
+        request_id.is_some()
+            && self.last_attach_request_id.as_deref() == request_id
+            && self.last_attach_reconnect_token.as_deref() == Some(reconnect_token)
+    }
+}
+
+fn new_credential() -> String {
+    Uuid::new_v4().simple().to_string()
+}
+
+fn new_credential_pair(mut source: impl FnMut() -> String) -> (String, String) {
+    let access_key = source();
+    let mut reconnect_token = source();
+    while reconnect_token == access_key {
+        reconnect_token = source();
+    }
+    (access_key, reconnect_token)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+
+    use super::{new_credential_pair, SessionControl, SessionStatus};
+
+    #[test]
+    fn credential_pair_retries_duplicate_values() {
+        let mut values = VecDeque::from([
+            "duplicate".to_string(),
+            "duplicate".to_string(),
+            "distinct".to_string(),
+        ]);
+
+        let (access_key, reconnect_token) =
+            new_credential_pair(|| values.pop_front().expect("test credential"));
+
+        assert_eq!(access_key, "duplicate");
+        assert_eq!(reconnect_token, "distinct");
+    }
+
+    #[test]
+    fn successful_attach_rotates_both_credentials() {
+        let mut control = SessionControl::new("owner-1", "output-1");
+        let access = control.access_key().to_string();
+        let reconnect = control.reconnect_token().to_string();
+
+        let rotated = control
+            .attach(&reconnect, None, "owner-2", "output-2")
+            .unwrap();
+
+        assert_ne!(rotated.access_key, access);
+        assert_ne!(rotated.reconnect_token, reconnect);
+        assert!(control
+            .attach(&reconnect, None, "owner-3", "output-3")
+            .is_err());
+    }
+
+    #[test]
+    fn failed_attach_leaves_the_reconnect_token_usable() {
+        let mut control = SessionControl::new("owner-1", "output-1");
+        let reconnect = control.reconnect_token().to_string();
+
+        assert!(control
+            .attach("invalid-token", None, "owner-2", "output-2")
+            .is_err());
+        assert!(control
+            .attach(&reconnect, None, "owner-2", "output-2")
+            .is_ok());
+    }
+
+    #[test]
+    fn stale_delivery_failure_does_not_detach_rebound_target() {
+        let mut control = SessionControl::new("owner-1", "output-1");
+        let old_access = control.access_key().to_string();
+        let reconnect = control.reconnect_token().to_string();
+        let rotated = control
+            .attach(&reconnect, None, "owner-2", "output-1")
+            .unwrap();
+
+        assert!(!control.detach_output_target("output-1", &old_access));
+        assert_eq!(control.status(), SessionStatus::Attached);
+        assert!(control.detach_output_target("output-1", &rotated.access_key));
+        assert_eq!(control.status(), SessionStatus::Detached);
+    }
+}

--- a/shell/ui/package.json
+++ b/shell/ui/package.json
@@ -11,12 +11,17 @@
   "dependencies": {
     "@iii-dev/console-ui": "workspace:*",
     "@pierre/trees": "1.0.0-beta.6",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "lucide-react": "^1.16.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
     "esbuild": "^0.25.0",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
     "typescript": "^5.9.2",
     "vitest": "^4.1.6"
   }

--- a/shell/ui/src/lib/terminal.tsx
+++ b/shell/ui/src/lib/terminal.tsx
@@ -177,6 +177,6 @@ const CSI_REGEX = /\x1b\[[0-9;?]*[ -/]*[@-~]/g
 // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI OSC (ESC ] … BEL) sequences.
 const OSC_REGEX = /\x1b\][^\x07]*\x07/g
 
-function stripAnsi(s: string): string {
+export function stripAnsi(s: string): string {
   return s.replace(CSI_REGEX, '').replace(OSC_REGEX, '')
 }

--- a/shell/ui/src/page/HoverTip.tsx
+++ b/shell/ui/src/page/HoverTip.tsx
@@ -1,0 +1,71 @@
+import {
+  type ReactNode,
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react'
+import { createPortal } from 'react-dom'
+
+export function HoverTip({
+  label,
+  children,
+}: {
+  label: string
+  children: ReactNode
+}) {
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null)
+  const bubbleRef = useRef<HTMLSpanElement>(null)
+  const triggerCenterRef = useRef(0)
+
+  const hide = useCallback(() => setPos(null), [])
+  const show = useCallback(
+    (event: { currentTarget: EventTarget & Element }) => {
+      const rect = event.currentTarget.getBoundingClientRect()
+      triggerCenterRef.current = rect.left + rect.width / 2
+      setPos({
+        top: rect.bottom + 6,
+        left: Math.max(8, rect.left),
+      })
+    },
+    [],
+  )
+
+  useLayoutEffect(() => {
+    if (!pos || !bubbleRef.current) return
+    const width = bubbleRef.current.getBoundingClientRect().width
+    const maxLeft = Math.max(8, window.innerWidth - width - 8)
+    const left = Math.min(
+      Math.max(8, triggerCenterRef.current - width / 2),
+      maxLeft,
+    )
+    if (Math.abs(left - pos.left) > 0.5) {
+      setPos((current) => (current ? { ...current, left } : current))
+    }
+  }, [pos])
+
+  return (
+    <fieldset
+      className="shui-hover-tip"
+      onMouseEnter={show}
+      onMouseLeave={hide}
+      onFocus={show}
+      onBlur={hide}
+    >
+      {children}
+      {pos
+        ? createPortal(
+            <span
+              ref={bubbleRef}
+              className="shui-hover-tip-bubble"
+              role="tooltip"
+              style={{ top: pos.top, left: pos.left }}
+            >
+              {label}
+            </span>,
+            document.body,
+          )
+        : null}
+    </fieldset>
+  )
+}

--- a/shell/ui/src/page/TerminalPane.tsx
+++ b/shell/ui/src/page/TerminalPane.tsx
@@ -1,0 +1,82 @@
+import { ArrowDown, RefreshCw, SquareTerminal } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { HoverTip } from './HoverTip'
+import type { TerminalSession } from './terminal-session'
+
+export type { TerminalSession } from './terminal-session'
+export { useTerminalSession } from './terminal-session'
+
+interface TerminalPaneProps {
+  session: TerminalSession
+  actions?: ReactNode
+}
+
+export function TerminalPane({ session, actions }: TerminalPaneProps) {
+  const {
+    atBottom,
+    cwd,
+    error,
+    jumpToLatest,
+    restart,
+    setContainer,
+    startFresh,
+    status,
+  } = session
+
+  return (
+    <div className="shui-terminal">
+      <div className="shui-terminal-chrome">
+        <SquareTerminal aria-hidden className="shui-terminal-chrome-icon" />
+        <span>zsh</span>
+        <span className={`shui-terminal-state ${status}`}>{status}</span>
+        <span className="shui-terminal-chrome-cwd" title={cwd}>
+          {cwd}
+        </span>
+        <span className="shui-terminal-chrome-spacer" />
+        {!atBottom ? (
+          <HoverTip label="Jump to latest output">
+            <button
+              type="button"
+              className="shui-terminal-action"
+              onClick={jumpToLatest}
+              aria-label="Jump to latest output"
+            >
+              <ArrowDown aria-hidden />
+            </button>
+          </HoverTip>
+        ) : null}
+        {status === 'disconnected' ? (
+          <HoverTip label="Start fresh shell">
+            <button
+              type="button"
+              className="shui-terminal-action"
+              onClick={startFresh}
+              aria-label="Start fresh shell"
+            >
+              <RefreshCw aria-hidden />
+            </button>
+          </HoverTip>
+        ) : status === 'exited' || status === 'error' ? (
+          <HoverTip label="Restart terminal session">
+            <button
+              type="button"
+              className="shui-terminal-action"
+              onClick={restart}
+              aria-label="Restart terminal session"
+            >
+              <RefreshCw aria-hidden />
+            </button>
+          </HoverTip>
+        ) : null}
+        {actions}
+      </div>
+      {error ? <div className="shui-terminal-error">{error}</div> : null}
+      <div
+        ref={setContainer}
+        className="shui-xterm"
+        role="application"
+        aria-label="Interactive zsh terminal"
+      />
+    </div>
+  )
+}

--- a/shell/ui/src/page/TerminalPanel.tsx
+++ b/shell/ui/src/page/TerminalPanel.tsx
@@ -1,0 +1,296 @@
+import {
+  PanelBottom,
+  PanelRight,
+  SquareTerminal,
+  Trash2,
+  X,
+} from 'lucide-react'
+import {
+  type CSSProperties,
+  type Dispatch,
+  type KeyboardEvent,
+  type PointerEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
+import { HoverTip } from './HoverTip'
+import type { TerminalDock } from './persist'
+import {
+  TerminalWorkspace,
+  type TerminalWorkspaceHandle,
+} from './TerminalWorkspace'
+import type {
+  TerminalWorkspaceAction,
+  TerminalWorkspaceState,
+} from './terminal-layout'
+import type { TerminalOutputRouter } from './terminal-output-router'
+import type { TerminalConnectionCoordinator } from './terminal-session-state'
+
+interface ResizeState {
+  start: number
+  startSize: number
+  maxSize: number
+}
+
+interface TerminalPanelSharedProps {
+  dock: TerminalDock
+  size: number
+  onDockChange: (dock: TerminalDock) => void
+  onSizeChange: (size: number) => void
+  onClose: () => void
+}
+
+interface TerminalPanelProps extends TerminalPanelSharedProps {
+  state: TerminalWorkspaceState
+  dispatch: Dispatch<TerminalWorkspaceAction>
+  root: string
+  visible: boolean
+  router: TerminalOutputRouter | null
+  leaseStore: Storage | null
+  storageKey: string
+  connectionCoordinators: Map<string, TerminalConnectionCoordinator>
+}
+
+function clampSize(size: number, maxSize: number): number {
+  return Math.min(Math.max(160, maxSize), Math.max(160, Math.round(size)))
+}
+
+function terminalPanelStyle(
+  dock: TerminalDock,
+  size: number,
+): CSSProperties | undefined {
+  switch (dock) {
+    case 'bottom':
+      return { height: size }
+    case 'right':
+      return { width: size }
+    case 'editor':
+      return undefined
+    default: {
+      const exhaustive: never = dock
+      return exhaustive
+    }
+  }
+}
+
+function DockActions({
+  dock,
+  onDockChange,
+  onClose,
+}: Pick<TerminalPanelSharedProps, 'dock' | 'onDockChange' | 'onClose'>) {
+  return (
+    <>
+      <HoverTip label="Dock terminal at bottom">
+        <button
+          type="button"
+          className={`shui-terminal-action${dock === 'bottom' ? ' active' : ''}`}
+          onClick={() => onDockChange('bottom')}
+          aria-label="Dock terminal at bottom"
+          aria-pressed={dock === 'bottom'}
+        >
+          <PanelBottom aria-hidden />
+        </button>
+      </HoverTip>
+      <HoverTip label="Dock terminal on right">
+        <button
+          type="button"
+          className={`shui-terminal-action${dock === 'right' ? ' active' : ''}`}
+          onClick={() => onDockChange('right')}
+          aria-label="Dock terminal on right"
+          aria-pressed={dock === 'right'}
+        >
+          <PanelRight aria-hidden />
+        </button>
+      </HoverTip>
+      <HoverTip label="Open terminal as an editor tab">
+        <button
+          type="button"
+          className={`shui-terminal-action${dock === 'editor' ? ' active' : ''}`}
+          onClick={() => onDockChange('editor')}
+          aria-label="Open terminal as an editor tab"
+          aria-pressed={dock === 'editor'}
+        >
+          <SquareTerminal aria-hidden />
+        </button>
+      </HoverTip>
+      <HoverTip label="Hide terminal">
+        <button
+          type="button"
+          className="shui-terminal-action"
+          onClick={onClose}
+          aria-label="Hide terminal"
+        >
+          <X aria-hidden />
+        </button>
+      </HoverTip>
+    </>
+  )
+}
+
+export function TerminalPanel(props: TerminalPanelProps) {
+  const { dock, size, onDockChange, onSizeChange, onClose } = props
+  const resizeRef = useRef<ResizeState | null>(null)
+  const panelRef = useRef<HTMLElement>(null)
+  const workspaceRef = useRef<TerminalWorkspaceHandle>(null)
+  const [resizeBounds, setResizeBounds] = useState({ size, max: 1200 })
+  const docked = dock !== 'editor'
+  const style = terminalPanelStyle(dock, size)
+
+  useEffect(() => {
+    const panel = panelRef.current
+    const frame = panel?.parentElement
+    if (!panel || !frame || !docked) return
+    const update = () => {
+      const panelRect = panel.getBoundingClientRect()
+      const frameRect = frame.getBoundingClientRect()
+      setResizeBounds({
+        size: dock === 'bottom' ? panelRect.height : panelRect.width,
+        max:
+          dock === 'bottom'
+            ? Math.max(160, frameRect.height - 120)
+            : Math.max(160, frameRect.width - 240),
+      })
+    }
+    update()
+    const observer = new ResizeObserver(update)
+    observer.observe(panel)
+    observer.observe(frame)
+    return () => observer.disconnect()
+  }, [dock, docked])
+
+  const onPointerDown = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      if (!docked) return
+      const panel = event.currentTarget.parentElement
+      const frame = panel?.parentElement
+      const panelRect = panel?.getBoundingClientRect()
+      const frameRect = frame?.getBoundingClientRect()
+      resizeRef.current = {
+        start: dock === 'bottom' ? event.clientY : event.clientX,
+        startSize:
+          dock === 'bottom'
+            ? (panelRect?.height ?? size)
+            : (panelRect?.width ?? size),
+        maxSize:
+          dock === 'bottom'
+            ? Math.max(160, (frameRect?.height ?? window.innerHeight) - 120)
+            : Math.max(160, (frameRect?.width ?? window.innerWidth) - 240),
+      }
+      event.preventDefault()
+      event.currentTarget.setPointerCapture(event.pointerId)
+    },
+    [dock, docked, size],
+  )
+
+  const onPointerMove = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      const resize = resizeRef.current
+      if (!resize) return
+      const current = dock === 'bottom' ? event.clientY : event.clientX
+      onSizeChange(
+        clampSize(resize.startSize - (current - resize.start), resize.maxSize),
+      )
+    },
+    [dock, onSizeChange],
+  )
+
+  const onPointerUp = useCallback((event: PointerEvent<HTMLDivElement>) => {
+    resizeRef.current = null
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId)
+    }
+  }, [])
+
+  const onResizeKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      const grow =
+        (dock === 'bottom' && event.key === 'ArrowUp') ||
+        (dock === 'right' && event.key === 'ArrowLeft')
+      const shrink =
+        (dock === 'bottom' && event.key === 'ArrowDown') ||
+        (dock === 'right' && event.key === 'ArrowRight')
+      if (!grow && !shrink) return
+      event.preventDefault()
+      const frame = event.currentTarget.parentElement?.parentElement
+      const panelRect =
+        event.currentTarget.parentElement?.getBoundingClientRect()
+      const frameRect = frame?.getBoundingClientRect()
+      const maxSize =
+        dock === 'bottom'
+          ? Math.max(160, (frameRect?.height ?? window.innerHeight) - 120)
+          : Math.max(160, (frameRect?.width ?? window.innerWidth) - 240)
+      const currentSize =
+        dock === 'bottom'
+          ? (panelRect?.height ?? size)
+          : (panelRect?.width ?? size)
+      onSizeChange(clampSize(currentSize + (grow ? 16 : -16), maxSize))
+    },
+    [dock, onSizeChange, size],
+  )
+
+  return (
+    <section
+      ref={panelRef}
+      className="shui-terminal-panel"
+      data-terminal-dock={dock}
+      style={style}
+      aria-label="Terminal"
+    >
+      {docked ? (
+        // biome-ignore lint/a11y/useSemanticElements: this is an interactive range separator, not a static thematic break.
+        <div
+          role="separator"
+          tabIndex={0}
+          className="shui-terminal-resize"
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onPointerCancel={onPointerUp}
+          onLostPointerCapture={onPointerUp}
+          onKeyDown={onResizeKeyDown}
+          aria-label={`Resize ${dock} terminal`}
+          aria-orientation={dock === 'bottom' ? 'horizontal' : 'vertical'}
+          aria-valuemin={160}
+          aria-valuemax={Math.round(resizeBounds.max)}
+          aria-valuenow={Math.round(resizeBounds.size)}
+          title="Drag to resize terminal"
+        >
+          <span aria-hidden />
+        </div>
+      ) : null}
+      <div className="shui-terminal-panel-chrome">
+        <SquareTerminal aria-hidden />
+        <span>Terminal workspace</span>
+        <span className="shui-terminal-chrome-spacer" />
+        <HoverTip label="Close disconnected terminals">
+          <button
+            type="button"
+            className="shui-terminal-action"
+            onClick={() => void workspaceRef.current?.closeDisconnected()}
+            aria-label="Close disconnected terminals"
+          >
+            <Trash2 aria-hidden />
+          </button>
+        </HoverTip>
+        <DockActions
+          dock={dock}
+          onDockChange={onDockChange}
+          onClose={onClose}
+        />
+      </div>
+      <TerminalWorkspace
+        ref={workspaceRef}
+        state={props.state}
+        dispatch={props.dispatch}
+        root={props.root}
+        visible={props.visible}
+        router={props.router}
+        leaseStore={props.leaseStore}
+        storageKey={props.storageKey}
+        connectionCoordinators={props.connectionCoordinators}
+      />
+    </section>
+  )
+}

--- a/shell/ui/src/page/TerminalWorkspace.tsx
+++ b/shell/ui/src/page/TerminalWorkspace.tsx
@@ -1,0 +1,691 @@
+import { Columns2, Pencil, Plus, Rows2, X } from 'lucide-react'
+import {
+  type Dispatch,
+  forwardRef,
+  type KeyboardEvent,
+  type PointerEvent,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import { HoverTip } from './HoverTip'
+import { TerminalPane } from './TerminalPane'
+import {
+  countTerminalPanes,
+  MAX_TERMINAL_PANES_PER_TAB,
+  MAX_TERMINAL_SESSIONS,
+  type TerminalLayoutNode,
+  type TerminalWorkspaceAction,
+  type TerminalWorkspaceState,
+} from './terminal-layout'
+import {
+  type LocalTerminalLease,
+  loadRecoverableTerminalLeases,
+  removeRecoverableTerminalLease,
+  saveRecoverableTerminalLease,
+} from './terminal-leases'
+import {
+  type TerminalOutputRouter,
+  terminalOutputRouterHost,
+} from './terminal-output-router'
+import {
+  reclaimTerminalLease,
+  type TerminalSession,
+  useTerminalSession,
+} from './terminal-session'
+import {
+  createTerminalConnectionCoordinator,
+  type TerminalConnectionCoordinator,
+} from './terminal-session-state'
+
+export interface TerminalWorkspaceProps {
+  state: TerminalWorkspaceState
+  dispatch: Dispatch<TerminalWorkspaceAction>
+  root: string
+  visible: boolean
+  router: TerminalOutputRouter | null
+  leaseStore: Storage | null
+  storageKey: string
+  connectionCoordinators: Map<string, TerminalConnectionCoordinator>
+}
+
+export interface TerminalWorkspaceHandle {
+  closeDisconnected(): Promise<void>
+}
+
+interface LayoutContext {
+  state: TerminalWorkspaceState
+  dispatch: Dispatch<TerminalWorkspaceAction>
+  root: string
+  visible: boolean
+  router: TerminalOutputRouter | null
+  leaseStore: Storage | null
+  storageKey: string
+  tabPaneCount: number
+  registerSession: (paneId: string, session: TerminalSession | null) => void
+  closePane: (paneId: string) => Promise<void>
+  removePane: (paneId: string) => void
+  connectionCoordinator: (paneId: string) => TerminalConnectionCoordinator
+}
+
+interface SplitDragState {
+  start: number
+  ratio: number
+  size: number
+}
+
+let generatedId = 0
+
+function createId(prefix: string): string {
+  generatedId += 1
+  return `${prefix}-${Date.now().toString(36)}-${generatedId.toString(36)}`
+}
+
+function paneIdsInLayout(node: TerminalLayoutNode): string[] {
+  if (node.type === 'pane') return [node.paneId]
+  return [...paneIdsInLayout(node.first), ...paneIdsInLayout(node.second)]
+}
+
+function activeTab(state: TerminalWorkspaceState) {
+  return state.tabs.find((tab) => tab.id === state.activeTabId) ?? null
+}
+
+export async function reconcileTerminalWorkspaceLeases(
+  leases: readonly LocalTerminalLease[],
+  paneIds: ReadonlySet<string>,
+  reclaim: (lease: LocalTerminalLease) => Promise<string | null>,
+): Promise<string[]> {
+  const warnings: string[] = []
+  for (const lease of leases) {
+    if (paneIds.has(lease.paneId)) continue
+    try {
+      const warning = await reclaim(lease)
+      if (warning) warnings.push(warning)
+    } catch (error) {
+      warnings.push(error instanceof Error ? error.message : String(error))
+    }
+  }
+  return warnings
+}
+
+export function pruneTerminalConnectionCoordinators(
+  coordinators: Map<string, TerminalConnectionCoordinator>,
+  paneIds: ReadonlySet<string>,
+): void {
+  for (const paneId of coordinators.keys()) {
+    if (!paneIds.has(paneId)) coordinators.delete(paneId)
+  }
+}
+
+function TerminalPaneSlot({
+  paneId,
+  context,
+}: {
+  paneId: string
+  context: LayoutContext
+}) {
+  const pane = context.state.panes[paneId]
+  const focused = context.state.focusedPaneId === paneId
+  const splitDisabled =
+    context.tabPaneCount >= MAX_TERMINAL_PANES_PER_TAB ||
+    Object.keys(context.state.panes).length >= MAX_TERMINAL_SESSIONS
+  const session = useTerminalSession({
+    paneId,
+    root: pane?.cwd ?? context.root,
+    visible: context.visible,
+    router: context.router,
+    leaseStore: context.leaseStore,
+    storageKey: context.storageKey,
+    connectionCoordinator: context.connectionCoordinator(paneId),
+  })
+
+  useEffect(() => {
+    context.registerSession(paneId, session)
+    return () => context.registerSession(paneId, null)
+  }, [context, paneId, session])
+
+  const split = (direction: 'horizontal' | 'vertical') => {
+    context.dispatch({
+      type: 'pane-split',
+      paneId,
+      newPaneId: createId('pane'),
+      splitId: createId('split'),
+      direction,
+    })
+  }
+
+  return (
+    <div
+      className={`shui-terminal-pane-slot${focused ? ' focused' : ''}`}
+      data-terminal-pane-id={paneId}
+      onPointerDown={() => context.dispatch({ type: 'pane-focused', paneId })}
+    >
+      <TerminalPane
+        session={session}
+        actions={
+          <>
+            <HoverTip label="Split right">
+              <button
+                type="button"
+                className="shui-terminal-action"
+                onClick={() => split('horizontal')}
+                aria-label="Split right"
+                disabled={splitDisabled}
+              >
+                <Columns2 aria-hidden />
+              </button>
+            </HoverTip>
+            <HoverTip label="Split down">
+              <button
+                type="button"
+                className="shui-terminal-action"
+                onClick={() => split('vertical')}
+                aria-label="Split down"
+                disabled={splitDisabled}
+              >
+                <Rows2 aria-hidden />
+              </button>
+            </HoverTip>
+            <HoverTip
+              label={
+                session.status === 'disconnected'
+                  ? 'Remove terminal pane'
+                  : 'Close terminal pane'
+              }
+            >
+              <button
+                type="button"
+                className="shui-terminal-action"
+                onClick={() => {
+                  if (session.status === 'disconnected') {
+                    session.forget()
+                    context.removePane(paneId)
+                    return
+                  }
+                  void context.closePane(paneId)
+                }}
+                aria-label={
+                  session.status === 'disconnected'
+                    ? 'Remove terminal pane'
+                    : 'Close terminal pane'
+                }
+              >
+                <X aria-hidden />
+              </button>
+            </HoverTip>
+          </>
+        }
+      />
+    </div>
+  )
+}
+
+function TerminalSplit({
+  node,
+  context,
+}: {
+  node: Extract<TerminalLayoutNode, { type: 'split' }>
+  context: LayoutContext
+}) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const dragRef = useRef<SplitDragState | null>(null)
+  const horizontal = node.direction === 'horizontal'
+
+  const resize = (ratio: number) => {
+    context.dispatch({ type: 'split-resized', splitId: node.id, ratio })
+  }
+
+  const onPointerDown = (event: PointerEvent<HTMLDivElement>) => {
+    const rect = containerRef.current?.getBoundingClientRect()
+    const size = horizontal ? rect?.width : rect?.height
+    if (!size) return
+    dragRef.current = {
+      start: horizontal ? event.clientX : event.clientY,
+      ratio: node.ratio,
+      size,
+    }
+    event.currentTarget.setPointerCapture(event.pointerId)
+    event.preventDefault()
+  }
+
+  const onPointerMove = (event: PointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current
+    if (!drag) return
+    const current = horizontal ? event.clientX : event.clientY
+    resize(drag.ratio + (current - drag.start) / drag.size)
+  }
+
+  const onPointerUp = (event: PointerEvent<HTMLDivElement>) => {
+    dragRef.current = null
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId)
+    }
+  }
+
+  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    const decrease =
+      (horizontal && event.key === 'ArrowLeft') ||
+      (!horizontal && event.key === 'ArrowUp')
+    const increase =
+      (horizontal && event.key === 'ArrowRight') ||
+      (!horizontal && event.key === 'ArrowDown')
+    if (!decrease && !increase) return
+    event.preventDefault()
+    resize(node.ratio + (increase ? 0.05 : -0.05))
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className={`shui-terminal-split ${node.direction}`}
+      data-terminal-split-id={node.id}
+    >
+      <div
+        className="shui-terminal-split-child"
+        style={{ flexBasis: `${node.ratio * 100}%` }}
+      >
+        <TerminalLayoutView node={node.first} context={context} />
+      </div>
+      {/* biome-ignore lint/a11y/useSemanticElements: this is an interactive range separator, not a static thematic break. */}
+      <div
+        role="separator"
+        tabIndex={0}
+        className="shui-terminal-split-separator"
+        aria-label={`Resize ${node.direction} terminal split`}
+        aria-orientation={horizontal ? 'vertical' : 'horizontal'}
+        aria-valuemin={20}
+        aria-valuemax={80}
+        aria-valuenow={Math.round(node.ratio * 100)}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerUp}
+        onLostPointerCapture={onPointerUp}
+        onKeyDown={onKeyDown}
+      />
+      <div className="shui-terminal-split-child">
+        <TerminalLayoutView node={node.second} context={context} />
+      </div>
+    </div>
+  )
+}
+
+function TerminalLayoutView({
+  node,
+  context,
+}: {
+  node: TerminalLayoutNode
+  context: LayoutContext
+}) {
+  switch (node.type) {
+    case 'pane':
+      return <TerminalPaneSlot paneId={node.paneId} context={context} />
+    case 'split':
+      return <TerminalSplit node={node} context={context} />
+    default: {
+      const exhaustive: never = node
+      return exhaustive
+    }
+  }
+}
+
+export const TerminalWorkspace = forwardRef<
+  TerminalWorkspaceHandle,
+  TerminalWorkspaceProps
+>(function TerminalWorkspace(
+  {
+    state,
+    dispatch,
+    root,
+    visible,
+    router,
+    leaseStore,
+    storageKey,
+    connectionCoordinators,
+  },
+  ref,
+) {
+  const sessionsRef = useRef(new Map<string, TerminalSession>())
+  const orphanReclaimsRef = useRef(
+    new Map<string, Promise<string | null>>(),
+  )
+  const [editingTabId, setEditingTabId] = useState<string | null>(null)
+  const [editingTitle, setEditingTitle] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const selectedTab = activeTab(state)
+  const totalPaneCount = Object.keys(state.panes).length
+
+  const registerSession = useCallback(
+    (paneId: string, session: TerminalSession | null) => {
+      if (session) {
+        sessionsRef.current.set(paneId, session)
+      } else {
+        sessionsRef.current.delete(paneId)
+      }
+    },
+    [],
+  )
+
+  const connectionCoordinator = useCallback(
+    (paneId: string) => {
+      const existing = connectionCoordinators.get(paneId)
+      if (existing) return existing
+      const created = createTerminalConnectionCoordinator()
+      connectionCoordinators.set(paneId, created)
+      return created
+    },
+    [connectionCoordinators],
+  )
+
+  const closePty = useCallback(
+    async (paneId: string): Promise<string | null> => {
+      const session = sessionsRef.current.get(paneId)
+      if (session) {
+        return session.close()
+      }
+      if (!router) return null
+      const lease = loadRecoverableTerminalLeases(leaseStore, storageKey).find(
+        (entry) => entry.paneId === paneId,
+      )
+      if (!lease) return null
+      return reclaimTerminalLease(terminalOutputRouterHost(router), router, {
+        ...lease,
+        update: (updated) =>
+          saveRecoverableTerminalLease(leaseStore, storageKey, updated),
+        remove: () =>
+          removeRecoverableTerminalLease(leaseStore, storageKey, paneId),
+      })
+    },
+    [leaseStore, router, storageKey],
+  )
+
+  useEffect(() => {
+    const paneIds = new Set(Object.keys(state.panes))
+    pruneTerminalConnectionCoordinators(connectionCoordinators, paneIds)
+    if (!router) return
+    let cancelled = false
+    const host = terminalOutputRouterHost(router)
+    const leases = loadRecoverableTerminalLeases(leaseStore, storageKey)
+    void reconcileTerminalWorkspaceLeases(leases, paneIds, (lease) => {
+      const existing = orphanReclaimsRef.current.get(lease.sessionId)
+      if (existing) return existing
+      const reclaim = reclaimTerminalLease(host, router, {
+        ...lease,
+        update: (updated) =>
+          saveRecoverableTerminalLease(leaseStore, storageKey, updated),
+        remove: () =>
+          removeRecoverableTerminalLease(
+            leaseStore,
+            storageKey,
+            lease.paneId,
+          ),
+      }).finally(() => {
+        orphanReclaimsRef.current.delete(lease.sessionId)
+      })
+      orphanReclaimsRef.current.set(lease.sessionId, reclaim)
+      return reclaim
+    }).then((warnings) => {
+      if (!cancelled && warnings.length > 0) setError(warnings.join('; '))
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [
+    connectionCoordinators,
+    leaseStore,
+    router,
+    state.panes,
+    storageKey,
+  ])
+
+  const closePane = useCallback(
+    async (paneId: string) => {
+      setError(null)
+      try {
+        const warning = await closePty(paneId)
+        dispatch({ type: 'pane-closed', paneId })
+        if (warning) setError(warning)
+      } catch (closeError) {
+        setError(
+          closeError instanceof Error ? closeError.message : String(closeError),
+        )
+      }
+    },
+    [closePty, dispatch],
+  )
+
+  const removePane = useCallback(
+    (paneId: string) => dispatch({ type: 'pane-closed', paneId }),
+    [dispatch],
+  )
+
+  const closeTab = useCallback(
+    async (tabId: string) => {
+      const tab = state.tabs.find((entry) => entry.id === tabId)
+      if (!tab) return
+      const paneIds = paneIdsInLayout(tab.layout)
+      if (
+        !window.confirm(
+          `Close "${tab.title}" and ${paneIds.length} terminal session${paneIds.length === 1 ? '' : 's'}?`,
+        )
+      ) {
+        return
+      }
+      setError(null)
+      const warnings: string[] = []
+      for (const paneId of paneIds) {
+        try {
+          const warning = await closePty(paneId)
+          dispatch({ type: 'pane-closed', paneId })
+          if (warning) warnings.push(warning)
+        } catch (closeError) {
+          setError(
+            closeError instanceof Error
+              ? closeError.message
+              : String(closeError),
+          )
+          return
+        }
+      }
+      if (warnings.length > 0) setError(warnings.join('; '))
+    },
+    [closePty, dispatch, state.tabs],
+  )
+
+  const closeDisconnected = useCallback(async () => {
+    const activePaneIds = new Set(
+      selectedTab ? paneIdsInLayout(selectedTab.layout) : [],
+    )
+    const disconnected = Object.keys(state.panes).filter((paneId) => {
+      const session = sessionsRef.current.get(paneId)
+      return (
+        !activePaneIds.has(paneId) ||
+        session?.status === 'disconnected' ||
+        session?.status === 'error' ||
+        session?.status === 'exited'
+      )
+    })
+    for (const paneId of disconnected) {
+      await closePane(paneId)
+    }
+  }, [closePane, selectedTab, state.panes])
+
+  useImperativeHandle(ref, () => ({ closeDisconnected }), [closeDisconnected])
+
+  const context = useMemo<LayoutContext | null>(() => {
+    if (!selectedTab) return null
+    return {
+      state,
+      dispatch,
+      root,
+      visible,
+      router,
+      leaseStore,
+      storageKey,
+      tabPaneCount: countTerminalPanes(selectedTab.layout),
+      registerSession,
+      closePane,
+      removePane,
+      connectionCoordinator,
+    }
+  }, [
+    closePane,
+    connectionCoordinator,
+    dispatch,
+    leaseStore,
+    registerSession,
+    removePane,
+    root,
+    router,
+    selectedTab,
+    state,
+    storageKey,
+    visible,
+  ])
+
+  const createTab = () => {
+    dispatch({
+      type: 'tab-created',
+      tabId: createId('tab'),
+      paneId: createId('pane'),
+      root,
+    })
+  }
+
+  const beginRename = (tabId: string, title: string) => {
+    setEditingTabId(tabId)
+    setEditingTitle(title)
+  }
+
+  const commitRename = () => {
+    if (editingTabId && editingTitle.trim()) {
+      dispatch({
+        type: 'tab-renamed',
+        tabId: editingTabId,
+        title: editingTitle.trim(),
+      })
+    }
+    setEditingTabId(null)
+  }
+
+  const selectTabByKey = (
+    event: KeyboardEvent<HTMLButtonElement>,
+    index: number,
+  ) => {
+    let targetIndex: number | null = null
+    switch (event.key) {
+      case 'ArrowLeft':
+        targetIndex = (index - 1 + state.tabs.length) % state.tabs.length
+        break
+      case 'ArrowRight':
+        targetIndex = (index + 1) % state.tabs.length
+        break
+      case 'Home':
+        targetIndex = 0
+        break
+      case 'End':
+        targetIndex = state.tabs.length - 1
+        break
+      default:
+        return
+    }
+    event.preventDefault()
+    const target = state.tabs[targetIndex]
+    if (!target) return
+    dispatch({ type: 'tab-selected', tabId: target.id })
+    const tablist = event.currentTarget.closest('[role="tablist"]')
+    window.requestAnimationFrame(() => {
+      const tabs = tablist?.querySelectorAll<HTMLButtonElement>('[role="tab"]')
+      tabs?.[targetIndex]?.focus()
+    })
+  }
+
+  return (
+    <div className="shui-terminal-workspace">
+      <div
+        className="shui-terminal-tabs"
+        role="tablist"
+        aria-label="Terminal tabs"
+      >
+        {state.tabs.map((tab, index) => {
+          const selected = tab.id === state.activeTabId
+          return (
+            <div
+              className={`shui-terminal-tab${selected ? ' active' : ''}`}
+              key={tab.id}
+            >
+              {editingTabId === tab.id ? (
+                <input
+                  ref={(input) => input?.focus()}
+                  className="shui-terminal-tab-input"
+                  aria-label="Rename terminal tab"
+                  value={editingTitle}
+                  onChange={(event) => setEditingTitle(event.target.value)}
+                  onBlur={commitRename}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter') commitRename()
+                    if (event.key === 'Escape') setEditingTabId(null)
+                  }}
+                />
+              ) : (
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={selected}
+                  className="shui-terminal-tab-select"
+                  onClick={() =>
+                    dispatch({ type: 'tab-selected', tabId: tab.id })
+                  }
+                  onDoubleClick={() => beginRename(tab.id, tab.title)}
+                  onKeyDown={(event) => selectTabByKey(event, index)}
+                >
+                  {tab.title}
+                </button>
+              )}
+              <button
+                type="button"
+                className="shui-terminal-tab-action"
+                aria-label={`Rename ${tab.title}`}
+                onClick={() => beginRename(tab.id, tab.title)}
+              >
+                <Pencil aria-hidden />
+              </button>
+              <button
+                type="button"
+                className="shui-terminal-tab-action"
+                aria-label={`Close ${tab.title}`}
+                onClick={() => void closeTab(tab.id)}
+              >
+                <X aria-hidden />
+              </button>
+            </div>
+          )
+        })}
+        <HoverTip label="New terminal">
+          <button
+            type="button"
+            className="shui-terminal-tab-new"
+            onClick={createTab}
+            aria-label="New terminal"
+            disabled={totalPaneCount >= MAX_TERMINAL_SESSIONS}
+          >
+            <Plus aria-hidden />
+          </button>
+        </HoverTip>
+      </div>
+      {error ? (
+        <div className="shui-terminal-workspace-error">{error}</div>
+      ) : null}
+      <div className="shui-terminal-layout">
+        {selectedTab && context ? (
+          <TerminalLayoutView node={selectedTab.layout} context={context} />
+        ) : (
+          <div className="shui-terminal-empty">No terminal sessions</div>
+        )}
+      </div>
+    </div>
+  )
+})

--- a/shell/ui/src/page/__tests__/persist.test.ts
+++ b/shell/ui/src/page/__tests__/persist.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createTabUiStateSaver, loadTabUiState } from '../persist'
+import { createTerminalWorkspace } from '../terminal-layout'
+
+function hostWithTabState(state: Record<string, unknown>) {
+  return {
+    iii: {
+      trigger: async () => ({
+        value: {
+          tabs: {
+            'tab-1': state,
+          },
+        },
+      }),
+    },
+  } as never
+}
+
+describe('loadTabUiState', () => {
+  it('restores terminal drawer, jobs, and sidebar flags', async () => {
+    const host = {
+      iii: {
+        trigger: async () => ({ value: { tabs: {} } }),
+      },
+    } as never
+    const hostWithState = hostWithTabState({
+      root: '/repo',
+      open: [],
+      active: null,
+      expanded: ['src'],
+      showHidden: true,
+      sideWidth: 280,
+      workspaceMode: 'terminal',
+      terminalOpen: true,
+      terminalDock: 'right',
+      terminalActive: true,
+      terminalBottomSize: 320,
+      terminalRightSize: 480,
+      terminalJobIds: ['job-1'],
+    })
+    expect(await loadTabUiState(host, 'tab-1')).toBeNull()
+    expect(await loadTabUiState(hostWithState, 'tab-1')).toEqual({
+      root: '/repo',
+      open: [],
+      active: null,
+      expanded: ['src'],
+      showHidden: true,
+      sideWidth: 280,
+      terminalOpen: true,
+      terminalDock: 'right',
+      terminalActive: true,
+      terminalBottomSize: 320,
+      terminalRightSize: 480,
+      terminalJobIds: ['job-1'],
+      terminalWorkspace: {
+        tabs: [
+          {
+            id: 'tab-1',
+            title: 'zsh 1',
+            layout: { type: 'pane', paneId: 'pane-1' },
+          },
+        ],
+        panes: {
+          'pane-1': { id: 'pane-1', cwd: '/repo' },
+        },
+        activeTabId: 'tab-1',
+        focusedPaneId: 'pane-1',
+      },
+    })
+  })
+
+  it('migrates a legacy terminal drawer into one tab and pane', async () => {
+    const restored = await loadTabUiState(
+      hostWithTabState({
+        root: '/repo',
+        open: [],
+        active: null,
+        expanded: [],
+        terminalOpen: true,
+        terminalDock: 'right',
+      }),
+      'tab-1',
+    )
+
+    expect(restored?.terminalWorkspace?.tabs).toHaveLength(1)
+    expect(Object.values(restored?.terminalWorkspace?.panes ?? {})).toEqual([
+      expect.objectContaining({ cwd: '/repo' }),
+    ])
+  })
+
+  it('persists workspace layout without session credentials', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('window', {
+      setTimeout: globalThis.setTimeout,
+      clearTimeout: globalThis.clearTimeout,
+    })
+    let saved: unknown = null
+    const host = {
+      iii: {
+        trigger: async (id: string, payload: unknown) => {
+          if (id === 'configuration::get') return { value: { tabs: {} } }
+          saved = payload
+          return null
+        },
+      },
+    } as never
+    const saver = createTabUiStateSaver(host, 'tab-1')
+
+    saver.save({
+      root: '/repo',
+      open: [],
+      active: null,
+      expanded: [],
+      terminalOpen: true,
+      terminalWorkspace: createTerminalWorkspace('/repo'),
+    })
+    await vi.advanceTimersByTimeAsync(600)
+
+    const serialized = JSON.stringify(saved)
+    expect(serialized).toContain('"terminalWorkspace"')
+    expect(serialized).not.toContain('accessKey')
+    expect(serialized).not.toContain('reconnectToken')
+    saver.dispose()
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+})

--- a/shell/ui/src/page/__tests__/terminal-layout.test.ts
+++ b/shell/ui/src/page/__tests__/terminal-layout.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createTerminalWorkspace,
+  normalizeTerminalWorkspace,
+  reduceTerminalWorkspace,
+} from '../terminal-layout'
+
+describe('terminal workspace layout', () => {
+  it('creates and activates a second terminal tab', () => {
+    const initial = createTerminalWorkspace('/repo')
+    const next = reduceTerminalWorkspace(initial, {
+      type: 'tab-created',
+      tabId: 'tab-2',
+      paneId: 'pane-2',
+      root: '/repo',
+    })
+
+    expect(next.tabs.map((tab) => tab.id)).toEqual([
+      initial.tabs[0].id,
+      'tab-2',
+    ])
+    expect(next.activeTabId).toBe('tab-2')
+    expect(next.focusedPaneId).toBe('pane-2')
+  })
+
+  it('rejects a fifth pane in one terminal tab', () => {
+    let state = createTerminalWorkspace('/repo')
+    const firstPane = state.focusedPaneId as string
+    for (const index of [2, 3, 4]) {
+      state = reduceTerminalWorkspace(state, {
+        type: 'pane-split',
+        paneId: state.focusedPaneId as string,
+        newPaneId: `pane-${index}`,
+        splitId: `split-${index}`,
+        direction: index % 2 === 0 ? 'horizontal' : 'vertical',
+      })
+    }
+    expect(Object.keys(state.panes)).toHaveLength(4)
+
+    const rejected = reduceTerminalWorkspace(state, {
+      type: 'pane-split',
+      paneId: firstPane,
+      newPaneId: 'pane-5',
+      splitId: 'split-5',
+      direction: 'horizontal',
+    })
+
+    expect(rejected).toBe(state)
+  })
+
+  it('rejects tab-created when pane ID already exists', () => {
+    const initial = createTerminalWorkspace('/repo')
+    const rejected = reduceTerminalWorkspace(initial, {
+      type: 'tab-created',
+      tabId: 'tab-2',
+      paneId: 'pane-1',
+      root: '/repo',
+    })
+
+    expect(rejected).toBe(initial)
+    expect(rejected.tabs).toHaveLength(1)
+  })
+
+  it('rejects pane-split when new pane ID already exists', () => {
+    const initial = createTerminalWorkspace('/repo')
+    const rejected = reduceTerminalWorkspace(initial, {
+      type: 'pane-split',
+      paneId: 'pane-1',
+      newPaneId: 'pane-1',
+      splitId: 'split-2',
+      direction: 'horizontal',
+    })
+
+    expect(rejected).toBe(initial)
+    expect(Object.keys(rejected.panes)).toEqual(['pane-1'])
+  })
+
+  it('rejects pane-split when the split ID already exists', () => {
+    const split = reduceTerminalWorkspace(createTerminalWorkspace('/repo'), {
+      type: 'pane-split',
+      paneId: 'pane-1',
+      newPaneId: 'pane-2',
+      splitId: 'split-1',
+      direction: 'horizontal',
+    })
+    const rejected = reduceTerminalWorkspace(split, {
+      type: 'pane-split',
+      paneId: 'pane-2',
+      newPaneId: 'pane-3',
+      splitId: 'split-1',
+      direction: 'vertical',
+    })
+
+    expect(rejected).toBe(split)
+  })
+
+  it('drops duplicate pane references and orphaned pane state while normalizing', () => {
+    const normalized = normalizeTerminalWorkspace(
+      {
+        tabs: [
+          {
+            id: 'tab-1',
+            title: 'zsh 1',
+            layout: { type: 'pane', paneId: 'pane-1' },
+          },
+          {
+            id: 'tab-2',
+            title: 'zsh 2',
+            layout: { type: 'pane', paneId: 'pane-1' },
+          },
+        ],
+        panes: {
+          'pane-1': { id: 'pane-1', cwd: '/repo' },
+          orphan: { id: 'orphan', cwd: '/repo' },
+        },
+        activeTabId: 'tab-2',
+        focusedPaneId: 'pane-1',
+      },
+      '/repo',
+    )
+
+    expect(normalized.tabs.map((tab) => tab.id)).toEqual(['tab-1'])
+    expect(Object.keys(normalized.panes)).toEqual(['pane-1'])
+    expect(normalized.activeTabId).toBe('tab-1')
+  })
+
+  it('restores normalized workspace state after asynchronous page boot', () => {
+    const initial = createTerminalWorkspace('/')
+    const restored = createTerminalWorkspace('/repo')
+    const next = reduceTerminalWorkspace(initial, {
+      type: 'workspace-restored',
+      state: restored,
+    })
+
+    expect(next).toBe(restored)
+  })
+})

--- a/shell/ui/src/page/__tests__/terminal-leases.test.ts
+++ b/shell/ui/src/page/__tests__/terminal-leases.test.ts
@@ -1,0 +1,356 @@
+import { describe, expect, it } from 'vitest'
+import { createTerminalWorkspace } from '../terminal-layout'
+import {
+  loadTerminalLeases,
+  removeTerminalLease,
+  saveTerminalLease,
+  TerminalLeaseStorageError,
+} from '../terminal-leases'
+
+const MAX_LEASE_PAYLOAD_BYTES = 64 * 1024
+const textEncoder = new TextEncoder()
+
+function memoryStorage(): Storage {
+  const values = new Map<string, string>()
+  return {
+    get length() {
+      return values.size
+    },
+    clear: () => values.clear(),
+    getItem: (key) => values.get(key) ?? null,
+    key: (index) => [...values.keys()][index] ?? null,
+    removeItem: (key) => {
+      values.delete(key)
+    },
+    setItem: (key, value) => {
+      values.set(key, value)
+    },
+  }
+}
+
+describe('terminal leases', () => {
+  it('stores reconnect tokens only in browser storage', () => {
+    const storage = memoryStorage()
+    saveTerminalLease(storage, 'origin:tab', {
+      paneId: 'pane-1',
+      sessionId: 'session-1',
+      reconnectToken: 'secret',
+      lastSequence: 7,
+    })
+
+    expect(loadTerminalLeases(storage, 'origin:tab')).toEqual([
+      expect.objectContaining({ reconnectToken: 'secret' }),
+    ])
+    expect(
+      JSON.stringify({
+        terminalWorkspace: createTerminalWorkspace('/repo'),
+      }),
+    ).not.toContain('secret')
+  })
+
+  it('rejects access keys on save', () => {
+    const storage = memoryStorage()
+    expect(() =>
+      saveTerminalLease(storage, 'origin:tab', {
+        paneId: 'pane-1',
+        sessionId: 'session-1',
+        reconnectToken: 'token',
+        lastSequence: 0,
+        accessKey: 'must-not-persist',
+      }),
+    ).toThrow(/access keys must not be persisted/)
+    expect(loadTerminalLeases(storage, 'origin:tab')).toEqual([])
+  })
+
+  it('rejects malformed leases on save', () => {
+    const storage = memoryStorage()
+    expect(() =>
+      saveTerminalLease(storage, 'origin:tab', {
+        paneId: '',
+        sessionId: 'session-1',
+        reconnectToken: 'token',
+        lastSequence: 0,
+      }),
+    ).toThrow(/invalid terminal lease/)
+    expect(() =>
+      saveTerminalLease(storage, 'origin:tab', {
+        paneId: 'pane-1',
+        sessionId: 'session-1',
+        reconnectToken: 'token',
+        lastSequence: -1,
+      }),
+    ).toThrow(/invalid terminal lease/)
+  })
+
+  it('rejects malformed stored payloads on load', () => {
+    const storage = memoryStorage()
+    storage.setItem('origin:tab', '{not-json')
+    expect(loadTerminalLeases(storage, 'origin:tab')).toEqual([])
+
+    storage.setItem(
+      'origin:tab',
+      JSON.stringify([
+        {
+          paneId: 'pane-1',
+          sessionId: 'session-1',
+          reconnectToken: '',
+          lastSequence: 0,
+        },
+      ]),
+    )
+    expect(loadTerminalLeases(storage, 'origin:tab')).toEqual([])
+
+    storage.setItem(
+      'origin:tab',
+      JSON.stringify([
+        {
+          paneId: 'pane-1',
+          sessionId: 'session-1',
+          reconnectToken: 'token',
+          lastSequence: 0,
+          accessKey: 'secret',
+        },
+      ]),
+    )
+    expect(loadTerminalLeases(storage, 'origin:tab')).toEqual([])
+  })
+
+  it('rejects duplicate pane ids in stored payloads', () => {
+    const storage = memoryStorage()
+    storage.setItem(
+      'origin:tab',
+      JSON.stringify([
+        {
+          paneId: 'pane-1',
+          sessionId: 'session-1',
+          reconnectToken: 'token-a',
+          lastSequence: 1,
+        },
+        {
+          paneId: 'pane-1',
+          sessionId: 'session-2',
+          reconnectToken: 'token-b',
+          lastSequence: 2,
+        },
+      ]),
+    )
+    expect(loadTerminalLeases(storage, 'origin:tab')).toEqual([])
+  })
+
+  it('rejects stored payloads larger than 64 KiB by utf-8 byte length', () => {
+    const storage = memoryStorage()
+    const overLimit = 'x'.repeat(MAX_LEASE_PAYLOAD_BYTES + 1)
+    storage.setItem('origin:tab', overLimit)
+    expect(textEncoder.encode(overLimit).length).toBeGreaterThan(
+      MAX_LEASE_PAYLOAD_BYTES,
+    )
+    expect(loadTerminalLeases(storage, 'origin:tab')).toEqual([])
+  })
+
+  it('accepts stored payloads at the exact 64 KiB utf-8 boundary', () => {
+    const storage = memoryStorage()
+    const lease = {
+      paneId: 'pane-1',
+      sessionId: 'session-1',
+      reconnectToken: 'token',
+      lastSequence: 0,
+    }
+    const serialized = JSON.stringify([lease])
+    const payload = `${serialized}${' '.repeat(
+      MAX_LEASE_PAYLOAD_BYTES - textEncoder.encode(serialized).length,
+    )}`
+    expect(textEncoder.encode(payload).length).toBe(MAX_LEASE_PAYLOAD_BYTES)
+    storage.setItem('origin:tab', payload)
+    expect(loadTerminalLeases(storage, 'origin:tab')).toEqual([lease])
+  })
+
+  it('rejects multibyte payloads that fit in utf-16 but exceed 64 KiB utf-8', () => {
+    const storage = memoryStorage()
+    const multibyte = '\u{1F600}'.repeat(22_000)
+    const payload = JSON.stringify([
+      {
+        paneId: 'pane-1',
+        sessionId: 'session-1',
+        reconnectToken: multibyte,
+        lastSequence: 0,
+      },
+    ])
+    expect(payload.length).toBeLessThan(MAX_LEASE_PAYLOAD_BYTES)
+    expect(textEncoder.encode(payload).length).toBeGreaterThan(
+      MAX_LEASE_PAYLOAD_BYTES,
+    )
+    storage.setItem('origin:tab', payload)
+    expect(loadTerminalLeases(storage, 'origin:tab')).toEqual([])
+  })
+
+  it('rejects saves that exceed 64 KiB by utf-8 byte length', () => {
+    const storage = memoryStorage()
+    saveTerminalLease(storage, 'origin:tab', {
+      paneId: 'pane-1',
+      sessionId: 'session-1',
+      reconnectToken: 'existing',
+      lastSequence: 0,
+    })
+    const multibyte = '\u{1F600}'.repeat(22_000)
+    expect(() =>
+      saveTerminalLease(storage, 'origin:tab', {
+        paneId: 'pane-2',
+        sessionId: 'session-2',
+        reconnectToken: multibyte,
+        lastSequence: 0,
+      }),
+    ).toThrow(/terminal lease payload exceeds 64 KiB/)
+    expect(loadTerminalLeases(storage, 'origin:tab')).toEqual([
+      {
+        paneId: 'pane-1',
+        sessionId: 'session-1',
+        reconnectToken: 'existing',
+        lastSequence: 0,
+      },
+    ])
+  })
+
+  it('returns an empty list when storage read fails on load', () => {
+    const storage = {
+      get length() {
+        return 0
+      },
+      clear: () => {},
+      getItem: () => {
+        throw new DOMException('read failed', 'SecurityError')
+      },
+      key: () => null,
+      removeItem: () => {},
+      setItem: () => {},
+    }
+    expect(loadTerminalLeases(storage, 'origin:tab')).toEqual([])
+  })
+
+  it('throws TerminalLeaseStorageError when storage read fails on save', () => {
+    const storage = {
+      get length() {
+        return 0
+      },
+      clear: () => {},
+      getItem: () => {
+        throw new DOMException('read failed', 'SecurityError')
+      },
+      key: () => null,
+      removeItem: () => {},
+      setItem: () => {},
+    }
+    expect(() =>
+      saveTerminalLease(storage, 'origin:tab', {
+        paneId: 'pane-1',
+        sessionId: 'session-1',
+        reconnectToken: 'token',
+        lastSequence: 0,
+      }),
+    ).toThrow(TerminalLeaseStorageError)
+  })
+
+  it('throws TerminalLeaseStorageError when storage write fails on save', () => {
+    const backing = memoryStorage()
+    saveTerminalLease(backing, 'origin:tab', {
+      paneId: 'pane-1',
+      sessionId: 'session-1',
+      reconnectToken: 'existing',
+      lastSequence: 0,
+    })
+    const storage = {
+      ...backing,
+      setItem: (_key: string, _value: string) => {
+        throw new DOMException('quota exceeded', 'QuotaExceededError')
+      },
+    }
+    expect(() =>
+      saveTerminalLease(storage, 'origin:tab', {
+        paneId: 'pane-2',
+        sessionId: 'session-2',
+        reconnectToken: 'token',
+        lastSequence: 0,
+      }),
+    ).toThrow(TerminalLeaseStorageError)
+    expect(loadTerminalLeases(backing, 'origin:tab')).toEqual([
+      {
+        paneId: 'pane-1',
+        sessionId: 'session-1',
+        reconnectToken: 'existing',
+        lastSequence: 0,
+      },
+    ])
+  })
+
+  it('throws TerminalLeaseStorageError when storage read fails on remove', () => {
+    const storage = {
+      get length() {
+        return 0
+      },
+      clear: () => {},
+      getItem: () => {
+        throw new DOMException('read failed', 'SecurityError')
+      },
+      key: () => null,
+      removeItem: () => {},
+      setItem: () => {},
+    }
+    expect(() => removeTerminalLease(storage, 'origin:tab', 'pane-1')).toThrow(
+      TerminalLeaseStorageError,
+    )
+  })
+
+  it('throws TerminalLeaseStorageError when storage remove fails', () => {
+    const backing = memoryStorage()
+    saveTerminalLease(backing, 'origin:tab', {
+      paneId: 'pane-1',
+      sessionId: 'session-1',
+      reconnectToken: 'token',
+      lastSequence: 0,
+    })
+    const storage = {
+      ...backing,
+      removeItem: () => {
+        throw new DOMException('remove failed', 'SecurityError')
+      },
+    }
+    expect(() => removeTerminalLease(storage, 'origin:tab', 'pane-1')).toThrow(
+      TerminalLeaseStorageError,
+    )
+    expect(loadTerminalLeases(backing, 'origin:tab')).toEqual([
+      {
+        paneId: 'pane-1',
+        sessionId: 'session-1',
+        reconnectToken: 'token',
+        lastSequence: 0,
+      },
+    ])
+  })
+
+  it('upserts leases by pane id and removes them', () => {
+    const storage = memoryStorage()
+    saveTerminalLease(storage, 'origin:tab', {
+      paneId: 'pane-1',
+      sessionId: 'session-1',
+      reconnectToken: 'token-a',
+      lastSequence: 1,
+    })
+    saveTerminalLease(storage, 'origin:tab', {
+      paneId: 'pane-1',
+      sessionId: 'session-1',
+      reconnectToken: 'token-b',
+      lastSequence: 9,
+    })
+    expect(loadTerminalLeases(storage, 'origin:tab')).toEqual([
+      {
+        paneId: 'pane-1',
+        sessionId: 'session-1',
+        reconnectToken: 'token-b',
+        lastSequence: 9,
+      },
+    ])
+
+    removeTerminalLease(storage, 'origin:tab', 'pane-1')
+    expect(loadTerminalLeases(storage, 'origin:tab')).toEqual([])
+    expect(storage.getItem('origin:tab')).toBeNull()
+  })
+})

--- a/shell/ui/src/page/__tests__/terminal-output-router.test.ts
+++ b/shell/ui/src/page/__tests__/terminal-output-router.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createTerminalOutputRouter,
+  type PtyOutputEvent,
+} from '../terminal-output-router'
+
+function event(
+  sessionId: string,
+  sequence: number,
+  data = 'eA==',
+): PtyOutputEvent {
+  return {
+    session_id: sessionId,
+    sequence,
+    data,
+    eof: false,
+    exit_code: null,
+    signal: null,
+    error: null,
+  }
+}
+
+describe('TerminalOutputRouter', () => {
+  it('routes interleaved events by session id', () => {
+    let emit: ((event: PtyOutputEvent) => void) | undefined
+    const host = {
+      iii: {
+        browserId: 'console-test',
+        on: (_id: string, listener: (event: PtyOutputEvent) => void) => {
+          emit = listener
+          return () => {
+            emit = undefined
+          }
+        },
+      },
+    } as never
+    const router = createTerminalOutputRouter(host)
+    const first: number[] = []
+    const second: number[] = []
+    router.subscribe('session-1', (output) => first.push(output.sequence))
+    router.subscribe('session-2', (output) => second.push(output.sequence))
+
+    emit?.(event('session-2', 1))
+    emit?.(event('session-1', 1))
+    emit?.(event('session-2', 2))
+
+    expect(first).toEqual([1])
+    expect(second).toEqual([1, 2])
+    router.dispose()
+  })
+
+  it('bounds unsubscribed output queues to 2 MiB of raw data', () => {
+    let emit: ((event: PtyOutputEvent) => void) | undefined
+    const host = {
+      iii: {
+        browserId: 'console-test',
+        on: (_id: string, listener: (event: PtyOutputEvent) => void) => {
+          emit = listener
+          return () => undefined
+        },
+      },
+    } as never
+    const router = createTerminalOutputRouter(host)
+    const oneMiB = btoa('x'.repeat(1024 * 1024))
+
+    emit?.(event('session-1', 1, oneMiB))
+    emit?.(event('session-1', 2, oneMiB))
+    emit?.(event('session-1', 3, oneMiB))
+
+    expect(router.drain('session-1').map((output) => output.sequence)).toEqual([
+      2, 3,
+    ])
+    expect(router.drain('session-1')).toEqual([])
+    router.dispose()
+  })
+})

--- a/shell/ui/src/page/__tests__/terminal-session.test.ts
+++ b/shell/ui/src/page/__tests__/terminal-session.test.ts
@@ -1,0 +1,607 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('react', () => ({
+  useCallback: (callback: unknown) => callback,
+  useEffect: () => undefined,
+  useMemo: (factory: () => unknown) => factory(),
+  useReducer: () => [],
+  useRef: () => ({ current: null }),
+  useState: () => [],
+}))
+
+import {
+  closeTerminalConnection,
+  connectTerminalSession,
+  createTerminalConnectionCoordinator,
+  createTerminalSessionState,
+  detachTerminalSessionForUnmount,
+  disposeTerminalConnection,
+  legacyTerminalStorageKey,
+  normalizeTerminalDimensions,
+  reclaimTerminalLease,
+  reduceTerminalLease,
+  reduceTerminalSessionState,
+  shouldDetachStaleConnection,
+  useTerminalSession,
+} from '../terminal-session'
+import {
+  loadRecoverableTerminalLeases,
+  removeRecoverableTerminalLease,
+} from '../terminal-leases'
+
+describe('terminal session state', () => {
+  it('exports the per-pane session controller hook', () => {
+    expect(typeof useTerminalSession).toBe('function')
+  })
+
+  it('uses a reload-stable lease key for the legacy terminal', () => {
+    expect(legacyTerminalStorageKey('/repo')).toBe(
+      'iii::shell-ui::terminal-leases::legacy::/repo',
+    )
+  })
+
+  it('clamps xterm dimensions to the backend PTY boundary', () => {
+    expect(normalizeTerminalDimensions(1, 0)).toEqual({ cols: 2, rows: 2 })
+    expect(normalizeTerminalDimensions(501, 900)).toEqual({
+      cols: 500,
+      rows: 500,
+    })
+  })
+
+  it('does not detach a connection owned by a newer retry generation', () => {
+    expect(shouldDetachStaleConnection(true, 1, 2)).toBe(false)
+    expect(shouldDetachStaleConnection(true, 2, 2)).toBe(true)
+  })
+
+  it('fences a pending connection after the pane remounts', () => {
+    const requestIds = ['request-1', 'request-2']
+    const coordinator = createTerminalConnectionCoordinator(
+      () => requestIds.shift() ?? 'request-3',
+    )
+    const oldMount = coordinator.begin()
+    const newMount = coordinator.begin()
+
+    expect(newMount.requestId).toBe(oldMount.requestId)
+    expect(coordinator.isCurrent(oldMount.generation)).toBe(false)
+    expect(coordinator.isCurrent(newMount.generation)).toBe(true)
+    coordinator.complete(newMount.generation)
+    expect(coordinator.begin().requestId).toBe('request-2')
+  })
+
+  it('transitions from connecting to ready', () => {
+    const state = reduceTerminalSessionState(
+      createTerminalSessionState('/repo'),
+      {
+        type: 'connected',
+        sessionId: 'session-1',
+        cwd: '/repo',
+      },
+    )
+
+    expect(state).toEqual({
+      status: 'ready',
+      cwd: '/repo',
+      error: null,
+      notice: null,
+      sessionId: 'session-1',
+      lastSequence: 0,
+    })
+  })
+
+  it('transitions from connecting to disconnected', () => {
+    const state = reduceTerminalSessionState(
+      createTerminalSessionState('/repo'),
+      {
+        type: 'disconnected',
+        error: 'terminal session does not exist',
+      },
+    )
+
+    expect(state.status).toBe('disconnected')
+    expect(state.error).toBe('terminal session does not exist')
+    expect(state.sessionId).toBeNull()
+  })
+
+  it('transitions from ready to exited', () => {
+    const ready = reduceTerminalSessionState(
+      createTerminalSessionState('/repo'),
+      {
+        type: 'connected',
+        sessionId: 'session-1',
+        cwd: '/repo',
+      },
+    )
+    const exited = reduceTerminalSessionState(ready, {
+      type: 'exited',
+      error: null,
+    })
+
+    expect(exited.status).toBe('exited')
+    expect(exited.sessionId).toBe('session-1')
+  })
+
+  it('records a replay truncation notice', () => {
+    const state = reduceTerminalSessionState(
+      createTerminalSessionState('/repo'),
+      {
+        type: 'replay-truncated',
+      },
+    )
+
+    expect(state.notice).toBe(
+      '\r\n[terminal output truncated; showing retained output]\r\n',
+    )
+  })
+
+  it('replaces the pane lease after restart', () => {
+    const next = {
+      paneId: 'pane-1',
+      sessionId: 'session-2',
+      reconnectToken: 'token-2',
+      lastSequence: 0,
+    }
+
+    expect(
+      reduceTerminalLease(
+        {
+          paneId: 'pane-1',
+          sessionId: 'session-1',
+          reconnectToken: 'token-1',
+          lastSequence: 9,
+        },
+        { type: 'restarted', lease: next },
+      ),
+    ).toEqual(next)
+  })
+
+  it('removes the pane lease after close', () => {
+    expect(
+      reduceTerminalLease(
+        {
+          paneId: 'pane-1',
+          sessionId: 'session-1',
+          reconnectToken: 'token-1',
+          lastSequence: 9,
+        },
+        { type: 'closed' },
+      ),
+    ).toBeNull()
+  })
+})
+
+describe('reclaimTerminalLease', () => {
+  it('attaches before closing with rotated access and removes the lease', async () => {
+    const calls: Array<{ id: string; payload: Record<string, unknown> }> = []
+    let subscribed = false
+    const host = {
+      iii: {
+        trigger: async (id: string, payload: Record<string, unknown>) => {
+          expect(subscribed).toBe(true)
+          calls.push({ id, payload })
+          if (id === 'shell::pty::attach') {
+            return {
+              access_key: 'rotated-access',
+              reconnect_token: 'rotated-reconnect',
+              frames: [],
+              truncated: false,
+              next_sequence: 10,
+              cwd: '/repo',
+              status: 'attached',
+            }
+          }
+          return { closed: true }
+        },
+      },
+    } as never
+    const router = {
+      outputFunctionId: 'iii::shell-ui::pty-output::console-test',
+      subscribe: () => {
+        subscribed = true
+        return () => {
+          subscribed = false
+        }
+      },
+      drain: () => [],
+      dispose: () => undefined,
+    }
+    const updates: string[] = []
+    let removed = false
+
+    await reclaimTerminalLease(host, router, {
+      paneId: 'pane-1',
+      sessionId: 'session-1',
+      reconnectToken: 'reconnect',
+      lastSequence: 9,
+      update: (lease) => updates.push(lease.reconnectToken),
+      remove: () => {
+        removed = true
+      },
+    })
+
+    expect(calls.map((call) => call.id)).toEqual([
+      'shell::pty::attach',
+      'shell::pty::close',
+    ])
+    expect(calls[1]?.payload.access_key).toBe('rotated-access')
+    expect(updates).toEqual(['rotated-reconnect'])
+    expect(removed).toBe(true)
+    expect(subscribed).toBe(false)
+  })
+
+  it('removes a stale lease after the backend confirms the session is missing', async () => {
+    const host = {
+      iii: {
+        trigger: async () => {
+          throw new Error('terminal session does not exist')
+        },
+      },
+    } as never
+    const router = {
+      outputFunctionId: 'iii::shell-ui::pty-output::console-test',
+      subscribe: () => () => undefined,
+      drain: () => [],
+      dispose: () => undefined,
+    }
+    let removed = false
+
+    await reclaimTerminalLease(host, router, {
+      paneId: 'pane-1',
+      sessionId: 'missing',
+      reconnectToken: 'reconnect',
+      lastSequence: 9,
+      update: () => undefined,
+      remove: () => {
+        removed = true
+      },
+    })
+
+    expect(removed).toBe(true)
+  })
+})
+
+describe('connectTerminalSession', () => {
+  it('subscribes before attach and deduplicates queued live replay overlap', async () => {
+    let emit:
+      | ((event: {
+          session_id: string
+          sequence: number
+          data: string | null
+          eof: boolean
+          exit_code: number | null
+          signal: string | null
+          error: string | null
+        }) => void)
+      | null = null
+    const router = {
+      outputFunctionId: 'iii::shell-ui::pty-output::console-test',
+      subscribe: (_sessionId: string, listener: typeof emit) => {
+        emit = listener
+        return () => {
+          emit = null
+        }
+      },
+      drain: () => [],
+      dispose: () => undefined,
+    }
+    const host = {
+      iii: {
+        trigger: async () => {
+          expect(emit).not.toBeNull()
+          emit?.({
+            session_id: 'session-1',
+            sequence: 5,
+            data: 'Zml2ZQ==',
+            eof: false,
+            exit_code: null,
+            signal: null,
+            error: null,
+          })
+          return {
+            access_key: 'access-2',
+            reconnect_token: 'reconnect-2',
+            frames: [
+              { sequence: 4, data: 'Zm91cg==' },
+              { sequence: 5, data: 'Zml2ZQ==' },
+            ],
+            truncated: false,
+            next_sequence: 6,
+            cwd: '/repo',
+            status: 'attached',
+          }
+        },
+      },
+    } as never
+
+    const connection = await connectTerminalSession({
+      host,
+      router,
+      root: '/repo',
+      requestId: 'request-1',
+      lease: {
+        paneId: 'pane-1',
+        sessionId: 'session-1',
+        reconnectToken: 'reconnect-1',
+        lastSequence: 3,
+      },
+      cols: 80,
+      rows: 24,
+    })
+    const activated = connection.activate(() => undefined)
+
+    expect(activated.frames).toEqual([
+      { sequence: 4, data: 'Zm91cg==' },
+      { sequence: 5, data: 'Zml2ZQ==' },
+    ])
+    connection.unsubscribe()
+  })
+
+  it('replays retained output when xterm was disposed before reattach', async () => {
+    let attachPayload: Record<string, unknown> | null = null
+    const router = {
+      outputFunctionId: 'iii::shell-ui::pty-output::console-test',
+      subscribe: () => () => undefined,
+      drain: () => [],
+      dispose: () => undefined,
+    }
+    const host = {
+      iii: {
+        trigger: async (_id: string, payload: Record<string, unknown>) => {
+          attachPayload = payload
+          return {
+            access_key: 'access-2',
+            reconnect_token: 'reconnect-2',
+            frames: [
+              { sequence: 1, data: 'b25l' },
+              { sequence: 2, data: 'dHdv' },
+            ],
+            truncated: false,
+            next_sequence: 3,
+            cwd: '/repo',
+            status: 'attached',
+          }
+        },
+      },
+    } as never
+
+    const connection = await connectTerminalSession({
+      host,
+      router,
+      root: '/repo',
+      requestId: 'request-1',
+      lease: {
+        paneId: 'pane-1',
+        sessionId: 'session-1',
+        reconnectToken: 'reconnect-1',
+        lastSequence: 2,
+      },
+      cols: 80,
+      rows: 24,
+    })
+
+    expect(attachPayload).toMatchObject({ after_sequence: 0 })
+    expect(connection.activate(() => undefined).frames).toEqual([
+      { sequence: 1, data: 'b25l' },
+      { sequence: 2, data: 'dHdv' },
+    ])
+    connection.unsubscribe()
+  })
+
+  it('bounds output queued during attach and requests replay after eviction', async () => {
+    let emit:
+      | ((event: {
+          session_id: string
+          sequence: number
+          data: string | null
+          eof: boolean
+          exit_code: number | null
+          signal: string | null
+          error: string | null
+        }) => void)
+      | null = null
+    const router = {
+      outputFunctionId: 'iii::shell-ui::pty-output::console-test',
+      subscribe: (_sessionId: string, listener: typeof emit) => {
+        emit = listener
+        return () => undefined
+      },
+      drain: () => [],
+      dispose: () => undefined,
+    }
+    const oneMiB = btoa('x'.repeat(1024 * 1024))
+    const host = {
+      iii: {
+        trigger: async () => {
+          for (let sequence = 1; sequence <= 3; sequence += 1) {
+            emit?.({
+              session_id: 'session-1',
+              sequence,
+              data: oneMiB,
+              eof: false,
+              exit_code: null,
+              signal: null,
+              error: null,
+            })
+          }
+          return {
+            access_key: 'access-2',
+            reconnect_token: 'reconnect-2',
+            frames: [],
+            truncated: false,
+            next_sequence: 1,
+            cwd: '/repo',
+            status: 'attached',
+          }
+        },
+      },
+    } as never
+
+    const connection = await connectTerminalSession({
+      host,
+      router,
+      root: '/repo',
+      requestId: 'request-1',
+      lease: {
+        paneId: 'pane-1',
+        sessionId: 'session-1',
+        reconnectToken: 'reconnect-1',
+        lastSequence: 0,
+      },
+      cols: 80,
+      rows: 24,
+    })
+    const activated = connection.activate(() => undefined)
+
+    expect(activated.requiresReplay).toBe(true)
+    expect(activated.frames).toEqual([])
+  })
+})
+
+describe('disposeTerminalConnection', () => {
+  it('unsubscribes, drains, and detaches an initialized connection', async () => {
+    const calls: Array<{ id: string; payload: Record<string, unknown> }> = []
+    const drained: string[] = []
+    let unsubscribed = false
+    const host = {
+      iii: {
+        trigger: async (id: string, payload: Record<string, unknown>) => {
+          calls.push({ id, payload })
+        },
+      },
+    } as never
+    const router = {
+      outputFunctionId: 'iii::shell-ui::pty-output::console-test',
+      subscribe: () => () => undefined,
+      drain: (sessionId: string) => {
+        drained.push(sessionId)
+        return []
+      },
+      dispose: () => undefined,
+    }
+
+    await disposeTerminalConnection(host, router, {
+      sessionId: 'session-1',
+      accessKey: 'access-1',
+      reconnectToken: 'reconnect-1',
+      cwd: '/repo',
+      status: 'attached',
+      truncated: false,
+      nextSequence: 1,
+      activate: () => ({
+        frames: [],
+        events: [],
+        requiresReplay: false,
+        replayThrough: 0,
+      }),
+      unsubscribe: () => {
+        unsubscribed = true
+      },
+    })
+
+    expect(unsubscribed).toBe(true)
+    expect(drained).toEqual(['session-1'])
+    expect(calls).toEqual([
+      {
+        id: 'shell::pty::detach',
+        payload: {
+          session_id: 'session-1',
+          access_key: 'access-1',
+        },
+      },
+    ])
+  })
+})
+
+describe('detachTerminalSessionForUnmount', () => {
+  it('keeps the reconnect lease in memory when storage is unavailable', async () => {
+    const calls: Array<{ id: string; payload: Record<string, unknown> }> = []
+    let unsubscribed = false
+    const host = {
+      iii: {
+        trigger: async (id: string, payload: Record<string, unknown>) => {
+          calls.push({ id, payload })
+        },
+      },
+    } as never
+    const router = {
+      outputFunctionId: 'iii::shell-ui::pty-output::console-test',
+      subscribe: () => () => undefined,
+      drain: () => [],
+      dispose: () => undefined,
+    }
+    const storageKey = 'unavailable-storage'
+
+    await detachTerminalSessionForUnmount(
+      host,
+      router,
+      storageKey,
+      'pane-1',
+      {
+        sessionId: 'session-1',
+        accessKey: 'access-1',
+        reconnectToken: 'reconnect-1',
+        lastSequence: 7,
+        unsubscribe: () => {
+          unsubscribed = true
+        },
+      },
+    )
+
+    expect(unsubscribed).toBe(true)
+    expect(calls).toEqual([
+      {
+        id: 'shell::pty::detach',
+        payload: {
+          session_id: 'session-1',
+          access_key: 'access-1',
+        },
+      },
+    ])
+    expect(loadRecoverableTerminalLeases(null, storageKey)).toEqual([
+      {
+        paneId: 'pane-1',
+        sessionId: 'session-1',
+        reconnectToken: 'reconnect-1',
+        lastSequence: 7,
+      },
+    ])
+    removeRecoverableTerminalLease(null, storageKey, 'pane-1')
+  })
+})
+
+describe('closeTerminalConnection', () => {
+  it('closes an initialized connection instead of detaching it', async () => {
+    const calls: string[] = []
+    const host = {
+      iii: {
+        trigger: async (id: string) => {
+          calls.push(id)
+        },
+      },
+    } as never
+    const router = {
+      outputFunctionId: 'iii::shell-ui::pty-output::console-test',
+      subscribe: () => () => undefined,
+      drain: () => [],
+      dispose: () => undefined,
+    }
+
+    await closeTerminalConnection(host, router, {
+      sessionId: 'session-1',
+      accessKey: 'access-1',
+      reconnectToken: 'reconnect-1',
+      cwd: '/repo',
+      status: 'attached',
+      truncated: false,
+      nextSequence: 1,
+      activate: () => ({
+        frames: [],
+        events: [],
+        requiresReplay: false,
+        replayThrough: 0,
+      }),
+      unsubscribe: () => undefined,
+    })
+
+    expect(calls).toEqual(['shell::pty::close'])
+  })
+})

--- a/shell/ui/src/page/__tests__/terminal-stream.test.ts
+++ b/shell/ui/src/page/__tests__/terminal-stream.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import { bufferTerminalFrame, mergeTerminalFrames } from '../terminal-stream'
+
+describe('mergeTerminalFrames', () => {
+  it('deduplicates overlap and orders replay with queued live frames', () => {
+    expect(
+      mergeTerminalFrames(
+        [
+          { sequence: 4, data: 'four' },
+          { sequence: 5, data: 'five' },
+        ],
+        [
+          { sequence: 5, data: 'five' },
+          { sequence: 6, data: 'six' },
+        ],
+        3,
+      ),
+    ).toEqual([
+      { sequence: 4, data: 'four' },
+      { sequence: 5, data: 'five' },
+      { sequence: 6, data: 'six' },
+    ])
+  })
+
+  it('discards frames at or below afterSequence', () => {
+    expect(
+      mergeTerminalFrames(
+        [
+          { sequence: 2, data: 'two' },
+          { sequence: 3, data: 'three' },
+        ],
+        [{ sequence: 3, data: 'three' }],
+        3,
+      ),
+    ).toEqual([])
+  })
+
+  it('rejects conflicting data for one sequence', () => {
+    expect(() =>
+      mergeTerminalFrames(
+        [{ sequence: 4, data: 'four-a' }],
+        [{ sequence: 4, data: 'four-b' }],
+        3,
+      ),
+    ).toThrow(/conflicting terminal frame data for sequence 4/)
+  })
+
+  it('rejects invalid afterSequence values', () => {
+    expect(() =>
+      mergeTerminalFrames([{ sequence: 4, data: 'four' }], [], -1),
+    ).toThrow(/invalid afterSequence/)
+    expect(() =>
+      mergeTerminalFrames([{ sequence: 4, data: 'four' }], [], 1.5),
+    ).toThrow(/invalid afterSequence/)
+    expect(() =>
+      mergeTerminalFrames([{ sequence: 4, data: 'four' }], [], Number.NaN),
+    ).toThrow(/invalid afterSequence/)
+  })
+
+  it('rejects invalid frame sequences in replay and pending', () => {
+    expect(() =>
+      mergeTerminalFrames([{ sequence: -1, data: 'bad' }], [], 0),
+    ).toThrow(/invalid frame sequence/)
+    expect(() =>
+      mergeTerminalFrames([], [{ sequence: 1.5, data: 'bad' }], 0),
+    ).toThrow(/invalid frame sequence/)
+    expect(() =>
+      mergeTerminalFrames(
+        [{ sequence: Number.MAX_SAFE_INTEGER + 1, data: 'bad' }],
+        [],
+        0,
+      ),
+    ).toThrow(/invalid frame sequence/)
+  })
+})
+
+describe('bufferTerminalFrame', () => {
+  it('holds out-of-order frames until gaps are filled', () => {
+    const pending = new Map()
+
+    expect(
+      bufferTerminalFrame(pending, { sequence: 12, data: 'twelve' }, 10),
+    ).toEqual([])
+    expect(
+      bufferTerminalFrame(pending, { sequence: 11, data: 'eleven' }, 10),
+    ).toEqual([
+      { sequence: 11, data: 'eleven' },
+      { sequence: 12, data: 'twelve' },
+    ])
+    expect(pending.size).toBe(0)
+  })
+})

--- a/shell/ui/src/page/__tests__/terminal-workspace.test.tsx
+++ b/shell/ui/src/page/__tests__/terminal-workspace.test.tsx
@@ -1,0 +1,144 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import {
+  pruneTerminalConnectionCoordinators,
+  reconcileTerminalWorkspaceLeases,
+  TerminalWorkspace,
+} from '../TerminalWorkspace'
+import type { TerminalWorkspaceState } from '../terminal-layout'
+import { createTerminalConnectionCoordinator } from '../terminal-session-state'
+
+function twoTabWorkspace(): TerminalWorkspaceState {
+  return {
+    tabs: [
+      {
+        id: 'tab-1',
+        title: 'zsh 1',
+        layout: { type: 'pane', paneId: 'pane-1' },
+      },
+      {
+        id: 'tab-2',
+        title: 'zsh 2',
+        layout: { type: 'pane', paneId: 'pane-2' },
+      },
+    ],
+    panes: {
+      'pane-1': { id: 'pane-1', cwd: '/repo' },
+      'pane-2': { id: 'pane-2', cwd: '/repo' },
+    },
+    activeTabId: 'tab-2',
+    focusedPaneId: 'pane-2',
+  }
+}
+
+function threePaneWorkspace(): TerminalWorkspaceState {
+  return {
+    tabs: [
+      {
+        id: 'tab-1',
+        title: 'zsh 1',
+        layout: {
+          type: 'split',
+          id: 'split-horizontal',
+          direction: 'horizontal',
+          ratio: 0.5,
+          first: { type: 'pane', paneId: 'pane-1' },
+          second: {
+            type: 'split',
+            id: 'split-vertical',
+            direction: 'vertical',
+            ratio: 0.5,
+            first: { type: 'pane', paneId: 'pane-2' },
+            second: { type: 'pane', paneId: 'pane-3' },
+          },
+        },
+      },
+    ],
+    panes: {
+      'pane-1': { id: 'pane-1', cwd: '/repo' },
+      'pane-2': { id: 'pane-2', cwd: '/repo' },
+      'pane-3': { id: 'pane-3', cwd: '/repo' },
+    },
+    activeTabId: 'tab-1',
+    focusedPaneId: 'pane-1',
+  }
+}
+
+describe('TerminalWorkspace', () => {
+  it('renders and selects terminal tabs', () => {
+    const html = renderToStaticMarkup(
+      <TerminalWorkspace
+        state={twoTabWorkspace()}
+        dispatch={() => undefined}
+        root="/repo"
+        visible={false}
+        router={null}
+        leaseStore={null}
+        storageKey="test"
+        connectionCoordinators={new Map()}
+      />,
+    )
+
+    expect(html).toContain('zsh 1')
+    expect(html).toContain('zsh 2')
+    expect(html).toContain('aria-selected="true"')
+  })
+
+  it('renders horizontal and vertical split separators', () => {
+    const html = renderToStaticMarkup(
+      <TerminalWorkspace
+        state={threePaneWorkspace()}
+        dispatch={() => undefined}
+        root="/repo"
+        visible={false}
+        router={null}
+        leaseStore={null}
+        storageKey="test"
+        connectionCoordinators={new Map()}
+      />,
+    )
+
+    expect(html).toContain('aria-orientation="horizontal"')
+    expect(html).toContain('aria-orientation="vertical"')
+    expect(html.match(/role="separator"/g) ?? []).toHaveLength(2)
+  })
+
+  it('reclaims stored leases whose panes were not restored', async () => {
+    const reclaimed: string[] = []
+    const warnings = await reconcileTerminalWorkspaceLeases(
+      [
+        {
+          paneId: 'pane-1',
+          sessionId: 'session-1',
+          reconnectToken: 'token-1',
+          lastSequence: 1,
+        },
+        {
+          paneId: 'orphan-pane',
+          sessionId: 'orphan-session',
+          reconnectToken: 'orphan-token',
+          lastSequence: 2,
+        },
+      ],
+      new Set(['pane-1']),
+      async (lease) => {
+        reclaimed.push(lease.sessionId)
+        return null
+      },
+    )
+
+    expect(reclaimed).toEqual(['orphan-session'])
+    expect(warnings).toEqual([])
+  })
+
+  it('prunes connection coordinators for closed panes', () => {
+    const coordinators = new Map([
+      ['pane-1', createTerminalConnectionCoordinator(() => 'request-1')],
+      ['closed-pane', createTerminalConnectionCoordinator(() => 'request-2')],
+    ])
+
+    pruneTerminalConnectionCoordinators(coordinators, new Set(['pane-1']))
+
+    expect([...coordinators.keys()]).toEqual(['pane-1'])
+  })
+})

--- a/shell/ui/src/page/index.tsx
+++ b/shell/ui/src/page/index.tsx
@@ -29,15 +29,29 @@ import {
   EyeOff,
   FolderTree,
   MoreHorizontal,
+  PanelLeft,
+  PanelRight,
   RefreshCw,
   Rows3,
   Search,
   SquareTerminal,
+  Terminal,
   X,
 } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from 'react'
 import { errorMessage } from '../lib/format'
-import { captureWorkspaceBaseline, classifyWorkspaceBaselinePath } from './baseline'
+import {
+  captureWorkspaceBaseline,
+  classifyWorkspaceBaselinePath,
+} from './baseline'
+import { ChangeDiffPane } from './ChangeDiffPane'
 import {
   type CoderInfo,
   coderInfo,
@@ -59,43 +73,54 @@ import {
   currentReviewDirtyPaths,
   refreshCleanEditorCacheEntry,
 } from './editor-cache'
-import { ChangeDiffPane } from './ChangeDiffPane'
 import { FilesTab } from './FilesTab'
 import {
   type GitChange,
   type GitCommitSummary,
   type GitComparisonEntry,
   type GitComparisonScope,
-  type GitRevisionComparisonEntry,
   type GitRefSummary,
+  type GitRevisionComparisonEntry,
   type GitState,
-  gitChanges,
   gitBranchComparison,
+  gitChanges,
   gitCommitComparison,
   gitComparison,
   gitRecentCommits,
   gitRefs,
 } from './git'
+import { HoverTip } from './HoverTip'
 import { useWorkspaceChanges } from './live'
 import { normalizeLiveReviewEvent } from './live-review'
-import { createTabUiStateSaver, loadTabUiState, type TabUiState } from './persist'
-import { diffForReviewEntry, mergeGitReviewEntries, mergeReviewEntry, type ReviewEntry } from './review'
-import { useShellReviewSummaryBridge } from './review-summary-store'
-import { changedParentDirs, withReviewChanges } from './review-tree'
+import { parseShellPanelContext } from './panel-context'
+import {
+  createTabUiStateSaver,
+  loadTabUiState,
+  type TabUiState,
+  type TerminalDock,
+} from './persist'
+import {
+  createReviewSaveBarrier,
+  type ReviewEditDraft,
+  type ReviewFileSummary,
+  type ReviewOptions,
+  ReviewPane,
+  runReviewTransition,
+} from './ReviewPane'
 import {
   ReviewScopePicker,
   type ReviewScopeSelection,
 } from './ReviewScopePicker'
 import {
-  createReviewSaveBarrier,
-  ReviewPane,
-  type ReviewEditDraft,
-  type ReviewFileSummary,
-  type ReviewOptions,
-  runReviewTransition,
-} from './ReviewPane'
+  diffForReviewEntry,
+  mergeGitReviewEntries,
+  mergeReviewEntry,
+  type ReviewEntry,
+} from './review'
+import { useShellReviewSummaryBridge } from './review-summary-store'
+import { changedParentDirs, withReviewChanges } from './review-tree'
 import { SearchTab } from './SearchTab'
-import { parseShellPanelContext } from './panel-context'
+import { TerminalPanel } from './TerminalPanel'
 import {
   activateTab,
   basename,
@@ -108,6 +133,13 @@ import {
   restoreTabs,
   type TabsState,
 } from './tabs'
+import {
+  createTerminalWorkspace,
+  normalizeTerminalWorkspace,
+  reduceTerminalWorkspace,
+} from './terminal-layout'
+import { createTerminalOutputRouter } from './terminal-output-router'
+import type { TerminalConnectionCoordinator } from './terminal-session-state'
 import { useHarnessPreTurn, useHarnessTurn } from './turn'
 import {
   canCaptureHarnessWorkspaceChange,
@@ -118,10 +150,10 @@ import {
   deepLinkRootTarget,
   ownsRequestToken,
   ownsScopedRequestToken,
+  type RootTargetValidation,
   rebasePathAfterValidation,
   rootValidationRetryDelay,
   type ScopedRequestToken,
-  type RootTargetValidation,
   validateRootTarget,
   workingDirectoryNeedsFollow,
   workingDirectoryRetryMessage,
@@ -203,23 +235,46 @@ function reviewEntriesFromGit(
 const SIDEBAR_DEFAULT_WIDTH = 244
 const SIDEBAR_MIN_WIDTH = 180
 const SIDEBAR_MAX_WIDTH = 560
+const TERMINAL_BOTTOM_DEFAULT_SIZE = 280
+const TERMINAL_RIGHT_DEFAULT_SIZE = 420
 function reviewablePath(rel: string): boolean {
   // This page's own persisted UI state changes on every tab/expand and
   // must never become part of the user's review set.
   if (rel.endsWith('shell-ui.yaml')) return false
-  const noise = ['Library', 'node_modules', 'target', 'dist', 'build', 'out', 'vendor', '__pycache__']
+  const noise = [
+    'Library',
+    'node_modules',
+    'target',
+    'dist',
+    'build',
+    'out',
+    'vendor',
+    '__pycache__',
+  ]
   const segments = rel.split('/')
-  if (segments.some((segment) => segment === '.git' || noise.includes(segment))) return false
-  return !/\.(o|a|d|rlib|rmeta|so|dylib|dll|class|pyc|wasm|map|log|output|tmp|swp|part|pid|sock)$/.test(rel)
+  if (segments.some((segment) => segment === '.git' || noise.includes(segment)))
+    return false
+  return !/\.(o|a|d|rlib|rmeta|so|dylib|dll|class|pyc|wasm|map|log|output|tmp|swp|part|pid|sock)$/.test(
+    rel,
+  )
 }
 
 function clampSidebarWidth(w: number): number {
   return Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, Math.round(w)))
 }
 
+function clampTerminalSize(size: number | undefined, fallback: number): number {
+  if (size === undefined || !Number.isFinite(size)) return fallback
+  return Math.min(1200, Math.max(160, Math.round(size)))
+}
+
 const SIDE_TABS: { id: SideTab; label: string; Icon: typeof FolderTree }[] = [
-  { id: 'files', label: 'files', Icon: FolderTree },
-  { id: 'search', label: 'search', Icon: Search },
+  {
+    id: 'files',
+    label: 'File tree — browse workspace files',
+    Icon: FolderTree,
+  },
+  { id: 'search', label: 'Search — find text in files', Icon: Search },
 ]
 
 export function ShellExplorerPage({
@@ -237,7 +292,9 @@ export function ShellExplorerPage({
   const [reviewKey, setReviewKey] = useState<string | null>(observedReviewKey)
   const [info, setInfo] = useState<CoderInfo | null>(null)
   const [infoError, setInfoError] = useState<string | null>(null)
-  const [restored, setRestored] = useState<TabUiState | null | 'loading'>('loading')
+  const [restored, setRestored] = useState<TabUiState | null | 'loading'>(
+    'loading',
+  )
   const [root, setRoot] = useState<string | null>(null)
   const rootRef = useRef(root)
   rootRef.current = root
@@ -249,7 +306,10 @@ export function ShellExplorerPage({
     path: string
     request: number
   } | null>(null)
-  const workingDirRetryRef = useRef({ path: null as string | null, failures: 0 })
+  const workingDirRetryRef = useRef({
+    path: null as string | null,
+    failures: 0,
+  })
   const workingDirRetryTimerRef = useRef<number | null>(null)
   const manualRootRequestSeqRef = useRef(0)
   const manualRootActiveRequestRef = useRef<number | null>(null)
@@ -260,6 +320,33 @@ export function ShellExplorerPage({
   const rootResolveSeqRef = useRef(0)
   const rootTransitionRef = useRef(false)
   const [sideTab, setSideTab] = useState<SideTab>('files')
+  const [terminalOpen, setTerminalOpen] = useState(false)
+  const [terminalDock, setTerminalDock] = useState<TerminalDock>('bottom')
+  const [terminalActive, setTerminalActive] = useState(false)
+  const [terminalBottomSize, setTerminalBottomSize] = useState(
+    TERMINAL_BOTTOM_DEFAULT_SIZE,
+  )
+  const [terminalRightSize, setTerminalRightSize] = useState(
+    TERMINAL_RIGHT_DEFAULT_SIZE,
+  )
+  const [terminalWorkspace, dispatchTerminalWorkspace] = useReducer(
+    reduceTerminalWorkspace,
+    '/',
+    createTerminalWorkspace,
+  )
+  const terminalRouter = useMemo(() => createTerminalOutputRouter(host), [host])
+  const terminalConnectionCoordinators = useRef(
+    new Map<string, TerminalConnectionCoordinator>(),
+  ).current
+  useEffect(() => () => terminalRouter.dispose(), [terminalRouter])
+  const terminalLeaseStore = useMemo(() => {
+    try {
+      return window.localStorage
+    } catch {
+      return null
+    }
+  }, [])
+  const terminalStorageKey = `iii::shell-ui::terminal-leases::${tabId}`
   const [collapsed, setCollapsed] = useState(false)
   const [sideWidth, setSideWidth] = useState(SIDEBAR_DEFAULT_WIDTH)
   const [tree, setTree] = useState<FlatTree | null>(null)
@@ -271,7 +358,9 @@ export function ShellExplorerPage({
   // The base tree snapshot is node-budgeted; expanding a folder the
   // snapshot didn't reach fetches its subtree on demand. An entry with
   // no paths marks a fetched-and-empty folder (no refetch loop).
-  const [subtrees, setSubtrees] = useState<ReadonlyMap<string, FlatTree>>(new Map())
+  const [subtrees, setSubtrees] = useState<ReadonlyMap<string, FlatTree>>(
+    new Map(),
+  )
   const [tabs, setTabs] = useState<TabsState>(EMPTY_TABS)
   const [expanded, setExpanded] = useState<string[]>([])
   const [reveal, setReveal] = useState<string | null>(null)
@@ -286,9 +375,9 @@ export function ShellExplorerPage({
     reviewSaveBarrierRef.current = createReviewSaveBarrier()
   }
   const reviewSaveBarrier = reviewSaveBarrierRef.current
-  const [reviewSavingPaths, setReviewSavingPaths] = useState<ReadonlySet<string>>(
-    new Set(),
-  )
+  const [reviewSavingPaths, setReviewSavingPaths] = useState<
+    ReadonlySet<string>
+  >(new Set())
   const reviewSavePending = reviewSavingPaths.size > 0
   const [diff, setDiff] = useState<DiffSelection | null>(null)
   const diffRequestRef = useRef(0)
@@ -296,22 +385,33 @@ export function ShellExplorerPage({
   const [reviewCollapseEpoch, setReviewCollapseEpoch] = useState(0)
   const [reviewExpandEpoch, setReviewExpandEpoch] = useState(0)
   const [reviewMenuOpen, setReviewMenuOpen] = useState(false)
-  const [reviewScope, setReviewScope] = useState<ReviewScopeSelection>(LAST_TURN_SCOPE)
+  const [reviewScope, setReviewScope] =
+    useState<ReviewScopeSelection>(LAST_TURN_SCOPE)
   const reviewScopeRef = useRef(reviewScope)
   reviewScopeRef.current = reviewScope
-  const [scopeEntries, setScopeEntries] = useState<ReadonlyMap<string, ReviewEntry>>(new Map())
+  const [scopeEntries, setScopeEntries] = useState<
+    ReadonlyMap<string, ReviewEntry>
+  >(new Map())
   const scopeEntriesRef = useRef<ReadonlyMap<string, ReviewEntry>>(scopeEntries)
   scopeEntriesRef.current = scopeEntries
-  const [scopeSummary, setScopeSummary] = useState<readonly ReviewFileSummary[]>([])
+  const [scopeSummary, setScopeSummary] = useState<
+    readonly ReviewFileSummary[]
+  >([])
   const [scopeLoading, setScopeLoading] = useState(false)
   const [scopeError, setScopeError] = useState<string | null>(null)
-  const [scopeCommits, setScopeCommits] = useState<readonly GitCommitSummary[]>([])
+  const [scopeCommits, setScopeCommits] = useState<readonly GitCommitSummary[]>(
+    [],
+  )
   const [scopeRefs, setScopeRefs] = useState<readonly GitRefSummary[]>([])
   const [scopeMetadataLoading, setScopeMetadataLoading] = useState(false)
-  const [scopeMetadataError, setScopeMetadataError] = useState<string | null>(null)
+  const [scopeMetadataError, setScopeMetadataError] = useState<string | null>(
+    null,
+  )
   const scopeLoadSeqRef = useRef(0)
   const scopeMetadataSeqRef = useRef(0)
-  const [reviewSummary, setReviewSummary] = useState<readonly ReviewFileSummary[]>([])
+  const [reviewSummary, setReviewSummary] = useState<
+    readonly ReviewFileSummary[]
+  >([])
   const [reviewOptions, setReviewOptions] = useState<ReviewOptions>({
     diffStyle: 'unified',
     wordWrap: true,
@@ -320,13 +420,18 @@ export function ShellExplorerPage({
     expandUnchanged: false,
     richPreview: false,
   })
-  const [reviewEntries, setReviewEntries] = useState<ReadonlyMap<string, ReviewEntry>>(new Map())
-  const reviewEntriesRef = useRef<ReadonlyMap<string, ReviewEntry>>(reviewEntries)
+  const [reviewEntries, setReviewEntries] = useState<
+    ReadonlyMap<string, ReviewEntry>
+  >(new Map())
+  const reviewEntriesRef =
+    useRef<ReadonlyMap<string, ReviewEntry>>(reviewEntries)
   reviewEntriesRef.current = reviewEntries
   // For ordinary non-Git folders, snapshot initial text before Harness
   // writes so every later row can open a real before/after diff.
   const baselineRef = useRef<Map<string, string>>(new Map())
-  const baselineKindsRef = useRef<ReadonlyMap<string, TreeNode['kind']>>(new Map())
+  const baselineKindsRef = useRef<ReadonlyMap<string, TreeNode['kind']>>(
+    new Map(),
+  )
   const baselineCompleteRef = useRef(false)
   const baselineCapturedRef = useRef(false)
   const baselineReadyRef = useRef<Promise<void>>(Promise.resolve())
@@ -375,7 +480,8 @@ export function ShellExplorerPage({
       const next = new Set(previous)
       for (const path of restored) {
         const cached = cacheRef.current.get(path)
-        if (cached !== undefined && cached.draft !== cached.savedContent) next.add(path)
+        if (cached !== undefined && cached.draft !== cached.savedContent)
+          next.add(path)
         else next.delete(path)
       }
       return next
@@ -420,7 +526,11 @@ export function ShellExplorerPage({
     )
     const count = new Set([...dirtyPaths, ...dirtyReviewPaths]).size
     if (count === 0) return true
-    if (!window.confirm(`discard unsaved changes in ${count} ${count === 1 ? 'file' : 'files'}?`)) {
+    if (
+      !window.confirm(
+        `discard unsaved changes in ${count} ${count === 1 ? 'file' : 'files'}?`,
+      )
+    ) {
       return false
     }
     restoreReviewEditCaches(reviewEditBackupsRef.current.keys())
@@ -453,54 +563,58 @@ export function ShellExplorerPage({
     return true
   }, [reviewSaveBarrier])
 
-  const beginReviewTurn = useCallback((turnId: string) => {
-    if (turnId === lastReviewKeyRef.current) return false
-    if (!reviewSaveBarrier.canTransition()) return false
-    const reviewDrafts = [...reviewDirtyPathsRef.current]
-    if (reviewDrafts.length > 0) {
-      setTabs((previous) => {
-        let next = previous
-        for (const path of reviewDrafts) next = openPinned(next, path)
-        return next
-      })
-    }
-    reviewEditBackupsRef.current.clear()
-    setReviewDirtyPaths(new Set())
-    lastReviewKeyRef.current = turnId
-    setReviewKey(turnId)
-    reviewEpochRef.current += 1
-    reviewWindowRef.current = {
-      turnId,
-      epoch: reviewEpochRef.current,
-      active: false,
-      completedAtMs: null,
-    }
-    scopeMetadataSeqRef.current += 1
-    diffRequestRef.current += 1
-    if (liveTimerRef.current !== null) window.clearTimeout(liveTimerRef.current)
-    liveTimerRef.current = null
-    changedAbsRef.current = new Map()
-    reviewEligibleAbsRef.current = new Set()
-    changedDirsRef.current = new Set()
-    followRef.current = null
-    preparedTurnRef.current = null
-    baselineRef.current = new Map()
-    baselineKindsRef.current = new Map()
-    baselineCompleteRef.current = false
-    baselineCapturedRef.current = false
-    baselineReadyRef.current = Promise.resolve()
-    reviewEntriesRef.current = new Map()
-    setReviewEntries(new Map())
-    scopeEntriesRef.current = new Map()
-    setScopeEntries(new Map())
-    setScopeSummary([])
-    setScopeMetadataLoading(false)
-    setScopeMetadataError(null)
-    forceLastTurnScope()
-    setReviewSummary([])
-    setDiff(null)
-    return true
-  }, [forceLastTurnScope, reviewSaveBarrier])
+  const beginReviewTurn = useCallback(
+    (turnId: string) => {
+      if (turnId === lastReviewKeyRef.current) return false
+      if (!reviewSaveBarrier.canTransition()) return false
+      const reviewDrafts = [...reviewDirtyPathsRef.current]
+      if (reviewDrafts.length > 0) {
+        setTabs((previous) => {
+          let next = previous
+          for (const path of reviewDrafts) next = openPinned(next, path)
+          return next
+        })
+      }
+      reviewEditBackupsRef.current.clear()
+      setReviewDirtyPaths(new Set())
+      lastReviewKeyRef.current = turnId
+      setReviewKey(turnId)
+      reviewEpochRef.current += 1
+      reviewWindowRef.current = {
+        turnId,
+        epoch: reviewEpochRef.current,
+        active: false,
+        completedAtMs: null,
+      }
+      scopeMetadataSeqRef.current += 1
+      diffRequestRef.current += 1
+      if (liveTimerRef.current !== null)
+        window.clearTimeout(liveTimerRef.current)
+      liveTimerRef.current = null
+      changedAbsRef.current = new Map()
+      reviewEligibleAbsRef.current = new Set()
+      changedDirsRef.current = new Set()
+      followRef.current = null
+      preparedTurnRef.current = null
+      baselineRef.current = new Map()
+      baselineKindsRef.current = new Map()
+      baselineCompleteRef.current = false
+      baselineCapturedRef.current = false
+      baselineReadyRef.current = Promise.resolve()
+      reviewEntriesRef.current = new Map()
+      setReviewEntries(new Map())
+      scopeEntriesRef.current = new Map()
+      setScopeEntries(new Map())
+      setScopeSummary([])
+      setScopeMetadataLoading(false)
+      setScopeMetadataError(null)
+      forceLastTurnScope()
+      setReviewSummary([])
+      setDiff(null)
+      return true
+    },
+    [forceLastTurnScope, reviewSaveBarrier],
+  )
 
   // This runs inside Harness's awaited pre-turn hook: the snapshot is fully
   // frozen before model/tool execution can create, edit, rename, or delete.
@@ -606,29 +720,78 @@ export function ShellExplorerPage({
       .then(({ path: next }) => {
         if (cancelled || rootResolveSeqRef.current !== seq) return
         if (requestedWorkingDir !== null) {
-          acknowledgedWorkingDirRef.current = acknowledgeValidatedWorkingDirectory(
-            acknowledgedWorkingDirRef.current,
-            requestedWorkingDir,
-            workingDirRef.current,
-            true,
+          acknowledgedWorkingDirRef.current =
+            acknowledgeValidatedWorkingDirectory(
+              acknowledgedWorkingDirRef.current,
+              requestedWorkingDir,
+              workingDirRef.current,
+              true,
+            )
+        }
+        function restoreTerminalUiState(state: TabUiState): void {
+          if (state.terminalOpen) setTerminalOpen(true)
+          if (state.terminalDock) setTerminalDock(state.terminalDock)
+          if (state.terminalActive) setTerminalActive(true)
+          setTerminalBottomSize(
+            clampTerminalSize(
+              state.terminalBottomSize,
+              TERMINAL_BOTTOM_DEFAULT_SIZE,
+            ),
           )
+          setTerminalRightSize(
+            clampTerminalSize(
+              state.terminalRightSize,
+              TERMINAL_RIGHT_DEFAULT_SIZE,
+            ),
+          )
+          dispatchTerminalWorkspace({
+            type: 'workspace-restored',
+            state: state.terminalWorkspace
+              ? normalizeTerminalWorkspace(state.terminalWorkspace, next)
+              : createTerminalWorkspace(next),
+          })
         }
         setRoot(next)
-        if (restored?.root && requested === restored.root && next === restored.root) {
+        if (
+          restored?.root &&
+          requested === restored.root &&
+          next === restored.root
+        ) {
           setTabs(restoreTabs(restored.open, restored.active))
           setExpanded(restored.expanded)
           setShowHidden(restored.showHidden ?? false)
-          setSideWidth(clampSidebarWidth(restored.sideWidth ?? SIDEBAR_DEFAULT_WIDTH))
-        } else if (restored && !restored.root && requested === info.primary_root) {
+          setSideWidth(
+            clampSidebarWidth(restored.sideWidth ?? SIDEBAR_DEFAULT_WIDTH),
+          )
+          restoreTerminalUiState(restored)
+        } else if (
+          restored &&
+          !restored.root &&
+          requested === info.primary_root
+        ) {
           // Legacy/first save without a root: restore against the primary.
           setTabs(restoreTabs(restored.open, restored.active))
           setExpanded(restored.expanded)
           setShowHidden(restored.showHidden ?? false)
-          setSideWidth(clampSidebarWidth(restored.sideWidth ?? SIDEBAR_DEFAULT_WIDTH))
+          setSideWidth(
+            clampSidebarWidth(restored.sideWidth ?? SIDEBAR_DEFAULT_WIDTH),
+          )
+          restoreTerminalUiState(restored)
+        } else {
+          dispatchTerminalWorkspace({
+            type: 'workspace-restored',
+            state: createTerminalWorkspace(next),
+          })
         }
       })
       .catch(() => {
-        if (!cancelled && rootResolveSeqRef.current === seq) setRoot(info.primary_root)
+        if (!cancelled && rootResolveSeqRef.current === seq) {
+          setRoot(info.primary_root)
+          dispatchTerminalWorkspace({
+            type: 'workspace-restored',
+            state: createTerminalWorkspace(info.primary_root),
+          })
+        }
       })
     return () => {
       cancelled = true
@@ -713,10 +876,13 @@ export function ShellExplorerPage({
     })
   }, [git, reviewKey])
 
-  const visibleReviewEntries = reviewScope.kind === 'last-turn' ? reviewEntries : scopeEntries
-  const visibleReviewEntriesRef = useRef<ReadonlyMap<string, ReviewEntry>>(visibleReviewEntries)
+  const visibleReviewEntries =
+    reviewScope.kind === 'last-turn' ? reviewEntries : scopeEntries
+  const visibleReviewEntriesRef =
+    useRef<ReadonlyMap<string, ReviewEntry>>(visibleReviewEntries)
   visibleReviewEntriesRef.current = visibleReviewEntries
-  const visibleReviewSummary = reviewScope.kind === 'last-turn' ? reviewSummary : scopeSummary
+  const visibleReviewSummary =
+    reviewScope.kind === 'last-turn' ? reviewSummary : scopeSummary
   const reviewChanges = useMemo<readonly GitChange[]>(
     () => [...visibleReviewEntries.values()].map((entry) => entry.change),
     [visibleReviewEntries],
@@ -742,8 +908,14 @@ export function ShellExplorerPage({
   )
   // The Files tree is also the review navigator. Review-only rows keep
   // deleted files visible even after they disappear from coder::tree.
-  const reviewTree = useMemo(() => withReviewChanges(mergedTree, reviewChanges), [mergedTree, reviewChanges])
-  const changedDirsKey = useMemo(() => changedParentDirs(reviewChanges).join('\n'), [reviewChanges])
+  const reviewTree = useMemo(
+    () => withReviewChanges(mergedTree, reviewChanges),
+    [mergedTree, reviewChanges],
+  )
+  const changedDirsKey = useMemo(
+    () => changedParentDirs(reviewChanges).join('\n'),
+    [reviewChanges],
+  )
   useEffect(() => {
     if (changedDirsKey === '') return
     const changedDirs = changedDirsKey.split('\n')
@@ -788,10 +960,17 @@ export function ShellExplorerPage({
           // Inaccessible folder — recorded as fetched-and-empty so the
           // load effect doesn't refetch it on every live burst; a change
           // under it drops the entry and retries.
-          setSubtrees((prev) => new Map(prev).set(dir, { paths: [], kinds: new Map(), truncations: [] }))
+          setSubtrees((prev) =>
+            new Map(prev).set(dir, {
+              paths: [],
+              kinds: new Map(),
+              truncations: [],
+            }),
+          )
         })
         .finally(() => {
-          if (rootGenerationRef.current === generation) subtreeLoadRef.current.delete(dir)
+          if (rootGenerationRef.current === generation)
+            subtreeLoadRef.current.delete(dir)
         })
     }
   }, [expanded, mergedTree, subtrees, root, showHidden, host])
@@ -830,12 +1009,23 @@ export function ShellExplorerPage({
     if (!changedAbsRef.current.has(absPath)) return
     coderReadFile(host, absPath)
       .then((out) => {
-        if (rootGenerationRef.current !== generation || rootRef.current !== currentRoot) return
+        if (
+          rootGenerationRef.current !== generation ||
+          rootRef.current !== currentRoot
+        )
+          return
         if (tabsRef.current.active !== active) return
         const content = out.content ?? ''
         const entry = cacheRef.current.get(active)
         if (!entry) return
-        if (!refreshCleanEditorCacheEntry(entry, content, out.revision ?? undefined)) return
+        if (
+          !refreshCleanEditorCacheEntry(
+            entry,
+            content,
+            out.revision ?? undefined,
+          )
+        )
+          return
         setFileBump((n) => n + 1)
       })
       .catch(() => {
@@ -850,15 +1040,19 @@ export function ShellExplorerPage({
   diffRef.current = diff
   const treeRef = useRef(tree)
   treeRef.current = tree
-  const openReviewEntry = useCallback((entry: ReviewEntry) => {
-    if (!reviewSaveBarrier.canTransition()) return false
-    diffRequestRef.current += 1
-    setContextDiff(null)
-    setTabs((state) => openPreview(state, entry.path))
-    setDiff(diffForReviewEntry(entry))
-    setReviewRefreshEpoch((value) => value + 1)
-    return true
-  }, [reviewSaveBarrier])
+  const openReviewEntry = useCallback(
+    (entry: ReviewEntry) => {
+      if (!reviewSaveBarrier.canTransition()) return false
+      setTerminalActive(false)
+      diffRequestRef.current += 1
+      setContextDiff(null)
+      setTabs((state) => openPreview(state, entry.path))
+      setDiff(diffForReviewEntry(entry))
+      setReviewRefreshEpoch((value) => value + 1)
+      return true
+    },
+    [reviewSaveBarrier],
+  )
 
   const loadScopeMetadata = useCallback(() => {
     if (root === null) return
@@ -867,7 +1061,8 @@ export function ShellExplorerPage({
     setScopeMetadataError(null)
     void Promise.all([gitRecentCommits(host, root), gitRefs(host, root)])
       .then(([commits, refs]) => {
-        if (scopeMetadataSeqRef.current !== seq || rootRef.current !== root) return
+        if (scopeMetadataSeqRef.current !== seq || rootRef.current !== root)
+          return
         setScopeCommits(commits.kind === 'ready' ? commits.commits : [])
         setScopeRefs(refs.kind === 'ready' ? refs.refs : [])
         const failure =
@@ -892,16 +1087,20 @@ export function ShellExplorerPage({
       setScopeLoading(true)
       setScopeError(null)
       const comparison =
-        scope.kind === 'uncommitted' || scope.kind === 'unstaged' || scope.kind === 'staged'
+        scope.kind === 'uncommitted' ||
+        scope.kind === 'unstaged' ||
+        scope.kind === 'staged'
           ? gitComparison(host, root, scope.kind satisfies GitComparisonScope)
           : scope.kind === 'commit'
             ? gitCommitComparison(host, root, scope.sha)
             : gitBranchComparison(host, root, scope.ref)
       void comparison
         .then((state) => {
-          if (scopeLoadSeqRef.current !== seq || rootRef.current !== root) return
+          if (scopeLoadSeqRef.current !== seq || rootRef.current !== root)
+            return
           if (state.kind !== 'ready') {
-            const message = state.kind === 'error' ? state.message : 'not a git repository'
+            const message =
+              state.kind === 'error' ? state.message : 'not a git repository'
             scopeEntriesRef.current = new Map()
             setScopeEntries(new Map())
             setScopeError(message)
@@ -913,7 +1112,9 @@ export function ShellExplorerPage({
           scopeEntriesRef.current = next
           setScopeEntries(next)
           const activePath = diffRef.current?.change.path
-          const entry = (activePath ? next.get(activePath) : undefined) ?? next.values().next().value
+          const entry =
+            (activePath ? next.get(activePath) : undefined) ??
+            next.values().next().value
           if (entry) openReviewEntry(entry)
           else {
             diffRequestRef.current += 1
@@ -921,7 +1122,8 @@ export function ShellExplorerPage({
           }
         })
         .catch((error: unknown) => {
-          if (scopeLoadSeqRef.current !== seq || rootRef.current !== root) return
+          if (scopeLoadSeqRef.current !== seq || rootRef.current !== root)
+            return
           scopeEntriesRef.current = new Map()
           setScopeEntries(new Map())
           setScopeError(errorMessage(error))
@@ -935,17 +1137,20 @@ export function ShellExplorerPage({
     [host, root, openReviewEntry],
   )
 
-  const onReviewEditDirtyChange = useCallback((path: string, dirty: boolean) => {
-    // The page-owned draft remains authoritative until the row explicitly
-    // sends a clean draft, cancels, or saves.
-    if (!dirty) return
-    setReviewDirtyPaths((previous) => {
-      if (previous.has(path)) return previous
-      const next = new Set(previous)
-      next.add(path)
-      return next
-    })
-  }, [])
+  const onReviewEditDirtyChange = useCallback(
+    (path: string, dirty: boolean) => {
+      // The page-owned draft remains authoritative until the row explicitly
+      // sends a clean draft, cancels, or saves.
+      if (!dirty) return
+      setReviewDirtyPaths((previous) => {
+        if (previous.has(path)) return previous
+        const next = new Set(previous)
+        next.add(path)
+        return next
+      })
+    },
+    [],
+  )
 
   const onReviewEditSavingChange = useCallback(
     (path: string, saving: boolean) => {
@@ -954,33 +1159,36 @@ export function ShellExplorerPage({
     [reviewSaveBarrier],
   )
 
-  const onRequestReviewEdit = useCallback((path: string) => {
-    if (!reviewSaveBarrier.canTransition()) return false
-    if (reviewEditBackupsRef.current.has(path)) return true
-    const cached = cacheRef.current.get(path)
-    if (
-      cached !== undefined &&
-      cached.draft !== cached.savedContent &&
-      !window.confirm(`discard the existing editor draft for ${path}?`)
-    ) {
-      return false
-    }
-    reviewEditBackupsRef.current.set(path, {
-      cache:
-        cached === undefined
-          ? null
-          : { ...cached, draft: cached.savedContent },
-      hadTab: tabsRef.current.tabs.some((tab) => tab.path === path),
-    })
-    if (cached !== undefined && cached.draft !== cached.savedContent) {
-      setDirtyPaths((previous) => {
-        const next = new Set(previous)
-        next.delete(path)
-        return next
+  const onRequestReviewEdit = useCallback(
+    (path: string) => {
+      if (!reviewSaveBarrier.canTransition()) return false
+      if (reviewEditBackupsRef.current.has(path)) return true
+      const cached = cacheRef.current.get(path)
+      if (
+        cached !== undefined &&
+        cached.draft !== cached.savedContent &&
+        !window.confirm(`discard the existing editor draft for ${path}?`)
+      ) {
+        return false
+      }
+      reviewEditBackupsRef.current.set(path, {
+        cache:
+          cached === undefined
+            ? null
+            : { ...cached, draft: cached.savedContent },
+        hadTab: tabsRef.current.tabs.some((tab) => tab.path === path),
       })
-    }
-    return true
-  }, [reviewSaveBarrier])
+      if (cached !== undefined && cached.draft !== cached.savedContent) {
+        setDirtyPaths((previous) => {
+          const next = new Set(previous)
+          next.delete(path)
+          return next
+        })
+      }
+      return true
+    },
+    [reviewSaveBarrier],
+  )
 
   const onReviewEditDraftChange = useCallback(
     (path: string, edit: ReviewEditDraft | null) => {
@@ -1122,7 +1330,9 @@ export function ShellExplorerPage({
     } else {
       const currentRoot = rootRef.current
       if (currentRoot) {
-        const prefix = currentRoot.endsWith('/') ? currentRoot : `${currentRoot}/`
+        const prefix = currentRoot.endsWith('/')
+          ? currentRoot
+          : `${currentRoot}/`
         if (eventAbs.startsWith(prefix)) {
           const rel = eventAbs.slice(prefix.length)
           if (
@@ -1148,10 +1358,15 @@ export function ShellExplorerPage({
       // complete. New watcher events coalesce into the same maps meanwhile.
       void baselineReadyRef.current.then(() => {
         liveTimerRef.current = null
-        if (rootGenerationRef.current !== generation || reviewEpochRef.current !== reviewEpoch) return
+        if (
+          rootGenerationRef.current !== generation ||
+          reviewEpochRef.current !== reviewEpoch
+        )
+          return
         // Capture the pre-refresh tree: watcher kinds are noisy, while this
         // tells an atomic replacement from a truly new path.
-        const knownBefore = treeRef.current === null ? null : new Set(treeRef.current.paths)
+        const knownBefore =
+          treeRef.current === null ? null : new Set(treeRef.current.paths)
         const kindsBefore = treeRef.current?.kinds
         reloadActiveFile()
         const follow = followRef.current
@@ -1165,7 +1380,9 @@ export function ShellExplorerPage({
         const currentRoot = rootRef.current
         if (currentRoot === null) return
 
-        const prefix = currentRoot.endsWith('/') ? currentRoot : `${currentRoot}/`
+        const prefix = currentRoot.endsWith('/')
+          ? currentRoot
+          : `${currentRoot}/`
         const fileEvents = [...changed]
           .filter(
             ([abs]) =>
@@ -1212,9 +1429,14 @@ export function ShellExplorerPage({
           ) {
             return
           }
-          const existsByPath = new Map(results?.map((result) => [result.path, result.success] as const) ?? [])
+          const existsByPath = new Map(
+            results?.map((result) => [result.path, result.success] as const) ??
+              [],
+          )
           const currentGitChanges = state?.kind === 'ready' ? state.changes : []
-          const currentGitByPath = new Map(currentGitChanges.map((change) => [change.path, change] as const))
+          const currentGitByPath = new Map(
+            currentGitChanges.map((change) => [change.path, change] as const),
+          )
           let nextReview = reviewEntriesRef.current
           for (const { abs, rawKind, rel } of fileEvents) {
             const baselinePath = baselineCapturedRef.current
@@ -1227,15 +1449,18 @@ export function ShellExplorerPage({
                 )
               : null
             const priorKind = baselineCapturedRef.current
-              ? baselinePath?.priorKind ?? null
+              ? (baselinePath?.priorKind ?? null)
               : kindsBefore === undefined
                 ? undefined
                 : kindsBefore.get(rel) === 'file'
                   ? 'file'
-                  : kindsBefore.get(rel) === 'dir' || knownBefore?.has(`${rel}/`)
+                  : kindsBefore.get(rel) === 'dir' ||
+                      knownBefore?.has(`${rel}/`)
                     ? 'dir'
                     : null
-            const baseline = baselineRef.current.get(rel) ?? cacheRef.current.get(rel)?.savedContent
+            const baseline =
+              baselineRef.current.get(rel) ??
+              cacheRef.current.get(rel)?.savedContent
             const baselineUnavailable =
               baselinePath?.priorKind === 'file' && baseline === undefined
             const decision = normalizeLiveReviewEvent({
@@ -1248,7 +1473,11 @@ export function ShellExplorerPage({
                   ? rawKind !== 'deleted'
                   : existsByPath.get(abs) === true,
             })
-            if (decision.action === 'ignore-directory' || decision.action === 'ignore-delete') continue
+            if (
+              decision.action === 'ignore-directory' ||
+              decision.action === 'ignore-delete'
+            )
+              continue
             nextReview = mergeReviewEntry(
               nextReview,
               rel,
@@ -1260,7 +1489,11 @@ export function ShellExplorerPage({
               baselineUnavailable ? undefined : currentGitByPath.get(rel),
             )
           }
-          const enriched = mergeGitReviewEntries(nextReview, currentGitChanges, false)
+          const enriched = mergeGitReviewEntries(
+            nextReview,
+            currentGitChanges,
+            false,
+          )
           reviewEntriesRef.current = enriched
           setReviewEntries(enriched)
 
@@ -1317,17 +1550,40 @@ export function ShellExplorerPage({
       expanded,
       showHidden,
       sideWidth,
+      terminalOpen,
+      terminalDock,
+      terminalActive,
+      terminalBottomSize,
+      terminalRightSize,
+      terminalWorkspace,
     })
-  }, [saver, root, tabs, expanded, showHidden, sideWidth])
+  }, [
+    saver,
+    root,
+    tabs,
+    expanded,
+    showHidden,
+    sideWidth,
+    terminalOpen,
+    terminalDock,
+    terminalActive,
+    terminalBottomSize,
+    terminalRightSize,
+    terminalWorkspace,
+  ])
 
   // ── open/close/pin actions ──
-  const previewFile = useCallback((relPath: string) => {
-    setContextDiff(null)
-    if (!confirmDiscardReviewEdits()) return
-    diffRequestRef.current += 1
-    setDiff(null)
-    setTabs((s) => openPreview(s, relPath))
-  }, [confirmDiscardReviewEdits])
+  const previewFile = useCallback(
+    (relPath: string) => {
+      setContextDiff(null)
+      if (!confirmDiscardReviewEdits()) return
+      setTerminalActive(false)
+      diffRequestRef.current += 1
+      setDiff(null)
+      setTabs((s) => openPreview(s, relPath))
+    },
+    [confirmDiscardReviewEdits],
+  )
 
   const activateFile = useCallback(
     (relPath: string) => {
@@ -1346,6 +1602,7 @@ export function ShellExplorerPage({
         return
       }
       if (!confirmDiscardReviewEdits()) return
+      setTerminalActive(false)
       diffRequestRef.current += 1
       setContextDiff(null)
       setDiff(null)
@@ -1380,7 +1637,10 @@ export function ShellExplorerPage({
         setTabs((s) => closeTab(s, relPath))
         return
       }
-      if (dirtyPaths.has(relPath) && !window.confirm(`discard unsaved changes to ${relPath}?`)) {
+      if (
+        dirtyPaths.has(relPath) &&
+        !window.confirm(`discard unsaved changes to ${relPath}?`)
+      ) {
         return
       }
       cacheRef.current.delete(relPath)
@@ -1420,119 +1680,132 @@ export function ShellExplorerPage({
       if (!drag) return
       const delta = e.clientX - drag.startX
       // A right-hugging sidebar widens as the handle moves LEFT.
-      setSideWidth(clampSidebarWidth(panelSide === 'right' ? drag.startWidth - delta : drag.startWidth + delta))
+      setSideWidth(
+        clampSidebarWidth(
+          panelSide === 'right'
+            ? drag.startWidth - delta
+            : drag.startWidth + delta,
+        ),
+      )
     },
     [panelSide],
   )
-  const onHandlePointerUp = useCallback((e: React.PointerEvent<HTMLButtonElement>) => {
-    dragRef.current = null
-    try {
-      e.currentTarget.releasePointerCapture(e.pointerId)
-    } catch {
-      // never captured — nothing to release
-    }
-  }, [])
+  const onHandlePointerUp = useCallback(
+    (e: React.PointerEvent<HTMLButtonElement>) => {
+      dragRef.current = null
+      try {
+        e.currentTarget.releasePointerCapture(e.pointerId)
+      } catch {
+        // never captured — nothing to release
+      }
+    },
+    [],
+  )
 
-  const changeRoot = useCallback((
-    nextRoot: string,
-    onResolved?: (outcome: RootChangeOutcome, path?: string) => void,
-  ): boolean => {
-    if (!reviewSaveBarrier.canTransition()) return false
-    const resolveSeq = ++rootResolveSeqRef.current
-    void validateRootTarget(
-      () => workspaceValidate(host, nextRoot),
-      () => rootResolveSeqRef.current === resolveSeq,
-    ).then((result) => {
-      if (result.outcome !== 'validated') {
-        onResolved?.(result.outcome)
-        if (result.outcome === 'failed') {
-          setRootChangeSettledEpoch((epoch) => epoch + 1)
+  const changeRoot = useCallback(
+    (
+      nextRoot: string,
+      onResolved?: (outcome: RootChangeOutcome, path?: string) => void,
+    ): boolean => {
+      if (!reviewSaveBarrier.canTransition()) return false
+      const resolveSeq = ++rootResolveSeqRef.current
+      void validateRootTarget(
+        () => workspaceValidate(host, nextRoot),
+        () => rootResolveSeqRef.current === resolveSeq,
+      ).then((result) => {
+        if (result.outcome !== 'validated') {
+          onResolved?.(result.outcome)
+          if (result.outcome === 'failed') {
+            setRootChangeSettledEpoch((epoch) => epoch + 1)
+          }
+          return
         }
-        return
-      }
-      if (result.path === rootRef.current) {
-        refreshTree()
-        void refreshGit()
-        onResolved?.('validated', result.path)
-        setRootChangeSettledEpoch((epoch) => epoch + 1)
-        return
-      }
-      // Validation can take long enough for a draft or save to begin. Confirm
-      // at commit time so the validated transition cannot discard newer work.
-      if (!confirmDiscardAllEdits()) {
-        onResolved?.('declined')
-        setRootChangeSettledEpoch((epoch) => epoch + 1)
-        return
-      }
-      if (rootResolveSeqRef.current !== resolveSeq) {
-        onResolved?.('superseded')
-        return
-      }
+        if (result.path === rootRef.current) {
+          refreshTree()
+          void refreshGit()
+          onResolved?.('validated', result.path)
+          setRootChangeSettledEpoch((epoch) => epoch + 1)
+          return
+        }
+        // Validation can take long enough for a draft or save to begin. Confirm
+        // at commit time so the validated transition cannot discard newer work.
+        if (!confirmDiscardAllEdits()) {
+          onResolved?.('declined')
+          setRootChangeSettledEpoch((epoch) => epoch + 1)
+          return
+        }
+        if (rootResolveSeqRef.current !== resolveSeq) {
+          onResolved?.('superseded')
+          return
+        }
 
-      const path = result.path
-      rootTransitionRef.current = true
-      rootGenerationRef.current += 1
-      reviewEpochRef.current += 1
-      scopeMetadataSeqRef.current += 1
-      treeSeqRef.current += 1
-      gitSeqRef.current += 1
-      diffRequestRef.current += 1
-      if (liveTimerRef.current !== null) window.clearTimeout(liveTimerRef.current)
-      liveTimerRef.current = null
-      followRef.current = null
-      changedAbsRef.current = new Map()
-      reviewEligibleAbsRef.current = new Set()
-      changedDirsRef.current = new Set()
-      subtreeLoadRef.current.clear()
-      baselineRef.current.clear()
-      baselineKindsRef.current = new Map()
-      baselineCompleteRef.current = false
-      baselineCapturedRef.current = false
-      baselineReadyRef.current = Promise.resolve()
-      preparedTurnRef.current = null
-      reviewEntriesRef.current = new Map()
-      reviewEditBackupsRef.current.clear()
-      cacheRef.current.clear()
-      setDirtyPaths(new Set())
-      setTabs(EMPTY_TABS)
-      setExpanded([])
-      setDiff(null)
-      setContextDiff(null)
-      setReviewEntries(new Map())
-      scopeEntriesRef.current = new Map()
-      setScopeEntries(new Map())
-      setReviewSummary([])
-      setScopeSummary([])
-      setScopeCommits([])
-      setScopeRefs([])
-      setScopeMetadataLoading(false)
-      setScopeMetadataError(null)
-      forceLastTurnScope()
-      setTree(null)
-      setGit(null)
-      setSubtrees(new Map())
-      if (path === rootRef.current) {
-        rootTransitionRef.current = false
-        refreshTree()
-        void refreshGit()
-      } else {
-        // Keep event filtering coherent until React renders the new root.
-        rootRef.current = path
-        setRoot(path)
-        rootTransitionRef.current = false
-      }
-      onResolved?.('validated', path)
-      setRootChangeSettledEpoch((epoch) => epoch + 1)
-    })
-    return true
-  }, [
-    confirmDiscardAllEdits,
-    forceLastTurnScope,
-    host,
-    refreshGit,
-    refreshTree,
-    reviewSaveBarrier,
-  ])
+        const path = result.path
+        rootTransitionRef.current = true
+        rootGenerationRef.current += 1
+        reviewEpochRef.current += 1
+        scopeMetadataSeqRef.current += 1
+        treeSeqRef.current += 1
+        gitSeqRef.current += 1
+        diffRequestRef.current += 1
+        if (liveTimerRef.current !== null)
+          window.clearTimeout(liveTimerRef.current)
+        liveTimerRef.current = null
+        followRef.current = null
+        changedAbsRef.current = new Map()
+        reviewEligibleAbsRef.current = new Set()
+        changedDirsRef.current = new Set()
+        subtreeLoadRef.current.clear()
+        baselineRef.current.clear()
+        baselineKindsRef.current = new Map()
+        baselineCompleteRef.current = false
+        baselineCapturedRef.current = false
+        baselineReadyRef.current = Promise.resolve()
+        preparedTurnRef.current = null
+        reviewEntriesRef.current = new Map()
+        reviewEditBackupsRef.current.clear()
+        cacheRef.current.clear()
+        setDirtyPaths(new Set())
+        setTabs(EMPTY_TABS)
+        setExpanded([])
+        setDiff(null)
+        setContextDiff(null)
+        setReviewEntries(new Map())
+        scopeEntriesRef.current = new Map()
+        setScopeEntries(new Map())
+        setReviewSummary([])
+        setScopeSummary([])
+        setScopeCommits([])
+        setScopeRefs([])
+        setScopeMetadataLoading(false)
+        setScopeMetadataError(null)
+        forceLastTurnScope()
+        setTree(null)
+        setGit(null)
+        setSubtrees(new Map())
+        if (path === rootRef.current) {
+          rootTransitionRef.current = false
+          refreshTree()
+          void refreshGit()
+        } else {
+          // Keep event filtering coherent until React renders the new root.
+          rootRef.current = path
+          setRoot(path)
+          rootTransitionRef.current = false
+        }
+        onResolved?.('validated', path)
+        setRootChangeSettledEpoch((epoch) => epoch + 1)
+      })
+      return true
+    },
+    [
+      confirmDiscardAllEdits,
+      forceLastTurnScope,
+      host,
+      refreshGit,
+      refreshTree,
+      reviewSaveBarrier,
+    ],
+  )
 
   // ── follow the chat's working directory ──
   // Picking another folder in chat re-roots the explorer (the split-screen
@@ -1573,12 +1846,13 @@ export function ShellExplorerPage({
       if (workingDirFollowPendingRef.current?.request !== request) return
       workingDirFollowPendingRef.current = null
       if (outcome === 'validated') {
-        acknowledgedWorkingDirRef.current = acknowledgeValidatedWorkingDirectory(
-          acknowledgedWorkingDirRef.current,
-          next,
-          workingDirRef.current,
-          true,
-        )
+        acknowledgedWorkingDirRef.current =
+          acknowledgeValidatedWorkingDirectory(
+            acknowledgedWorkingDirRef.current,
+            next,
+            workingDirRef.current,
+            true,
+          )
         workingDirRetryRef.current = { path: next, failures: 0 }
         setWorkingDirError(null)
       } else if (outcome === 'failed' && workingDirRef.current === next) {
@@ -1596,9 +1870,7 @@ export function ShellExplorerPage({
           )
         }
       } else if (outcome === 'declined' && workingDirRef.current === next) {
-        setWorkingDirError(
-          workingDirectoryRetryMessage(next, 'declined', null),
-        )
+        setWorkingDirError(workingDirectoryRetryMessage(next, 'declined', null))
       }
     })
     if (!accepted && workingDirFollowPendingRef.current?.request === request) {
@@ -1615,36 +1887,40 @@ export function ShellExplorerPage({
     [],
   )
 
-  const changeManualRoot = useCallback((nextRoot: string) => {
-    const chatDir = workingDirRef.current
-    // Suppress both a scheduled retry and an in-flight chat result before the
-    // manual validation starts. changeRoot's new sequence supersedes the latter.
-    const request = ++manualRootRequestSeqRef.current
-    manualRootActiveRequestRef.current = request
-    workingDirFollowPendingRef.current = null
-    setWorkingDirError(null)
-    if (workingDirRetryTimerRef.current !== null) {
-      window.clearTimeout(workingDirRetryTimerRef.current)
-      workingDirRetryTimerRef.current = null
-    }
-    const accepted = changeRoot(nextRoot, (outcome) => {
-      if (!ownsRequestToken(manualRootActiveRequestRef.current, request)) return
-      manualRootActiveRequestRef.current = null
-      if (outcome === 'validated' && workingDirRef.current === chatDir) {
-        acknowledgedWorkingDirRef.current = chatDir
-        workingDirRetryRef.current = { path: chatDir, failures: 0 }
-      } else {
-        // Validation failure or a declined discard releases the unchanged chat
-        // directory to follow again.
+  const changeManualRoot = useCallback(
+    (nextRoot: string) => {
+      const chatDir = workingDirRef.current
+      // Suppress both a scheduled retry and an in-flight chat result before the
+      // manual validation starts. changeRoot's new sequence supersedes the latter.
+      const request = ++manualRootRequestSeqRef.current
+      manualRootActiveRequestRef.current = request
+      workingDirFollowPendingRef.current = null
+      setWorkingDirError(null)
+      if (workingDirRetryTimerRef.current !== null) {
+        window.clearTimeout(workingDirRetryTimerRef.current)
+        workingDirRetryTimerRef.current = null
+      }
+      const accepted = changeRoot(nextRoot, (outcome) => {
+        if (!ownsRequestToken(manualRootActiveRequestRef.current, request))
+          return
+        manualRootActiveRequestRef.current = null
+        if (outcome === 'validated' && workingDirRef.current === chatDir) {
+          acknowledgedWorkingDirRef.current = chatDir
+          workingDirRetryRef.current = { path: chatDir, failures: 0 }
+        } else {
+          // Validation failure or a declined discard releases the unchanged chat
+          // directory to follow again.
+          setWorkingDirRetryEpoch((epoch) => epoch + 1)
+        }
+      })
+      if (accepted) return
+      if (ownsRequestToken(manualRootActiveRequestRef.current, request)) {
+        manualRootActiveRequestRef.current = null
         setWorkingDirRetryEpoch((epoch) => epoch + 1)
       }
-    })
-    if (accepted) return
-    if (ownsRequestToken(manualRootActiveRequestRef.current, request)) {
-      manualRootActiveRequestRef.current = null
-      setWorkingDirRetryEpoch((epoch) => epoch + 1)
-    }
-  }, [changeRoot])
+    },
+    [changeRoot],
+  )
 
   // ── deep link: #/ext/shell/open/<encoded-abs>[:line] ──
   // The chat's "open in shell" lands here. The request is captured (and
@@ -1674,7 +1950,10 @@ export function ShellExplorerPage({
       )
       const raw = m[1]
       const colon = raw.lastIndexOf(':')
-      const encoded = colon !== -1 && /^\d+$/.test(raw.slice(colon + 1)) ? raw.slice(0, colon) : raw
+      const encoded =
+        colon !== -1 && /^\d+$/.test(raw.slice(colon + 1))
+          ? raw.slice(0, colon)
+          : raw
       let abs: string
       try {
         abs = decodeURIComponent(encoded)
@@ -1758,7 +2037,8 @@ export function ShellExplorerPage({
           if (delay !== null && pendingOpenRetryTimerRef.current === null) {
             pendingOpenWaitingForRetryRef.current = true
             pendingOpenRetryTimerRef.current = window.setTimeout(() => {
-              if (pendingOpenCaptureSeqRef.current !== requestToken.scope) return
+              if (pendingOpenCaptureSeqRef.current !== requestToken.scope)
+                return
               pendingOpenRetryTimerRef.current = null
               pendingOpenWaitingForRetryRef.current = false
               setOpenBump((bump) => bump + 1)
@@ -1805,6 +2085,7 @@ export function ShellExplorerPage({
   const openContextFile = useCallback(
     (path: string): boolean => {
       if (!reviewSaveBarrier.canTransition() || root === null) return false
+      setTerminalActive(false)
       setContextDiff(null)
       setSideTab('files')
       setCollapsed(false)
@@ -1851,6 +2132,7 @@ export function ShellExplorerPage({
     }
     if (!confirmDiscardReviewEdits()) return
     appliedContextRef.current = panelContext.id
+    setTerminalActive(false)
     setDiff(null)
     setContextDiff({
       eventId: panelContext.id,
@@ -1865,7 +2147,10 @@ export function ShellExplorerPage({
   }, [refreshGit])
 
   const treeGitStatus = useMemo<readonly GitStatusEntry[]>(() => {
-    return reviewChanges.map((change) => ({ path: change.path, status: change.status }))
+    return reviewChanges.map((change) => ({
+      path: change.path,
+      status: change.status,
+    }))
   }, [reviewChanges])
 
   // Chat-synced roots can be subfolders of a base path — surface the
@@ -1873,11 +2158,38 @@ export function ShellExplorerPage({
   // options don't contain (and the user can always pop back to a base).
   const rootOptions = useMemo(() => {
     if (!info || !root) return []
-    return info.base_paths.includes(root) ? info.base_paths : [root, ...info.base_paths]
+    return info.base_paths.includes(root)
+      ? info.base_paths
+      : [root, ...info.base_paths]
   }, [info, root])
+
+  const changeTerminalDock = useCallback((next: TerminalDock) => {
+    setTerminalOpen(true)
+    setTerminalDock(next)
+    setTerminalActive(next === 'editor')
+  }, [])
+
+  const closeTerminal = useCallback(() => {
+    setTerminalOpen(false)
+    setTerminalActive(false)
+  }, [])
+
+  const toggleTerminal = useCallback(() => {
+    if (!terminalOpen) {
+      setTerminalOpen(true)
+      setTerminalActive(terminalDock === 'editor')
+      return
+    }
+    if (terminalDock === 'editor' && !terminalActive) {
+      setTerminalActive(true)
+      return
+    }
+    closeTerminal()
+  }, [closeTerminal, terminalActive, terminalDock, terminalOpen])
 
   const header = (
     <PageHeader
+      className="shui-page-header"
       icon={<SquareTerminal />}
       title="shell"
       description={
@@ -1906,45 +2218,78 @@ export function ShellExplorerPage({
         info && root ? (
           <div className="shui-page-actions">
             {SIDE_TABS.map(({ id, label, Icon }) => (
-              <button
-                key={id}
-                type="button"
-                className={`shui-side-tab${sideTab === id ? ' active' : ''}`}
-                onClick={() => {
-                  setSideTab(id)
-                  setCollapsed(false)
-                }}
-                aria-label={label}
-                title={label}
-              >
-                <Icon aria-hidden className="shui-side-tab-icon" />
-              </button>
+              <HoverTip key={id} label={label}>
+                <button
+                  type="button"
+                  className={`shui-side-tab${sideTab === id ? ' active' : ''}`}
+                  onClick={() => {
+                    setSideTab(id)
+                    setCollapsed(false)
+                  }}
+                  aria-label={label}
+                >
+                  <Icon aria-hidden className="shui-side-tab-icon" />
+                </button>
+              </HoverTip>
             ))}
             {sideTab === 'files' && !collapsed ? (
+              <HoverTip
+                label={
+                  showHidden
+                    ? 'Hide hidden files (dotfiles)'
+                    : 'Show hidden files (dotfiles)'
+                }
+              >
+                <button
+                  type="button"
+                  className={`shui-side-tab${showHidden ? ' active' : ''}`}
+                  onClick={() => setShowHidden((value) => !value)}
+                  aria-pressed={showHidden}
+                  aria-label={
+                    showHidden ? 'Hide hidden files' : 'Show hidden files'
+                  }
+                >
+                  {showHidden ? (
+                    <Eye aria-hidden className="shui-side-tab-icon" />
+                  ) : (
+                    <EyeOff aria-hidden className="shui-side-tab-icon" />
+                  )}
+                </button>
+              </HoverTip>
+            ) : null}
+            <HoverTip
+              label={terminalOpen ? 'Hide terminal' : 'Open terminal (zsh)'}
+            >
               <button
                 type="button"
-                className={`shui-side-tab${showHidden ? ' active' : ''}`}
-                onClick={() => setShowHidden((value) => !value)}
-                aria-pressed={showHidden}
-                aria-label={showHidden ? 'hide hidden files' : 'show hidden files'}
-                title={showHidden ? 'hide hidden files' : 'show hidden files'}
+                className={`shui-side-tab${terminalOpen ? ' active' : ''}`}
+                onClick={toggleTerminal}
+                aria-pressed={terminalOpen}
+                aria-label={terminalOpen ? 'Hide terminal' : 'Open terminal'}
               >
-                {showHidden ? (
-                  <Eye aria-hidden className="shui-side-tab-icon" />
+                <Terminal aria-hidden className="shui-side-tab-icon" />
+              </button>
+            </HoverTip>
+            <HoverTip
+              label={
+                collapsed ? 'Show the file sidebar' : 'Hide the file sidebar'
+              }
+            >
+              <button
+                type="button"
+                className="shui-collapse-btn"
+                onClick={() => setCollapsed((value) => !value)}
+                aria-label={
+                  collapsed ? 'Show file sidebar' : 'Hide file sidebar'
+                }
+              >
+                {panelSide === 'right' ? (
+                  <PanelRight aria-hidden className="shui-side-tab-icon" />
                 ) : (
-                  <EyeOff aria-hidden className="shui-side-tab-icon" />
+                  <PanelLeft aria-hidden className="shui-side-tab-icon" />
                 )}
               </button>
-            ) : null}
-            <button
-              type="button"
-              className="shui-collapse-btn"
-              onClick={() => setCollapsed((value) => !value)}
-              aria-label={collapsed ? 'show explorer' : 'hide explorer'}
-              title={collapsed ? 'show explorer' : 'hide explorer'}
-            >
-              {panelSide === 'right' ? (collapsed ? '‹' : '›') : collapsed ? '›' : '‹'}
-            </button>
+            </HoverTip>
           </div>
         ) : undefined
       }
@@ -1963,7 +2308,8 @@ export function ShellExplorerPage({
       <PageShell>
         {header}
         <div className="shui-side-note warn pad">
-          shell explorer needs the worker's coder surface — coder::info failed: {infoError}
+          shell explorer needs the worker's coder surface — coder::info failed:{' '}
+          {infoError}
         </div>
       </PageShell>
     )
@@ -1980,55 +2326,62 @@ export function ShellExplorerPage({
   return (
     <PageShell>
       {header}
-      <PageBody side={panelSide}>
-        {!collapsed ? (
-          <PageSidebar width={sideWidth} className="shui-sidebar">
-            <button
-              type="button"
-              className={`shui-resize-handle ${panelSide === 'right' ? 'left' : 'right'}`}
-              onPointerDown={onHandlePointerDown}
-              onPointerMove={onHandlePointerMove}
-              onPointerUp={onHandlePointerUp}
-              onPointerCancel={onHandlePointerUp}
-              onLostPointerCapture={onHandlePointerUp}
-              onKeyDown={(event) => {
-                if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return
-                event.preventDefault()
-                const inward = panelSide === 'right' ? 'ArrowLeft' : 'ArrowRight'
-                setSideWidth((width) => clampSidebarWidth(width + (event.key === inward ? 10 : -10)))
-              }}
-              aria-label="resize sidebar"
-              title="drag to resize"
-            />
-            <div className="shui-side-body">
-              {sideTab === 'files' ? (
-                <FilesTab
-                  tree={reviewTree}
-                  gitStatus={treeGitStatus}
-                  theme={theme}
-                  hiddenFiltered={!showHidden}
-                  expanded={expanded}
-                  onExpandedChange={setExpanded}
-                  reveal={reveal}
-                  onRevealed={onRevealed}
-                  activePath={diff?.change.path ?? tabs.active}
-                  onActivateFile={activateFile}
-                  onPinFile={pinFile}
-                />
-              ) : (
-                <SearchTab
-                  host={host}
-                  root={root}
-                  onPreviewFile={previewFile}
-                  onPinFile={pinFile}
-                  onRevealFolder={revealFolder}
-                />
-              )}
-            </div>
-          </PageSidebar>
-        ) : null}
+      <div className={`shui-workspace-frame terminal-${terminalDock}`}>
+        <PageBody side={panelSide}>
+          {!collapsed ? (
+            <PageSidebar width={sideWidth} className="shui-sidebar">
+              <button
+                type="button"
+                className={`shui-resize-handle ${panelSide === 'right' ? 'left' : 'right'}`}
+                onPointerDown={onHandlePointerDown}
+                onPointerMove={onHandlePointerMove}
+                onPointerUp={onHandlePointerUp}
+                onPointerCancel={onHandlePointerUp}
+                onLostPointerCapture={onHandlePointerUp}
+                onKeyDown={(event) => {
+                  if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight')
+                    return
+                  event.preventDefault()
+                  const inward =
+                    panelSide === 'right' ? 'ArrowLeft' : 'ArrowRight'
+                  setSideWidth((width) =>
+                    clampSidebarWidth(
+                      width + (event.key === inward ? 10 : -10),
+                    ),
+                  )
+                }}
+                aria-label="resize sidebar"
+                title="drag to resize"
+              />
+              <div className="shui-side-body">
+                {sideTab === 'files' ? (
+                  <FilesTab
+                    tree={reviewTree}
+                    gitStatus={treeGitStatus}
+                    theme={theme}
+                    hiddenFiltered={!showHidden}
+                    expanded={expanded}
+                    onExpandedChange={setExpanded}
+                    reveal={reveal}
+                    onRevealed={onRevealed}
+                    activePath={diff?.change.path ?? tabs.active}
+                    onActivateFile={activateFile}
+                    onPinFile={pinFile}
+                  />
+                ) : (
+                  <SearchTab
+                    host={host}
+                    root={root}
+                    onPreviewFile={previewFile}
+                    onPinFile={pinFile}
+                    onRevealFolder={revealFolder}
+                  />
+                )}
+              </div>
+            </PageSidebar>
+          ) : null}
 
-        <PageMain>
+          <PageMain>
             {workingDirError ? (
               <div className="shui-review-message warn" role="alert">
                 <span>{workingDirError}</span>
@@ -2068,254 +2421,386 @@ export function ShellExplorerPage({
                 </button>
               </div>
             ) : null}
-            <div className="shui-review-toolbar">
-              {reviewSavePending ? (
-                <span
-                  className="shui-review-count"
-                  role="status"
-                  aria-live="polite"
-                >
-                  saving {reviewSavingPaths.size === 1 ? 'review file' : `${reviewSavingPaths.size} review files`}… navigation paused
-                </span>
-              ) : null}
-              <ReviewScopePicker
-                value={reviewScope}
-                commits={scopeCommits}
-                branches={scopeRefs.map((ref) => ({
-                  ref: ref.fullName,
-                  name: ref.name,
-                  current: ref.current,
-                }))}
-                metadataLoading={scopeMetadataLoading}
-                metadataError={scopeMetadataError}
-                onOpen={loadScopeMetadata}
-                onChange={selectReviewScope}
-              />
-              <span className="shui-review-count">
-                {scopeLoading
-                  ? 'loading…'
-                  : `${orderedReviewEntries.length} ${orderedReviewEntries.length === 1 ? 'file' : 'files'}`}
-              </span>
-              {scopeError ? (
-                <span className="shui-review-scope-error" title={scopeError}>unavailable</span>
-              ) : null}
-              {reviewTotals.ready > 0 ? (
-                <>
-                  <span className="shui-review-total add">+{reviewTotals.add}</span>
-                  <span className="shui-review-total del">−{reviewTotals.del}</span>
-                </>
-              ) : null}
-              {reviewTotals.pending > 0 || reviewTotals.unavailable > 0 ? (
-                <span
-                  className="shui-review-total"
-                  title={`${reviewTotals.pending} pending, ${reviewTotals.unavailable} unavailable`}
-                  aria-label={`${reviewTotals.pending} change totals pending, ${reviewTotals.unavailable} unavailable`}
-                >
-                  …
-                </span>
-              ) : null}
-              <span className="spacer" />
-              <button
-                type="button"
-                className="shui-review-action"
-                onClick={() => {
-                  refreshTree()
-                  void refreshGit()
-                  if (reviewScope.kind === 'last-turn') {
-                    setReviewRefreshEpoch((value) => value + 1)
-                  } else {
-                    loadReviewScope(reviewScope)
-                  }
-                }}
-                aria-label="refresh review"
-                title="refresh"
-              >
-                <RefreshCw aria-hidden />
-              </button>
-              <button
-                type="button"
-                className="shui-review-action"
-                onClick={() => setReviewExpandEpoch((value) => value + 1)}
-                aria-label="expand all diffs"
-                title="expand all diffs"
-              >
-                <ChevronsUpDown aria-hidden />
-              </button>
-              <button
-                type="button"
-                className="shui-review-action"
-                onClick={() => setReviewCollapseEpoch((value) => value + 1)}
-                aria-label="collapse all diffs"
-                title="collapse all diffs"
-              >
-                <ChevronsDownUp aria-hidden />
-              </button>
-              <button
-                type="button"
-                className="shui-review-action"
-                onClick={() =>
-                  setReviewOptions((previous) => ({
-                    ...previous,
-                    diffStyle: previous.diffStyle === 'unified' ? 'split' : 'unified',
-                  }))
-                }
-                aria-label={`switch to ${reviewOptions.diffStyle === 'unified' ? 'split' : 'unified'} diff`}
-                title={`switch to ${reviewOptions.diffStyle === 'unified' ? 'split' : 'unified'} diff`}
-              >
-                {reviewOptions.diffStyle === 'unified' ? <Columns2 aria-hidden /> : <Rows3 aria-hidden />}
-              </button>
-              <div className="shui-review-menu-wrap">
-                <button
-                  type="button"
-                  className={`shui-review-action${reviewMenuOpen ? ' active' : ''}`}
-                  onClick={() => setReviewMenuOpen((value) => !value)}
-                  aria-expanded={reviewMenuOpen}
-                  aria-label="review options"
-                  title="review options"
-                >
-                  <MoreHorizontal aria-hidden />
-                </button>
-                {reviewMenuOpen ? (
-                  <div className="shui-review-menu" role="menu">
-                    <ReviewOption
-                      label="Enable word wrap"
-                      checked={reviewOptions.wordWrap}
-                      onChange={(wordWrap) => setReviewOptions((value) => ({ ...value, wordWrap }))}
-                    />
-                    <ReviewOption
-                      label="Enable word diffs"
-                      checked={reviewOptions.wordDiffs}
-                      onChange={(wordDiffs) => setReviewOptions((value) => ({ ...value, wordDiffs }))}
-                    />
-                    <ReviewOption
-                      label="Hide whitespace"
-                      checked={reviewOptions.hideWhitespace}
-                      onChange={(hideWhitespace) =>
-                        setReviewOptions((value) => ({ ...value, hideWhitespace }))
-                      }
-                    />
-                    <ReviewOption
-                      label="Load full files"
-                      checked={reviewOptions.expandUnchanged}
-                      onChange={(expandUnchanged) =>
-                        setReviewOptions((value) => ({ ...value, expandUnchanged }))
-                      }
-                    />
-                    <ReviewOption
-                      label="Enable rich preview"
-                      checked={reviewOptions.richPreview}
-                      onChange={(richPreview) =>
-                        setReviewOptions((value) => ({ ...value, richPreview }))
-                      }
-                    />
-                  </div>
+            {!(terminalOpen && terminalDock === 'editor' && terminalActive) ? (
+              <div className="shui-review-toolbar">
+                {reviewSavePending ? (
+                  <span
+                    className="shui-review-count"
+                    role="status"
+                    aria-live="polite"
+                  >
+                    saving{' '}
+                    {reviewSavingPaths.size === 1
+                      ? 'review file'
+                      : `${reviewSavingPaths.size} review files`}
+                    … navigation paused
+                  </span>
                 ) : null}
+                <ReviewScopePicker
+                  value={reviewScope}
+                  commits={scopeCommits}
+                  branches={scopeRefs.map((ref) => ({
+                    ref: ref.fullName,
+                    name: ref.name,
+                    current: ref.current,
+                  }))}
+                  metadataLoading={scopeMetadataLoading}
+                  metadataError={scopeMetadataError}
+                  onOpen={loadScopeMetadata}
+                  onChange={selectReviewScope}
+                />
+                <span className="shui-review-count">
+                  {scopeLoading
+                    ? 'loading…'
+                    : `${orderedReviewEntries.length} ${orderedReviewEntries.length === 1 ? 'file' : 'files'}`}
+                </span>
+                {scopeError ? (
+                  <span className="shui-review-scope-error" title={scopeError}>
+                    unavailable
+                  </span>
+                ) : null}
+                {reviewTotals.ready > 0 ? (
+                  <>
+                    <span className="shui-review-total add">
+                      +{reviewTotals.add}
+                    </span>
+                    <span className="shui-review-total del">
+                      −{reviewTotals.del}
+                    </span>
+                  </>
+                ) : null}
+                {reviewTotals.pending > 0 || reviewTotals.unavailable > 0 ? (
+                  <span
+                    className="shui-review-total"
+                    role="status"
+                    title={`${reviewTotals.pending} pending, ${reviewTotals.unavailable} unavailable`}
+                    aria-label={`${reviewTotals.pending} change totals pending, ${reviewTotals.unavailable} unavailable`}
+                  >
+                    …
+                  </span>
+                ) : null}
+                <span className="spacer" />
+                <HoverTip label="Reload this review">
+                  <button
+                    type="button"
+                    className="shui-review-action"
+                    onClick={() => {
+                      refreshTree()
+                      void refreshGit()
+                      if (reviewScope.kind === 'last-turn') {
+                        setReviewRefreshEpoch((value) => value + 1)
+                      } else {
+                        loadReviewScope(reviewScope)
+                      }
+                    }}
+                    aria-label="Reload this review"
+                  >
+                    <RefreshCw aria-hidden />
+                  </button>
+                </HoverTip>
+                <HoverTip label="Expand all diffs">
+                  <button
+                    type="button"
+                    className="shui-review-action"
+                    onClick={() => setReviewExpandEpoch((value) => value + 1)}
+                    aria-label="Expand all diffs"
+                  >
+                    <ChevronsUpDown aria-hidden />
+                  </button>
+                </HoverTip>
+                <HoverTip label="Collapse all diffs">
+                  <button
+                    type="button"
+                    className="shui-review-action"
+                    onClick={() => setReviewCollapseEpoch((value) => value + 1)}
+                    aria-label="Collapse all diffs"
+                  >
+                    <ChevronsDownUp aria-hidden />
+                  </button>
+                </HoverTip>
+                <HoverTip
+                  label={
+                    reviewOptions.diffStyle === 'unified'
+                      ? 'Show split diff (side by side)'
+                      : 'Show unified diff (one column)'
+                  }
+                >
+                  <button
+                    type="button"
+                    className="shui-review-action"
+                    onClick={() =>
+                      setReviewOptions((previous) => ({
+                        ...previous,
+                        diffStyle:
+                          previous.diffStyle === 'unified'
+                            ? 'split'
+                            : 'unified',
+                      }))
+                    }
+                    aria-label={
+                      reviewOptions.diffStyle === 'unified'
+                        ? 'Show split diff'
+                        : 'Show unified diff'
+                    }
+                  >
+                    {reviewOptions.diffStyle === 'unified' ? (
+                      <Columns2 aria-hidden />
+                    ) : (
+                      <Rows3 aria-hidden />
+                    )}
+                  </button>
+                </HoverTip>
+                <div className="shui-review-menu-wrap">
+                  <HoverTip label="Diff display options">
+                    <button
+                      type="button"
+                      className={`shui-review-action${reviewMenuOpen ? ' active' : ''}`}
+                      onClick={() => setReviewMenuOpen((value) => !value)}
+                      aria-expanded={reviewMenuOpen}
+                      aria-label="Diff display options"
+                    >
+                      <MoreHorizontal aria-hidden />
+                    </button>
+                  </HoverTip>
+                  {reviewMenuOpen ? (
+                    <div className="shui-review-menu" role="menu">
+                      <ReviewOption
+                        label="Enable word wrap"
+                        checked={reviewOptions.wordWrap}
+                        onChange={(wordWrap) =>
+                          setReviewOptions((value) => ({ ...value, wordWrap }))
+                        }
+                      />
+                      <ReviewOption
+                        label="Enable word diffs"
+                        checked={reviewOptions.wordDiffs}
+                        onChange={(wordDiffs) =>
+                          setReviewOptions((value) => ({ ...value, wordDiffs }))
+                        }
+                      />
+                      <ReviewOption
+                        label="Hide whitespace"
+                        checked={reviewOptions.hideWhitespace}
+                        onChange={(hideWhitespace) =>
+                          setReviewOptions((value) => ({
+                            ...value,
+                            hideWhitespace,
+                          }))
+                        }
+                      />
+                      <ReviewOption
+                        label="Load full files"
+                        checked={reviewOptions.expandUnchanged}
+                        onChange={(expandUnchanged) =>
+                          setReviewOptions((value) => ({
+                            ...value,
+                            expandUnchanged,
+                          }))
+                        }
+                      />
+                      <ReviewOption
+                        label="Enable rich preview"
+                        checked={reviewOptions.richPreview}
+                        onChange={(richPreview) =>
+                          setReviewOptions((value) => ({
+                            ...value,
+                            richPreview,
+                          }))
+                        }
+                      />
+                    </div>
+                  ) : null}
+                </div>
               </div>
-            </div>
-          {diff === null && tabs.tabs.length > 0 ? (
-            <div className="shui-editor-tabs" role="tablist">
-              {tabs.tabs.map((tab) => {
-                const active =
-                  diff === null &&
-                  contextDiff === null &&
-                  tab.path === tabs.active
-                return (
-                  <div key={tab.path} className={`shui-etab${active ? ' active' : ''}${tab.pinned ? '' : ' preview'}`}>
+            ) : null}
+            {(diff === null && tabs.tabs.length > 0) ||
+            (terminalOpen && terminalDock === 'editor') ? (
+              <div className="shui-editor-tabs" role="tablist">
+                {tabs.tabs.map((tab) => {
+                  const active =
+                    !terminalActive &&
+                    diff === null &&
+                    contextDiff === null &&
+                    tab.path === tabs.active
+                  return (
+                    <div
+                      key={tab.path}
+                      className={`shui-etab${active ? ' active' : ''}${tab.pinned ? '' : ' preview'}`}
+                    >
+                      <button
+                        type="button"
+                        className="open"
+                        role="tab"
+                        aria-selected={active}
+                        title={tab.path}
+                        onClick={() =>
+                          runReviewTransition(reviewSaveBarrier, () => {
+                            setTerminalActive(false)
+                            diffRequestRef.current += 1
+                            setContextDiff(null)
+                            setDiff(null)
+                            setTabs((s) => activateTab(s, tab.path))
+                          })
+                        }
+                        onDoubleClick={() =>
+                          runReviewTransition(reviewSaveBarrier, () => {
+                            setTabs((s) => pinTab(s, tab.path))
+                          })
+                        }
+                      >
+                        {basename(tab.path)}
+                        {dirtyPaths.has(tab.path) ? (
+                          <span
+                            className="shui-dirty"
+                            title="unsaved changes"
+                          />
+                        ) : null}
+                      </button>
+                      <HoverTip label={`Close ${basename(tab.path)}`}>
+                        <button
+                          type="button"
+                          className="close"
+                          aria-label={`close ${basename(tab.path)}`}
+                          onClick={() => onCloseTab(tab.path)}
+                        >
+                          <X aria-hidden className="shui-x-icon" />
+                        </button>
+                      </HoverTip>
+                    </div>
+                  )
+                })}
+                {terminalOpen && terminalDock === 'editor' ? (
+                  <div
+                    className={`shui-etab${terminalActive ? ' active' : ''}`}
+                  >
                     <button
                       type="button"
                       className="open"
                       role="tab"
-                      aria-selected={active}
-                      title={tab.path}
-                      onClick={() =>
-                        runReviewTransition(reviewSaveBarrier, () => {
-                          diffRequestRef.current += 1
-                          setContextDiff(null)
-                          setDiff(null)
-                          setTabs((s) => activateTab(s, tab.path))
-                        })
-                      }
-                      onDoubleClick={() =>
-                        runReviewTransition(reviewSaveBarrier, () => {
-                          setTabs((s) => pinTab(s, tab.path))
-                        })
-                      }
+                      aria-selected={terminalActive}
+                      onClick={() => setTerminalActive(true)}
                     >
-                      {basename(tab.path)}
-                      {dirtyPaths.has(tab.path) ? <span className="shui-dirty" title="unsaved changes" /> : null}
+                      <Terminal aria-hidden className="shui-etab-icon" />
+                      {terminalWorkspace.tabs.find(
+                        (tab) => tab.id === terminalWorkspace.activeTabId,
+                      )?.title ?? 'zsh'}
                     </button>
-                    <button
-                      type="button"
-                      className="close"
-                      aria-label={`close ${basename(tab.path)}`}
-                      title="close"
-                      onClick={() => onCloseTab(tab.path)}
-                    >
-                      <X aria-hidden className="shui-x-icon" />
-                    </button>
+                    <HoverTip label="Close terminal">
+                      <button
+                        type="button"
+                        className="close"
+                        aria-label="Close terminal"
+                        onClick={closeTerminal}
+                      >
+                        <X aria-hidden className="shui-x-icon" />
+                      </button>
+                    </HoverTip>
                   </div>
-                )
-              })}
-            </div>
-          ) : null}
+                ) : null}
+              </div>
+            ) : null}
 
-          {contextDiff !== null ? (
-            <ChangeDiffPane
-              key={contextDiff.eventId}
-              host={host}
-              changeId={contextDiff.changeId}
-              path={contextDiff.path}
-              canViewFile={contextDiff.canViewFile}
-              onViewFile={openContextFile}
-            />
-          ) : diff !== null ? (
-            <ReviewPane
-              host={host}
-              root={root}
-              entries={orderedReviewEntries}
-              activePath={diff.change.path}
-              options={reviewOptions}
-              collapseEpoch={reviewCollapseEpoch}
-              expandEpoch={reviewExpandEpoch}
-              refreshEpoch={reviewRefreshEpoch}
-              onRequestEdit={onRequestReviewEdit}
-              onEditDraftChange={onReviewEditDraftChange}
-              onEditDirtyChange={onReviewEditDirtyChange}
-              onEditSavingChange={onReviewEditSavingChange}
-              onFileSaved={onReviewFileSaved}
-              onActivate={(path) => {
-                const entry = visibleReviewEntriesRef.current.get(path)
-                if (entry) openReviewEntry(entry)
-              }}
-              onSummaryChange={reviewScope.kind === 'last-turn' ? setReviewSummary : setScopeSummary}
-            />
-          ) : scopeLoading ? (
-            <div className="shui-main-empty">
-              <span className="t-ghost">loading review…</span>
-            </div>
-          ) : scopeError ? (
-            <div className="shui-main-empty">
-              <span className="t-warn">{scopeError}</span>
-            </div>
-          ) : tabs.active !== null ? (
-            <EditorPane
-              // fileBump remounts after an agent-side write to the active
-              // file: the pane rehydrates from the refreshed cache entry.
-              key={`${tabs.active}:${fileBump}`}
-              host={host}
-              root={root}
-              relPath={tabs.active}
-              cache={cacheRef.current}
-              onSaved={onSaved}
-              onDirtyChange={onDirtyChange}
-            />
-          ) : (
-            <div className="shui-main-empty">
-              <span className="t-ghost">select a file to edit or review</span>
-            </div>
-          )}
-        </PageMain>
-      </PageBody>
+            {terminalOpen && terminalDock === 'editor' && terminalActive ? (
+              <TerminalPanel
+                state={terminalWorkspace}
+                dispatch={dispatchTerminalWorkspace}
+                root={root}
+                visible
+                router={terminalRouter}
+                leaseStore={terminalLeaseStore}
+                storageKey={terminalStorageKey}
+                connectionCoordinators={terminalConnectionCoordinators}
+                dock={terminalDock}
+                size={terminalBottomSize}
+                onDockChange={changeTerminalDock}
+                onSizeChange={setTerminalBottomSize}
+                onClose={closeTerminal}
+              />
+            ) : contextDiff !== null ? (
+              <ChangeDiffPane
+                key={contextDiff.eventId}
+                host={host}
+                changeId={contextDiff.changeId}
+                path={contextDiff.path}
+                canViewFile={contextDiff.canViewFile}
+                onViewFile={openContextFile}
+              />
+            ) : diff !== null ? (
+              <ReviewPane
+                host={host}
+                root={root}
+                entries={orderedReviewEntries}
+                activePath={diff.change.path}
+                options={reviewOptions}
+                collapseEpoch={reviewCollapseEpoch}
+                expandEpoch={reviewExpandEpoch}
+                refreshEpoch={reviewRefreshEpoch}
+                onRequestEdit={onRequestReviewEdit}
+                onEditDraftChange={onReviewEditDraftChange}
+                onEditDirtyChange={onReviewEditDirtyChange}
+                onEditSavingChange={onReviewEditSavingChange}
+                onFileSaved={onReviewFileSaved}
+                onActivate={(path) => {
+                  const entry = visibleReviewEntriesRef.current.get(path)
+                  if (entry) openReviewEntry(entry)
+                }}
+                onSummaryChange={
+                  reviewScope.kind === 'last-turn'
+                    ? setReviewSummary
+                    : setScopeSummary
+                }
+              />
+            ) : scopeLoading ? (
+              <div className="shui-main-empty">
+                <span className="t-ghost">loading review…</span>
+              </div>
+            ) : scopeError ? (
+              <div className="shui-main-empty">
+                <span className="t-warn">{scopeError}</span>
+              </div>
+            ) : tabs.active !== null ? (
+              <EditorPane
+                // fileBump remounts after an agent-side write to the active
+                // file: the pane rehydrates from the refreshed cache entry.
+                key={`${tabs.active}:${fileBump}`}
+                host={host}
+                root={root}
+                relPath={tabs.active}
+                cache={cacheRef.current}
+                onSaved={onSaved}
+                onDirtyChange={onDirtyChange}
+              />
+            ) : (
+              <div className="shui-main-empty">
+                <span className="t-ghost">select a file to edit or review</span>
+              </div>
+            )}
+          </PageMain>
+        </PageBody>
+        {terminalOpen && terminalDock !== 'editor' ? (
+          <TerminalPanel
+            state={terminalWorkspace}
+            dispatch={dispatchTerminalWorkspace}
+            root={root}
+            visible
+            router={terminalRouter}
+            leaseStore={terminalLeaseStore}
+            storageKey={terminalStorageKey}
+            connectionCoordinators={terminalConnectionCoordinators}
+            dock={terminalDock}
+            size={
+              terminalDock === 'bottom' ? terminalBottomSize : terminalRightSize
+            }
+            onDockChange={changeTerminalDock}
+            onSizeChange={
+              terminalDock === 'bottom'
+                ? setTerminalBottomSize
+                : setTerminalRightSize
+            }
+            onClose={closeTerminal}
+          />
+        ) : null}
+      </div>
     </PageShell>
   )
 }

--- a/shell/ui/src/page/persist.ts
+++ b/shell/ui/src/page/persist.ts
@@ -12,8 +12,15 @@
 
 import type { Host } from '@iii-dev/console-ui'
 import type { OpenTab } from './tabs'
+import {
+  createTerminalWorkspace,
+  normalizeTerminalWorkspace,
+  type TerminalWorkspaceState,
+} from './terminal-layout'
 
 export const UI_STATE_CONFIG_ID = 'shell-ui'
+
+export type TerminalDock = 'bottom' | 'right' | 'editor'
 
 export interface TabUiState {
   root?: string
@@ -24,6 +31,14 @@ export interface TabUiState {
   showHidden?: boolean
   /** Sidebar width in px from the drag handle; absent = default. */
   sideWidth?: number
+  /** Dockable terminal panel; absent in legacy saves = closed at bottom. */
+  terminalOpen?: boolean
+  terminalDock?: TerminalDock
+  terminalActive?: boolean
+  terminalBottomSize?: number
+  terminalRightSize?: number
+  terminalJobIds?: string[]
+  terminalWorkspace?: TerminalWorkspaceState
 }
 
 function isUnavailable(err: unknown): boolean {
@@ -63,13 +78,51 @@ export async function loadTabUiState(
   const entry = (tabs as Record<string, unknown>)[tabId]
   if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return null
   const raw = entry as Record<string, unknown>
+  const root = typeof raw.root === 'string' ? raw.root : undefined
+  const terminalOpen =
+    raw.terminalOpen === true || raw.workspaceMode === 'terminal'
+      ? true
+      : undefined
+  let terminalWorkspace: TerminalWorkspaceState | undefined
+  if (raw.terminalWorkspace != null) {
+    terminalWorkspace = normalizeTerminalWorkspace(
+      raw.terminalWorkspace,
+      root ?? '/',
+    )
+  } else if (terminalOpen) {
+    terminalWorkspace = createTerminalWorkspace(root ?? '/')
+  }
   return {
-    root: typeof raw.root === 'string' ? raw.root : undefined,
+    root,
     open: Array.isArray(raw.open) ? (raw.open as OpenTab[]) : [],
     active: typeof raw.active === 'string' ? raw.active : null,
     expanded: Array.isArray(raw.expanded)
       ? raw.expanded.filter((p): p is string => typeof p === 'string')
       : [],
+    showHidden:
+      typeof raw.showHidden === 'boolean' ? raw.showHidden : undefined,
+    sideWidth: typeof raw.sideWidth === 'number' ? raw.sideWidth : undefined,
+    terminalOpen,
+    terminalDock:
+      raw.terminalDock === 'bottom' ||
+      raw.terminalDock === 'right' ||
+      raw.terminalDock === 'editor'
+        ? raw.terminalDock
+        : undefined,
+    terminalActive:
+      typeof raw.terminalActive === 'boolean' ? raw.terminalActive : undefined,
+    terminalBottomSize:
+      typeof raw.terminalBottomSize === 'number'
+        ? raw.terminalBottomSize
+        : undefined,
+    terminalRightSize:
+      typeof raw.terminalRightSize === 'number'
+        ? raw.terminalRightSize
+        : undefined,
+    terminalJobIds: Array.isArray(raw.terminalJobIds)
+      ? raw.terminalJobIds.filter((id): id is string => typeof id === 'string')
+      : undefined,
+    terminalWorkspace,
   }
 }
 

--- a/shell/ui/src/page/terminal-connection.ts
+++ b/shell/ui/src/page/terminal-connection.ts
@@ -1,0 +1,298 @@
+import type { Host } from '@iii-dev/console-ui'
+import { errorMessage } from '../lib/format'
+import type { LocalTerminalLease } from './terminal-leases'
+import type {
+  OutputListener,
+  PtyOutputEvent,
+  TerminalOutputRouter,
+} from './terminal-output-router'
+import type { PtySessionStatus } from './terminal-session-state'
+import { mergeTerminalFrames, type TerminalFrame } from './terminal-stream'
+
+interface PtyAttachResponse {
+  access_key: string
+  reconnect_token: string
+  frames: TerminalFrame[]
+  truncated: boolean
+  next_sequence: number
+  cwd: string
+  status: PtySessionStatus
+}
+
+interface PtyOpenResponse {
+  session_id: string
+  access_key: string
+  reconnect_token: string
+  pid: number | null
+  cwd: string
+}
+
+export interface ActivatedTerminalConnection {
+  frames: TerminalFrame[]
+  events: PtyOutputEvent[]
+  requiresReplay: boolean
+  replayThrough: number
+}
+
+export interface TerminalConnection {
+  sessionId: string
+  accessKey: string
+  reconnectToken: string
+  cwd: string
+  status: PtySessionStatus
+  truncated: boolean
+  nextSequence: number
+  activate(listener: OutputListener): ActivatedTerminalConnection
+  unsubscribe(): void
+}
+
+interface ConnectTerminalSessionOptions {
+  host: Host
+  router: TerminalOutputRouter
+  root: string
+  lease: LocalTerminalLease | null
+  requestId: string
+  cols: number
+  rows: number
+}
+
+export interface ReclaimableTerminalLease extends LocalTerminalLease {
+  update: (lease: LocalTerminalLease) => void
+  remove: () => void
+}
+
+const MAX_PENDING_OUTPUT_BYTES = 2 * 1024 * 1024
+const MAX_PENDING_OUTPUT_EVENTS = 4096
+
+function outputBytes(event: PtyOutputEvent): number {
+  if (!event.data) return 0
+  let padding = 0
+  if (event.data.endsWith('==')) padding = 2
+  else if (event.data.endsWith('=')) padding = 1
+  return Math.floor((event.data.length * 3) / 4) - padding
+}
+
+function stopRoutingOutput(
+  router: TerminalOutputRouter,
+  connection: TerminalConnection,
+): void {
+  connection.unsubscribe()
+  router.drain(connection.sessionId)
+}
+
+export function backendConfirmedSessionMissing(error: unknown): boolean {
+  const message = errorMessage(error)
+  return (
+    message.includes('terminal session does not exist') ||
+    message.includes('terminal session is closed')
+  )
+}
+
+export function legacyTerminalStorageKey(root: string): string {
+  return `iii::shell-ui::terminal-leases::legacy::${root}`
+}
+
+export async function connectTerminalSession({
+  host,
+  router,
+  root,
+  lease,
+  requestId,
+  cols,
+  rows,
+}: ConnectTerminalSessionOptions): Promise<TerminalConnection> {
+  let liveListener: OutputListener | null = null
+  const pending: PtyOutputEvent[] = []
+  let pendingBytes = 0
+  let pendingTruncated = false
+  const enqueue = (event: PtyOutputEvent) => {
+    pending.push(event)
+    pendingBytes += outputBytes(event)
+    while (
+      pending.length > MAX_PENDING_OUTPUT_EVENTS ||
+      pendingBytes > MAX_PENDING_OUTPUT_BYTES
+    ) {
+      const removed = pending.shift()
+      if (!removed) break
+      pendingBytes -= outputBytes(removed)
+      pendingTruncated = true
+    }
+  }
+  const receive: OutputListener = (event) => {
+    if (liveListener) {
+      liveListener(event)
+      return
+    }
+    enqueue(event)
+  }
+  let sessionId: string
+  let accessKey: string
+  let reconnectToken: string
+  let cwd: string
+  let status: PtySessionStatus
+  let replay: TerminalFrame[]
+  let truncated: boolean
+  let nextSequence: number
+  const afterSequence = 0
+  let unsubscribe: () => void
+
+  if (lease) {
+    sessionId = lease.sessionId
+    unsubscribe = router.subscribe(sessionId, receive)
+    for (const event of router.drain(sessionId)) enqueue(event)
+    let attached: PtyAttachResponse
+    try {
+      attached = await host.iii.trigger<PtyAttachResponse>(
+        'shell::pty::attach',
+        {
+          request_id: requestId,
+          session_id: sessionId,
+          reconnect_token: lease.reconnectToken,
+          output_function_id: router.outputFunctionId,
+          cols,
+          rows,
+          after_sequence: afterSequence,
+        },
+        { timeoutMs: 5_000 },
+      )
+    } catch (error) {
+      unsubscribe()
+      throw error
+    }
+    accessKey = attached.access_key
+    reconnectToken = attached.reconnect_token
+    cwd = attached.cwd
+    status = attached.status
+    replay = attached.frames
+    truncated = attached.truncated
+    nextSequence = attached.next_sequence
+  } else {
+    const opened = await host.iii.trigger<PtyOpenResponse>(
+      'shell::pty::open',
+      {
+        request_id: requestId,
+        cwd: root,
+        cols,
+        rows,
+        output_function_id: router.outputFunctionId,
+      },
+      { timeoutMs: 5_000 },
+    )
+    sessionId = opened.session_id
+    accessKey = opened.access_key
+    reconnectToken = opened.reconnect_token
+    cwd = opened.cwd
+    status = 'attached'
+    replay = []
+    truncated = false
+    nextSequence = 1
+    unsubscribe = router.subscribe(sessionId, receive)
+    for (const event of router.drain(sessionId)) enqueue(event)
+  }
+
+  return {
+    sessionId,
+    accessKey,
+    reconnectToken,
+    cwd,
+    status,
+    truncated,
+    nextSequence,
+    activate(listener) {
+      liveListener = listener
+      const queued = pending.splice(0)
+      const queuedFrames = queued.flatMap((event) =>
+        event.data ? [{ sequence: event.sequence, data: event.data }] : [],
+      )
+      return {
+        frames: pendingTruncated
+          ? replay
+          : mergeTerminalFrames(replay, queuedFrames, afterSequence),
+        events: queued.filter((event) => event.eof),
+        requiresReplay: pendingTruncated,
+        replayThrough: Math.max(0, nextSequence - 1),
+      }
+    },
+    unsubscribe,
+  }
+}
+
+export async function disposeTerminalConnection(
+  host: Host,
+  router: TerminalOutputRouter,
+  connection: TerminalConnection,
+): Promise<void> {
+  stopRoutingOutput(router, connection)
+  await host.iii.trigger('shell::pty::detach', {
+    session_id: connection.sessionId,
+    access_key: connection.accessKey,
+  })
+}
+
+export async function closeTerminalConnection(
+  host: Host,
+  router: TerminalOutputRouter,
+  connection: TerminalConnection,
+): Promise<void> {
+  stopRoutingOutput(router, connection)
+  await host.iii.trigger('shell::pty::close', {
+    session_id: connection.sessionId,
+    access_key: connection.accessKey,
+  })
+}
+
+export async function reclaimTerminalLease(
+  host: Host,
+  router: TerminalOutputRouter,
+  lease: ReclaimableTerminalLease,
+): Promise<string | null> {
+  const unsubscribe = router.subscribe(lease.sessionId, () => undefined)
+  router.drain(lease.sessionId)
+  try {
+    const attached = await host.iii.trigger<PtyAttachResponse>(
+      'shell::pty::attach',
+      {
+        session_id: lease.sessionId,
+        reconnect_token: lease.reconnectToken,
+        output_function_id: router.outputFunctionId,
+        cols: 80,
+        rows: 24,
+        after_sequence: lease.lastSequence,
+      },
+    )
+    let warning: string | null = null
+    try {
+      lease.update({
+        paneId: lease.paneId,
+        sessionId: lease.sessionId,
+        reconnectToken: attached.reconnect_token,
+        lastSequence: lease.lastSequence,
+      })
+    } catch (error) {
+      warning = errorMessage(error)
+    }
+    await host.iii.trigger('shell::pty::close', {
+      session_id: lease.sessionId,
+      access_key: attached.access_key,
+    })
+    try {
+      lease.remove()
+    } catch (error) {
+      warning = warning
+        ? `${warning}; ${errorMessage(error)}`
+        : errorMessage(error)
+    }
+    return warning
+  } catch (error) {
+    if (!backendConfirmedSessionMissing(error)) throw error
+    try {
+      lease.remove()
+      return null
+    } catch (storageError) {
+      return errorMessage(storageError)
+    }
+  } finally {
+    unsubscribe()
+    router.drain(lease.sessionId)
+  }
+}

--- a/shell/ui/src/page/terminal-layout.ts
+++ b/shell/ui/src/page/terminal-layout.ts
@@ -1,0 +1,476 @@
+export const MAX_TERMINAL_PANES_PER_TAB = 4
+export const MAX_TERMINAL_SESSIONS = 16
+
+export interface TerminalPaneState {
+  id: string
+  cwd: string
+}
+
+export interface TerminalTabState {
+  id: string
+  title: string
+  layout: TerminalLayoutNode
+}
+
+export interface TerminalWorkspaceState {
+  tabs: TerminalTabState[]
+  panes: Record<string, TerminalPaneState>
+  activeTabId: string | null
+  focusedPaneId: string | null
+}
+
+export type TerminalLayoutNode =
+  | { type: 'pane'; paneId: string }
+  | {
+      type: 'split'
+      id: string
+      direction: 'horizontal' | 'vertical'
+      ratio: number
+      first: TerminalLayoutNode
+      second: TerminalLayoutNode
+    }
+
+export type TerminalWorkspaceAction =
+  | { type: 'workspace-restored'; state: TerminalWorkspaceState }
+  | { type: 'tab-created'; tabId: string; paneId: string; root: string }
+  | { type: 'tab-selected'; tabId: string }
+  | { type: 'tab-renamed'; tabId: string; title: string }
+  | { type: 'tab-closed'; tabId: string }
+  | {
+      type: 'pane-split'
+      paneId: string
+      newPaneId: string
+      splitId: string
+      direction: 'horizontal' | 'vertical'
+    }
+  | { type: 'pane-focused'; paneId: string }
+  | { type: 'pane-closed'; paneId: string }
+  | { type: 'split-resized'; splitId: string; ratio: number }
+
+const DEFAULT_SPLIT_RATIO = 0.5
+const MIN_SPLIT_RATIO = 0.2
+const MAX_SPLIT_RATIO = 0.8
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0
+}
+
+export function clampSplitRatio(ratio: number): number {
+  return Math.min(MAX_SPLIT_RATIO, Math.max(MIN_SPLIT_RATIO, ratio))
+}
+
+export function countTerminalPanes(layout: TerminalLayoutNode): number {
+  if (layout.type === 'pane') return 1
+  return countTerminalPanes(layout.first) + countTerminalPanes(layout.second)
+}
+
+function findTabIndexById(
+  state: TerminalWorkspaceState,
+  tabId: string,
+): number {
+  return state.tabs.findIndex((tab) => tab.id === tabId)
+}
+
+function findTabByPaneId(
+  state: TerminalWorkspaceState,
+  paneId: string,
+): TerminalTabState | undefined {
+  return state.tabs.find((tab) => paneIdsInLayout(tab.layout).includes(paneId))
+}
+
+function paneIdsInLayout(layout: TerminalLayoutNode): string[] {
+  if (layout.type === 'pane') return [layout.paneId]
+  return [...paneIdsInLayout(layout.first), ...paneIdsInLayout(layout.second)]
+}
+
+function splitIdsInLayout(layout: TerminalLayoutNode): string[] {
+  if (layout.type === 'pane') return []
+  return [
+    layout.id,
+    ...splitIdsInLayout(layout.first),
+    ...splitIdsInLayout(layout.second),
+  ]
+}
+
+function firstPaneIdInLayout(layout: TerminalLayoutNode): string {
+  if (layout.type === 'pane') return layout.paneId
+  return firstPaneIdInLayout(layout.first)
+}
+
+function replacePaneInLayout(
+  layout: TerminalLayoutNode,
+  paneId: string,
+  replacement: TerminalLayoutNode,
+): TerminalLayoutNode {
+  if (layout.type === 'pane') {
+    return layout.paneId === paneId ? replacement : layout
+  }
+  const first = replacePaneInLayout(layout.first, paneId, replacement)
+  const second = replacePaneInLayout(layout.second, paneId, replacement)
+  if (first === layout.first && second === layout.second) return layout
+  return { ...layout, first, second }
+}
+
+function removePaneFromLayout(
+  layout: TerminalLayoutNode,
+  paneId: string,
+): TerminalLayoutNode | null {
+  if (layout.type === 'pane') {
+    return layout.paneId === paneId ? null : layout
+  }
+  const first = removePaneFromLayout(layout.first, paneId)
+  const second = removePaneFromLayout(layout.second, paneId)
+  if (first === null) return second
+  if (second === null) return first
+  return { ...layout, first, second }
+}
+
+function resizeSplitInLayout(
+  layout: TerminalLayoutNode,
+  splitId: string,
+  ratio: number,
+): TerminalLayoutNode {
+  if (layout.type === 'pane') return layout
+  if (layout.id === splitId) {
+    return { ...layout, ratio: clampSplitRatio(ratio) }
+  }
+  return {
+    ...layout,
+    first: resizeSplitInLayout(layout.first, splitId, ratio),
+    second: resizeSplitInLayout(layout.second, splitId, ratio),
+  }
+}
+
+function nearestTabIdAfterClose(
+  tabs: TerminalTabState[],
+  closedIndex: number,
+): string | null {
+  if (tabs.length === 0) return null
+  const right = tabs[closedIndex]
+  if (right) return right.id
+  return tabs[closedIndex - 1]?.id ?? tabs[0]?.id ?? null
+}
+
+function tabTitleForIndex(index: number): string {
+  return `zsh ${index + 1}`
+}
+
+export function createTerminalWorkspace(root: string): TerminalWorkspaceState {
+  const tabId = 'tab-1'
+  const paneId = 'pane-1'
+  return {
+    tabs: [
+      {
+        id: tabId,
+        title: tabTitleForIndex(0),
+        layout: { type: 'pane', paneId },
+      },
+    ],
+    panes: {
+      [paneId]: { id: paneId, cwd: root },
+    },
+    activeTabId: tabId,
+    focusedPaneId: paneId,
+  }
+}
+
+function isValidLayoutNode(
+  node: unknown,
+  paneIds: Set<string>,
+): node is TerminalLayoutNode {
+  if (!node || typeof node !== 'object') return false
+  const raw = node as Record<string, unknown>
+  if (raw.type === 'pane') {
+    return isNonEmptyString(raw.paneId) && paneIds.has(raw.paneId)
+  }
+  if (raw.type !== 'split') return false
+  if (
+    !isNonEmptyString(raw.id) ||
+    (raw.direction !== 'horizontal' && raw.direction !== 'vertical') ||
+    typeof raw.ratio !== 'number'
+  ) {
+    return false
+  }
+  return (
+    isValidLayoutNode(raw.first, paneIds) &&
+    isValidLayoutNode(raw.second, paneIds)
+  )
+}
+
+export function normalizeTerminalWorkspace(
+  value: unknown,
+  root: string,
+): TerminalWorkspaceState {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return createTerminalWorkspace(root)
+  }
+  const raw = value as Record<string, unknown>
+  if (!Array.isArray(raw.tabs) || raw.tabs.length === 0) {
+    return createTerminalWorkspace(root)
+  }
+
+  const panes: Record<string, TerminalPaneState> = {}
+  for (const [paneId, paneValue] of Object.entries(raw.panes ?? {})) {
+    if (!isNonEmptyString(paneId)) continue
+    if (
+      !paneValue ||
+      typeof paneValue !== 'object' ||
+      Array.isArray(paneValue)
+    ) {
+      continue
+    }
+    const paneRaw = paneValue as Record<string, unknown>
+    const cwd =
+      typeof paneRaw.cwd === 'string' && paneRaw.cwd.length > 0
+        ? paneRaw.cwd
+        : root
+    panes[paneId] = { id: paneId, cwd }
+  }
+
+  const paneIds = new Set(Object.keys(panes))
+  const usedPaneIds = new Set<string>()
+  const usedSplitIds = new Set<string>()
+  const tabs: TerminalTabState[] = []
+  for (const tabValue of raw.tabs) {
+    if (!tabValue || typeof tabValue !== 'object' || Array.isArray(tabValue)) {
+      continue
+    }
+    const tabRaw = tabValue as Record<string, unknown>
+    if (!isNonEmptyString(tabRaw.id) || !isNonEmptyString(tabRaw.title)) {
+      continue
+    }
+    if (!isValidLayoutNode(tabRaw.layout, paneIds)) continue
+    if (countTerminalPanes(tabRaw.layout) > MAX_TERMINAL_PANES_PER_TAB) continue
+    const layoutPaneIds = paneIdsInLayout(tabRaw.layout)
+    const layoutSplitIds = splitIdsInLayout(tabRaw.layout)
+    if (new Set(layoutPaneIds).size !== layoutPaneIds.length) continue
+    if (new Set(layoutSplitIds).size !== layoutSplitIds.length) continue
+    if (layoutPaneIds.some((paneId) => usedPaneIds.has(paneId))) continue
+    if (layoutSplitIds.some((splitId) => usedSplitIds.has(splitId))) continue
+    for (const paneId of layoutPaneIds) usedPaneIds.add(paneId)
+    for (const splitId of layoutSplitIds) usedSplitIds.add(splitId)
+    tabs.push({
+      id: tabRaw.id,
+      title: tabRaw.title,
+      layout: normalizeLayoutRatios(tabRaw.layout),
+    })
+  }
+
+  const referencedPanes = Object.fromEntries(
+    [...usedPaneIds].map((paneId) => [paneId, panes[paneId]]),
+  )
+  if (
+    tabs.length === 0 ||
+    Object.keys(referencedPanes).length > MAX_TERMINAL_SESSIONS
+  ) {
+    return createTerminalWorkspace(root)
+  }
+
+  const activeTabId =
+    isNonEmptyString(raw.activeTabId) &&
+    tabs.some((tab) => tab.id === raw.activeTabId)
+      ? raw.activeTabId
+      : tabs[0].id
+
+  const activeTab = tabs.find((tab) => tab.id === activeTabId) ?? tabs[0]
+  const focusedPaneId =
+    isNonEmptyString(raw.focusedPaneId) &&
+    usedPaneIds.has(raw.focusedPaneId) &&
+    paneIdsInLayout(activeTab.layout).includes(raw.focusedPaneId)
+      ? raw.focusedPaneId
+      : firstPaneIdInLayout(activeTab.layout)
+
+  return {
+    tabs,
+    panes: referencedPanes,
+    activeTabId,
+    focusedPaneId,
+  }
+}
+
+function normalizeLayoutRatios(layout: TerminalLayoutNode): TerminalLayoutNode {
+  if (layout.type === 'pane') return layout
+  return {
+    ...layout,
+    ratio: clampSplitRatio(layout.ratio),
+    first: normalizeLayoutRatios(layout.first),
+    second: normalizeLayoutRatios(layout.second),
+  }
+}
+
+export function reduceTerminalWorkspace(
+  state: TerminalWorkspaceState,
+  action: TerminalWorkspaceAction,
+): TerminalWorkspaceState {
+  switch (action.type) {
+    case 'workspace-restored':
+      return action.state
+    case 'tab-created': {
+      const tabIndex = findTabIndexById(state, action.tabId)
+      if (tabIndex >= 0) return state
+      if (action.paneId in state.panes) return state
+      if (Object.keys(state.panes).length >= MAX_TERMINAL_SESSIONS) return state
+      return {
+        ...state,
+        tabs: [
+          ...state.tabs,
+          {
+            id: action.tabId,
+            title: tabTitleForIndex(state.tabs.length),
+            layout: { type: 'pane', paneId: action.paneId },
+          },
+        ],
+        panes: {
+          ...state.panes,
+          [action.paneId]: { id: action.paneId, cwd: action.root },
+        },
+        activeTabId: action.tabId,
+        focusedPaneId: action.paneId,
+      }
+    }
+    case 'tab-selected': {
+      const tab = state.tabs.find((entry) => entry.id === action.tabId)
+      if (!tab) return state
+      return {
+        ...state,
+        activeTabId: tab.id,
+        focusedPaneId: firstPaneIdInLayout(tab.layout),
+      }
+    }
+    case 'tab-renamed': {
+      const tabIndex = findTabIndexById(state, action.tabId)
+      if (tabIndex < 0) return state
+      const tabs = [...state.tabs]
+      tabs[tabIndex] = { ...tabs[tabIndex], title: action.title }
+      return { ...state, tabs }
+    }
+    case 'tab-closed': {
+      const tabIndex = findTabIndexById(state, action.tabId)
+      if (tabIndex < 0) return state
+      const closingTab = state.tabs[tabIndex]
+      const removedPaneIds = paneIdsInLayout(closingTab.layout)
+      const panes = { ...state.panes }
+      for (const paneId of removedPaneIds) {
+        delete panes[paneId]
+      }
+      const tabs = state.tabs.filter((tab) => tab.id !== action.tabId)
+      if (tabs.length === 0) {
+        return {
+          tabs: [],
+          panes: {},
+          activeTabId: null,
+          focusedPaneId: null,
+        }
+      }
+      const activeTabId =
+        state.activeTabId === action.tabId
+          ? nearestTabIdAfterClose(tabs, tabIndex)
+          : state.activeTabId
+      const activeTab = tabs.find((tab) => tab.id === activeTabId) ?? tabs[0]
+      let focusedPaneId = state.focusedPaneId
+      if (
+        !focusedPaneId ||
+        removedPaneIds.includes(focusedPaneId) ||
+        !tabs.some((tab) =>
+          paneIdsInLayout(tab.layout).includes(focusedPaneId as string),
+        )
+      ) {
+        focusedPaneId = firstPaneIdInLayout(activeTab.layout)
+      }
+      return {
+        tabs,
+        panes,
+        activeTabId: activeTab.id,
+        focusedPaneId,
+      }
+    }
+    case 'pane-split': {
+      const tab = findTabByPaneId(state, action.paneId)
+      if (!tab) return state
+      if (action.newPaneId in state.panes) return state
+      if (
+        state.tabs.some((entry) =>
+          splitIdsInLayout(entry.layout).includes(action.splitId),
+        )
+      ) {
+        return state
+      }
+      if (countTerminalPanes(tab.layout) >= MAX_TERMINAL_PANES_PER_TAB)
+        return state
+      if (Object.keys(state.panes).length >= MAX_TERMINAL_SESSIONS) return state
+      const sourcePane = state.panes[action.paneId]
+      if (!sourcePane) return state
+      const replacement: TerminalLayoutNode = {
+        type: 'split',
+        id: action.splitId,
+        direction: action.direction,
+        ratio: DEFAULT_SPLIT_RATIO,
+        first: { type: 'pane', paneId: action.paneId },
+        second: { type: 'pane', paneId: action.newPaneId },
+      }
+      const layout = replacePaneInLayout(tab.layout, action.paneId, replacement)
+      const tabs = state.tabs.map((entry) =>
+        entry.id === tab.id ? { ...entry, layout } : entry,
+      )
+      return {
+        ...state,
+        tabs,
+        panes: {
+          ...state.panes,
+          [action.newPaneId]: {
+            id: action.newPaneId,
+            cwd: sourcePane.cwd,
+          },
+        },
+        focusedPaneId: action.newPaneId,
+      }
+    }
+    case 'pane-focused': {
+      const tab = findTabByPaneId(state, action.paneId)
+      if (!tab) return state
+      return {
+        ...state,
+        activeTabId: tab.id,
+        focusedPaneId: action.paneId,
+      }
+    }
+    case 'pane-closed': {
+      const tab = findTabByPaneId(state, action.paneId)
+      if (!tab) return state
+      if (countTerminalPanes(tab.layout) === 1) {
+        return reduceTerminalWorkspace(state, {
+          type: 'tab-closed',
+          tabId: tab.id,
+        })
+      }
+      const layout = removePaneFromLayout(tab.layout, action.paneId)
+      if (!layout) return state
+      const panes = { ...state.panes }
+      delete panes[action.paneId]
+      const tabs = state.tabs.map((entry) =>
+        entry.id === tab.id ? { ...entry, layout } : entry,
+      )
+      const focusedPaneId =
+        state.focusedPaneId === action.paneId
+          ? firstPaneIdInLayout(layout)
+          : state.focusedPaneId
+      return {
+        ...state,
+        tabs,
+        panes,
+        focusedPaneId,
+      }
+    }
+    case 'split-resized': {
+      const tabs = state.tabs.map((tab) => ({
+        ...tab,
+        layout: resizeSplitInLayout(tab.layout, action.splitId, action.ratio),
+      }))
+      return { ...state, tabs }
+    }
+    default: {
+      const _exhaustive: never = action
+      return _exhaustive
+    }
+  }
+}

--- a/shell/ui/src/page/terminal-leases.ts
+++ b/shell/ui/src/page/terminal-leases.ts
@@ -1,0 +1,212 @@
+export interface LocalTerminalLease {
+  paneId: string
+  sessionId: string
+  reconnectToken: string
+  lastSequence: number
+}
+
+export class TerminalLeaseStorageError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options)
+    this.name = 'TerminalLeaseStorageError'
+  }
+}
+
+const MAX_LEASE_PAYLOAD_BYTES = 64 * 1024
+const textEncoder = new TextEncoder()
+const inMemoryTerminalLeases = new Map<
+  string,
+  Map<string, LocalTerminalLease>
+>()
+
+type LeaseInput = LocalTerminalLease & { accessKey?: unknown }
+
+function payloadByteLength(value: string): number {
+  return textEncoder.encode(value).length
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0
+}
+
+function isValidLastSequence(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0
+}
+
+function parseLease(value: unknown): LocalTerminalLease | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const raw = value as Record<string, unknown>
+  if ('accessKey' in raw) return null
+  if (
+    !isNonEmptyString(raw.paneId) ||
+    !isNonEmptyString(raw.sessionId) ||
+    !isNonEmptyString(raw.reconnectToken) ||
+    !isValidLastSequence(raw.lastSequence)
+  ) {
+    return null
+  }
+  return {
+    paneId: raw.paneId,
+    sessionId: raw.sessionId,
+    reconnectToken: raw.reconnectToken,
+    lastSequence: raw.lastSequence,
+  }
+}
+
+function readStoredLeases(raw: string | null): LocalTerminalLease[] {
+  if (raw == null) return []
+  if (payloadByteLength(raw) > MAX_LEASE_PAYLOAD_BYTES) return []
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return []
+  }
+  if (!Array.isArray(parsed)) return []
+
+  const leases: LocalTerminalLease[] = []
+  const seenPaneIds = new Set<string>()
+  for (const entry of parsed) {
+    const lease = parseLease(entry)
+    if (!lease || seenPaneIds.has(lease.paneId)) return []
+    seenPaneIds.add(lease.paneId)
+    leases.push(lease)
+  }
+  return leases
+}
+
+function serializeLeases(leases: LocalTerminalLease[]): string {
+  return JSON.stringify(leases)
+}
+
+function assertSavableLease(lease: LeaseInput): LocalTerminalLease {
+  if ('accessKey' in lease && lease.accessKey !== undefined) {
+    throw new Error('access keys must not be persisted in terminal leases')
+  }
+  const parsed = parseLease(lease)
+  if (!parsed) {
+    throw new Error('invalid terminal lease')
+  }
+  return parsed
+}
+
+function readStorageItem(storage: Storage, key: string): string | null {
+  try {
+    return storage.getItem(key)
+  } catch (err) {
+    throw new TerminalLeaseStorageError(
+      'failed to read terminal leases from storage',
+      { cause: err },
+    )
+  }
+}
+
+function writeStorageItem(storage: Storage, key: string, value: string): void {
+  try {
+    storage.setItem(key, value)
+  } catch (err) {
+    throw new TerminalLeaseStorageError(
+      'failed to write terminal leases to storage',
+      { cause: err },
+    )
+  }
+}
+
+function deleteStorageItem(storage: Storage, key: string): void {
+  try {
+    storage.removeItem(key)
+  } catch (err) {
+    throw new TerminalLeaseStorageError(
+      'failed to remove terminal leases from storage',
+      { cause: err },
+    )
+  }
+}
+
+export function loadTerminalLeases(
+  storage: Storage,
+  key: string,
+): LocalTerminalLease[] {
+  try {
+    return readStoredLeases(readStorageItem(storage, key))
+  } catch (err) {
+    if (err instanceof TerminalLeaseStorageError) return []
+    throw err
+  }
+}
+
+export function saveTerminalLease(
+  storage: Storage,
+  key: string,
+  lease: LeaseInput,
+): void {
+  const nextLease = assertSavableLease(lease)
+  const leases = readStoredLeases(readStorageItem(storage, key))
+  const index = leases.findIndex((entry) => entry.paneId === nextLease.paneId)
+  if (index >= 0) {
+    leases[index] = nextLease
+  } else {
+    leases.push(nextLease)
+  }
+  const serialized = serializeLeases(leases)
+  if (payloadByteLength(serialized) > MAX_LEASE_PAYLOAD_BYTES) {
+    throw new Error('terminal lease payload exceeds 64 KiB')
+  }
+  writeStorageItem(storage, key, serialized)
+}
+
+export function removeTerminalLease(
+  storage: Storage,
+  key: string,
+  paneId: string,
+): void {
+  if (!isNonEmptyString(paneId)) return
+  const leases = readStoredLeases(readStorageItem(storage, key)).filter(
+    (entry) => entry.paneId !== paneId,
+  )
+  if (leases.length === 0) {
+    deleteStorageItem(storage, key)
+    return
+  }
+  writeStorageItem(storage, key, serializeLeases(leases))
+}
+
+export function loadRecoverableTerminalLeases(
+  storage: Storage | null,
+  key: string,
+): LocalTerminalLease[] {
+  const leases = new Map<string, LocalTerminalLease>()
+  if (storage) {
+    for (const lease of loadTerminalLeases(storage, key)) {
+      leases.set(lease.paneId, lease)
+    }
+  }
+  for (const lease of inMemoryTerminalLeases.get(key)?.values() ?? []) {
+    leases.set(lease.paneId, lease)
+  }
+  return [...leases.values()]
+}
+
+export function saveRecoverableTerminalLease(
+  storage: Storage | null,
+  key: string,
+  lease: LeaseInput,
+): void {
+  const nextLease = assertSavableLease(lease)
+  const leases =
+    inMemoryTerminalLeases.get(key) ?? new Map<string, LocalTerminalLease>()
+  leases.set(nextLease.paneId, nextLease)
+  inMemoryTerminalLeases.set(key, leases)
+  if (storage) saveTerminalLease(storage, key, nextLease)
+}
+
+export function removeRecoverableTerminalLease(
+  storage: Storage | null,
+  key: string,
+  paneId: string,
+): void {
+  const leases = inMemoryTerminalLeases.get(key)
+  leases?.delete(paneId)
+  if (leases?.size === 0) inMemoryTerminalLeases.delete(key)
+  if (storage) removeTerminalLease(storage, key, paneId)
+}

--- a/shell/ui/src/page/terminal-output-router.ts
+++ b/shell/ui/src/page/terminal-output-router.ts
@@ -1,0 +1,97 @@
+import type { Host } from '@iii-dev/console-ui'
+
+const OUTPUT_HANDLER = 'iii::shell-ui::pty-output'
+const MAX_UNSUBSCRIBED_OUTPUT_BYTES = 2 * 1024 * 1024
+
+interface OutputQueue {
+  events: PtyOutputEvent[]
+  rawBytes: number
+}
+
+export interface PtyOutputEvent {
+  session_id: string
+  sequence: number
+  data: string | null
+  eof: boolean
+  exit_code: number | null
+  signal: string | null
+  error: string | null
+}
+
+export type OutputListener = (event: PtyOutputEvent) => void
+
+export interface TerminalOutputRouter {
+  outputFunctionId: string
+  subscribe(sessionId: string, listener: OutputListener): () => void
+  drain(sessionId: string): PtyOutputEvent[]
+  dispose(): void
+}
+
+const routerHosts = new WeakMap<TerminalOutputRouter, Host>()
+
+export function terminalOutputRouterHost(router: TerminalOutputRouter): Host {
+  const host = routerHosts.get(router)
+  if (!host) throw new Error('terminal output router is disposed')
+  return host
+}
+
+function outputBytes(data: string | null): number {
+  if (!data) return 0
+  let padding = 0
+  if (data.endsWith('==')) padding = 2
+  else if (data.endsWith('=')) padding = 1
+  return Math.floor((data.length * 3) / 4) - padding
+}
+
+export function createTerminalOutputRouter(host: Host): TerminalOutputRouter {
+  const listeners = new Map<string, Set<OutputListener>>()
+  const queues = new Map<string, OutputQueue>()
+  let disposed = false
+  const offOutput = host.iii.on<PtyOutputEvent>(OUTPUT_HANDLER, (event) => {
+    if (disposed) return
+    const sessionListeners = listeners.get(event.session_id)
+    if (sessionListeners) {
+      for (const listener of sessionListeners) listener(event)
+      return
+    }
+    const queue = queues.get(event.session_id) ?? { events: [], rawBytes: 0 }
+    queue.events.push(event)
+    queue.rawBytes += outputBytes(event.data)
+    while (
+      queue.rawBytes > MAX_UNSUBSCRIBED_OUTPUT_BYTES &&
+      queue.events.length > 0
+    ) {
+      const removed = queue.events.shift()
+      if (removed) queue.rawBytes -= outputBytes(removed.data)
+    }
+    if (queue.events.length > 0) queues.set(event.session_id, queue)
+  })
+  const router: TerminalOutputRouter = {
+    outputFunctionId: `${OUTPUT_HANDLER}::${host.iii.browserId}`,
+    subscribe(sessionId, listener) {
+      if (disposed) throw new Error('terminal output router is disposed')
+      const sessionListeners = listeners.get(sessionId) ?? new Set()
+      sessionListeners.add(listener)
+      listeners.set(sessionId, sessionListeners)
+      return () => {
+        sessionListeners.delete(listener)
+        if (sessionListeners.size === 0) listeners.delete(sessionId)
+      }
+    },
+    drain(sessionId) {
+      const queue = queues.get(sessionId)
+      queues.delete(sessionId)
+      return queue?.events ?? []
+    },
+    dispose() {
+      if (disposed) return
+      disposed = true
+      offOutput()
+      listeners.clear()
+      queues.clear()
+      routerHosts.delete(router)
+    },
+  }
+  routerHosts.set(router, host)
+  return router
+}

--- a/shell/ui/src/page/terminal-session-state.ts
+++ b/shell/ui/src/page/terminal-session-state.ts
@@ -1,0 +1,238 @@
+import type { LocalTerminalLease } from './terminal-leases'
+
+export type TerminalStatus =
+  | 'connecting'
+  | 'ready'
+  | 'reconnecting'
+  | 'disconnected'
+  | 'exited'
+  | 'error'
+
+export interface TerminalSessionState {
+  status: TerminalStatus
+  cwd: string
+  error: string | null
+  notice: string | null
+  sessionId: string | null
+  lastSequence: number
+}
+
+export const REPLAY_TRUNCATION_NOTICE =
+  '\r\n[terminal output truncated; showing retained output]\r\n'
+
+export type TerminalSessionAction =
+  | {
+      type: 'connected'
+      sessionId: string
+      cwd: string
+    }
+  | {
+      type: 'disconnected'
+      error: string
+    }
+  | {
+      type: 'reconnecting'
+      error: string
+    }
+  | {
+      type: 'exited'
+      error: string | null
+    }
+  | {
+      type: 'replay-truncated'
+    }
+  | {
+      type: 'connecting'
+      cwd: string
+    }
+  | {
+      type: 'frame-applied'
+      sequence: number
+    }
+  | {
+      type: 'failed'
+      error: string
+    }
+  | {
+      type: 'closed'
+    }
+
+export type TerminalLeaseAction =
+  | {
+      type: 'restarted'
+      lease: LocalTerminalLease
+    }
+  | {
+      type: 'closed'
+    }
+
+export type PtySessionStatus =
+  | 'attached'
+  | 'detached'
+  | {
+      exited: {
+        exit_code: number | null
+        signal: string | null
+        error: string | null
+      }
+    }
+
+export interface TerminalConnectionAttempt {
+  generation: number
+  requestId: string
+}
+
+export interface TerminalConnectionCoordinator {
+  begin(): TerminalConnectionAttempt
+  invalidate(): void
+  isCurrent(generation: number): boolean
+  complete(generation: number): void
+}
+
+export function createTerminalConnectionCoordinator(
+  createRequestId: () => string = () => crypto.randomUUID(),
+): TerminalConnectionCoordinator {
+  let generation = 0
+  let requestId = createRequestId()
+  return {
+    begin() {
+      generation += 1
+      return { generation, requestId }
+    },
+    invalidate() {
+      generation += 1
+    },
+    isCurrent(candidate) {
+      return generation === candidate
+    },
+    complete(candidate) {
+      if (generation === candidate) requestId = createRequestId()
+    },
+  }
+}
+
+export function normalizeTerminalDimensions(
+  cols: number,
+  rows: number,
+): { cols: number; rows: number } {
+  return {
+    cols: Math.min(500, Math.max(2, cols)),
+    rows: Math.min(500, Math.max(2, rows)),
+  }
+}
+
+export function shouldDetachStaleConnection(
+  cancelled: boolean,
+  generation: number,
+  currentGeneration: number,
+): boolean {
+  return cancelled && generation === currentGeneration
+}
+
+export function createTerminalSessionState(root: string): TerminalSessionState {
+  return {
+    status: 'connecting',
+    cwd: root,
+    error: null,
+    notice: null,
+    sessionId: null,
+    lastSequence: 0,
+  }
+}
+
+export function reduceTerminalSessionState(
+  state: TerminalSessionState,
+  action: TerminalSessionAction,
+): TerminalSessionState {
+  switch (action.type) {
+    case 'connected':
+      return {
+        ...state,
+        status: 'ready',
+        cwd: action.cwd,
+        error: null,
+        sessionId: action.sessionId,
+      }
+    case 'disconnected':
+      return {
+        ...state,
+        status: 'disconnected',
+        error: action.error,
+        sessionId: null,
+      }
+    case 'reconnecting':
+      return {
+        ...state,
+        status: 'reconnecting',
+        error: action.error,
+      }
+    case 'exited':
+      return {
+        ...state,
+        status: action.error ? 'error' : 'exited',
+        error: action.error,
+      }
+    case 'replay-truncated':
+      return {
+        ...state,
+        notice: REPLAY_TRUNCATION_NOTICE,
+      }
+    case 'connecting':
+      return createTerminalSessionState(action.cwd)
+    case 'frame-applied':
+      return {
+        ...state,
+        lastSequence: Math.max(state.lastSequence, action.sequence),
+      }
+    case 'failed':
+      return {
+        ...state,
+        status: 'error',
+        error: action.error,
+      }
+    case 'closed':
+      return {
+        ...state,
+        status: 'disconnected',
+        error: null,
+        sessionId: null,
+      }
+    default: {
+      const exhaustive: never = action
+      return exhaustive
+    }
+  }
+}
+
+export function reduceTerminalLease(
+  _lease: LocalTerminalLease | null,
+  action: TerminalLeaseAction,
+): LocalTerminalLease | null {
+  switch (action.type) {
+    case 'restarted':
+      return action.lease
+    case 'closed':
+      return null
+    default: {
+      const exhaustive: never = action
+      return exhaustive
+    }
+  }
+}
+
+export function exitedStatus(status: PtySessionStatus): {
+  exit_code: number | null
+  signal: string | null
+  error: string | null
+} | null {
+  if (typeof status === 'object') return status.exited
+  switch (status) {
+    case 'attached':
+    case 'detached':
+      return null
+    default: {
+      const exhaustive: never = status
+      return exhaustive
+    }
+  }
+}

--- a/shell/ui/src/page/terminal-session.ts
+++ b/shell/ui/src/page/terminal-session.ts
@@ -1,0 +1,916 @@
+import type { Host } from '@iii-dev/console-ui'
+import { FitAddon } from '@xterm/addon-fit'
+import { Terminal } from '@xterm/xterm'
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from 'react'
+import { errorMessage } from '../lib/format'
+import {
+  backendConfirmedSessionMissing,
+  closeTerminalConnection,
+  connectTerminalSession,
+  disposeTerminalConnection,
+  legacyTerminalStorageKey,
+  reclaimTerminalLease,
+  type TerminalConnection,
+} from './terminal-connection'
+import {
+  type LocalTerminalLease,
+  loadRecoverableTerminalLeases,
+  removeRecoverableTerminalLease,
+  saveRecoverableTerminalLease,
+} from './terminal-leases'
+import {
+  createTerminalOutputRouter,
+  type PtyOutputEvent,
+  terminalOutputRouterHost,
+  type TerminalOutputRouter,
+} from './terminal-output-router'
+import {
+  createTerminalConnectionCoordinator,
+  createTerminalSessionState,
+  exitedStatus,
+  normalizeTerminalDimensions,
+  REPLAY_TRUNCATION_NOTICE,
+  reduceTerminalLease,
+  reduceTerminalSessionState,
+  shouldDetachStaleConnection,
+  type TerminalConnectionCoordinator,
+  type TerminalStatus,
+} from './terminal-session-state'
+import { bufferTerminalFrame, type TerminalFrame } from './terminal-stream'
+
+export type {
+  ActivatedTerminalConnection,
+  ReclaimableTerminalLease,
+  TerminalConnection,
+} from './terminal-connection'
+export type {
+  PtySessionStatus,
+  TerminalLeaseAction,
+  TerminalSessionAction,
+  TerminalSessionState,
+  TerminalStatus,
+} from './terminal-session-state'
+export {
+  closeTerminalConnection,
+  connectTerminalSession,
+  createTerminalConnectionCoordinator,
+  createTerminalSessionState,
+  disposeTerminalConnection,
+  legacyTerminalStorageKey,
+  normalizeTerminalDimensions,
+  REPLAY_TRUNCATION_NOTICE,
+  reclaimTerminalLease,
+  reduceTerminalLease,
+  reduceTerminalSessionState,
+  shouldDetachStaleConnection,
+}
+
+export interface TerminalSessionOptions {
+  paneId: string
+  root: string
+  visible: boolean
+  router: TerminalOutputRouter | null
+  leaseStore: Storage | null
+  storageKey?: string
+  connectionCoordinator?: TerminalConnectionCoordinator
+}
+
+interface LegacyTerminalSessionOptions {
+  host: Host
+  root: string
+  branch: string | null
+  jobIds: string[]
+  onJobIdsChange: (ids: string[]) => void
+}
+
+interface ActiveTerminalSession {
+  generation: number
+  sessionId: string
+  accessKey: string
+  reconnectToken: string
+  lastSequence: number
+  unsubscribe: () => void
+}
+
+export type UnmountTerminalSession = Omit<ActiveTerminalSession, 'generation'>
+
+export interface TerminalSession {
+  atBottom: boolean
+  cwd: string
+  error: string | null
+  focus: () => void
+  jumpToLatest: () => void
+  restart: () => void
+  startFresh: () => void
+  forget: () => void
+  close: () => Promise<string | null>
+  setContainer: (node: HTMLDivElement | null) => void
+  status: TerminalStatus
+}
+
+const MAX_QUEUED_INPUT_BYTES = 64 * 1024
+const HEARTBEAT_MS = 10_000
+
+function decodeBase64(value: string): Uint8Array {
+  const binary = window.atob(value)
+  const bytes = new Uint8Array(binary.length)
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index)
+  }
+  return bytes
+}
+
+function encodeBase64(bytes: Uint8Array): string {
+  let binary = ''
+  for (let offset = 0; offset < bytes.length; offset += 0x8000) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + 0x8000))
+  }
+  return window.btoa(binary)
+}
+
+function binaryStringToBytes(value: string): Uint8Array {
+  const bytes = new Uint8Array(value.length)
+  for (let index = 0; index < value.length; index += 1) {
+    bytes[index] = value.charCodeAt(index) & 0xff
+  }
+  return bytes
+}
+
+function browserLocalStorage(): Storage | null {
+  if (typeof window === 'undefined') return null
+  try {
+    return window.localStorage
+  } catch {
+    return null
+  }
+}
+
+function findPaneLease(
+  storage: Storage | null,
+  storageKey: string,
+  paneId: string,
+): LocalTerminalLease | null {
+  return (
+    loadRecoverableTerminalLeases(storage, storageKey).find(
+      (lease) => lease.paneId === paneId,
+    ) ?? null
+  )
+}
+
+export async function detachTerminalSessionForUnmount(
+  host: Host,
+  router: TerminalOutputRouter,
+  storageKey: string,
+  paneId: string,
+  active: UnmountTerminalSession,
+): Promise<void> {
+  saveRecoverableTerminalLease(null, storageKey, {
+    paneId,
+    sessionId: active.sessionId,
+    reconnectToken: active.reconnectToken,
+    lastSequence: active.lastSequence,
+  })
+  active.unsubscribe()
+  router.drain(active.sessionId)
+  await host.iii.trigger('shell::pty::detach', {
+    session_id: active.sessionId,
+    access_key: active.accessKey,
+  })
+}
+
+export function useTerminalSession(
+  options: TerminalSessionOptions | LegacyTerminalSessionOptions,
+): TerminalSession {
+  const legacyHost = 'host' in options ? options.host : null
+  const ownedRouter = useMemo(
+    () => (legacyHost ? createTerminalOutputRouter(legacyHost) : null),
+    [legacyHost],
+  )
+  useEffect(() => () => ownedRouter?.dispose(), [ownedRouter])
+
+  const paneId = 'host' in options ? 'legacy-terminal' : options.paneId
+  const root = options.root
+  const visible = 'host' in options ? root.length > 0 : options.visible
+  const router = 'host' in options ? ownedRouter : options.router
+  const leaseStore =
+    'host' in options ? browserLocalStorage() : options.leaseStore
+  const storageKey =
+    'host' in options
+      ? legacyTerminalStorageKey(root)
+      : (options.storageKey ?? 'iii::shell-ui::terminal-leases')
+  const host = router ? terminalOutputRouterHost(router) : legacyHost
+  const [container, setContainer] = useState<HTMLDivElement | null>(null)
+  const [state, dispatch] = useReducer(
+    reduceTerminalSessionState,
+    root,
+    createTerminalSessionState,
+  )
+  const [atBottom, setAtBottom] = useState(true)
+  const [restartToken, setRestartToken] = useState(0)
+  const terminalRef = useRef<Terminal | null>(null)
+  const terminalCleanupRef = useRef<(() => void) | null>(null)
+  const activeRef = useRef<ActiveTerminalSession | null>(null)
+  const leaseRef = useRef<LocalTerminalLease | null>(null)
+  const dimensionsRef = useRef({ cols: 80, rows: 24 })
+  const preMountOutputRef = useRef<Uint8Array[]>([])
+  const queuedInputRef = useRef<Uint8Array[]>([])
+  const queuedInputBytesRef = useRef(0)
+  const inputChainRef = useRef(Promise.resolve())
+  const resizeTimerRef = useRef<number | null>(null)
+  const gapReplayTimerRef = useRef<number | null>(null)
+  const connectionPromiseRef = useRef<Promise<TerminalConnection> | null>(null)
+  const localCoordinatorRef = useRef<TerminalConnectionCoordinator | null>(null)
+  if (!localCoordinatorRef.current) {
+    localCoordinatorRef.current = createTerminalConnectionCoordinator()
+  }
+  const connectionCoordinator =
+    'host' in options
+      ? localCoordinatorRef.current
+      : (options.connectionCoordinator ?? localCoordinatorRef.current)
+  const exitNotifiedRef = useRef(false)
+  const liveFramesRef = useRef(new Map<number, TerminalFrame>())
+
+  const saveLease = useCallback(
+    (lease: LocalTerminalLease) => {
+      leaseRef.current = lease
+      saveRecoverableTerminalLease(leaseStore, storageKey, lease)
+    },
+    [leaseStore, storageKey],
+  )
+
+  const removeLease = useCallback(() => {
+    leaseRef.current = null
+    removeRecoverableTerminalLease(leaseStore, storageKey, paneId)
+  }, [leaseStore, paneId, storageKey])
+
+  const appendOutput = useCallback((data: Uint8Array) => {
+    const terminal = terminalRef.current
+    if (!terminal) {
+      preMountOutputRef.current.push(data)
+      return
+    }
+    const viewport = terminal.buffer.active.viewportY
+    const following = viewport >= terminal.buffer.active.baseY
+    terminal.write(data, () => {
+      if (following) {
+        terminal.scrollToBottom()
+      } else {
+        terminal.scrollToLine(viewport)
+      }
+    })
+  }, [])
+
+  const applyFrame = useCallback(
+    (frame: TerminalFrame) => {
+      const active = activeRef.current
+      if (!active || frame.sequence <= active.lastSequence) return
+      try {
+        appendOutput(decodeBase64(frame.data))
+      } catch (error) {
+        dispatch({
+          type: 'failed',
+          error: `Terminal output decode failed: ${errorMessage(error)}`,
+        })
+        return
+      }
+      active.lastSequence = frame.sequence
+      try {
+        saveLease({
+          paneId,
+          sessionId: active.sessionId,
+          reconnectToken: active.reconnectToken,
+          lastSequence: active.lastSequence,
+        })
+      } catch (error) {
+        dispatch({ type: 'failed', error: errorMessage(error) })
+      }
+      dispatch({ type: 'frame-applied', sequence: frame.sequence })
+    },
+    [appendOutput, paneId, saveLease],
+  )
+
+  const scheduleReplay = useCallback(() => {
+    if (gapReplayTimerRef.current !== null) return
+    gapReplayTimerRef.current = window.setTimeout(() => {
+      gapReplayTimerRef.current = null
+      setRestartToken((token) => token + 1)
+    }, 250)
+  }, [])
+
+  const applyExit = useCallback(
+    (exit: {
+      exit_code: number | null
+      signal: string | null
+      error: string | null
+    }) => {
+      if (!exitNotifiedRef.current) {
+        let detail = `exit ${exit.exit_code ?? '?'}`
+        if (exit.error) detail = `error: ${exit.error}`
+        else if (exit.signal) detail = exit.signal
+        appendOutput(new TextEncoder().encode(`\r\n[process ${detail}]\r\n`))
+        exitNotifiedRef.current = true
+      }
+      dispatch({ type: 'exited', error: exit.error })
+    },
+    [appendOutput],
+  )
+
+  const applyOutputEvent = useCallback(
+    (event: PtyOutputEvent) => {
+      const active = activeRef.current
+      if (!active || event.session_id !== active.sessionId) return
+      if (event.data) {
+        let frames: TerminalFrame[]
+        try {
+          frames = bufferTerminalFrame(
+            liveFramesRef.current,
+            { sequence: event.sequence, data: event.data },
+            active.lastSequence,
+          )
+        } catch (error) {
+          dispatch({ type: 'failed', error: errorMessage(error) })
+          return
+        }
+        for (const frame of frames) applyFrame(frame)
+        if (liveFramesRef.current.size > 0) {
+          scheduleReplay()
+        } else if (gapReplayTimerRef.current !== null) {
+          window.clearTimeout(gapReplayTimerRef.current)
+          gapReplayTimerRef.current = null
+        }
+      }
+      if (event.eof) {
+        applyExit({
+          exit_code: event.exit_code,
+          signal: event.signal,
+          error: event.error,
+        })
+      }
+    },
+    [applyExit, applyFrame, scheduleReplay],
+  )
+
+  const writeInput = useCallback(
+    (session: ActiveTerminalSession, data: Uint8Array) => {
+      if (!host) return
+      inputChainRef.current = inputChainRef.current
+        .catch(() => undefined)
+        .then(async () => {
+          try {
+            await host.iii.trigger('shell::pty::write', {
+              session_id: session.sessionId,
+              access_key: session.accessKey,
+              data: encodeBase64(data),
+            })
+          } catch (error) {
+            if (
+              activeRef.current?.sessionId === session.sessionId &&
+              activeRef.current.generation === session.generation
+            ) {
+              dispatch({ type: 'failed', error: errorMessage(error) })
+            }
+          }
+        })
+    },
+    [host],
+  )
+
+  const sendInput = useCallback(
+    (data: Uint8Array) => {
+      if (data.byteLength === 0) return
+      const active = activeRef.current
+      if (active) {
+        writeInput(active, data)
+        return
+      }
+      if (
+        queuedInputBytesRef.current + data.byteLength >
+        MAX_QUEUED_INPUT_BYTES
+      ) {
+        dispatch({
+          type: 'failed',
+          error: `Terminal input queue exceeds ${MAX_QUEUED_INPUT_BYTES} bytes`,
+        })
+        return
+      }
+      queuedInputRef.current.push(data)
+      queuedInputBytesRef.current += data.byteLength
+    },
+    [writeInput],
+  )
+
+  const sendResize = useCallback(
+    (cols: number, rows: number) => {
+      const dimensions = normalizeTerminalDimensions(cols, rows)
+      dimensionsRef.current = dimensions
+      const active = activeRef.current
+      if (!active || !host) return
+      if (resizeTimerRef.current !== null) {
+        window.clearTimeout(resizeTimerRef.current)
+      }
+      resizeTimerRef.current = window.setTimeout(() => {
+        resizeTimerRef.current = null
+        void host.iii
+          .trigger('shell::pty::resize', {
+            session_id: active.sessionId,
+            access_key: active.accessKey,
+            cols: dimensions.cols,
+            rows: dimensions.rows,
+          })
+          .catch((error) => {
+            if (
+              activeRef.current?.sessionId === active.sessionId &&
+              activeRef.current.generation === active.generation
+            ) {
+              dispatch({ type: 'failed', error: errorMessage(error) })
+            }
+          })
+      }, 60)
+    },
+    [host],
+  )
+
+  useEffect(() => {
+    if (!visible || !container) return
+    const styles = window.getComputedStyle(container)
+    const color = (name: string, fallback: string) =>
+      styles.getPropertyValue(name).trim() || fallback
+    const terminal = new Terminal({
+      cursorBlink: true,
+      cursorStyle: 'block',
+      fontFamily: color(
+        '--font-mono',
+        'ui-monospace, SFMono-Regular, Menlo, monospace',
+      ),
+      fontSize: 13,
+      lineHeight: 1.2,
+      scrollback: 10_000,
+      scrollOnUserInput: true,
+      theme: {
+        background: color('--color-bg', '#111111'),
+        foreground: color('--color-ink', '#e5e5e5'),
+        cursor: color('--color-ink', '#e5e5e5'),
+        cursorAccent: color('--color-bg', '#111111'),
+        selectionBackground: color('--color-surface-active', '#3a3a3a'),
+      },
+    })
+    const fitAddon = new FitAddon()
+    const terminalHost = document.createElement('div')
+    terminalHost.className = 'shui-xterm-host'
+    terminal.loadAddon(fitAddon)
+    container.appendChild(terminalHost)
+    terminal.open(terminalHost)
+    terminalRef.current = terminal
+
+    const input = terminal.onData((data) =>
+      sendInput(new TextEncoder().encode(data)),
+    )
+    const binary = terminal.onBinary((data) =>
+      sendInput(binaryStringToBytes(data)),
+    )
+    const resized = terminal.onResize(({ cols, rows }) =>
+      sendResize(cols, rows),
+    )
+    const scrolled = terminal.onScroll((viewportY) => {
+      setAtBottom(viewportY >= terminal.buffer.active.baseY)
+    })
+    for (const chunk of preMountOutputRef.current) terminal.write(chunk)
+    preMountOutputRef.current = []
+
+    const fitTerminal = () => {
+      try {
+        fitAddon.fit()
+      } catch {
+        return
+      }
+      dimensionsRef.current = normalizeTerminalDimensions(
+        terminal.cols,
+        terminal.rows,
+      )
+    }
+    const observer = new ResizeObserver(fitTerminal)
+    observer.observe(container)
+    const frame = window.requestAnimationFrame(() => {
+      fitTerminal()
+      terminal.focus()
+    })
+
+    terminalCleanupRef.current = () => {
+      window.cancelAnimationFrame(frame)
+      observer.disconnect()
+      scrolled.dispose()
+      resized.dispose()
+      binary.dispose()
+      input.dispose()
+      terminal.dispose()
+      if (terminalRef.current === terminal) terminalRef.current = null
+    }
+    return () => {
+      terminalCleanupRef.current?.()
+      terminalCleanupRef.current = null
+    }
+  }, [container, sendInput, sendResize, visible])
+
+  useEffect(() => {
+    void restartToken
+    if (!visible || !router || !host || !root) return
+    let cancelled = false
+    const attempt = connectionCoordinator.begin()
+    const { generation } = attempt
+    const { cols, rows } = dimensionsRef.current
+    const lease = findPaneLease(leaseStore, storageKey, paneId)
+    leaseRef.current = lease
+    exitNotifiedRef.current = false
+    preMountOutputRef.current = []
+    queuedInputRef.current = []
+    queuedInputBytesRef.current = 0
+    inputChainRef.current = Promise.resolve()
+    activeRef.current = null
+    liveFramesRef.current.clear()
+    dispatch({ type: 'connecting', cwd: root })
+    terminalRef.current?.reset()
+
+    const connectionPromise = connectTerminalSession({
+      host,
+      router,
+      root,
+      lease,
+      requestId: attempt.requestId,
+      cols,
+      rows,
+    })
+    connectionPromiseRef.current = connectionPromise
+    void connectionPromise
+      .then(async (connection) => {
+        let credentialsPersisted = false
+        try {
+          if (cancelled || !connectionCoordinator.isCurrent(generation)) {
+            try {
+              saveLease({
+                paneId,
+                sessionId: connection.sessionId,
+                reconnectToken: connection.reconnectToken,
+                lastSequence: lease?.lastSequence ?? 0,
+              })
+            } catch {
+              await closeTerminalConnection(host, router, connection)
+              removeLease()
+              return
+            }
+            if (cancelled && connectionCoordinator.isCurrent(generation)) {
+              await disposeTerminalConnection(host, router, connection)
+            } else {
+              connection.unsubscribe()
+            }
+            return
+          }
+          const nextLease = reduceTerminalLease(lease, {
+            type: 'restarted',
+            lease: {
+              paneId,
+              sessionId: connection.sessionId,
+              reconnectToken: connection.reconnectToken,
+              lastSequence: 0,
+            },
+          })
+          if (!nextLease) {
+            throw new Error('terminal connection did not produce a lease')
+          }
+          saveLease(nextLease)
+          credentialsPersisted = true
+          if (cancelled) {
+            await disposeTerminalConnection(host, router, connection)
+            return
+          }
+
+          const active: ActiveTerminalSession = {
+            generation,
+            sessionId: connection.sessionId,
+            accessKey: connection.accessKey,
+            reconnectToken: connection.reconnectToken,
+            lastSequence: nextLease.lastSequence,
+            unsubscribe: connection.unsubscribe,
+          }
+          activeRef.current = active
+          dispatch({
+            type: 'connected',
+            sessionId: connection.sessionId,
+            cwd: connection.cwd,
+          })
+          const activated = connection.activate(applyOutputEvent)
+          if (connection.truncated) {
+            dispatch({ type: 'replay-truncated' })
+            appendOutput(new TextEncoder().encode(REPLAY_TRUNCATION_NOTICE))
+          }
+          if (activated.requiresReplay) {
+            scheduleReplay()
+          } else {
+            for (const frame of activated.frames) {
+              if (frame.sequence <= activated.replayThrough) {
+                applyFrame(frame)
+                continue
+              }
+              const contiguous = bufferTerminalFrame(
+                liveFramesRef.current,
+                frame,
+                active.lastSequence,
+              )
+              for (const pendingFrame of contiguous) applyFrame(pendingFrame)
+            }
+            if (liveFramesRef.current.size > 0) scheduleReplay()
+          }
+          for (const event of activated.events) applyOutputEvent(event)
+
+          const exited = exitedStatus(connection.status)
+          if (exited) {
+            applyExit(exited)
+          } else if (connection.status === 'detached') {
+            dispatch({
+              type: 'disconnected',
+              error: 'terminal session detached during attach',
+            })
+          }
+          connectionCoordinator.complete(generation)
+
+          const queuedInput = queuedInputRef.current
+          queuedInputRef.current = []
+          queuedInputBytesRef.current = 0
+          for (const data of queuedInput) writeInput(active, data)
+          const latest = dimensionsRef.current
+          if (latest.cols !== cols || latest.rows !== rows) {
+            sendResize(latest.cols, latest.rows)
+          }
+        } catch (error) {
+          if (
+            activeRef.current?.sessionId === connection.sessionId &&
+            activeRef.current.generation === generation
+          ) {
+            activeRef.current = null
+          }
+          try {
+            if (credentialsPersisted) {
+              await disposeTerminalConnection(host, router, connection)
+            } else {
+              await closeTerminalConnection(host, router, connection)
+              removeLease()
+            }
+          } catch (cleanupError) {
+            throw new Error(
+              `${errorMessage(error)}; terminal cleanup failed: ${errorMessage(cleanupError)}`,
+            )
+          }
+          throw error
+        }
+      })
+      .catch((error) => {
+        if (cancelled) return
+        if (lease && backendConfirmedSessionMissing(error)) {
+          removeLease()
+          setRestartToken((token) => token + 1)
+          return
+        }
+        if (
+          lease &&
+          !errorMessage(error).includes('reconnect token is invalid')
+        ) {
+          dispatch({
+            type: 'reconnecting',
+            error: errorMessage(error),
+          })
+          scheduleReplay()
+          return
+        }
+        dispatch({
+          type: lease ? 'disconnected' : 'failed',
+          error: errorMessage(error),
+        })
+      })
+      .finally(() => {
+        if (connectionPromiseRef.current === connectionPromise) {
+          connectionPromiseRef.current = null
+        }
+      })
+
+    return () => {
+      cancelled = true
+      const active = activeRef.current
+      activeRef.current = null
+      queuedInputRef.current = []
+      queuedInputBytesRef.current = 0
+      if (!active) return
+      void detachTerminalSessionForUnmount(
+        host,
+        router,
+        storageKey,
+        paneId,
+        active,
+      ).catch(() => undefined)
+    }
+  }, [
+    appendOutput,
+    applyExit,
+    applyFrame,
+    applyOutputEvent,
+    connectionCoordinator,
+    host,
+    leaseStore,
+    paneId,
+    removeLease,
+    restartToken,
+    root,
+    router,
+    saveLease,
+    scheduleReplay,
+    sendResize,
+    storageKey,
+    visible,
+    writeInput,
+  ])
+
+  useEffect(() => {
+    if (!visible || !host) return
+    let interrupted = false
+    let retryScheduled = false
+    return host.iii.addConnectionStateListener((connectionState) => {
+      if (connectionState === 'connected') {
+        if (interrupted && !retryScheduled) {
+          interrupted = false
+          retryScheduled = true
+          connectionCoordinator.invalidate()
+          setRestartToken((token) => token + 1)
+          retryScheduled = false
+        }
+        return
+      }
+      interrupted = true
+      if (activeRef.current || connectionPromiseRef.current) {
+        dispatch({
+          type: 'reconnecting',
+          error: 'Terminal transport disconnected; reconnecting',
+        })
+      }
+    })
+  }, [connectionCoordinator, host, visible])
+
+  useEffect(() => {
+    if (!visible || !host) return
+    const heartbeat = window.setInterval(() => {
+      const active = activeRef.current
+      if (!active) return
+      const { cols, rows } = dimensionsRef.current
+      void host.iii
+        .trigger('shell::pty::resize', {
+          session_id: active.sessionId,
+          access_key: active.accessKey,
+          cols,
+          rows,
+        })
+        .catch((error) => {
+          if (
+            activeRef.current?.sessionId === active.sessionId &&
+            activeRef.current.generation === active.generation
+          ) {
+            dispatch({ type: 'failed', error: errorMessage(error) })
+          }
+        })
+    }, HEARTBEAT_MS)
+    return () => window.clearInterval(heartbeat)
+  }, [host, visible])
+
+  useEffect(
+    () => () => {
+      if (resizeTimerRef.current !== null) {
+        window.clearTimeout(resizeTimerRef.current)
+      }
+      if (gapReplayTimerRef.current !== null) {
+        window.clearTimeout(gapReplayTimerRef.current)
+      }
+    },
+    [],
+  )
+
+  const close = useCallback(async () => {
+    if (connectionPromiseRef.current) {
+      try {
+        await connectionPromiseRef.current
+      } catch {
+        connectionPromiseRef.current = null
+      }
+    }
+    const active = activeRef.current
+    if (active && host) {
+      try {
+        await host.iii.trigger('shell::pty::close', {
+          session_id: active.sessionId,
+          access_key: active.accessKey,
+        })
+      } catch (error) {
+        if (!backendConfirmedSessionMissing(error)) {
+          dispatch({ type: 'failed', error: errorMessage(error) })
+          throw error
+        }
+      }
+      active.unsubscribe()
+      router?.drain(active.sessionId)
+      activeRef.current = null
+      let warning: string | null = null
+      try {
+        removeLease()
+      } catch (error) {
+        warning = errorMessage(error)
+      }
+      dispatch({ type: 'closed' })
+      return warning
+    }
+
+    const lease =
+      leaseRef.current ?? findPaneLease(leaseStore, storageKey, paneId)
+    if (lease && host && router) {
+      try {
+        const warning = await reclaimTerminalLease(host, router, {
+          ...lease,
+          update: saveLease,
+          remove: removeLease,
+        })
+        dispatch({ type: 'closed' })
+        return warning
+      } catch (error) {
+        dispatch({ type: 'failed', error: errorMessage(error) })
+        throw error
+      }
+    }
+    try {
+      removeLease()
+    } catch (error) {
+      dispatch({ type: 'closed' })
+      return errorMessage(error)
+    }
+    dispatch({ type: 'closed' })
+    return null
+  }, [host, leaseStore, paneId, removeLease, router, saveLease, storageKey])
+
+  const restart = useCallback(() => {
+    void close()
+      .then(() => {
+        terminalRef.current?.reset()
+        preMountOutputRef.current = []
+        setRestartToken((token) => token + 1)
+      })
+      .catch(() => undefined)
+  }, [close])
+
+  const forget = useCallback(() => {
+    const active = activeRef.current
+    activeRef.current = null
+    if (active) {
+      active.unsubscribe()
+      router?.drain(active.sessionId)
+      if (host) {
+        void host.iii
+          .trigger('shell::pty::detach', {
+            session_id: active.sessionId,
+            access_key: active.accessKey,
+          })
+          .catch(() => undefined)
+      }
+    }
+    liveFramesRef.current.clear()
+    removeLease()
+    dispatch({ type: 'closed' })
+  }, [host, removeLease, router])
+
+  const startFresh = useCallback(() => {
+    forget()
+    terminalRef.current?.reset()
+    preMountOutputRef.current = []
+    setRestartToken((token) => token + 1)
+  }, [forget])
+
+  const focus = useCallback(() => terminalRef.current?.focus(), [])
+  const jumpToLatest = useCallback(() => {
+    terminalRef.current?.scrollToBottom()
+    terminalRef.current?.focus()
+    setAtBottom(true)
+  }, [])
+
+  return {
+    atBottom,
+    cwd: state.cwd,
+    error: state.error,
+    focus,
+    jumpToLatest,
+    restart,
+    startFresh,
+    forget,
+    close,
+    setContainer,
+    status: state.status,
+  }
+}

--- a/shell/ui/src/page/terminal-stream.ts
+++ b/shell/ui/src/page/terminal-stream.ts
@@ -1,0 +1,79 @@
+export interface TerminalFrame {
+  sequence: number
+  data: string
+}
+
+function isNonNegativeSafeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
+}
+
+function assertAfterSequence(afterSequence: number): void {
+  if (!isNonNegativeSafeInteger(afterSequence)) {
+    throw new Error('invalid afterSequence')
+  }
+}
+
+function assertFrameSequence(sequence: number): void {
+  if (!isNonNegativeSafeInteger(sequence)) {
+    throw new Error('invalid frame sequence')
+  }
+}
+
+function framesEqual(left: TerminalFrame, right: TerminalFrame): boolean {
+  return left.sequence === right.sequence && left.data === right.data
+}
+
+export function bufferTerminalFrame(
+  pending: Map<number, TerminalFrame>,
+  frame: TerminalFrame,
+  afterSequence: number,
+): TerminalFrame[] {
+  assertAfterSequence(afterSequence)
+  assertFrameSequence(frame.sequence)
+  if (frame.sequence <= afterSequence) return []
+  const existing = pending.get(frame.sequence)
+  if (existing && !framesEqual(existing, frame)) {
+    throw new Error(
+      `conflicting terminal frame data for sequence ${frame.sequence}`,
+    )
+  }
+  pending.set(frame.sequence, frame)
+  const contiguous: TerminalFrame[] = []
+  let sequence = afterSequence + 1
+  while (pending.has(sequence)) {
+    const next = pending.get(sequence)
+    pending.delete(sequence)
+    if (next) contiguous.push(next)
+    sequence += 1
+  }
+  return contiguous
+}
+
+export function mergeTerminalFrames(
+  replay: TerminalFrame[],
+  pending: TerminalFrame[],
+  afterSequence: number,
+): TerminalFrame[] {
+  assertAfterSequence(afterSequence)
+
+  const merged = new Map<number, TerminalFrame>()
+
+  for (const frame of [...replay, ...pending]) {
+    assertFrameSequence(frame.sequence)
+    if (frame.sequence <= afterSequence) continue
+    const existing = merged.get(frame.sequence)
+    if (existing) {
+      if (!framesEqual(existing, frame)) {
+        throw new Error(
+          `conflicting terminal frame data for sequence ${frame.sequence}`,
+        )
+      }
+      continue
+    }
+    merged.set(frame.sequence, frame)
+  }
+
+  return [...merged.values()].sort(
+    (left, right) => left.sequence - right.sequence,
+  )
+}

--- a/shell/ui/styles.css
+++ b/shell/ui/styles.css
@@ -1,3 +1,5 @@
+@import "@xterm/xterm/css/xterm.css";
+
 /*
  * The shell worker's console stylesheet, shipped as its own
  * `console:style` asset (shell/styles.css). Every rule is scoped under
@@ -445,10 +447,40 @@
   height: 14px;
 }
 
+[data-iii-ui="shell"] .shui-page-header {
+  overflow: visible;
+  z-index: 8;
+}
 [data-iii-ui="shell"] .shui-page-actions {
   display: flex;
   align-items: center;
   gap: 2px;
+  overflow: visible;
+}
+[data-iii-ui="shell"] .shui-hover-tip {
+  display: inline-flex;
+  align-items: center;
+  min-inline-size: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+.shui-hover-tip-bubble {
+  position: fixed;
+  z-index: 10000;
+  box-sizing: border-box;
+  max-width: calc(100vw - 16px);
+  padding: 5px 8px;
+  border-radius: 4px;
+  background: var(--color-ink, #111);
+  color: var(--color-bg, #f5f5f5);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.25;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  pointer-events: none;
+  box-shadow: 0 4px 12px color-mix(in srgb, #000 22%, transparent);
 }
 
 [data-iii-ui="shell"] .shui-header-root-select {
@@ -469,14 +501,16 @@
 }
 
 [data-iii-ui="shell"] .shui-collapse-btn {
-  font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 13px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   color: var(--color-ink-faint);
   background: transparent;
   border: 1px solid transparent;
   border-radius: 2px;
-  width: 22px;
-  height: 22px;
+  width: 28px;
+  height: 28px;
+  padding: 0;
   cursor: pointer;
 }
 [data-iii-ui="shell"] .shui-collapse-btn:hover {
@@ -515,6 +549,7 @@
   min-height: 0;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 }
 [data-iii-ui="shell"] .shui-tree-filter-shell {
   flex: none;
@@ -1644,5 +1679,397 @@
   }
   [data-iii-ui="shell"] .shui-file-change-view span {
     display: none;
+  }
+}
+[data-iii-ui="shell"] .shui-workspace-frame {
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+  display: flex;
+  overflow: hidden;
+}
+[data-iii-ui="shell"] .shui-workspace-frame.terminal-bottom {
+  flex-direction: column;
+}
+[data-iii-ui="shell"] .shui-workspace-frame.terminal-right {
+  flex-direction: row;
+}
+[data-iii-ui="shell"] .shui-workspace-frame > :first-child {
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+}
+[data-iii-ui="shell"] .shui-terminal-panel {
+  position: relative;
+  min-height: 0;
+  min-width: 0;
+  flex: none;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--color-bg, #111);
+}
+[data-iii-ui="shell"] .shui-terminal-panel[data-terminal-dock="bottom"] {
+  width: 100%;
+  min-height: 160px;
+  max-height: calc(100% - 120px);
+  border-top: 1px solid var(--color-edge);
+}
+[data-iii-ui="shell"] .shui-terminal-panel[data-terminal-dock="right"] {
+  height: 100%;
+  min-width: 160px;
+  max-width: calc(100% - 240px);
+  border-left: 1px solid var(--color-edge);
+}
+[data-iii-ui="shell"] .shui-terminal-panel[data-terminal-dock="editor"] {
+  flex: 1;
+  width: 100%;
+  height: 100%;
+}
+[data-iii-ui="shell"] .shui-terminal-panel-chrome {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 34px;
+  padding: 4px 8px 4px 10px;
+  color: var(--color-ink-faint);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11px;
+  border-bottom: 1px solid var(--color-edge);
+}
+[data-iii-ui="shell"] .shui-terminal-panel-chrome > svg {
+  width: 14px;
+  height: 14px;
+}
+[data-iii-ui="shell"] .shui-terminal-workspace {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+}
+[data-iii-ui="shell"] .shui-terminal-tabs {
+  flex: none;
+  display: flex;
+  align-items: stretch;
+  min-width: 0;
+  min-height: 32px;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--color-edge);
+  scrollbar-width: thin;
+}
+[data-iii-ui="shell"] .shui-terminal-tab {
+  flex: none;
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  color: var(--color-ink-faint);
+  border-right: 1px solid var(--color-edge);
+  background: var(--color-bg);
+}
+[data-iii-ui="shell"] .shui-terminal-tab.active {
+  color: var(--color-ink);
+  background: var(--color-surface-active);
+  box-shadow: inset 0 -1px 0 var(--color-accent);
+}
+[data-iii-ui="shell"] .shui-terminal-tab-select {
+  max-width: 150px;
+  padding: 7px 8px 7px 10px;
+  overflow: hidden;
+  color: inherit;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+}
+[data-iii-ui="shell"] .shui-terminal-tab-action,
+[data-iii-ui="shell"] .shui-terminal-tab-new {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  min-width: 26px;
+  padding: 0;
+  color: var(--color-ink-ghost);
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+}
+[data-iii-ui="shell"] .shui-terminal-tab-action:hover,
+[data-iii-ui="shell"] .shui-terminal-tab-new:hover {
+  color: var(--color-ink);
+  background: var(--color-surface-hover);
+}
+[data-iii-ui="shell"] .shui-terminal-tab-action svg,
+[data-iii-ui="shell"] .shui-terminal-tab-new svg {
+  width: 12px;
+  height: 12px;
+}
+[data-iii-ui="shell"] .shui-terminal-tab-input {
+  width: 110px;
+  margin: 3px;
+  padding: 3px 5px;
+  color: var(--color-ink);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11px;
+  border: 1px solid var(--color-rule-focus);
+  border-radius: 2px;
+  background: var(--color-bg);
+  outline: none;
+}
+[data-iii-ui="shell"] .shui-terminal-layout {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+}
+[data-iii-ui="shell"] .shui-terminal-split {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+[data-iii-ui="shell"] .shui-terminal-split.horizontal {
+  flex-direction: row;
+}
+[data-iii-ui="shell"] .shui-terminal-split.vertical {
+  flex-direction: column;
+}
+[data-iii-ui="shell"] .shui-terminal-split-child {
+  flex: 1 1 0;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+[data-iii-ui="shell"] .shui-terminal-split-separator {
+  z-index: 2;
+  flex: none;
+  padding: 0;
+  border: 0;
+  background: var(--color-edge);
+  touch-action: none;
+}
+[data-iii-ui="shell"] .shui-terminal-split.horizontal > .shui-terminal-split-separator {
+  width: 5px;
+  cursor: ew-resize;
+}
+[data-iii-ui="shell"] .shui-terminal-split.vertical > .shui-terminal-split-separator {
+  height: 5px;
+  cursor: ns-resize;
+}
+[data-iii-ui="shell"] .shui-terminal-split-separator:hover,
+[data-iii-ui="shell"] .shui-terminal-split-separator:focus-visible {
+  background: var(--color-accent);
+  outline: none;
+}
+[data-iii-ui="shell"] .shui-terminal-pane-slot {
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px transparent;
+}
+[data-iii-ui="shell"] .shui-terminal-pane-slot.focused {
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-accent) 55%, transparent);
+}
+[data-iii-ui="shell"] .shui-terminal-workspace-error {
+  flex: none;
+  padding: 5px 9px;
+  color: var(--color-warn);
+  font-size: 11px;
+  border-bottom: 1px solid color-mix(in srgb, var(--color-warn) 25%, transparent);
+}
+[data-iii-ui="shell"] .shui-terminal-empty {
+  display: grid;
+  width: 100%;
+  height: 100%;
+  place-items: center;
+  color: var(--color-ink-ghost);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 12px;
+}
+[data-iii-ui="shell"] .shui-terminal-resize {
+  position: absolute;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  touch-action: none;
+}
+[data-iii-ui="shell"] .shui-terminal-resize span {
+  display: block;
+  border-radius: 999px;
+  background: var(--color-ink-ghost);
+}
+[data-iii-ui="shell"] .shui-terminal-panel[data-terminal-dock="bottom"] > .shui-terminal-resize {
+  top: -4px;
+  left: 0;
+  width: 100%;
+  height: 9px;
+  cursor: ns-resize;
+}
+[data-iii-ui="shell"] .shui-terminal-panel[data-terminal-dock="bottom"] > .shui-terminal-resize span {
+  width: 36px;
+  height: 3px;
+}
+[data-iii-ui="shell"] .shui-terminal-panel[data-terminal-dock="right"] > .shui-terminal-resize {
+  top: 0;
+  left: -4px;
+  width: 9px;
+  height: 100%;
+  cursor: ew-resize;
+}
+[data-iii-ui="shell"] .shui-terminal-panel[data-terminal-dock="right"] > .shui-terminal-resize span {
+  width: 3px;
+  height: 36px;
+}
+[data-iii-ui="shell"] .shui-terminal-resize:hover span,
+[data-iii-ui="shell"] .shui-terminal-resize:focus-visible span {
+  background: var(--color-accent);
+}
+[data-iii-ui="shell"] .shui-terminal {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  height: 100%;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 12.5px;
+}
+[data-iii-ui="shell"] .shui-terminal-chrome {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  font-size: 12px;
+  color: var(--color-ink-faint);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-ink) 10%, transparent);
+}
+[data-iii-ui="shell"] .shui-terminal-chrome-icon {
+  width: 14px;
+  height: 14px;
+}
+[data-iii-ui="shell"] .shui-terminal-chrome-cwd {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+}
+[data-iii-ui="shell"] .shui-terminal-state {
+  flex: none;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-ink-ghost);
+}
+[data-iii-ui="shell"] .shui-terminal-state.ready {
+  color: var(--color-accent);
+}
+[data-iii-ui="shell"] .shui-terminal-state.error {
+  color: var(--color-warn);
+}
+[data-iii-ui="shell"] .shui-terminal-chrome-spacer {
+  flex: 1;
+}
+[data-iii-ui="shell"] .shui-terminal-action {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 0;
+  border-radius: 3px;
+  color: var(--color-ink-faint);
+  background: transparent;
+  cursor: pointer;
+  transition: transform 120ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+[data-iii-ui="shell"] .shui-terminal-action:hover,
+[data-iii-ui="shell"] .shui-terminal-action.active {
+  color: var(--color-ink);
+  background: var(--color-surface-hover);
+}
+[data-iii-ui="shell"] .shui-terminal-action:active {
+  transform: scale(0.97);
+}
+[data-iii-ui="shell"] .shui-terminal-action:focus-visible {
+  outline: 1px solid var(--color-rule-focus);
+  outline-offset: 1px;
+}
+[data-iii-ui="shell"] .shui-terminal-action:disabled,
+[data-iii-ui="shell"] .shui-terminal-tab-new:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+[data-iii-ui="shell"] .shui-terminal-action svg {
+  width: 14px;
+  height: 14px;
+}
+[data-iii-ui="shell"] .shui-terminal-error {
+  flex: none;
+  padding: 5px 10px;
+  overflow: hidden;
+  color: var(--color-warn);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  border-bottom: 1px solid color-mix(in srgb, var(--color-warn) 25%, transparent);
+}
+[data-iii-ui="shell"] .shui-xterm {
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+  padding: 8px 10px;
+  background: var(--color-bg, #111);
+}
+[data-iii-ui="shell"] .shui-xterm-host {
+  width: 100%;
+  height: 100%;
+}
+[data-iii-ui="shell"] .shui-xterm .xterm {
+  width: 100%;
+  height: 100%;
+}
+[data-iii-ui="shell"] .shui-xterm .xterm-viewport {
+  scrollbar-color: var(--color-ink-ghost) transparent;
+}
+[data-iii-ui="shell"] .shui-etab-icon {
+  width: 13px;
+  height: 13px;
+  flex: none;
+}
+
+@media (max-width: 760px) {
+  [data-iii-ui="shell"] .shui-terminal-panel-chrome {
+    gap: 3px;
+    padding-inline: 6px;
+  }
+  [data-iii-ui="shell"] .shui-terminal-panel-chrome > span:not(.shui-terminal-chrome-spacer) {
+    display: none;
+  }
+  [data-iii-ui="shell"] .shui-terminal-tab-select {
+    max-width: 92px;
+  }
+  [data-iii-ui="shell"] .shui-terminal-tab-action {
+    width: 22px;
+    min-width: 22px;
+  }
+  [data-iii-ui="shell"] .shui-terminal-chrome {
+    gap: 4px;
+    padding-inline: 7px;
   }
 }


### PR DESCRIPTION
Refs MOT-4407

The shell terminal is now a real interactive session, not a command form. Users can run tools like Claude and tmux, keep more than one pane open, and come back to the same session after a reload.

## What changed

- Persistent login-shell PTY with xterm rendering.
- Tabs plus horizontal and vertical splits, up to 4 panes per tab and 16 sessions.
- Dock the terminal at the bottom, on the right, or as an editor tab, with resize handles and hover labels.
- Reload reconnects the same PTY and replays recent output.
- Agents cannot open or drive PTY sessions. Console UI owns that path.

## Verification

- Shell Rust tests and clippy passed.
- Shell UI: 273 tests passed, production build passed.
- Isolated Playwright covered docking, tabs, splits, resize, reload replay, tmux, Claude, cleanup, and the session cap.
- Live `:3113` opened a ready PTY, ran tmux and Claude, created 2 tabs / 3 panes, and restored output after reload.
