### PR TITLE
(MOT-4452) fix: clarify LLM failure messages

### DIFF
--- a/console/web/e2e/provider-family-errors.spec.ts
+++ b/console/web/e2e/provider-family-errors.spec.ts
@@ -1,3 +1,4 @@
+import type { Page } from '@playwright/test'
 import { expect, expectPassingResult, openSession, test } from './harness-stack'
 
 const cases = [
@@ -18,14 +19,33 @@ const cases = [
   },
 ] as const
 
+const failureSummary = 'The provider rejected this request.'
+const nextAction =
+  'Review the selected model and provider settings, then try again.'
 const recoveryMessage =
   'Confirm the chat can continue after the provider issue is corrected.'
+
+async function expectFailureNotice(page: Page) {
+  const notice = page
+    .locator('[data-message-role="system-notice"][data-message-tone="error"]')
+    .filter({ hasText: failureSummary })
+  await expect(notice).toHaveCount(1)
+  await expect(notice.locator('[data-message-summary]')).toHaveText(
+    failureSummary,
+  )
+  await expect(notice.locator('[data-message-next-actions] li')).toHaveText(
+    nextAction,
+  )
+  const details = notice.locator('[data-message-technical-details]')
+  await expect(details).not.toHaveAttribute('open', '')
+  return details
+}
 
 for (const fixture of cases) {
   test.describe(`${fixture.family} provider failure`, () => {
     test.use({ scenario: fixture.scenario })
 
-    test('renders and captures the permanent error notice', async ({
+    test('renders a durable human-readable error with technical details', async ({
       page,
       stack,
     }, testInfo) => {
@@ -39,13 +59,18 @@ for (const fixture of cases) {
         session_id: stack.ready.session.id,
         status: 'failed',
       })
-      const notice = page
-        .locator(
-          '[data-message-role="system-notice"][data-message-tone="error"]',
-        )
-        .filter({ hasText: fixture.reason })
-      await expect(notice).toHaveCount(1)
-      await expect(notice).toContainText('turn failed [llm.permanent]')
+      const details = await expectFailureNotice(page)
+      await details.locator('summary').click()
+      await expect(details).toHaveAttribute('open', '')
+      await expect(
+        details.locator('[data-technical-detail="code"]'),
+      ).toHaveText('invocation_failed')
+      await expect(
+        details.locator('[data-technical-detail="class"]'),
+      ).toHaveText('llm.permanent')
+      await expect(
+        details.locator('[data-technical-detail="detail"]'),
+      ).toContainText(fixture.reason)
 
       const screenshot = testInfo.outputPath(`${fixture.scenario}.png`)
       await page.screenshot({ path: screenshot, fullPage: true })
@@ -53,6 +78,23 @@ for (const fixture of cases) {
         path: screenshot,
         contentType: 'image/png',
       })
+
+      await page.reload()
+      const session = page.getByRole('button', {
+        name: `open ${stack.ready.session.title}`,
+        exact: true,
+      })
+      await session.click()
+      await expect(session).toHaveAttribute('aria-current', 'page')
+      await expect(
+        page.locator(`[data-chat-session-id="${stack.ready.session.id}"]`),
+      ).toHaveAttribute('data-chat-session-hydrated', 'true')
+
+      const rehydratedDetails = await expectFailureNotice(page)
+      await rehydratedDetails.locator('summary').click()
+      await expect(
+        rehydratedDetails.locator('[data-technical-detail="detail"]'),
+      ).toContainText(fixture.reason)
 
       const recovered = stack.waitForTurnCompleted()
       await composer.pressSequentially(recoveryMessage)

--- a/console/web/src/components/chat/Message.tsx
+++ b/console/web/src/components/chat/Message.tsx
@@ -132,6 +132,12 @@ export function Message({
 
 function SystemNotice({ message }: { message: SystemMessageType }) {
   const tone = message.tone ?? 'info'
+  const detailRows: Array<[string, string]> = message.technicalDetails
+    ? Object.entries(message.technicalDetails).flatMap(([key, value]) =>
+        typeof value === 'string' && value.length > 0 ? [[key, value]] : [],
+      )
+    : []
+  const structured = Boolean(message.nextActions?.length || detailRows.length)
   const toneCls =
     tone === 'error'
       ? 'border-l-danger text-danger'
@@ -143,11 +149,50 @@ function SystemNotice({ message }: { message: SystemMessageType }) {
       data-message-role="system-notice"
       data-message-tone={tone}
       className={cn(
-        'border-l-2 pl-3 py-1 font-mono text-[12px] uppercase tracking-[0.04em]',
+        'border-l-2 pl-3 py-1 font-mono text-[12px]',
+        structured ? 'tracking-normal' : 'uppercase tracking-[0.04em]',
         toneCls,
       )}
     >
-      {message.content}
+      <div data-message-summary>{message.content}</div>
+      {message.nextActions?.length ? (
+        <div
+          data-message-next-actions
+          className="mt-2 text-ink-faint normal-case"
+        >
+          <div className="text-[10px] uppercase tracking-[0.08em]">
+            What you can do
+          </div>
+          <ul className="mt-1 list-disc space-y-1 pl-4">
+            {message.nextActions.map((action) => (
+              <li key={action}>{action}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+      {detailRows.length > 0 ? (
+        <details
+          data-message-technical-details
+          className="mt-2 text-ink-faint normal-case"
+        >
+          <summary className="cursor-pointer select-none text-[10px] uppercase tracking-[0.08em] hover:text-ink">
+            Technical details
+          </summary>
+          <dl className="mt-2 grid grid-cols-[max-content_minmax(0,1fr)] gap-x-3 gap-y-1 border-l border-rule-2 pl-3 text-[11px]">
+            {detailRows.map(([key, value]) => (
+              <div key={key} className="contents">
+                <dt className="uppercase text-ink-ghost">{key}</dt>
+                <dd
+                  data-technical-detail={key}
+                  className="break-words text-ink-faint"
+                >
+                  {value}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </details>
+      ) : null}
     </article>
   )
 }

--- a/console/web/src/lib/sessions/entry-mapper.test.ts
+++ b/console/web/src/lib/sessions/entry-mapper.test.ts
@@ -342,8 +342,11 @@ describe('entrySegments', () => {
     expect(err).toMatchObject({
       role: 'system',
       tone: 'error',
-      content:
-        'turn failed — remote error (router/provider_unavailable): provider zai unavailable',
+      content: 'The response could not be completed.',
+      technicalDetails: {
+        detail:
+          'remote error (router/provider_unavailable): provider zai unavailable',
+      },
       createdAt: 9,
     })
     const [fired] = entrySegments({
@@ -392,7 +395,8 @@ describe('entrySegments', () => {
       role: 'system',
       kind: 'notice',
       tone: 'error',
-      content: 'turn failed — provider zai unavailable',
+      content: 'The response could not be completed.',
+      technicalDetails: { detail: 'provider zai unavailable' },
     })
     const [notice] = entrySegments({
       entry_id: 'e_t1_max_turns',
@@ -475,7 +479,12 @@ describe('entrySegments', () => {
         data: {
           status: 'error',
           code: 'llm.transient',
-          summary: 'stream ended without a terminal frame',
+          class: 'llm.transient',
+          summary: 'The response was interrupted.',
+          detail: 'stream ended without a terminal frame',
+          provider: 'zai',
+          model: 'glm-5',
+          next_actions: ['Try again in a moment.', '', 42],
           partial_result_available: true,
           recovery: { attempted: 1, max_attempts: 1, outcome: 'exhausted' },
           timestamp: 42,
@@ -489,9 +498,49 @@ describe('entrySegments', () => {
       createdAt: 42,
     })
     if (notice.role !== 'system') throw new Error('expected a system notice')
-    expect(notice.content).toContain('turn failed [llm.transient]')
-    expect(notice.content).toContain('partial output above was preserved')
-    expect(notice.content).toContain('recovery exhausted (1/1)')
+    expect(notice.content).toBe(
+      'The response was interrupted. A partial response was preserved in this conversation and may be incomplete. Automatic recovery stopped after 1 of 1 attempts.',
+    )
+    expect(notice.content).not.toContain('llm.transient')
+    expect(notice.content).not.toContain('terminal frame')
+    expect(notice.nextActions).toEqual(['Try again in a moment.'])
+    expect(notice.technicalDetails).toEqual({
+      code: 'llm.transient',
+      class: 'llm.transient',
+      detail: 'stream ended without a terminal frame',
+      provider: 'zai',
+      model: 'glm-5',
+    })
+  })
+
+  it('keeps permanent provider diagnostics out of the primary copy', () => {
+    const [notice] = entrySegments({
+      entry_id: 'e-permanent-error',
+      custom: {
+        custom_type: 'error',
+        data: {
+          status: 'error',
+          summary: 'The provider rejected this request.',
+          next_actions: [
+            'Review the selected model and provider settings, then try again.',
+          ],
+          code: 'llm.permanent',
+          class: 'llm.permanent',
+          detail: 'openai responses: credit balance exhausted',
+        },
+      },
+    })
+    expect(notice).toMatchObject({
+      content: 'The provider rejected this request.',
+      nextActions: [
+        'Review the selected model and provider settings, then try again.',
+      ],
+      technicalDetails: {
+        code: 'llm.permanent',
+        class: 'llm.permanent',
+        detail: 'openai responses: credit balance exhausted',
+      },
+    })
   })
 
   it('renders recovery and blocked reaction lifecycle entries', () => {

--- a/console/web/src/lib/sessions/entry-mapper.ts
+++ b/console/web/src/lib/sessions/entry-mapper.ts
@@ -30,6 +30,7 @@ import type {
   FunctionTriggerMessage,
   Message,
   SystemMessage,
+  SystemNoticeTechnicalDetails,
   TriggerFiredData,
   UserMessage,
 } from '@/types/chat'
@@ -165,6 +166,35 @@ function lifecycleNotice(
 
   if (customType === ERROR_CUSTOM_TYPE) {
     const code = typeof d.code === 'string' ? d.code : undefined
+    const errorClass = typeof d.class === 'string' ? d.class : undefined
+    const detail =
+      typeof d.detail === 'string'
+        ? d.detail
+        : typeof d.reason === 'string'
+          ? d.reason
+          : typeof d.message === 'string'
+            ? d.message
+            : undefined
+    const provider = typeof d.provider === 'string' ? d.provider : undefined
+    const model = typeof d.model === 'string' ? d.model : undefined
+    const technicalDetails: SystemNoticeTechnicalDetails = {
+      code,
+      class: errorClass,
+      detail,
+      provider,
+      model,
+    }
+    const hasTechnicalDetails = Object.values(technicalDetails).some(Boolean)
+    const nextActions = Array.isArray(d.next_actions)
+      ? d.next_actions.filter(
+          (action): action is string =>
+            typeof action === 'string' && action.trim().length > 0,
+        )
+      : []
+    const publicSummary =
+      typeof d.summary === 'string'
+        ? d.summary
+        : 'The response could not be completed.'
     const partial = d.partial_result_available === true
     const recovery =
       d.recovery && typeof d.recovery === 'object'
@@ -177,20 +207,22 @@ function lifecycleNotice(
         ? recovery.max_attempts
         : undefined
     const parts = [
-      `turn failed${code ? ` [${code}]` : ''}${summary ? ` — ${summary}` : ''}`,
+      publicSummary,
       partial
-        ? 'partial output above was preserved and may be incomplete'
+        ? 'A partial response was preserved in this conversation and may be incomplete.'
         : undefined,
       attempted > 0
-        ? `recovery exhausted (${attempted}/${maxAttempts ?? attempted})`
+        ? `Automatic recovery stopped after ${attempted} of ${maxAttempts ?? attempted} attempts.`
         : undefined,
     ].filter((part): part is string => Boolean(part))
     return {
       id: entryId,
       role: 'system',
       kind: 'notice',
-      content: parts.join(' · '),
+      content: parts.join(' '),
       tone: 'error',
+      ...(nextActions.length > 0 ? { nextActions } : {}),
+      ...(hasTechnicalDetails ? { technicalDetails } : {}),
       createdAt,
     }
   }

--- a/console/web/src/types/chat.ts
+++ b/console/web/src/types/chat.ts
@@ -199,6 +199,10 @@ export interface SystemMessage extends BaseMessage {
   content: string
   tone?: 'info' | 'warn' | 'error'
   kind?: 'notice' | 'compaction' | 'trigger-fired'
+  /** User-facing remediation supplied by a structured lifecycle record. */
+  nextActions?: string[]
+  /** Diagnostic context kept behind a collapsed disclosure. */
+  technicalDetails?: SystemNoticeTechnicalDetails
   /**
    * Live-only fallback for a durable transcript entry with the same id.
    * It may fill a delivery gap, but must never replace the transcript-backed
@@ -209,6 +213,14 @@ export interface SystemMessage extends BaseMessage {
   tokensBefore?: number
   /** Present on `kind: 'trigger-fired'`. */
   trigger?: TriggerFiredData
+}
+
+export interface SystemNoticeTechnicalDetails {
+  code?: string
+  class?: string
+  detail?: string
+  provider?: string
+  model?: string
 }
 
 export type Message =
@@ -244,6 +256,8 @@ export interface MessagePatch {
   /** SystemMessage variant. */
   tone?: 'info' | 'warn' | 'error'
   kind?: 'notice' | 'compaction'
+  nextActions?: string[]
+  technicalDetails?: SystemNoticeTechnicalDetails
   summaryText?: string
   tokensBefore?: number
 }

--- a/harness/src/clients/router.rs
+++ b/harness/src/clients/router.rs
@@ -22,7 +22,7 @@ use tokio::sync::mpsc;
 use tokio::sync::{watch, Notify};
 
 use crate::error::HarnessError;
-use crate::types::event::{AssistantMessageEvent, StopReason};
+use crate::types::event::{AssistantMessageEvent, ErrorKind, StopReason};
 use crate::types::message::{empty_assistant, AssistantMessage};
 use crate::types::model::{AgentFunction, Model, ThinkingLevel};
 
@@ -47,12 +47,95 @@ pub struct ChatParams {
     pub provider_options: Option<Value>,
 }
 
+/// Structured failure returned by `router::chat`.
+///
+/// `message` is safe public copy. `detail` retains provider/transport context
+/// for the durable operator record without making it the user-facing summary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChatError {
+    pub code: Option<String>,
+    pub message: String,
+    pub detail: Option<String>,
+    pub kind: Option<ErrorKind>,
+    pub retryable: Option<bool>,
+}
+
+impl ChatError {
+    fn with_terminal_fallback(
+        mut self,
+        terminal_detail: Option<&str>,
+        terminal_kind: Option<ErrorKind>,
+    ) -> Self {
+        if self.detail.is_none() {
+            self.detail = terminal_detail.map(str::to_string);
+        }
+        if self.kind.is_none() {
+            self.kind = terminal_kind;
+        }
+        if self.retryable.is_none() {
+            self.retryable = self.kind.map(ErrorKind::is_retryable);
+        }
+        self
+    }
+}
+
 /// The assembled result of one stream.
 pub struct ChatOutcome {
     pub message: AssistantMessage,
     pub ok: bool,
     pub stop_reason: Option<StopReason>,
-    pub error: Option<String>,
+    pub error: Option<ChatError>,
+}
+
+fn response_chat_error(response: &Value) -> Option<ChatError> {
+    let error = response.get("error")?.as_object()?;
+    Some(ChatError {
+        code: error
+            .get("code")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        message: error.get("message")?.as_str()?.to_string(),
+        detail: error
+            .get("detail")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        kind: error
+            .get("kind")
+            .cloned()
+            .and_then(|value| serde_json::from_value(value).ok()),
+        retryable: error.get("retryable").and_then(Value::as_bool),
+    })
+}
+
+fn dispatch_chat_error(error: &iii_sdk::errors::Error) -> ChatError {
+    match error {
+        iii_sdk::errors::Error::Remote { code, message, .. } => ChatError {
+            code: Some(code.clone()),
+            message: message.clone(),
+            detail: Some(error.to_string()),
+            kind: None,
+            retryable: None,
+        },
+        _ => ChatError {
+            code: None,
+            message: "The model request could not be completed.".into(),
+            detail: Some(error.to_string()),
+            kind: None,
+            retryable: None,
+        },
+    }
+}
+
+fn fallback_chat_message(kind: Option<ErrorKind>) -> &'static str {
+    match kind {
+        Some(ErrorKind::AuthExpired) => "The provider needs to be configured again.",
+        Some(ErrorKind::RateLimited) => {
+            "The provider is rate-limiting requests. Try again shortly."
+        }
+        Some(ErrorKind::ContextOverflow) => "The conversation is too large for the selected model.",
+        Some(ErrorKind::Transient) => "The provider was temporarily interrupted. Try again.",
+        Some(ErrorKind::Permanent) | None => "The provider rejected this request.",
+    }
 }
 
 /// Ceiling for `count_tokens`, independent of the generation-sized router
@@ -360,55 +443,74 @@ impl RouterClient {
                 .map_err(|e| HarnessError::Internal(format!("router::chat task: {e}")))?,
         };
 
+        let terminal_kind = final_message
+            .as_ref()
+            .and_then(|message| message.error_kind);
         let (ok, response_error) = match &response {
             Ok(v) => {
                 let ok = v.get("ok").and_then(Value::as_bool).unwrap_or(true);
-                let err = v
-                    .get("error")
-                    .and_then(|e| e.get("message"))
-                    .and_then(Value::as_str)
-                    .map(str::to_string);
-                (ok, err)
+                (ok, response_chat_error(v))
             }
-            Err(e) => (false, Some(e.to_string())),
+            Err(e) => (false, Some(dispatch_chat_error(e))),
         };
+        let response_error = response_error
+            .map(|error| error.with_terminal_fallback(terminal_error.as_deref(), terminal_kind));
 
-        let message = final_message.unwrap_or_else(|| {
+        let mut message = final_message.unwrap_or_else(|| {
             let mut m = empty_assistant(params.provider.as_deref().unwrap_or(""), &params.model);
             m.stop_reason = StopReason::Error;
             m.error_message = response_error
-                .clone()
+                .as_ref()
+                .map(|error| error.message.clone())
                 .or_else(|| terminal_error.clone())
-                .or_else(|| Some("router produced no terminal frame".to_string()));
+                .or_else(|| Some("The provider rejected this request.".to_string()));
             // A dispatch/ack rejection (e.g. provider unavailable) is
             // authoritative — retrying in-turn cannot help. Only a
             // frame-less-but-acked stream stays classified transient.
-            m.error_kind = Some(if response_error.is_some() {
-                crate::types::event::ErrorKind::Permanent
+            m.error_kind = Some(if let Some(error) = &response_error {
+                error.kind.unwrap_or_else(|| {
+                    if error.retryable == Some(true) {
+                        ErrorKind::Transient
+                    } else {
+                        ErrorKind::Permanent
+                    }
+                })
             } else {
-                crate::types::event::ErrorKind::Transient
+                ErrorKind::Transient
             });
             m
         });
+
+        // Error terminal frames can carry raw provider/transport text. Once the
+        // held-open chat response arrives, its ErrorShape message is the public
+        // copy; retain the terminal text only on ChatError.detail.
+        if let Some(error) = &response_error {
+            if message.stop_reason == StopReason::Error {
+                message.error_message = Some(error.message.clone());
+                message.error_kind = error.kind.or(message.error_kind);
+            }
+        }
 
         let stop_reason = Some(message.stop_reason);
         // A frame-less-but-acked stream synthesizes an Error message above
         // with no terminal_error/response_error set — derive the outcome
         // error from it so the turn fails instead of completing "ok" around
         // an empty error-stopped message.
-        let error = terminal_error
-            .or(response_error)
-            .or_else(|| {
-                (message.stop_reason == StopReason::Error).then(|| {
-                    message
-                        .error_message
-                        .clone()
-                        .unwrap_or_else(|| "router produced no terminal frame".to_string())
-                })
+        let failed = !ok || message.stop_reason == StopReason::Error;
+        let error = failed.then(|| {
+            response_error.unwrap_or_else(|| {
+                let kind = message.error_kind;
+                ChatError {
+                    code: None,
+                    message: fallback_chat_message(kind).to_string(),
+                    detail: terminal_error.or_else(|| message.error_message.clone()),
+                    kind,
+                    retryable: kind.map(ErrorKind::is_retryable),
+                }
             })
-            .filter(|_| !ok || message.stop_reason == StopReason::Error);
+        });
         Ok(ChatOutcome {
-            ok: ok && message.stop_reason != StopReason::Error && error.is_none(),
+            ok: !failed,
             message,
             stop_reason,
             error,
@@ -775,6 +877,89 @@ fn utf8_tail(s: &str, max: usize) -> &str {
         start += 1;
     }
     &s[start..]
+}
+
+#[cfg(test)]
+mod error_contract_tests {
+    use super::*;
+    use iii_sdk::errors::Error;
+    use serde_json::json;
+
+    #[test]
+    fn response_error_preserves_the_extended_router_contract() {
+        let parsed = response_chat_error(&json!({
+            "ok": false,
+            "error": {
+                "code": "router/provider_unavailable",
+                "message": "The selected provider is temporarily unavailable.",
+                "detail": "provider openai stream ended without a terminal frame",
+                "kind": "transient",
+                "retryable": true
+            }
+        }))
+        .expect("structured error");
+
+        assert_eq!(parsed.code.as_deref(), Some("router/provider_unavailable"));
+        assert_eq!(
+            parsed.message,
+            "The selected provider is temporarily unavailable."
+        );
+        assert_eq!(
+            parsed.detail.as_deref(),
+            Some("provider openai stream ended without a terminal frame")
+        );
+        assert_eq!(parsed.kind, Some(ErrorKind::Transient));
+        assert_eq!(parsed.retryable, Some(true));
+    }
+
+    #[test]
+    fn legacy_response_keeps_code_and_message_and_uses_terminal_fallbacks() {
+        let parsed = response_chat_error(&json!({
+            "ok": false,
+            "error": {
+                "code": "router/not_configured",
+                "message": "Provider setup is incomplete."
+            }
+        }))
+        .expect("legacy structured error")
+        .with_terminal_fallback(
+            Some("provider credentials are not configured"),
+            Some(ErrorKind::Permanent),
+        );
+
+        assert_eq!(parsed.code.as_deref(), Some("router/not_configured"));
+        assert_eq!(parsed.message, "Provider setup is incomplete.");
+        assert_eq!(
+            parsed.detail.as_deref(),
+            Some("provider credentials are not configured")
+        );
+        assert_eq!(parsed.kind, Some(ErrorKind::Permanent));
+        assert_eq!(parsed.retryable, Some(false));
+    }
+
+    #[test]
+    fn remote_dispatch_keeps_the_code_and_moves_the_raw_wrapper_to_detail() {
+        let parsed = dispatch_chat_error(&Error::Remote {
+            code: "router/ambiguous_model".into(),
+            message: "Choose a provider for this model.".into(),
+            stacktrace: None,
+        });
+
+        assert_eq!(parsed.code.as_deref(), Some("router/ambiguous_model"));
+        assert_eq!(parsed.message, "Choose a provider for this model.");
+        assert!(parsed
+            .detail
+            .as_deref()
+            .is_some_and(|detail| detail.contains("router/ambiguous_model")));
+    }
+
+    #[test]
+    fn permanent_fallback_copy_is_stable() {
+        assert_eq!(
+            fallback_chat_message(Some(ErrorKind::Permanent)),
+            "The provider rejected this request."
+        );
+    }
 }
 
 #[cfg(test)]

--- a/harness/src/turn_loop.rs
+++ b/harness/src/turn_loop.rs
@@ -12,7 +12,7 @@ use iii_sdk::{IIIClient, TriggerAction};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
-use crate::clients::router::{ChatParams, StreamSink};
+use crate::clients::router::{ChatError, ChatParams, StreamSink};
 use crate::clients::{LoadedEntry, SessionClient};
 use crate::deps::Deps;
 use crate::error::HarnessError;
@@ -29,34 +29,54 @@ use crate::types::turn::{
 };
 
 #[derive(Clone, Copy)]
-struct FailureInfo {
-    code: &'static str,
+struct FailureInfo<'a> {
+    code: &'a str,
     phase: &'static str,
     retryable: bool,
+    kind: Option<ErrorKind>,
+    detail: Option<&'a str>,
+    provider: Option<&'a str>,
+    model: Option<&'a str>,
 }
 
-const INTERNAL_FAILURE: FailureInfo = FailureInfo {
+const INTERNAL_FAILURE: FailureInfo<'static> = FailureInfo {
     code: "harness.turn_internal",
     phase: "execution",
     retryable: false,
+    kind: None,
+    detail: None,
+    provider: None,
+    model: None,
 };
 
-const CONTEXT_OVERFLOW_FAILURE: FailureInfo = FailureInfo {
+const CONTEXT_OVERFLOW_FAILURE: FailureInfo<'static> = FailureInfo {
     code: "harness.context_overflow",
     phase: "context_assembly",
     retryable: false,
+    kind: None,
+    detail: None,
+    provider: None,
+    model: None,
 };
 
-const BUDGET_EXCEEDED_FAILURE: FailureInfo = FailureInfo {
+const BUDGET_EXCEEDED_FAILURE: FailureInfo<'static> = FailureInfo {
     code: "harness.budget_exceeded",
     phase: "budget_preflight",
     retryable: false,
+    kind: None,
+    detail: None,
+    provider: None,
+    model: None,
 };
 
-const BUDGET_UNAVAILABLE_FAILURE: FailureInfo = FailureInfo {
+const BUDGET_UNAVAILABLE_FAILURE: FailureInfo<'static> = FailureInfo {
     code: "harness.budget_unavailable",
     phase: "budget_preflight",
     retryable: false,
+    kind: None,
+    detail: None,
+    provider: None,
+    model: None,
 };
 
 /// Provider adapters add framing outside the fields visible to the harness.
@@ -272,6 +292,10 @@ pub async fn run_step(
                     code: "harness.pre_turn_denied",
                     phase: "pre_turn",
                     retryable: false,
+                    kind: None,
+                    detail: None,
+                    provider: None,
+                    model: None,
                 },
             )
             .await;
@@ -316,6 +340,10 @@ pub async fn run_step(
                         code: "harness.output_contract_invalid",
                         phase: "output_validation",
                         retryable: false,
+                        kind: None,
+                        detail: None,
+                        provider: None,
+                        model: None,
                     },
                 )
                 .await
@@ -449,6 +477,10 @@ pub async fn run_step(
                         code: "harness.pre_generate_denied",
                         phase: "pre_generate",
                         retryable: false,
+                        kind: None,
+                        detail: None,
+                        provider: None,
+                        model: None,
                     },
                 )
                 .await;
@@ -487,6 +519,10 @@ pub async fn run_step(
                     code: "harness.empty_context",
                     phase: "context_assembly",
                     retryable: false,
+                    kind: None,
+                    detail: None,
+                    provider: None,
+                    model: None,
                 },
             )
             .await;
@@ -829,20 +865,35 @@ pub async fn run_step(
         return finalize_cancelled(deps, &session, &mut record, "cancelled").await;
     }
     if !outcome.ok {
-        let reason = outcome
-            .error
-            .clone()
-            .unwrap_or_else(|| "generation failed".to_string());
+        let generation_error = outcome.error.clone().unwrap_or_else(|| ChatError {
+            code: None,
+            message: "The provider rejected this request.".into(),
+            detail: Some("generation failed".into()),
+            kind: outcome.message.error_kind,
+            retryable: outcome.message.error_kind.map(ErrorKind::is_retryable),
+        });
+        let failure = llm_failure_info(
+            Some(&generation_error),
+            outcome.message.error_kind,
+            Some(outcome.message.provider.as_str()).filter(|provider| !provider.is_empty()),
+            Some(outcome.message.model.as_str()).filter(|model| !model.is_empty()),
+        );
+        let reason = generation_error.message.clone();
+        let detail = generation_error
+            .detail
+            .as_deref()
+            .unwrap_or(&generation_error.message)
+            .to_string();
         preserve_assistant_partial(&mut record.result, &outcome.message);
         if transient_resume_allowed(
-            outcome.message.error_kind,
+            failure.retryable.then_some(ErrorKind::Transient),
             record.transient_resumes,
             record.options.max_transient_resumes,
             record.turn_count,
             record.options.max_turns,
         ) {
             let attempt = record.transient_resumes + 1;
-            record_recovery_telemetry(&record, &reason, attempt);
+            record_recovery_telemetry(&record, &detail, attempt);
             let _ = session
                 .append_custom(
                     &record.session_id,
@@ -854,6 +905,11 @@ pub async fn run_step(
                             record.options.max_transient_resumes
                         ),
                         "reason": reason,
+                        "detail": detail,
+                        "code": failure.code,
+                        "class": failure_class(failure),
+                        "provider": failure.provider.or(record.options.provider.as_deref()),
+                        "model": failure.model.unwrap_or(&record.options.model),
                         "phase": "generation",
                         "attempt": attempt,
                         "max_attempts": record.options.max_transient_resumes,
@@ -889,14 +945,7 @@ pub async fn run_step(
             record.transient_resumes = attempt;
             return advance(deps, &mut record).await;
         }
-        return finalize_failed(
-            deps,
-            &session,
-            &mut record,
-            &reason,
-            llm_failure_info(outcome.message.error_kind),
-        )
-        .await;
+        return finalize_failed(deps, &session, &mut record, &reason, failure).await;
     }
 
     if record.transient_resumes > 0 {
@@ -1533,6 +1582,10 @@ async fn retry_or_giveup_with(
                 code: "harness.output_contract_invalid",
                 phase: "output_validation",
                 retryable: false,
+                kind: None,
+                detail: None,
+                provider: None,
+                model: None,
             },
         )
         .await
@@ -1627,19 +1680,170 @@ async fn finalize_completed(
     })
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct FailurePresentation {
+    summary: String,
+    next_actions: Vec<&'static str>,
+}
+
+fn failure_class(failure: FailureInfo<'_>) -> &'static str {
+    match failure.kind {
+        Some(ErrorKind::AuthExpired) => "llm.auth_expired",
+        Some(ErrorKind::RateLimited) => "llm.rate_limited",
+        Some(ErrorKind::ContextOverflow) => "llm.context_overflow",
+        Some(ErrorKind::Transient) => "llm.transient",
+        Some(ErrorKind::Permanent) => "llm.permanent",
+        None if failure.retryable => "llm.transient",
+        None => "llm.permanent",
+    }
+}
+
+fn failure_presentation(public_message: &str, failure: FailureInfo<'_>) -> FailurePresentation {
+    let (summary, next_actions): (&str, &[&str]) = match failure.code {
+        "router/not_configured" => (
+            "The selected provider is not configured.",
+            &[
+                "Open LLM Router settings and complete the provider setup.",
+                "Retry the turn after the provider is configured.",
+            ],
+        ),
+        "router/provider_unavailable" => (
+            "The selected provider is temporarily unavailable.",
+            &[
+                "Retry the turn in a moment.",
+                "Choose another available provider or model.",
+            ],
+        ),
+        "router/unknown_provider" => (
+            "The selected provider is no longer registered.",
+            &["Refresh the model list and choose another provider."],
+        ),
+        "router/no_provider_for_model" => (
+            "No configured provider can serve the selected model.",
+            &[
+                "Choose another model.",
+                "Configure a provider that supports this model.",
+            ],
+        ),
+        "router/ambiguous_model" => (
+            "The selected model is available from multiple providers.",
+            &["Choose a provider explicitly, then try again."],
+        ),
+        "router/invalid_request" => (
+            "The model request is invalid.",
+            &["Review the request fields, then try again."],
+        ),
+        "router/structured_output_unsupported" => (
+            "The selected model does not support structured output.",
+            &[
+                "Choose another model.",
+                "Disable structured output, then try again.",
+            ],
+        ),
+        "router/request_in_progress" => (
+            "A request with the same ID is already in progress.",
+            &["Wait for the active request to finish, then try again."],
+        ),
+        "router/capacity_exceeded" => (
+            "The provider is busy right now.",
+            &[
+                "Wait a moment, then retry the turn.",
+                "Choose another available provider or model.",
+            ],
+        ),
+        "router/stream_setup_failed" => (
+            "The response stream could not be started.",
+            &["Retry the turn in a moment."],
+        ),
+        "router/stream_idle_timeout" => (
+            "The provider stopped responding before the answer completed.",
+            &["Retry the turn to continue."],
+        ),
+        "router/stream_incomplete" => (
+            "The provider disconnected before completing the response.",
+            &["Retry the turn to continue."],
+        ),
+        "router/provider_auth_expired" => (
+            "The provider authentication needs attention.",
+            &[
+                "Update the provider credentials in LLM Router settings.",
+                "Retry the turn after the credentials are updated.",
+            ],
+        ),
+        "router/provider_rate_limited" => (
+            "The provider is busy right now.",
+            &["Wait a moment, then retry the turn."],
+        ),
+        "router/context_overflow" => (
+            "The conversation is too large for the selected model.",
+            &[
+                "Compact or shorten the conversation.",
+                "Choose a model with a larger context window.",
+            ],
+        ),
+        "router/provider_transient" => (
+            "The provider temporarily failed while generating a response.",
+            &["Retry the turn in a moment."],
+        ),
+        "router/provider_rejected" => (
+            "The provider rejected this request.",
+            &["Review the selected model and provider settings, then try again."],
+        ),
+        _ => match failure.kind {
+            Some(ErrorKind::AuthExpired) => (
+                "The provider authentication needs attention.",
+                &["Update the provider credentials, then try again."],
+            ),
+            Some(ErrorKind::RateLimited) => (
+                "The provider is busy right now.",
+                &["Wait a moment, then retry the turn."],
+            ),
+            Some(ErrorKind::ContextOverflow) => (
+                "The conversation is too large for the selected model.",
+                &[
+                    "Compact or shorten the conversation.",
+                    "Choose a model with a larger context window.",
+                ],
+            ),
+            Some(ErrorKind::Transient) => (
+                "The provider temporarily failed while generating a response.",
+                &["Retry the turn in a moment."],
+            ),
+            Some(ErrorKind::Permanent) => (
+                "The provider rejected this request.",
+                &["Review the selected model and provider settings, then try again."],
+            ),
+            None => (
+                public_message,
+                &[
+                    "Inspect the failure details.",
+                    "Retry only after correcting the dependency or request.",
+                ],
+            ),
+        },
+    };
+    FailurePresentation {
+        summary: summary.to_string(),
+        next_actions: next_actions.to_vec(),
+    }
+}
+
 async fn finalize_failed(
     deps: &Deps,
     session: &SessionClient,
     record: &mut TurnRecord,
-    reason: &str,
-    failure: FailureInfo,
+    public_message: &str,
+    failure: FailureInfo<'_>,
 ) -> Result<TurnStepResult, HarnessError> {
     let woke = drain_queued_best_effort(deps, session, &record.session_id).await;
     let cfg = deps.cfg().await;
+    let presentation = failure_presentation(public_message, failure);
+    let summary = presentation.summary;
+    let detail = failure.detail.unwrap_or(public_message);
     record.status = TurnStatus::Failed;
-    record.result_error = Some(reason.to_string());
+    record.result_error = Some(summary.clone());
     record.updated_at = AgentMessage::now_ms();
-    record_failure_telemetry(record, reason, failure);
+    record_failure_telemetry(record, detail, failure);
     crate::state::put_turn(&deps.iii, record, cfg.session_timeout_ms).await?;
     deps.cancels.clear(&record.turn_id);
     let _ = session
@@ -1648,10 +1852,14 @@ async fn finalize_failed(
             "error",
             json!({
                 "status": "error",
-                "summary": reason,
-                "reason": reason,
+                "summary": summary,
+                "reason": detail,
                 "code": failure.code,
-                "message": reason,
+                "class": failure_class(failure),
+                "message": public_message,
+                "detail": detail,
+                "provider": failure.provider.or(record.options.provider.as_deref()),
+                "model": failure.model.unwrap_or(&record.options.model),
                 "retryable": failure.retryable,
                 "phase": failure.phase,
                 "partial_result_available": record.result.is_some(),
@@ -1660,10 +1868,7 @@ async fn finalize_failed(
                     "max_attempts": record.options.max_transient_resumes,
                     "outcome": if record.transient_resumes > 0 { "exhausted" } else { "not_attempted" },
                 },
-                "next_actions": [
-                    "inspect the failure reason",
-                    "retry only after correcting the dependency or request"
-                ],
+                "next_actions": presentation.next_actions,
                 "artifacts": {
                     "session_id": record.session_id,
                     "turn_id": record.turn_id,
@@ -1675,7 +1880,7 @@ async fn finalize_failed(
         )
         .await;
     let _ = session
-        .set_status(&record.session_id, "error", Some(reason))
+        .set_status(&record.session_id, "error", Some(&summary))
         .await;
     deps.events
         .emit_completed(
@@ -1683,8 +1888,8 @@ async fn finalize_failed(
             &record.turn_id,
             "failed",
             record.result.as_ref(),
-            Some(reason),
-            Some(reason),
+            Some(&summary),
+            Some(&summary),
             record.parent.as_ref(),
             record.display_parent_session_id.as_deref(),
             turn_is_terminal(deps, &record.session_id).await,
@@ -1704,7 +1909,7 @@ async fn finalize_failed(
             &parent,
             "failed",
             record.result.as_ref(),
-            Some(reason),
+            Some(&summary),
         )
         .await;
     }
@@ -1726,38 +1931,34 @@ async fn finalize_failed(
     })
 }
 
-fn llm_failure_info(error_kind: Option<ErrorKind>) -> FailureInfo {
-    match error_kind {
-        Some(ErrorKind::AuthExpired) => FailureInfo {
-            code: "llm.auth_expired",
-            phase: "generation",
-            retryable: false,
-        },
-        Some(ErrorKind::RateLimited) => FailureInfo {
-            code: "llm.rate_limited",
-            phase: "generation",
-            retryable: true,
-        },
-        Some(ErrorKind::ContextOverflow) => FailureInfo {
-            code: "llm.context_overflow",
-            phase: "generation",
-            retryable: false,
-        },
-        Some(ErrorKind::Transient) => FailureInfo {
-            code: "llm.transient",
-            phase: "generation",
-            retryable: true,
-        },
-        Some(ErrorKind::Permanent) => FailureInfo {
-            code: "llm.permanent",
-            phase: "generation",
-            retryable: false,
-        },
-        None => FailureInfo {
-            code: "llm.generation_failed",
-            phase: "generation",
-            retryable: false,
-        },
+fn llm_failure_info<'a>(
+    error: Option<&'a ChatError>,
+    terminal_kind: Option<ErrorKind>,
+    provider: Option<&'a str>,
+    model: Option<&'a str>,
+) -> FailureInfo<'a> {
+    let kind = error.and_then(|error| error.kind).or(terminal_kind);
+    let fallback_code = match kind {
+        Some(ErrorKind::AuthExpired) => "llm.auth_expired",
+        Some(ErrorKind::RateLimited) => "llm.rate_limited",
+        Some(ErrorKind::ContextOverflow) => "llm.context_overflow",
+        Some(ErrorKind::Transient) => "llm.transient",
+        Some(ErrorKind::Permanent) => "llm.permanent",
+        None => "llm.generation_failed",
+    };
+    FailureInfo {
+        code: error
+            .and_then(|error| error.code.as_deref())
+            .filter(|code| !code.is_empty())
+            .unwrap_or(fallback_code),
+        phase: "generation",
+        retryable: error
+            .and_then(|error| error.retryable)
+            .unwrap_or_else(|| kind.is_some_and(ErrorKind::is_retryable)),
+        kind,
+        detail: error.and_then(|error| error.detail.as_deref()),
+        provider,
+        model,
     }
 }
 
@@ -1786,13 +1987,13 @@ fn record_recovery_telemetry(record: &TurnRecord, reason: &str, attempt: u32) {
     );
 }
 
-fn record_failure_telemetry(record: &TurnRecord, reason: &str, failure: FailureInfo) {
+fn record_failure_telemetry(record: &TurnRecord, reason: &str, failure: FailureInfo<'_>) {
     let cx = Context::current();
     let span = cx.span();
     if !span.span_context().is_valid() {
         return;
     }
-    span.set_attribute(KeyValue::new("error.type", failure.code));
+    span.set_attribute(KeyValue::new("error.type", failure.code.to_string()));
     span.set_attribute(KeyValue::new("error.message", reason.to_string()));
     span.set_attribute(KeyValue::new("iii.turn.failure_phase", failure.phase));
     span.set_attribute(KeyValue::new("iii.turn.retryable", failure.retryable));
@@ -2626,9 +2827,83 @@ mod tests {
     use super::{
         cancel_requested, count_model_visible, transient_resume_allowed, turn_step_matches,
     };
+    use crate::clients::router::ChatError;
     use crate::types::content::ContentBlock;
     use crate::types::event::{ErrorKind, StopReason};
     use crate::types::message::{AgentMessage, CustomMessage, CustomRoleTag};
+
+    #[test]
+    fn llm_failure_preserves_router_contract_and_runtime_attribution() {
+        let error = ChatError {
+            code: Some("router/provider_unavailable".into()),
+            message: "Provider unavailable.".into(),
+            detail: Some("provider openai stream function was not found".into()),
+            kind: Some(ErrorKind::Transient),
+            retryable: Some(true),
+        };
+        let failure = super::llm_failure_info(
+            Some(&error),
+            Some(ErrorKind::Permanent),
+            Some("openai"),
+            Some("gpt-test"),
+        );
+
+        assert_eq!(failure.code, "router/provider_unavailable");
+        assert_eq!(failure.kind, Some(ErrorKind::Transient));
+        assert!(failure.retryable);
+        assert_eq!(
+            failure.detail,
+            Some("provider openai stream function was not found")
+        );
+        assert_eq!(failure.provider, Some("openai"));
+        assert_eq!(failure.model, Some("gpt-test"));
+        assert_eq!(super::failure_class(failure), "llm.transient");
+    }
+
+    #[test]
+    fn router_code_selects_a_friendly_summary_and_actions() {
+        let error = ChatError {
+            code: Some("router/provider_unavailable".into()),
+            message: "legacy raw provider text".into(),
+            detail: Some("legacy raw provider text".into()),
+            kind: Some(ErrorKind::Transient),
+            retryable: Some(true),
+        };
+        let failure = super::llm_failure_info(Some(&error), None, Some("openai"), Some("gpt-test"));
+        let presentation = super::failure_presentation(&error.message, failure);
+
+        assert_eq!(
+            presentation.summary,
+            "The selected provider is temporarily unavailable."
+        );
+        assert_eq!(
+            presentation.next_actions,
+            vec![
+                "Retry the turn in a moment.",
+                "Choose another available provider or model."
+            ]
+        );
+    }
+
+    #[test]
+    fn generic_permanent_presentation_has_stable_copy() {
+        let error = ChatError {
+            code: Some("provider/custom_rejection".into()),
+            message: "raw rejection".into(),
+            detail: Some("raw rejection with upstream diagnostics".into()),
+            kind: Some(ErrorKind::Permanent),
+            retryable: Some(false),
+        };
+        let failure = super::llm_failure_info(Some(&error), None, None, Some("m"));
+        let presentation = super::failure_presentation(&error.message, failure);
+
+        assert_eq!(presentation.summary, "The provider rejected this request.");
+        assert_eq!(
+            presentation.next_actions,
+            vec!["Review the selected model and provider settings, then try again."]
+        );
+        assert_eq!(super::failure_class(failure), "llm.permanent");
+    }
 
     #[test]
     fn only_the_exact_current_turn_step_is_executable() {

--- a/harness/tests/integration/src/scenarios/provider_family_errors.rs
+++ b/harness/tests/integration/src/scenarios/provider_family_errors.rs
@@ -4,8 +4,9 @@
 //! Provider-specific request and error parsing lives in the hermetic provider
 //! contract suite. These fixtures begin at the normalized router boundary and
 //! pin the user-facing behavior shared by each protocol family: a permanent
-//! generation failure finalizes the turn, persists structured failure data,
-//! and remains visible after Console transcript reconciliation.
+//! generation failure finalizes the turn with one stable public summary while
+//! preserving the provider-specific diagnostic detail in the durable failure
+//! record. That contract must remain present after a later turn completes.
 
 use serde_json::Value;
 
@@ -17,6 +18,8 @@ use crate::fixtures::ScenarioFixture;
 const ANTHROPIC_REASON: &str = "anthropic messages: credit balance is too low";
 const CHAT_REASON: &str = "openai chat completions: insufficient quota";
 const RESPONSES_REASON: &str = "openai responses: credit balance exhausted";
+const PUBLIC_SUMMARY: &str = "The provider rejected this request.";
+const NEXT_ACTION: &str = "Review the selected model and provider settings, then try again.";
 const RECOVERY_MESSAGE: &str =
     "Confirm the chat can continue after the provider issue is corrected.";
 const RECOVERY_TEXT: &str = "provider family recovery complete";
@@ -64,7 +67,7 @@ fn scenario(case: FamilyCase) -> ScenarioFixture {
     Scenario::new(
         case.id,
         case.slug,
-        "A permanent provider failure is persisted and shown as an actionable Console notice.",
+        "A permanent provider failure persists one stable public summary and its provider-specific diagnostic detail.",
         ScenarioDriver::Playground,
         model.clone(),
     )
@@ -121,16 +124,37 @@ fn verify_permanent_failure(run: &RunEvidence, expected_reason: &str) -> anyhow:
     run.expect_message_counts(2, 2, 0)?;
     run.expect_no_duplicate_messages()?;
 
-    let error = run
+    let durable_errors = run
         .transcript
         .iter()
-        .filter_map(|item| item.get("custom"))
-        .find(|custom| custom.get("custom_type").and_then(Value::as_str) == Some("error"))
-        .ok_or_else(|| anyhow::anyhow!("durable error record is missing"))?;
+        .enumerate()
+        .filter_map(|(index, item)| {
+            let custom = item.get("custom")?;
+            (custom.get("custom_type").and_then(Value::as_str) == Some("error"))
+                .then_some((index, item, custom))
+        })
+        .collect::<Vec<_>>();
+    anyhow::ensure!(
+        durable_errors.len() == 1,
+        "expected one durable error record after recovery, found {}: {:?}",
+        durable_errors.len(),
+        run.transcript
+    );
+    let (error_index, item, error) = durable_errors[0];
+    anyhow::ensure!(
+        item.get("entry_id")
+            .and_then(Value::as_str)
+            .is_some_and(|entry_id| entry_id.starts_with("e_") && entry_id.ends_with("_error")),
+        "durable error record has no stable error entry id: {item}"
+    );
     let data = error.get("data").cloned().unwrap_or(Value::Null);
     anyhow::ensure!(
-        data.get("code").and_then(Value::as_str) == Some("llm.permanent"),
-        "failure code is not permanent: {data}"
+        data.get("code").and_then(Value::as_str) == Some("invocation_failed"),
+        "failure code did not preserve the router invocation error: {data}"
+    );
+    anyhow::ensure!(
+        data.get("class").and_then(Value::as_str) == Some("llm.permanent"),
+        "failure class is not permanent: {data}"
     );
     anyhow::ensure!(
         data.get("retryable").and_then(Value::as_bool) == Some(false),
@@ -141,10 +165,59 @@ fn verify_permanent_failure(run: &RunEvidence, expected_reason: &str) -> anyhow:
         "failure phase is not generation: {data}"
     );
     anyhow::ensure!(
-        data.get("summary")
+        data.get("summary").and_then(Value::as_str) == Some(PUBLIC_SUMMARY),
+        "failure summary is not the stable public message: {data}"
+    );
+    anyhow::ensure!(
+        !data
+            .get("summary")
             .and_then(Value::as_str)
             .is_some_and(|summary| summary.contains(expected_reason)),
-        "failure summary does not preserve the provider reason: {data}"
+        "failure summary contains provider-specific diagnostic detail: {data}"
+    );
+    anyhow::ensure!(
+        data.get("detail")
+            .and_then(Value::as_str)
+            .is_some_and(|detail| detail.contains(expected_reason)),
+        "failure detail does not preserve the provider reason: {data}"
+    );
+    anyhow::ensure!(
+        data.get("reason")
+            .and_then(Value::as_str)
+            .is_some_and(|reason| reason.contains(expected_reason)),
+        "compatibility reason does not preserve the provider reason: {data}"
+    );
+    anyhow::ensure!(
+        data.get("next_actions")
+            .and_then(Value::as_array)
+            .is_some_and(|actions| {
+                actions.len() == 1 && actions[0].as_str() == Some(NEXT_ACTION)
+            }),
+        "failure next actions are not actionable and stable: {data}"
+    );
+
+    let recovery_index = run
+        .transcript
+        .iter()
+        .enumerate()
+        .find_map(|(index, item)| {
+            let message = item.get("message")?;
+            (message.get("role").and_then(Value::as_str) == Some("assistant")
+                && message
+                    .get("content")
+                    .and_then(Value::as_array)
+                    .is_some_and(|blocks| {
+                        blocks.iter().any(|block| {
+                            block.get("type").and_then(Value::as_str) == Some("text")
+                                && block.get("text").and_then(Value::as_str) == Some(RECOVERY_TEXT)
+                        })
+                    }))
+            .then_some(index)
+        })
+        .ok_or_else(|| anyhow::anyhow!("recovery assistant message is missing"))?;
+    anyhow::ensure!(
+        error_index < recovery_index,
+        "durable failure record was not retained before the completed recovery turn"
     );
     Ok(())
 }
@@ -166,6 +239,19 @@ mod tests {
             assert!(failed.frames.is_empty());
             assert!(!failed.response.ok);
             assert!(fixture.script.generations[1].response.ok);
+        }
+    }
+
+    #[test]
+    fn provider_specific_reasons_share_one_public_failure_contract() {
+        assert_eq!(PUBLIC_SUMMARY, "The provider rejected this request.");
+        assert_eq!(
+            NEXT_ACTION,
+            "Review the selected model and provider settings, then try again."
+        );
+        for reason in [ANTHROPIC_REASON, CHAT_REASON, RESPONSES_REASON] {
+            assert_ne!(reason, PUBLIC_SUMMARY);
+            assert!(!PUBLIC_SUMMARY.contains(reason));
         }
     }
 }

--- a/llm-router/README.md
+++ b/llm-router/README.md
@@ -66,6 +66,20 @@ Only the read surface is agent-callable (`router::models::list` / `get` /
 `supports`, `router::provider::list`); everything else is denied to in-run
 agents — see [Security model](#security-model).
 
+### Error conventions
+
+Errors use stable `router/<code>` identifiers. Streaming failures return an
+`error` object with a user-facing `message`, the shared `kind`, `retryable`,
+and an optional diagnostic `detail`. User interfaces should show `message`
+and keep `code` / `detail` behind technical details; automation should branch
+on `code` and `retryable`, never parse the prose.
+
+The main recovery codes are `router/provider_unavailable`,
+`router/capacity_exceeded`, `router/stream_idle_timeout`,
+`router/stream_incomplete`, `router/provider_auth_expired`,
+`router/provider_rate_limited`, `router/context_overflow`, and
+`router/provider_rejected`.
+
 ### Provider protocol
 
 Token-gated after the first declare: the response to `register` carries a

--- a/llm-router/src/chat/chat.rs
+++ b/llm-router/src/chat/chat.rs
@@ -173,6 +173,58 @@ fn pre_stream_error_kind(code: RouterCode) -> ErrorKind {
     }
 }
 
+fn error_shape(
+    code: RouterCode,
+    kind: ErrorKind,
+    message: String,
+    detail: Option<String>,
+) -> ErrorShape {
+    ErrorShape {
+        code: code.as_str().to_string(),
+        message,
+        kind: Some(kind),
+        retryable: Some(kind.is_retryable()),
+        detail,
+    }
+}
+
+fn provider_error_presentation(
+    kind: ErrorKind,
+    provider: &str,
+    model: &str,
+) -> (RouterCode, String) {
+    match kind {
+        ErrorKind::AuthExpired => (
+            RouterCode::ProviderAuthExpired,
+            format!(
+                "Authentication for provider \"{provider}\" needs attention. Update its credentials, then try again."
+            ),
+        ),
+        ErrorKind::RateLimited => (
+            RouterCode::ProviderRateLimited,
+            format!("Provider \"{provider}\" is busy right now. Try again shortly."),
+        ),
+        ErrorKind::ContextOverflow => (
+            RouterCode::ContextOverflow,
+            format!(
+                "This conversation is too large for model \"{model}\". Compact it, shorten the input, or choose a model with a larger context window."
+            ),
+        ),
+        ErrorKind::Transient => (
+            RouterCode::ProviderTransient,
+            format!(
+                "Provider \"{provider}\" temporarily failed while generating a response. Try again."
+            ),
+        ),
+        ErrorKind::Permanent => (
+            RouterCode::ProviderRejected,
+            format!(
+                "Provider \"{provider}\" rejected this request. Review the selected model and provider settings, then try again."
+            ),
+        ),
+    }
+}
+
 fn take_provider_outcome(
     outcome_rx: &mut tokio::sync::oneshot::Receiver<ProviderCallOutcome>,
 ) -> Option<ProviderCallOutcome> {
@@ -265,7 +317,10 @@ fn provider_call_saturated_response(
     provider: &str,
     usage: Option<crate::types::events::Usage>,
 ) -> ChatResponse {
-    let message = format!("provider {provider} call capacity is saturated; retry later");
+    let detail = format!("provider {provider} call capacity is saturated");
+    let message = format!(
+        "Provider \"{provider}\" is handling too many requests right now. Wait a moment and try again."
+    );
     let terminal = send_error_terminal(
         sink,
         partial,
@@ -284,10 +339,12 @@ fn provider_call_saturated_response(
         model: model.to_string(),
         stop_reason: Some(StopReason::Error),
         usage: error.usage,
-        error: Some(ErrorShape {
-            code: "transient".into(),
+        error: Some(error_shape(
+            RouterCode::CapacityExceeded,
+            ErrorKind::Transient,
             message,
-        }),
+            Some(detail),
+        )),
     }
 }
 
@@ -321,14 +378,14 @@ impl ChatPipeline {
             return Err(fail_pre_stream(
                 "",
                 RouterCode::InvalidRequest,
-                "model is required".into(),
+                "Select a model before sending the request.".into(),
             ));
         }
         if !call.messages.is_array() {
             return Err(fail_pre_stream(
                 "",
                 RouterCode::InvalidRequest,
-                "messages must be an array".into(),
+                "The chat history is invalid. Start a new chat and try again.".into(),
             ));
         }
 
@@ -362,7 +419,9 @@ impl ChatPipeline {
                 return Err(fail_pre_stream(
                     &provider,
                     RouterCode::UnknownProvider,
-                    format!("unknown provider {provider}"),
+                    format!(
+                        "Provider \"{provider}\" is not registered. Choose a configured provider and try again."
+                    ),
                 ))
             }
         };
@@ -376,7 +435,10 @@ impl ChatPipeline {
                     return Err(fail_pre_stream(
                         &provider,
                         RouterCode::StructuredOutputUnsupported,
-                        format!("structured output unsupported for model {}", call.model),
+                        format!(
+                            "Model \"{}\" does not support structured output. Choose a compatible model or disable structured output.",
+                            call.model
+                        ),
                     ));
                 }
             }
@@ -406,8 +468,9 @@ impl ChatPipeline {
         let Some(entry_handle) = self.inflight.reserve(&request_id) else {
             return Err(fail_pre_stream(
                 &provider,
-                RouterCode::InvalidRequest,
-                format!("request_id {request_id} is already in flight"),
+                RouterCode::RequestInProgress,
+                "This request is already running. Wait for it to finish or stop it before trying again."
+                    .into(),
             ));
         };
         let result = self
@@ -458,16 +521,18 @@ impl ChatPipeline {
         let send_frame = |frame: &AssistantMessageEvent| {
             let _ = sink.send(&serde_json::to_string(frame).expect("serializable frame"));
         };
-        let respond_err = |stop: StopReason, code: &str, message: String, usage| ChatResponse {
+        let respond_err = |stop: StopReason,
+                           code: RouterCode,
+                           kind: ErrorKind,
+                           message: String,
+                           detail: Option<String>,
+                           usage| ChatResponse {
             ok: false,
             provider: provider.to_string(),
             model: call.model.clone(),
             stop_reason: Some(stop),
             usage,
-            error: Some(ErrorShape {
-                code: code.to_string(),
-                message,
-            }),
+            error: Some(error_shape(code, kind, message, detail)),
         };
 
         let max_attempts = 1 + settings.retry_max;
@@ -497,17 +562,19 @@ impl ChatPipeline {
             let channel = match create_router_channel(&self.iii).await {
                 Ok(channel) => channel,
                 Err(error) => {
-                    let message = format!("router channel creation failed: {error}");
-                    send_error_terminal(
+                    tracing::error!(%error, provider, model = %call.model, "router channel creation failed");
+                    let message =
+                        "The response stream could not be started. Try again.".to_string();
+                    return Err(fail_with_terminal(
                         sink.as_ref(),
                         last_partial.as_ref(),
                         &call.model,
                         provider,
-                        &message,
+                        RouterCode::StreamSetupFailed,
+                        message,
                         ErrorKind::Transient,
                         last_usage,
-                    );
-                    return Err(error);
+                    ));
                 }
             };
             let mut reader = channel.reader;
@@ -670,16 +737,17 @@ impl ChatPipeline {
                     let AssistantMessageEvent::Error { error } = terminal else {
                         unreachable!()
                     };
-                    let code = kind
-                        .and_then(|k| serde_json::to_value(k).ok())
-                        .and_then(|v| v.as_str().map(String::from))
-                        .unwrap_or_else(|| "transient".into());
+                    let kind = kind.unwrap_or(ErrorKind::Transient);
+                    let detail = error
+                        .error_message
+                        .unwrap_or_else(|| "provider returned an error without details".into());
+                    let (code, message) = provider_error_presentation(kind, provider, &call.model);
                     return Ok(respond_err(
                         StopReason::Error,
-                        &code,
-                        error
-                            .error_message
-                            .unwrap_or_else(|| "provider error".into()),
+                        code,
+                        kind,
+                        message,
+                        Some(detail),
                         error.usage,
                     ));
                 }
@@ -722,7 +790,9 @@ impl ChatPipeline {
                                 return Err(err);
                             }
                             if is_function_not_found(&err) {
-                                let message = format!("provider {provider} unavailable");
+                                let message = format!(
+                                    "Provider \"{provider}\" is temporarily unavailable. Try again or choose another provider."
+                                );
                                 let terminal_error = fail_with_terminal(
                                     sink.as_ref(),
                                     last_partial.as_ref(),
@@ -770,13 +840,27 @@ impl ChatPipeline {
                         }
                         continue;
                     }
-                    let message = if is_idle {
-                        format!(
-                            "provider {provider} stream idle past {}ms",
-                            settings.idle_timeout_ms
+                    let (code, message, detail) = if is_idle {
+                        (
+                            RouterCode::StreamIdleTimeout,
+                            format!(
+                                "Provider \"{provider}\" stopped responding before the answer completed. Try again."
+                            ),
+                            format!(
+                                "provider {provider} stream idle past {}ms",
+                                settings.idle_timeout_ms
+                            ),
                         )
                     } else {
-                        format!("provider {provider} stream ended without a terminal frame")
+                        (
+                            RouterCode::StreamIncomplete,
+                            format!(
+                                "Provider \"{provider}\" disconnected before completing the response. Try again."
+                            ),
+                            format!(
+                                "provider {provider} stream ended without a terminal frame"
+                            ),
+                        )
                     };
                     let terminal = synthesize_error(
                         last_partial.as_ref(),
@@ -793,8 +877,10 @@ impl ChatPipeline {
                     };
                     return Ok(respond_err(
                         StopReason::Error,
-                        "transient",
+                        code,
+                        ErrorKind::Transient,
                         message,
+                        Some(detail),
                         error.usage,
                     ));
                 }
@@ -941,6 +1027,16 @@ mod tests {
             RouterCode::NotConfigured,
             RouterCode::StructuredOutputUnsupported,
             RouterCode::RegistrationRejected,
+            RouterCode::RequestInProgress,
+            RouterCode::CapacityExceeded,
+            RouterCode::StreamSetupFailed,
+            RouterCode::StreamIdleTimeout,
+            RouterCode::StreamIncomplete,
+            RouterCode::ProviderAuthExpired,
+            RouterCode::ProviderRateLimited,
+            RouterCode::ContextOverflow,
+            RouterCode::ProviderTransient,
+            RouterCode::ProviderRejected,
         ] {
             assert_eq!(
                 pre_stream_error_kind(code),
@@ -948,6 +1044,44 @@ mod tests {
                 "{} must remain permanent",
                 code.as_str()
             );
+        }
+    }
+
+    #[test]
+    fn provider_errors_have_stable_codes_and_actionable_public_messages() {
+        let cases = [
+            (
+                ErrorKind::AuthExpired,
+                RouterCode::ProviderAuthExpired,
+                "Update its credentials",
+            ),
+            (
+                ErrorKind::RateLimited,
+                RouterCode::ProviderRateLimited,
+                "Try again shortly",
+            ),
+            (
+                ErrorKind::ContextOverflow,
+                RouterCode::ContextOverflow,
+                "larger context window",
+            ),
+            (
+                ErrorKind::Transient,
+                RouterCode::ProviderTransient,
+                "Try again",
+            ),
+            (
+                ErrorKind::Permanent,
+                RouterCode::ProviderRejected,
+                "provider settings",
+            ),
+        ];
+
+        for (kind, code, action) in cases {
+            let (actual_code, message) = provider_error_presentation(kind, "openai", "gpt-5");
+            assert_eq!(actual_code, code);
+            assert!(message.contains(action), "missing action in {message}");
+            assert!(!message.contains("terminal frame"));
         }
     }
 
@@ -1033,7 +1167,12 @@ mod tests {
             provider_call_saturated_response(&ch.writer, None, "busy-model", "busy-provider", None);
         assert!(!response.ok);
         assert_eq!(response.stop_reason, Some(StopReason::Error));
-        assert_eq!(response.error.as_ref().unwrap().code, "transient");
+        let error = response.error.as_ref().unwrap();
+        assert_eq!(error.code, RouterCode::CapacityExceeded.as_str());
+        assert_eq!(error.kind, Some(ErrorKind::Transient));
+        assert_eq!(error.retryable, Some(true));
+        assert!(error.message.contains("try again"));
+        assert!(error.detail.as_deref().unwrap().contains("capacity"));
 
         let mut reader = ch.reader;
         let ReadEvent::Msg(frame) = reader.next(Duration::from_millis(50)).await else {

--- a/llm-router/src/chat/complete.rs
+++ b/llm-router/src/chat/complete.rs
@@ -74,8 +74,8 @@ pub fn make_complete(
                 Some(AssistantMessageEvent::Error { error }) => error,
                 _ => {
                     return Err(RouterError::new(
-                        RouterCode::InvalidRequest,
-                        "stream produced no terminal frame",
+                        RouterCode::StreamIncomplete,
+                        "The provider ended the response before completion. Try again; if it continues, check the provider worker.",
                     )
                     .into())
                 }

--- a/llm-router/src/routing.rs
+++ b/llm-router/src/routing.rs
@@ -41,13 +41,17 @@ pub fn decide(input: &DecideInput) -> Result<Vec<String>, RouterError> {
         if !registered(provider) {
             return Err(RouterError::new(
                 RouterCode::UnknownProvider,
-                format!("unknown provider {provider}"),
+                format!(
+                    "Provider \"{provider}\" is not registered. Choose a configured provider and try again."
+                ),
             ));
         }
         if !available(provider) {
             return Err(RouterError::new(
                 RouterCode::ProviderUnavailable,
-                format!("provider {provider} unavailable"),
+                format!(
+                    "Provider \"{provider}\" is temporarily unavailable. Try again or choose another provider."
+                ),
             ));
         }
         return Ok(vec![provider.clone()]);
@@ -75,7 +79,7 @@ pub fn decide(input: &DecideInput) -> Result<Vec<String>, RouterError> {
             return Err(RouterError::new(
                 RouterCode::AmbiguousModel,
                 format!(
-                    "ambiguous model {} (providers: {})",
+                    "Model \"{}\" is available from multiple providers: {}. Choose a provider and try again.",
                     input.model,
                     available_owners.join(", ")
                 ),
@@ -123,7 +127,7 @@ pub fn decide(input: &DecideInput) -> Result<Vec<String>, RouterError> {
         return Err(RouterError::new(
             RouterCode::ProviderUnavailable,
             format!(
-                "no available provider for model {} (unavailable: {})",
+                "No provider currently available can serve model \"{}\" (unavailable: {}). Try again later or choose another model.",
                 input.model,
                 unavailable_matches.join(", ")
             ),
@@ -133,7 +137,10 @@ pub fn decide(input: &DecideInput) -> Result<Vec<String>, RouterError> {
     // 6. Loud failure.
     Err(RouterError::new(
         RouterCode::NoProviderForModel,
-        format!("no provider registered for model {}", input.model),
+        format!(
+            "No configured provider can serve model \"{}\". Choose another model or configure a compatible provider.",
+            input.model
+        ),
     ))
 }
 
@@ -150,9 +157,11 @@ pub fn make_route(
         let (registry, catalog, config) = (registry.clone(), catalog.clone(), config.clone());
         Box::pin(async move {
             if req.model.is_empty() {
-                return Err(
-                    RouterError::new(RouterCode::InvalidRequest, "model is required").into(),
-                );
+                return Err(RouterError::new(
+                    RouterCode::InvalidRequest,
+                    "Select a model before sending the request.",
+                )
+                .into());
             }
             let config = snapshot(&config);
             let heuristics = config.settings().routing_heuristics.clone();
@@ -233,7 +242,7 @@ mod tests {
         assert_eq!(err.code, RouterCode::AmbiguousModel);
         assert_eq!(
             err.message,
-            "ambiguous model shared-model (providers: lmstudio, openai)"
+            "Model \"shared-model\" is available from multiple providers: lmstudio, openai. Choose a provider and try again."
         );
     }
 
@@ -280,7 +289,10 @@ mod tests {
 
         let err = decide(&input).unwrap_err();
         assert_eq!(err.code, RouterCode::ProviderUnavailable);
-        assert_eq!(err.message, "provider openai unavailable");
+        assert_eq!(
+            err.message,
+            "Provider \"openai\" is temporarily unavailable. Try again or choose another provider."
+        );
     }
 
     #[test]
@@ -296,7 +308,7 @@ mod tests {
         assert_eq!(err.code, RouterCode::ProviderUnavailable);
         assert_eq!(
             err.message,
-            "no available provider for model shared-model (unavailable: lmstudio, openai)"
+            "No provider currently available can serve model \"shared-model\" (unavailable: lmstudio, openai). Try again later or choose another model."
         );
     }
 

--- a/llm-router/src/types/errors.rs
+++ b/llm-router/src/types/errors.rs
@@ -11,6 +11,16 @@ pub enum RouterCode {
     NotConfigured,
     StructuredOutputUnsupported,
     RegistrationRejected, // token mismatch (spec adaptation: identity binding)
+    RequestInProgress,
+    CapacityExceeded,
+    StreamSetupFailed,
+    StreamIdleTimeout,
+    StreamIncomplete,
+    ProviderAuthExpired,
+    ProviderRateLimited,
+    ContextOverflow,
+    ProviderTransient,
+    ProviderRejected,
 }
 
 impl RouterCode {
@@ -24,6 +34,16 @@ impl RouterCode {
             RouterCode::NotConfigured => "router/not_configured",
             RouterCode::StructuredOutputUnsupported => "router/structured_output_unsupported",
             RouterCode::RegistrationRejected => "router/registration_rejected",
+            RouterCode::RequestInProgress => "router/request_in_progress",
+            RouterCode::CapacityExceeded => "router/capacity_exceeded",
+            RouterCode::StreamSetupFailed => "router/stream_setup_failed",
+            RouterCode::StreamIdleTimeout => "router/stream_idle_timeout",
+            RouterCode::StreamIncomplete => "router/stream_incomplete",
+            RouterCode::ProviderAuthExpired => "router/provider_auth_expired",
+            RouterCode::ProviderRateLimited => "router/provider_rate_limited",
+            RouterCode::ContextOverflow => "router/context_overflow",
+            RouterCode::ProviderTransient => "router/provider_transient",
+            RouterCode::ProviderRejected => "router/provider_rejected",
         }
     }
 }

--- a/llm-router/src/types/router.rs
+++ b/llm-router/src/types/router.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 use std::collections::BTreeMap;
 
 use crate::types::credential::Credential;
-use crate::types::events::{StopReason, Usage};
+use crate::types::events::{ErrorKind, StopReason, Usage};
 use crate::types::messages::{AgentMessage, AssistantMessage};
 use crate::types::model::{AgentFunction, Model, ThinkingLevel};
 use iii_sdk::channel::StreamChannelRef;
@@ -51,6 +51,14 @@ pub struct ChatRequest {
 pub struct ErrorShape {
     pub code: String,
     pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<ErrorKind>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retryable: Option<bool>,
+    /// Provider/transport diagnostics for logs and expandable UI details.
+    /// `message` remains the stable, user-facing explanation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]


### PR DESCRIPTION
## Summary

- preserve structured Router error codes, classes, retryability, and diagnostics through Harness
- separate user-facing explanations and recovery actions from technical details in Console
- add stable error codes and actionable copy for routing, capacity, provider, and stream failures
- verify provider-family failures remain clear and durable across reload and a later successful turn

## Why

Users currently see raw provider and transport diagnostics as the primary failure message. This makes common failures difficult to understand and leaves the Console without enough structured context to recommend the right next step.

This stacked PR builds on #815, which hardens the terminal and retry lifecycle used by these failure paths.

## Screenshots

### Anthropic Messages

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/e55ebc50-8cce-4eb1-8169-914459ef496d" />


### OpenAI Chat Completions

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/3fbfcc60-f0da-464b-b16b-6c425e19b741" />

### OpenAI Responses

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/86b901cf-4577-47e2-914d-f0be66dc44d5" />


## Validation

- `llm-router`: 131 library tests passed
- `harness`: 324 library tests passed
- `harness-integration`: 2 provider-family contract tests passed
- `console/web`: 1,208 unit tests passed; application and E2E typechecks passed; Biome passed
- Playwright: 3 provider-family failure, reload, and recovery scenarios passed against an isolated stack built from this branch

Refs MOT-4452
