### PR TITLE
(MOT-4496) feat(iii-directory): prompt authoring, session skill addons, and slash-command injection

### DIFF
--- a/console/web/src/components/chat/AttachmentChip.tsx
+++ b/console/web/src/components/chat/AttachmentChip.tsx
@@ -1,6 +1,14 @@
-import { File, X } from 'lucide-react'
+import { Blocks, File, SquareSlash, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import type { Attachment } from '@/types/chat'
+
+/* Same icons as the composer's slash palette sources: a collapsed
+ * `<command>` block reads as the command it came from, not as a file. */
+function chipIcon(type: string) {
+  if (type === 'text/x-slash-command') return SquareSlash
+  if (type === 'text/x-skill') return Blocks
+  return File
+}
 
 interface AttachmentChipProps {
   attachment: Attachment
@@ -8,7 +16,7 @@ interface AttachmentChipProps {
   className?: string
 }
 
-function formatSize(bytes: number): string {
+export function formatSize(bytes: number): string {
   if (bytes < 1024) return `${bytes}b`
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)}kb`
   return `${(bytes / (1024 * 1024)).toFixed(1)}mb`
@@ -20,6 +28,7 @@ export function AttachmentChip({
   className,
 }: AttachmentChipProps) {
   const isImage = attachment.type.startsWith('image/') && attachment.dataUrl
+  const Icon = chipIcon(attachment.type)
   return (
     <div
       className={cn(
@@ -34,7 +43,7 @@ export function AttachmentChip({
           className="size-6 object-cover border border-rule-2"
         />
       ) : (
-        <File size={12} aria-hidden className="text-ink-faint shrink-0" />
+        <Icon size={12} aria-hidden className="text-ink-faint shrink-0" />
       )}
       <span className="truncate min-w-0">{attachment.name}</span>
       <span className="text-ink-ghost tabular-nums shrink-0">

--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -45,6 +45,7 @@ import { syncEditorWorkspace } from '@/lib/editor-sync'
 import { expandFileMentions, parseFileMentions } from '@/lib/file-mentions'
 import { formatStopReason } from '@/lib/format-stop-reason'
 import { newMessageId } from '@/lib/session-id'
+import { expandSlashInvocation, slashChip } from '@/lib/slash-commands'
 import { useExtSessionChips, useExtSessionTurnSummaries } from '@/lib/ui-slots'
 import { cn } from '@/lib/utils'
 import { fetchDefaultWorkingDir, validateWorkspaceDir } from '@/lib/working-dir'
@@ -590,6 +591,25 @@ export function ChatView({
               await expandFileMentions(workingDir, mentionPaths)
             ).blocks
           }
+        }
+        // Same expansion as the live send path: an edited queued message
+        // keeps its `/name` / `/skill:<id>` block instead of silently
+        // dropping it. Staying silent on a failed re-resolution would strip
+        // the body the queued message already carried with no explanation.
+        const slashExpansion =
+          backend.id === 'real'
+            ? await expandSlashInvocation(payload.text.trim())
+            : null
+        if (slashExpansion?.status === 'attached') {
+          attachedBlocks = [...(attachedBlocks ?? []), slashExpansion.block]
+        } else if (slashExpansion) {
+          onAppendMessage(
+            conversationId,
+            makeSystemNotice(
+              `could not attach ${slashExpansion.command} — the edited message will be sent as typed`,
+              'warn',
+            ),
+          )
         }
         // Same expansion as the live send path: a queued message's documents
         // and pictures have to reach the agent too, or editing a queued
@@ -1221,6 +1241,35 @@ export function ChatView({
             ),
           )
         }
+      }
+
+      // A leading `/name` (directory prompt) or `/skill:<id>` the palette
+      // offered expands here: the resolved body rides as another attachment
+      // block while the typed text (command + args) stays the user message.
+      // Prose that merely starts with a slash never resolves (the expander
+      // is gated on the palette's fetched entries).
+      const slashExpansion =
+        backend.id === 'real' ? await expandSlashInvocation(trimmed) : null
+      if (slashExpansion?.status === 'attached') {
+        attachedBlocks = [...(attachedBlocks ?? []), slashExpansion.block]
+        // The body travels as a block, never as visible text — show the same
+        // chip the hydrated transcript will collapse the block into.
+        if (!willQueue) {
+          onPatchMessage(conversationId, userMsg.id, {
+            attachments: [
+              ...(userMsg.attachments ?? []),
+              slashChip(slashExpansion.inv, slashExpansion.block.length),
+            ],
+          })
+        }
+      } else if (slashExpansion) {
+        onAppendMessage(
+          conversationId,
+          makeSystemNotice(
+            `could not attach ${slashExpansion.command} — sending the message as typed`,
+            'warn',
+          ),
+        )
       }
 
       // Mid-stream send (MOT-3837): a turn is already streaming, so the
@@ -1970,7 +2019,7 @@ export function ChatView({
               {backend.editQueued &&
               queuedDrafts.length > 0 &&
               !drainingQueue ? (
-                <div className="px-3 py-0.5 text-right text-[10px] lowercase text-ink-ghost max-sm:hidden">
+                <div className="px-3 py-0.5 text-right text-[11px] lowercase text-ink-ghost max-sm:hidden">
                   {browsedQueuedId
                     ? '↑ / ↓ cycle · enter saves in place · empty + enter removes'
                     : 'press ↑ in the composer to edit queued messages'}

--- a/console/web/src/components/chat/EmptyState.tsx
+++ b/console/web/src/components/chat/EmptyState.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/Button'
 import type { InstallStage } from '@/hooks/use-harness-status'
 import { normalizeErrorMessage } from '@/lib/providers'
 import { cn } from '@/lib/utils'
+import { SessionAddonsPicker } from './SessionAddonsPicker'
 import { StrategyToggle, SystemPromptPicker } from './SystemPromptPicker'
 import type { SystemPromptState } from './system-prompt-selection'
 
@@ -184,9 +185,21 @@ function ReadyBody({
               onChange={onSystemPromptChange}
             />
           </div>
+          <div className="flex flex-col gap-1.5">
+            <p className="font-sans text-base/6 text-ink-faint sm:text-sm/5">
+              optionally add skills to the system prompt:
+            </p>
+            <SessionAddonsPicker
+              value={systemPrompt}
+              onChange={onSystemPromptChange}
+              className="min-w-0"
+            />
+          </div>
           <p className="font-sans text-base/6 text-ink-faint sm:text-sm/5">
             {systemPrompt.choice === 'default'
-              ? "default uses the provider's built-in prompt"
+              ? systemPrompt.addons.length > 0
+                ? 'selected skills are added to the built-in prompt'
+                : "default uses the provider's built-in prompt"
               : systemPrompt.strategy === 'enrich'
                 ? 'enrich adds this prompt to the built-in prompt'
                 : 'replace uses this prompt instead of the built-in prompt'}

--- a/console/web/src/components/chat/Message.tsx
+++ b/console/web/src/components/chat/Message.tsx
@@ -1,4 +1,4 @@
-import { Bell, Check, Copy, Zap } from 'lucide-react'
+import { Bell, Blocks, Check, Copy, SquareSlash, Zap } from 'lucide-react'
 import { useState } from 'react'
 import { RegisterTriggerView } from '@/components/chat/engine/RegisterTriggerView'
 import { FilterChip } from '@/components/chat/engine/shared'
@@ -16,12 +16,13 @@ import { JsonHighlight } from '@/lib/syntax'
 import { cn } from '@/lib/utils'
 import type {
   AssistantMessage as AssistantMessageType,
+  Attachment,
   Message as MessageType,
   SystemMessage as SystemMessageType,
   TriggerFiredData,
   UserMessage as UserMessageType,
 } from '@/types/chat'
-import { AttachmentChip } from './AttachmentChip'
+import { AttachmentChip, formatSize } from './AttachmentChip'
 import { CopyMessageButton } from './CopyMessageButton'
 import { MemoryChip } from './MemoryChip'
 import type { TriggerRegistration } from './MessageList'
@@ -762,7 +763,50 @@ function SpawnTaskMessage({ message }: { message: UserMessageType }) {
   )
 }
 
+const SLASH_CHIP_TYPES = new Set(['text/x-slash-command', 'text/x-skill'])
+
+/**
+ * The `/command` token inside the user bubble: the typed command fused with
+ * its expansion metadata (body size), so the slash chip never repeats the
+ * same name one row below the bubble. Same anatomy as FunctionMentionPill —
+ * accent glyph, ink text, one alpha-surface step above the bubble.
+ */
+function SlashCommandToken({ chip }: { chip: Attachment }) {
+  const isSkill = chip.type === 'text/x-skill'
+  const Icon = isSkill ? Blocks : SquareSlash
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 px-1.5 h-[22px] rounded-xs bg-surface font-mono text-[13px] text-ink select-none"
+      title={`${isSkill ? 'skill' : 'prompt'} body attached · ${formatSize(chip.size)}`}
+    >
+      <Icon size={13} aria-hidden className="text-accent shrink-0" />
+      <span className="leading-none truncate">{chip.name}</span>
+      <span className="leading-none text-[11px] text-ink-ghost tabular-nums shrink-0">
+        {formatSize(chip.size)}
+      </span>
+    </span>
+  )
+}
+
 function UserMessage({ message }: { message: UserMessageType }) {
+  const attachments = message.attachments ?? []
+  /* A slash expansion's chip duplicates the command that already leads the
+     typed text — fuse it into the bubble as one token instead of orphaning
+     it in the strip below. A chip that doesn't match the leading token
+     (shouldn't happen) keeps the strip as a fallback. */
+  const slashChip = attachments.find(
+    (a) =>
+      SLASH_CHIP_TYPES.has(a.type) &&
+      message.content.startsWith(a.name) &&
+      (message.content.length === a.name.length ||
+        message.content.charAt(a.name.length) === ' '),
+  )
+  const chips = slashChip
+    ? attachments.filter((a) => a.id !== slashChip.id)
+    : attachments
+  const args = slashChip
+    ? message.content.slice(slashChip.name.length).trim()
+    : ''
   return (
     <article
       className="group flex flex-col items-end gap-2"
@@ -781,15 +825,27 @@ function UserMessage({ message }: { message: UserMessageType }) {
         className={cn(
           'max-w-[92%] rounded-sm bg-surface px-3.5 py-2.5 sm:max-w-[80%]',
           'break-words',
+          slashChip && 'flex flex-col items-start gap-1.5',
         )}
       >
-        <Markdown className="max-sm:[&_ol]:text-base max-sm:[&_p]:text-base max-sm:[&_ul]:text-base">
-          {message.content}
-        </Markdown>
+        {slashChip ? (
+          <>
+            <SlashCommandToken chip={slashChip} />
+            {args ? (
+              <Markdown className="max-sm:[&_ol]:text-base max-sm:[&_p]:text-base max-sm:[&_ul]:text-base">
+                {args}
+              </Markdown>
+            ) : null}
+          </>
+        ) : (
+          <Markdown className="max-sm:[&_ol]:text-base max-sm:[&_p]:text-base max-sm:[&_ul]:text-base">
+            {message.content}
+          </Markdown>
+        )}
       </div>
-      {message.attachments && message.attachments.length > 0 ? (
+      {chips.length > 0 ? (
         <div className="flex max-w-[92%] flex-wrap justify-end gap-2 sm:max-w-[80%]">
-          {message.attachments.map((a) => (
+          {chips.map((a) => (
             <AttachmentChip key={a.id} attachment={a} />
           ))}
         </div>

--- a/console/web/src/components/chat/SessionAddonsPicker.tsx
+++ b/console/web/src/components/chat/SessionAddonsPicker.tsx
@@ -1,0 +1,168 @@
+import { Blocks, Check, ChevronDown } from 'lucide-react'
+import { useCallback, useRef, useState } from 'react'
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/DropdownMenu'
+import { getSkill, listSkills } from '@/lib/backend/directory-prompts'
+import { getIiiClient } from '@/lib/iii-client'
+import { cn } from '@/lib/utils'
+import type { SystemPromptState } from './system-prompt-selection'
+
+/**
+ * Multi-select for the welcome screen's session skills: directory skills
+ * whose bodies are appended to the session's system prompt on the first
+ * send. A sibling of `SystemPromptPicker`, not a generalization —
+ * multi-select needs checkbox rows, which Radix Select can't do.
+ *
+ * Skills only: command prompts are user-invoked `/` commands in the
+ * composer, not session-start context. The `prompt` addon kind survives in
+ * the state model solely so metadata persisted by older builds still
+ * decodes and sends.
+ */
+export function SessionAddonsPicker({
+  value,
+  onChange,
+  disabled,
+  className,
+}: {
+  value: SystemPromptState
+  onChange: (next: SystemPromptState) => void
+  disabled?: boolean
+  className?: string
+}) {
+  const [entries, setEntries] = useState<
+    { name: string; description: string }[] | null
+  >(null)
+
+  /* The menu stays open across toggles and body resolution awaits the bus,
+     so the post-await state must come from the LATEST value — a closure
+     captured before the await would drop or duplicate concurrent toggles. */
+  const valueRef = useRef(value)
+  valueRef.current = value
+
+  /* Fetch on EVERY open, SystemPromptPicker-style: keep the last list while
+     loading, degrade to an empty list when the directory worker is absent. */
+  const handleOpenChange = useCallback(async (open: boolean) => {
+    if (!open) return
+    try {
+      const client = await getIiiClient()
+      setEntries(
+        (await listSkills(client)).map((s) => ({
+          name: s.id,
+          description: s.description || s.title,
+        })),
+      )
+    } catch {
+      setEntries((prev) => prev ?? [])
+    }
+  }, [])
+
+  const isChecked = useCallback(
+    (name: string) =>
+      value.addons.some((a) => a.kind === 'skill' && a.name === name),
+    [value.addons],
+  )
+
+  const toggle = useCallback(
+    async (name: string) => {
+      const cur = valueRef.current
+      if (cur.addons.some((a) => a.kind === 'skill' && a.name === name)) {
+        onChange({
+          ...cur,
+          addons: cur.addons.filter(
+            (a) => !(a.kind === 'skill' && a.name === name),
+          ),
+        })
+        return
+      }
+      /* Resolve the body at selection time — frozen server-side on the
+         first send, same contract as the identity prompt's namedBody. */
+      try {
+        const client = await getIiiClient()
+        const body = (await getSkill(client, name)).body
+        const latest = valueRef.current
+        if (latest.addons.some((a) => a.kind === 'skill' && a.name === name)) {
+          return
+        }
+        onChange({
+          ...latest,
+          addons: [...latest.addons, { kind: 'skill', name, body }],
+        })
+      } catch {
+        /* Unresolvable body = nothing to add; leave the selection as-is. */
+      }
+    },
+    [onChange],
+  )
+
+  const count = value.addons.filter((a) => a.kind === 'skill').length
+
+  return (
+    <DropdownMenu onOpenChange={handleOpenChange}>
+      <DropdownMenuTrigger
+        aria-label="session skills"
+        disabled={disabled}
+        className={cn(
+          'inline-flex w-full items-center justify-between gap-x-2 rounded-sm border border-transparent bg-bg px-3 h-9 text-ink font-mono text-[13px] lowercase hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus data-[state=open]:bg-surface-active transition-colors',
+          disabled && 'opacity-40 pointer-events-none',
+          className,
+        )}
+      >
+        <span className="inline-flex items-center gap-2 min-w-0">
+          <Blocks size={14} className="text-ink-faint" aria-hidden />
+          <span className="truncate">
+            {count > 0 ? `skills (${count})` : 'skills'}
+          </span>
+        </span>
+        <ChevronDown size={12} aria-hidden />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="start"
+        collisionPadding={8}
+        /* Width is anchored to the trigger and CAPPED: descriptions are full
+           sentences, and an uncapped popper sizes to the widest one — a
+           viewport-wide panel that clips its own checkmarks at the screen
+           edge. The cap is what makes the row-level truncation engage. */
+        className="min-w-[var(--radix-dropdown-menu-trigger-width)] max-w-[min(24rem,var(--radix-dropdown-menu-content-available-width))] max-h-[min(18rem,var(--radix-dropdown-menu-content-available-height))] overflow-y-auto text-[13px]"
+      >
+        {entries === null ? (
+          <DropdownMenuItem disabled>loading skills…</DropdownMenuItem>
+        ) : entries.length === 0 ? (
+          <DropdownMenuItem disabled>no skills available</DropdownMenuItem>
+        ) : (
+          entries.map((e) => (
+            <DropdownMenuCheckboxItem
+              key={e.name}
+              checked={isChecked(e.name)}
+              /* Keep the menu open across toggles: multi-select. */
+              onSelect={(ev) => ev.preventDefault()}
+              onCheckedChange={() => void toggle(e.name)}
+              /* Same accent ✓ as the StrategyToggle beside this picker. */
+              indicator={
+                <Check
+                  size={12}
+                  strokeWidth={2.5}
+                  className="text-accent"
+                  aria-hidden
+                />
+              }
+            >
+              <div className="min-w-0 flex-1" title={e.description}>
+                <div className="truncate">{e.name}</div>
+                {e.description ? (
+                  <div className="truncate text-[11px] leading-[1.5] text-ink-faint">
+                    {e.description}
+                  </div>
+                ) : null}
+              </div>
+            </DropdownMenuCheckboxItem>
+          ))
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/console/web/src/components/chat/lexical/SlashCommandsPlugin.tsx
+++ b/console/web/src/components/chat/lexical/SlashCommandsPlugin.tsx
@@ -8,9 +8,16 @@ import {
   type LexicalEditor,
   type TextNode,
 } from 'lexical'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { fuzzyFilterSlash, type SlashCommand } from '@/lib/slash-commands'
+import { listCommandPrompts, listSkills } from '@/lib/backend/directory-prompts'
+import { getIiiClient } from '@/lib/iii-client'
+import {
+  fuzzyFilterSlash,
+  mergeSlashEntries,
+  type SlashCommand,
+  setDynamicSlashEntries,
+} from '@/lib/slash-commands'
 import { FlipMenu } from './FlipMenu'
 
 class SlashCommandOption extends MenuOption {
@@ -26,8 +33,11 @@ interface SlashCommandsPluginProps {
   menuOpenRef?: React.RefObject<boolean>
 }
 
-// Anchored at column 0 so `/` mid-sentence ("either/or") doesn't fire.
-const SLASH_PATTERN = /^\/(\w*)$/
+// Anchored at column 0 so `/` mid-sentence ("either/or") doesn't fire. The
+// query is either a plain slug (built-ins + directory prompt names) or the
+// `/skill:<id>` form (ids are `/`-separated paths) — a bare second `/`
+// ("/home/…") disarms the palette at once instead of shadowing a typed path.
+const SLASH_PATTERN = /^\/(skill:[\w./-]*|[\w-]*)$/
 
 function slashTriggerFn(text: string, _editor: LexicalEditor) {
   const match = text.match(SLASH_PATTERN)
@@ -44,12 +54,49 @@ export function SlashCommandsPlugin({
 }: SlashCommandsPluginProps = {}) {
   const [query, setQuery] = useState<string | null>(null)
 
+  /* Directory-backed entries, refetched on EVERY open (SystemPromptPicker's
+     pattern) and kept while loading, so prompts/skills created or deleted
+     mid-session appear without a reload. The fetched list is also published
+     to the module registry that gates submit-time expansion. A failed or
+     absent directory worker degrades to built-ins only. */
+  const [dynamic, setDynamic] = useState<SlashCommand[] | null>(null)
+  const loadingRef = useRef(false)
+  const loadDynamic = useCallback(async () => {
+    if (loadingRef.current) return
+    loadingRef.current = true
+    try {
+      const client = await getIiiClient()
+      const [prompts, skills] = await Promise.all([
+        listCommandPrompts(client).catch(() => []),
+        listSkills(client).catch(() => []),
+      ])
+      const entries = [
+        ...prompts.map((p) => ({
+          command: `/${p.name}`,
+          description: p.description,
+          kind: 'prompt' as const,
+        })),
+        ...skills.map((s) => ({
+          command: `/skill:${s.id}`,
+          description: s.description || s.title,
+          kind: 'skill' as const,
+        })),
+      ]
+      setDynamic(entries)
+      setDynamicSlashEntries(entries)
+    } catch {
+      /* No client: keep whatever list the last open produced. */
+    } finally {
+      loadingRef.current = false
+    }
+  }, [])
+
   const options = useMemo(
     () =>
-      fuzzyFilterSlash(query ?? '').map(
+      fuzzyFilterSlash(query ?? '', mergeSlashEntries(dynamic ?? [])).map(
         (entry) => new SlashCommandOption(entry),
       ),
-    [query],
+    [query, dynamic],
   )
 
   const onSelectOption = useCallback(
@@ -75,6 +122,7 @@ export function SlashCommandsPlugin({
       onSelectOption={onSelectOption}
       onOpen={() => {
         if (menuOpenRef) menuOpenRef.current = true
+        void loadDynamic()
       }}
       onClose={() => {
         if (menuOpenRef) menuOpenRef.current = false

--- a/console/web/src/components/chat/system-prompt-selection.test.ts
+++ b/console/web/src/components/chat/system-prompt-selection.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   choiceToValue,
   DEFAULT_SYSTEM_PROMPT_STATE,
+  type SystemPromptState,
   selectionForSend,
   toSelection,
   valueToChoice,
@@ -19,6 +20,7 @@ describe('toSelection', () => {
         strategy: 'override',
         namedBody: '',
         customText: 'Talk like a pirate.',
+        addons: [],
       }),
     ).toEqual({ body: 'Talk like a pirate.', strategy: 'override' })
   })
@@ -30,6 +32,7 @@ describe('toSelection', () => {
         strategy: 'enrich',
         namedBody: '',
         customText: '   ',
+        addons: [],
       }),
     ).toBeNull()
   })
@@ -41,18 +44,74 @@ describe('toSelection', () => {
         strategy: 'enrich',
         namedBody: 'Arr.',
         customText: 'ignored',
+        addons: [],
       }),
     ).toEqual({ body: 'Arr.', strategy: 'enrich' })
+  })
+
+  it('addons on the default choice send alone, always as enrich', () => {
+    expect(
+      toSelection({
+        choice: 'default',
+        strategy: 'override',
+        namedBody: '',
+        customText: '',
+        addons: [
+          { kind: 'prompt', name: 'review', body: 'Review checklist.' },
+          { kind: 'skill', name: 'coder/index', body: 'Coder skill.' },
+        ],
+      }),
+    ).toEqual({
+      body: 'Review checklist.\n\nCoder skill.',
+      strategy: 'enrich',
+    })
+  })
+
+  it('addons append after the named body, strategy preserved', () => {
+    expect(
+      toSelection({
+        choice: { named: 'pirate' },
+        strategy: 'override',
+        namedBody: 'Arr.',
+        customText: '',
+        addons: [{ kind: 'prompt', name: 'review', body: 'Review checklist.' }],
+      }),
+    ).toEqual({ body: 'Arr.\n\nReview checklist.', strategy: 'override' })
+  })
+
+  it('a blank base never ships as override, even with a named choice', () => {
+    expect(
+      toSelection({
+        choice: { named: 'pirate' },
+        strategy: 'override',
+        namedBody: '   ',
+        customText: '',
+        addons: [{ kind: 'prompt', name: 'review', body: 'Review checklist.' }],
+      }),
+    ).toEqual({ body: 'Review checklist.', strategy: 'enrich' })
+  })
+
+  it('blank addon bodies are filtered out', () => {
+    expect(
+      toSelection({
+        choice: 'default',
+        strategy: 'enrich',
+        namedBody: '',
+        customText: '',
+        addons: [{ kind: 'prompt', name: 'empty', body: '   ' }],
+      }),
+    ).toBeNull()
   })
 })
 
 describe('selectionForSend', () => {
-  const named = {
+  const named: SystemPromptState = {
     choice: { named: 'pirate' },
     strategy: 'enrich',
     namedBody: 'Arr.',
     customText: '',
-  } as const
+    addons: [],
+  }
 
   it('first send (no turn yet) carries the selection', () => {
     expect(selectionForSend(named, false)).toEqual({

--- a/console/web/src/components/chat/system-prompt-selection.ts
+++ b/console/web/src/components/chat/system-prompt-selection.ts
@@ -1,5 +1,6 @@
 /**
- * Pure state for the chat system-prompt picker. `SystemPromptPicker.tsx`
+ * Pure state for the chat system-prompt picker and the prompt/skill addon
+ * pickers (`SessionAddonsPicker.tsx`). `SystemPromptPicker.tsx`
  * renders it on the new-session screen; the chosen value is stored on
  * `Conversation.systemPrompt` (see `use-conversations`), and `ChatView` maps
  * it onto `ChatStreamOptions.systemPrompt` via `selectionForSend` — the
@@ -21,6 +22,17 @@ export type PromptStrategy = 'enrich' | 'override'
 /** What the select shows: provider default, a named fs prompt, or free text. */
 export type SystemPromptChoice = 'default' | 'custom' | { named: string }
 
+/** One pre-selected directory prompt or skill whose body is appended to the
+ * session's system prompt (welcome-screen "prompts"/"skills" pickers). */
+export interface SystemPromptAddon {
+  kind: 'prompt' | 'skill'
+  /** Prompt name (`directory::prompts::*`) or skill id (`directory::skills::*`). */
+  name: string
+  /** Body resolved at selection time, frozen server-side on the first send —
+   * same contract as `namedBody`. */
+  body: string
+}
+
 export interface SystemPromptState {
   choice: SystemPromptChoice
   strategy: PromptStrategy
@@ -30,6 +42,7 @@ export interface SystemPromptState {
   namedBody: string
   /** Custom textarea content; kept while switching choices. */
   customText: string
+  addons: SystemPromptAddon[]
 }
 
 export const DEFAULT_SYSTEM_PROMPT_STATE: SystemPromptState = {
@@ -37,16 +50,28 @@ export const DEFAULT_SYSTEM_PROMPT_STATE: SystemPromptState = {
   strategy: 'enrich',
   namedBody: '',
   customText: '',
+  addons: [],
 }
 
 /** Map picker state to the per-send selection; null = send no prompt fields. */
 export function toSelection(
   s: SystemPromptState,
 ): SystemPromptSelection | null {
-  if (s.choice === 'default') return null
-  const body = s.choice === 'custom' ? s.customText : s.namedBody
-  if (!body.trim()) return null
-  return { body, strategy: s.strategy }
+  const base =
+    s.choice === 'default'
+      ? ''
+      : s.choice === 'custom'
+        ? s.customText
+        : s.namedBody
+  const parts = [base, ...s.addons.map((a) => a.body)].filter((p) => p.trim())
+  if (parts.length === 0) return null
+  return {
+    body: parts.join('\n\n'),
+    /* Addons on top of a blank base (default choice, or a named/custom body
+       that resolved empty) must never wipe the built-in prompt away, so a
+       blank base always ships as enrich. */
+    strategy: base.trim() ? s.strategy : 'enrich',
+  }
 }
 
 /**

--- a/console/web/src/hooks/use-conversations.test.ts
+++ b/console/web/src/hooks/use-conversations.test.ts
@@ -386,7 +386,60 @@ describe('mergeConversationMeta / system_prompt', () => {
       strategy: 'override',
       namedBody: 'Arr.',
       customText: '',
+      addons: [],
     })
+  })
+
+  it('restores addons riding the default choice', () => {
+    const next = mergeConversationMeta(
+      undefined,
+      sessionMeta({
+        metadata: {
+          system_prompt: {
+            choice: 'default',
+            strategy: 'enrich',
+            named_body: '',
+            addons: [
+              { kind: 'prompt', name: 'review', body: 'Review checklist.' },
+              { kind: 'skill', name: 'coder/index', body: 'Coder skill.' },
+            ],
+          },
+        },
+      }),
+    )
+    expect(next.systemPrompt).toEqual({
+      choice: 'default',
+      strategy: 'enrich',
+      namedBody: '',
+      customText: '',
+      addons: [
+        { kind: 'prompt', name: 'review', body: 'Review checklist.' },
+        { kind: 'skill', name: 'coder/index', body: 'Coder skill.' },
+      ],
+    })
+  })
+
+  it('drops malformed addon entries but keeps the valid ones', () => {
+    const next = mergeConversationMeta(
+      undefined,
+      sessionMeta({
+        metadata: {
+          system_prompt: {
+            choice: { named: 'pirate' },
+            named_body: 'Arr.',
+            addons: [
+              'nonsense',
+              { kind: 'rule', name: 'x', body: 'y' },
+              { kind: 'prompt', name: 'review' },
+              { kind: 'skill', name: 'coder/index', body: 'Coder skill.' },
+            ],
+          },
+        },
+      }),
+    )
+    expect(next.systemPrompt?.addons).toEqual([
+      { kind: 'skill', name: 'coder/index', body: 'Coder skill.' },
+    ])
   })
 
   it('degrades malformed persisted values to the default without throwing', () => {

--- a/console/web/src/hooks/use-conversations.ts
+++ b/console/web/src/hooks/use-conversations.ts
@@ -28,6 +28,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   DEFAULT_SYSTEM_PROMPT_STATE,
+  type SystemPromptAddon,
   type SystemPromptState,
 } from '@/components/chat/system-prompt-selection'
 import { getIiiClient } from '@/lib/iii-client'
@@ -116,11 +117,23 @@ function isMode(v: unknown): v is Mode {
 function encodeSystemPrompt(
   s: SystemPromptState | undefined,
 ): Record<string, unknown> | undefined {
-  if (!s || s.choice === 'default') return undefined
+  if (!s) return undefined
+  const addons = (s.addons ?? []).map(({ kind, name, body }) => ({
+    kind,
+    name,
+    body,
+  }))
+  if (s.choice === 'default' && addons.length === 0) return undefined
   return {
-    choice: s.choice === 'custom' ? 'custom' : { named: s.choice.named },
+    choice:
+      s.choice === 'default'
+        ? 'default'
+        : s.choice === 'custom'
+          ? 'custom'
+          : { named: s.choice.named },
     strategy: s.strategy,
     named_body: s.namedBody,
+    ...(addons.length > 0 ? { addons } : {}),
   }
 }
 
@@ -128,10 +141,10 @@ function encodeSystemPrompt(
  * Decode `metadata.system_prompt` defensively — it is untrusted wire JSON,
  * and an unreadable value must degrade to the default rather than throw.
  *
- * ponytail: only the `{named}` choice round-trips. `custom` cannot reach
- * here today because the sole writer is the new-session picker, which
- * renders no `custom…` row; extend this if another surface ever persists a
- * free-text choice.
+ * ponytail: only the `{named}` and `default`-with-addons shapes round-trip.
+ * `custom` cannot reach here today because the sole writer is the
+ * new-session picker, which renders no `custom…` row; extend this if
+ * another surface ever persists a free-text choice.
  */
 function decodeSystemPrompt(v: unknown): SystemPromptState {
   if (typeof v !== 'object' || v === null) return DEFAULT_SYSTEM_PROMPT_STATE
@@ -143,12 +156,24 @@ function decodeSystemPrompt(v: unknown): SystemPromptState {
     typeof (choice as Record<string, unknown>).named === 'string'
       ? ((choice as Record<string, unknown>).named as string)
       : null
-  if (!named) return DEFAULT_SYSTEM_PROMPT_STATE
+  const addons: SystemPromptAddon[] = Array.isArray(md.addons)
+    ? (md.addons as unknown[]).flatMap((a): SystemPromptAddon[] => {
+        if (typeof a !== 'object' || a === null) return []
+        const r = a as Record<string, unknown>
+        return (r.kind === 'prompt' || r.kind === 'skill') &&
+          typeof r.name === 'string' &&
+          typeof r.body === 'string'
+          ? [{ kind: r.kind, name: r.name, body: r.body }]
+          : []
+      })
+    : []
+  if (!named && addons.length === 0) return DEFAULT_SYSTEM_PROMPT_STATE
   return {
-    choice: { named },
+    choice: named ? { named } : 'default',
     strategy: md.strategy === 'override' ? 'override' : 'enrich',
-    namedBody: typeof md.named_body === 'string' ? md.named_body : '',
+    namedBody: named && typeof md.named_body === 'string' ? md.named_body : '',
     customText: '',
+    addons,
   }
 }
 

--- a/console/web/src/lib/backend/directory-prompts.test.ts
+++ b/console/web/src/lib/backend/directory-prompts.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it, vi } from 'vitest'
-import { getPrompt, listPrompts } from './directory-prompts'
+import {
+  getCommandPrompt,
+  getPrompt,
+  getSkill,
+  listCommandPrompts,
+  listPrompts,
+  listSkills,
+} from './directory-prompts'
+
+const TIMEOUT = { timeoutMs: 10_000 }
 
 function fakeClient(impl?: (fn: string, payload: unknown) => unknown) {
   const trigger = vi.fn(async (fn: string, payload: unknown) =>
@@ -19,6 +28,7 @@ describe('client calls', () => {
     expect(client.trigger).toHaveBeenCalledWith(
       'directory::system-prompts::list',
       {},
+      TIMEOUT,
     )
   })
 
@@ -32,9 +42,67 @@ describe('client calls', () => {
     expect((await getPrompt(client, 'pirate')).body).toBe('Arr.')
     expect(client.trigger).toHaveBeenCalledWith(
       'directory::system-prompts::get',
+      { name: 'pirate' },
+      TIMEOUT,
+    )
+  })
+
+  it('listCommandPrompts targets the command-prompt family', async () => {
+    const entries = [{ name: 'review', description: 'R.', modified_at: 't' }]
+    const client = fakeClient(() => ({ prompts: entries }))
+    expect(await listCommandPrompts(client)).toEqual(entries)
+    expect(client.trigger).toHaveBeenCalledWith(
+      'directory::prompts::list',
+      {},
+      TIMEOUT,
+    )
+  })
+
+  it('getCommandPrompt passes the name through', async () => {
+    const client = fakeClient(() => ({
+      name: 'review',
+      description: 'R.',
+      body: 'Check.',
+      modified_at: 't',
+    }))
+    expect((await getCommandPrompt(client, 'review')).body).toBe('Check.')
+    expect(client.trigger).toHaveBeenCalledWith(
+      'directory::prompts::get',
+      { name: 'review' },
+      TIMEOUT,
+    )
+  })
+
+  it('listSkills requests descriptions and unwraps the skills array', async () => {
+    const skills = [
       {
-        name: 'pirate',
+        id: 'coder/index',
+        title: 'coder',
+        description: 'D.',
+        modified_at: 't',
       },
+    ]
+    const client = fakeClient(() => ({ skills }))
+    expect(await listSkills(client)).toEqual(skills)
+    expect(client.trigger).toHaveBeenCalledWith(
+      'directory::skills::list',
+      { include_description: true },
+      TIMEOUT,
+    )
+  })
+
+  it('getSkill passes the id through', async () => {
+    const client = fakeClient(() => ({
+      id: 'coder/index',
+      title: 'coder',
+      body: 'Skill.',
+      modified_at: 't',
+    }))
+    expect((await getSkill(client, 'coder/index')).body).toBe('Skill.')
+    expect(client.trigger).toHaveBeenCalledWith(
+      'directory::skills::get',
+      { id: 'coder/index' },
+      TIMEOUT,
     )
   })
 })

--- a/console/web/src/lib/backend/directory-prompts.ts
+++ b/console/web/src/lib/backend/directory-prompts.ts
@@ -1,11 +1,23 @@
 /**
- * Thin READ client over `directory::system-prompts::*` for the chat's
- * new-session picker: list the names, resolve one body at selection time.
- * Authoring is deliberately absent — the iii-directory UI's system-prompts
- * tab owns `create` / `update`.
+ * Thin READ client over the iii-directory worker for the chat:
+ *
+ *  - `directory::system-prompts::*` — the new-session identity picker.
+ *  - `directory::prompts::*` — command templates, offered as session addons
+ *    on the welcome screen and as `/name` slash commands in the composer.
+ *  - `directory::skills::*` — skills, offered as session addons and as
+ *    `/skill:<id>` slash commands.
+ *
+ * The pattern everywhere: list the names, resolve one body at selection
+ * time. Authoring is deliberately absent — the iii-directory UI's page owns
+ * `create` / `update` / `delete`.
  */
 
 import type { IiiClient } from '@/lib/iii-client'
+
+/* These fetches sit on interactive surfaces (pickers, palette, send path);
+ * a hung directory worker must fail them fast, not hold the UI to the
+ * client's 5-minute default trigger timeout. */
+const FETCH_TIMEOUT_MS = 10_000
 
 export interface PromptEntry {
   name: string
@@ -17,10 +29,25 @@ export interface PromptBody extends PromptEntry {
   body: string
 }
 
+export interface SkillEntry {
+  id: string
+  title: string
+  description: string
+  modified_at: string
+}
+
+export interface SkillBody {
+  id: string
+  title: string
+  body: string
+  modified_at: string
+}
+
 export async function listPrompts(client: IiiClient): Promise<PromptEntry[]> {
   const res = await client.trigger<{ prompts: PromptEntry[] }>(
     'directory::system-prompts::list',
     {},
+    { timeoutMs: FETCH_TIMEOUT_MS },
   )
   return res.prompts
 }
@@ -29,7 +56,51 @@ export async function getPrompt(
   client: IiiClient,
   name: string,
 ): Promise<PromptBody> {
-  return client.trigger<PromptBody>('directory::system-prompts::get', {
-    name,
-  })
+  return client.trigger<PromptBody>(
+    'directory::system-prompts::get',
+    { name },
+    { timeoutMs: FETCH_TIMEOUT_MS },
+  )
+}
+
+export async function listCommandPrompts(
+  client: IiiClient,
+): Promise<PromptEntry[]> {
+  const res = await client.trigger<{ prompts: PromptEntry[] }>(
+    'directory::prompts::list',
+    {},
+    { timeoutMs: FETCH_TIMEOUT_MS },
+  )
+  return res.prompts
+}
+
+export async function getCommandPrompt(
+  client: IiiClient,
+  name: string,
+): Promise<PromptBody> {
+  return client.trigger<PromptBody>(
+    'directory::prompts::get',
+    { name },
+    { timeoutMs: FETCH_TIMEOUT_MS },
+  )
+}
+
+export async function listSkills(client: IiiClient): Promise<SkillEntry[]> {
+  const res = await client.trigger<{ skills: SkillEntry[] }>(
+    'directory::skills::list',
+    { include_description: true },
+    { timeoutMs: FETCH_TIMEOUT_MS },
+  )
+  return res.skills
+}
+
+export async function getSkill(
+  client: IiiClient,
+  id: string,
+): Promise<SkillBody> {
+  return client.trigger<SkillBody>(
+    'directory::skills::get',
+    { id },
+    { timeoutMs: FETCH_TIMEOUT_MS },
+  )
 }

--- a/console/web/src/lib/sessions/entry-mapper.test.ts
+++ b/console/web/src/lib/sessions/entry-mapper.test.ts
@@ -165,6 +165,45 @@ describe('entrySegments', () => {
     })
   })
 
+  it('collapses command and skill blocks into chips instead of dumping bodies', () => {
+    const commandBlock =
+      '<command name="review-pr">\nThe entire prompt body.\n</command>'
+    const skillBlock =
+      '<skill id="coder/index">\nThe entire skill body.\n</skill>'
+    const item: TranscriptItem = {
+      entry_id: 'msg-4-user-0',
+      message: {
+        role: 'user',
+        content: [
+          { type: 'text', text: '/review-pr the auth changes' },
+          { type: 'text', text: commandBlock },
+          { type: 'text', text: skillBlock },
+        ],
+        timestamp: 1,
+      },
+    }
+    const [msg] = entrySegments(item)
+    expect(msg).toMatchObject({
+      role: 'user',
+      content: '/review-pr the auth changes',
+      attachments: [
+        {
+          id: 'slash-/review-pr',
+          name: '/review-pr',
+          size: commandBlock.length,
+          type: 'text/x-slash-command',
+        },
+        {
+          id: 'slash-/skill:coder/index',
+          name: '/skill:coder/index',
+          size: skillBlock.length,
+          type: 'text/x-skill',
+        },
+      ],
+    })
+    expect((msg as { content: string }).content).not.toContain('entire')
+  })
+
   it('marks only trusted notification user entries', () => {
     expect(
       entrySegments(userItem('e-1', 'normal', { notification: false }))[0],

--- a/console/web/src/lib/sessions/entry-mapper.ts
+++ b/console/web/src/lib/sessions/entry-mapper.ts
@@ -25,6 +25,7 @@
  */
 
 import { parseAttachedFileHeader } from '@/lib/file-mentions'
+import { parseSlashBlockHeader, slashChip } from '@/lib/slash-commands'
 import type {
   Attachment,
   FunctionTriggerMessage,
@@ -324,7 +325,9 @@ function textOf(blocks: ContentBlock[]): string {
  * `<attached-file …>` blocks are console-authored `#file(...)` mention and
  * document expansions — rendering their full content in the user bubble would
  * dump whole files into the chat, so they collapse to chips instead (failure
- * placeholders keep the error visible in the chip name).
+ * placeholders keep the error visible in the chip name). `<command>` /
+ * `<skill>` blocks are `/name` slash expansions and collapse the same way —
+ * the typed command stays the visible text, the body becomes a chip.
  *
  * An image block is the picture itself, sent to a vision model. It becomes a
  * chip carrying its own thumbnail: without this a conversation reloaded from
@@ -361,6 +364,11 @@ function splitUserContent(blocks: ContentBlock[]): {
         size: header.size ?? 0,
         type: 'text/x-file-mention',
       })
+      continue
+    }
+    const slash = parseSlashBlockHeader(block.text)
+    if (slash) {
+      attachments.push(slashChip(slash, block.text.length))
     } else {
       text += block.text
     }

--- a/console/web/src/lib/slash-commands.test.ts
+++ b/console/web/src/lib/slash-commands.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest'
+import {
+  expandSlashInvocation,
+  fuzzyFilterSlash,
+  mergeSlashEntries,
+  parseSlashBlockHeader,
+  parseSlashInvocation,
+  SLASH_COMMANDS,
+  setDynamicSlashEntries,
+  slashAttachmentBlock,
+  slashChip,
+} from './slash-commands'
+
+describe('parseSlashInvocation', () => {
+  it('parses a leading /name as a prompt, args untouched', () => {
+    expect(parseSlashInvocation('/review-pr the auth changes')).toEqual({
+      kind: 'prompt',
+      name: 'review-pr',
+    })
+    expect(parseSlashInvocation('/review-pr')).toEqual({
+      kind: 'prompt',
+      name: 'review-pr',
+    })
+  })
+
+  it('parses /skill:<id> including slashes in the id', () => {
+    expect(parseSlashInvocation('/skill:coder/index do the thing')).toEqual({
+      kind: 'skill',
+      id: 'coder/index',
+    })
+  })
+
+  it('built-ins are not invocations', () => {
+    expect(parseSlashInvocation('/compact')).toBeNull()
+    expect(parseSlashInvocation('/compact now')).toBeNull()
+  })
+
+  it('a leading absolute path is not an invocation', () => {
+    expect(parseSlashInvocation('/home/x/y is broken')).toBeNull()
+  })
+
+  it('plain text is not an invocation', () => {
+    expect(parseSlashInvocation('hello /review-pr')).toBeNull()
+    expect(parseSlashInvocation('either/or')).toBeNull()
+  })
+})
+
+describe('mergeSlashEntries', () => {
+  it('built-ins first; dynamic names shadowed by a built-in are dropped', () => {
+    const merged = mergeSlashEntries([
+      {
+        command: '/compact',
+        description: 'a prompt named compact',
+        kind: 'prompt',
+      },
+      { command: '/review-pr', description: 'review a pr', kind: 'prompt' },
+    ])
+    expect(merged.slice(0, SLASH_COMMANDS.length)).toEqual(SLASH_COMMANDS)
+    expect(merged.filter((c) => c.command === '/compact')).toHaveLength(1)
+    expect(merged.some((c) => c.command === '/review-pr')).toBe(true)
+  })
+})
+
+describe('slashAttachmentBlock', () => {
+  it('wraps prompt and skill bodies distinctly', () => {
+    expect(
+      slashAttachmentBlock({ kind: 'prompt', name: 'review-pr' }, 'Check X.'),
+    ).toBe('<command name="review-pr">\nCheck X.\n</command>')
+    expect(
+      slashAttachmentBlock({ kind: 'skill', id: 'coder/index' }, 'Skill.'),
+    ).toBe('<skill id="coder/index">\nSkill.\n</skill>')
+  })
+})
+
+describe('parseSlashBlockHeader', () => {
+  it('round-trips both block shapes back to their invocation', () => {
+    for (const inv of [
+      { kind: 'prompt', name: 'review-pr' },
+      { kind: 'skill', id: 'coder/index' },
+    ] as const) {
+      expect(parseSlashBlockHeader(slashAttachmentBlock(inv, 'body'))).toEqual(
+        inv,
+      )
+    }
+  })
+
+  it('ignores plain text and attached-file blocks', () => {
+    expect(parseSlashBlockHeader('hello <command name="x">')).toBeNull()
+    expect(
+      parseSlashBlockHeader('<attached-file path="a.rs">x</attached-file>'),
+    ).toBeNull()
+  })
+})
+
+describe('slashChip', () => {
+  it('builds the collapsed chip per kind', () => {
+    expect(slashChip({ kind: 'prompt', name: 'review-pr' }, 42)).toEqual({
+      id: 'slash-/review-pr',
+      name: '/review-pr',
+      size: 42,
+      type: 'text/x-slash-command',
+    })
+    expect(slashChip({ kind: 'skill', id: 'coder/index' }, 7)).toEqual({
+      id: 'slash-/skill:coder/index',
+      name: '/skill:coder/index',
+      size: 7,
+      type: 'text/x-skill',
+    })
+  })
+})
+
+describe('expandSlashInvocation gate', () => {
+  /* Only the palette-known gate is unit-testable (it returns before any
+     client is touched); the resolution path needs a live bus. */
+  it('never expands before the palette has fetched entries', async () => {
+    setDynamicSlashEntries(null)
+    expect(await expandSlashInvocation('/review-pr x')).toBeNull()
+  })
+
+  it('never expands slugs the palette did not offer', async () => {
+    setDynamicSlashEntries([
+      { command: '/review-pr', description: 'review a pr', kind: 'prompt' },
+    ])
+    expect(await expandSlashInvocation('/etc is full')).toBeNull()
+    expect(await expandSlashInvocation('/compact now')).toBeNull()
+    expect(await expandSlashInvocation('/skill:coder/index go')).toBeNull()
+    setDynamicSlashEntries(null)
+  })
+})
+
+describe('fuzzyFilterSlash', () => {
+  const entries = mergeSlashEntries([
+    { command: '/review-pr', description: 'review a pr', kind: 'prompt' },
+    { command: '/skill:coder/index', description: 'coder', kind: 'skill' },
+  ])
+
+  it('empty query returns everything up to the limit', () => {
+    expect(fuzzyFilterSlash('', entries)).toHaveLength(entries.length)
+  })
+
+  it('matches command and description substrings across kinds', () => {
+    expect(fuzzyFilterSlash('review', entries).map((c) => c.command)).toEqual([
+      '/review-pr',
+    ])
+    expect(
+      fuzzyFilterSlash('skill:cod', entries).map((c) => c.command),
+    ).toEqual(['/skill:coder/index'])
+  })
+})

--- a/console/web/src/lib/slash-commands.ts
+++ b/console/web/src/lib/slash-commands.ts
@@ -1,6 +1,22 @@
+/**
+ * The composer's `/` command registry. Built-ins live in `SLASH_COMMANDS`;
+ * the palette (`SlashCommandsPlugin`) merges in dynamic entries from the
+ * iii-directory worker — command prompts as `/name`, skills as
+ * `/skill:<id>` — and both send paths in `ChatView` expand a leading
+ * invocation into an attachment block via `expandSlashInvocation`.
+ *
+ * Prompt names are strict `[a-z0-9_-]` slugs (iii-directory
+ * `validate_name`), so they can never collide with the `skill:` prefix.
+ * Built-ins always win a name collision.
+ */
+
+import { getCommandPrompt, getSkill } from '@/lib/backend/directory-prompts'
+import { getIiiClient } from '@/lib/iii-client'
+
 export interface SlashCommand {
   command: string
   description: string
+  kind?: 'builtin' | 'prompt' | 'skill'
 }
 
 export const SLASH_COMMANDS: SlashCommand[] = [
@@ -10,12 +26,127 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   },
 ]
 
-export function fuzzyFilterSlash(query: string, limit = 8): SlashCommand[] {
+export function fuzzyFilterSlash(
+  query: string,
+  entries: SlashCommand[] = SLASH_COMMANDS,
+  limit = 8,
+): SlashCommand[] {
   const q = query.trim().toLowerCase()
-  if (!q) return SLASH_COMMANDS.slice(0, limit)
-  return SLASH_COMMANDS.filter(
-    (c) =>
-      c.command.toLowerCase().includes(q) ||
-      c.description.toLowerCase().includes(q),
-  ).slice(0, limit)
+  if (!q) return entries.slice(0, limit)
+  return entries
+    .filter(
+      (c) =>
+        c.command.toLowerCase().includes(q) ||
+        c.description.toLowerCase().includes(q),
+    )
+    .slice(0, limit)
+}
+
+/** Built-ins first; dynamic entries shadowed by a built-in name are dropped. */
+export function mergeSlashEntries(dynamic: SlashCommand[]): SlashCommand[] {
+  const builtins = new Set(SLASH_COMMANDS.map((c) => c.command))
+  return [...SLASH_COMMANDS, ...dynamic.filter((c) => !builtins.has(c.command))]
+}
+
+export type SlashInvocation =
+  | { kind: 'prompt'; name: string }
+  | { kind: 'skill'; id: string }
+
+const SKILL_INVOCATION = /^\/skill:([\w./-]+)(?:\s|$)/
+/* Exact server charset from iii-directory's `validate_name`. The `(?:\s|$)`
+ * guard means a message starting with an absolute path (`/home/x/y`) never
+ * parses as an invocation — a `/` follows the first segment. */
+const PROMPT_INVOCATION = /^\/([a-z0-9_-]+)(?:\s|$)/
+
+/** A leading `/name` / `/skill:<id>`, or null (plain text and built-ins). */
+export function parseSlashInvocation(text: string): SlashInvocation | null {
+  const skill = text.match(SKILL_INVOCATION)
+  if (skill) return { kind: 'skill', id: skill[1] }
+  const prompt = text.match(PROMPT_INVOCATION)
+  if (!prompt) return null
+  if (SLASH_COMMANDS.some((c) => c.command === `/${prompt[1]}`)) return null
+  return { kind: 'prompt', name: prompt[1] }
+}
+
+/** Wrap a resolved body as the attachment block riding with the send. */
+export function slashAttachmentBlock(
+  inv: SlashInvocation,
+  body: string,
+): string {
+  return inv.kind === 'prompt'
+    ? `<command name="${inv.name}">\n${body}\n</command>`
+    : `<skill id="${inv.id}">\n${body}\n</skill>`
+}
+
+export function invocationCommand(inv: SlashInvocation): string {
+  return inv.kind === 'prompt' ? `/${inv.name}` : `/skill:${inv.id}`
+}
+
+/**
+ * Parse the header of a `<command name="…">` / `<skill id="…">` block back
+ * into its invocation. The exact inverse of `slashAttachmentBlock` — names
+ * are strict slugs and skill ids path charsets, so no attribute escaping
+ * exists to undo.
+ */
+export function parseSlashBlockHeader(text: string): SlashInvocation | null {
+  const command = text.match(/^<command name="([^"]+)">/)
+  if (command) return { kind: 'prompt', name: command[1] }
+  const skill = text.match(/^<skill id="([^"]+)">/)
+  if (skill) return { kind: 'skill', id: skill[1] }
+  return null
+}
+
+/**
+ * The attachment chip a slash block collapses to — shared by the optimistic
+ * send row and the transcript hydration path so both render identically.
+ */
+export function slashChip(
+  inv: SlashInvocation,
+  blockSize: number,
+): { id: string; name: string; size: number; type: string } {
+  const command = invocationCommand(inv)
+  return {
+    id: `slash-${command}`,
+    name: command,
+    size: blockSize,
+    type: inv.kind === 'prompt' ? 'text/x-slash-command' : 'text/x-skill',
+  }
+}
+
+/* The entries the palette last fetched. The submit-time expander resolves
+ * ONLY invocations the palette actually offered, so prose that merely
+ * starts with a slash ("/etc is full") never fires a directory RPC. */
+let dynamicSlashEntries: SlashCommand[] | null = null
+
+export function setDynamicSlashEntries(entries: SlashCommand[] | null): void {
+  dynamicSlashEntries = entries
+}
+
+export type SlashExpansion =
+  | { status: 'attached'; block: string; inv: SlashInvocation }
+  | { status: 'failed'; command: string }
+
+/**
+ * Shared submit-time expansion for the fresh-send and queued-edit paths: a
+ * leading palette-known `/name` / `/skill:<id>` resolves its body into an
+ * attachment block; `failed` means the caller should warn and send the text
+ * as typed; null means the text is not an invocation (or not palette-known).
+ */
+export async function expandSlashInvocation(
+  text: string,
+): Promise<SlashExpansion | null> {
+  const inv = parseSlashInvocation(text)
+  if (!inv) return null
+  const command = invocationCommand(inv)
+  if (!dynamicSlashEntries?.some((e) => e.command === command)) return null
+  try {
+    const client = await getIiiClient()
+    const body =
+      inv.kind === 'prompt'
+        ? (await getCommandPrompt(client, inv.name)).body
+        : (await getSkill(client, inv.id)).body
+    return { status: 'attached', block: slashAttachmentBlock(inv, body), inv }
+  } catch {
+    return { status: 'failed', command }
+  }
 }

--- a/iii-directory/README.md
+++ b/iii-directory/README.md
@@ -25,8 +25,8 @@ Skills and prompts are sourced from a single configured folder on disk
 functions, which pull markdown into `skills_folder` from either the
 [workers registry](https://workers.iii.dev) or a GitHub repo, plus the
 per-kind single-file editors — `directory::skills::update`,
-`directory::prompts::{create,update}` and
-`directory::system-prompts::{create,update}`. Once downloaded, files
+`directory::prompts::{create,update,delete}` and
+`directory::system-prompts::{create,update,delete}`. Once downloaded, files
 belong to the developer — edit them however you want, in the editor of
 your choice: a change made directly on disk fires the matching
 `on-change` with `op: "external"` (see [Custom trigger
@@ -284,6 +284,7 @@ other adapter.
 | `directory::prompts::get` | Fetch one prompt's body + `{name, description, modified_at}`. Plain shape, no envelope. Pass `raw: true` to additionally get the FULL on-disk file (frontmatter included) as `raw`. |
 | `directory::prompts::update` | Overwrite one EXISTING prompt file with new full-file content: `{ name, content }`. The frontmatter must keep a non-empty `description` (and a valid `name` when declared) — the same rules the scanner enforces. Atomic write; fans out `directory::prompts::on-change` with `op: "update"`. Returns the prompt's effective name after the write. |
 | `directory::prompts::create` | Create a NEW command-template prompt file at `<skills_folder>/prompts/<name>.md` from full-file content: `{ name, content }`, where `content` is the FULL file including frontmatter. The frontmatter must carry a non-empty `description` (and a `name` matching the request, when declared) — the same rules `update` enforces. Refuses a `name` that already exists anywhere in the merged command-prompt scan, and a target path that already exists on disk even if the scanner would skip it. Atomic write; fans out `directory::prompts::on-change` with `op: "create"`. Returns `{ name, description, bytes, modified_at }`. |
+| `directory::prompts::delete` | Permanently remove one EXISTING command-template prompt file by `{ name }`. Resolves against the same merged scan as `list`/`get`, fans out `directory::prompts::on-change` with `op: "delete"`, and returns `{ name }`. |
 
 ### `directory::system-prompts::*` (filesystem reader + editor)
 
@@ -340,7 +341,7 @@ There is **no** `directory::skills::register` /
 | Trigger type | Fires when | Payload to subscribers |
 |---|---|---|
 | `directory::skills::on-change` | After a `directory::skills::download` that wrote at least one skill markdown file, a `directory::skills::update`, or external (file pasted/edited/deleted directly on disk) | download: `{ "op": "download", "namespace": "<ns>", "source": "repo" \| "registry" }`; update: `{ "op": "update", "namespace": "<ns>", "id": "<id>" }`; external (file pasted/edited/deleted directly on disk): `{ "op": "external" }` |
-| `directory::prompts::on-change` | After a `directory::skills::download` that wrote at least one prompt markdown file, a `directory::prompts::update`, a `directory::prompts::create`, or external (file pasted/edited/deleted directly on disk) | download: `{ "op": "download", "namespace": "<ns>", "source": "repo" \| "registry" }`; update: `{ "op": "update", "name": "<name>" }`; create: `{ "op": "create", "name": "<name>" }`; external (file pasted/edited/deleted directly on disk): `{ "op": "external" }` |
+| `directory::prompts::on-change` | After a `directory::skills::download` that wrote at least one prompt markdown file, a `directory::prompts::update`, `create`, `delete`, or external (file pasted/edited/deleted directly on disk) | download: `{ "op": "download", "namespace": "<ns>", "source": "repo" \| "registry" }`; update/create/delete: `{ "op": "<operation>", "name": "<name>" }`; external (file pasted/edited/deleted directly on disk): `{ "op": "external" }` |
 | `directory::system-prompts::on-change` | After a `directory::skills::download` that wrote at least one system prompt markdown file, a `directory::system-prompts::update`, `create`, `delete`, or external file change | download: `{ "op": "download", "namespace": "<ns>", "source": "repo" \| "registry" }`; update/create/delete: `{ "op": "<operation>", "name": "<name>" }`; external: `{ "op": "external" }` |
 
 Dispatches are fire-and-forget (Void), so the write path doesn't

--- a/iii-directory/skills/SKILL.md
+++ b/iii-directory/skills/SKILL.md
@@ -70,6 +70,7 @@ workers can appear without a manual download.
 - `directory::prompts::get` — read one prompt template's body by name; `raw: true` also returns the full on-disk file for round-tripping.
 - `directory::prompts::create` — create a NEW command template at `<skills_folder>/prompts/<name>.md` from full-file content; refuses a name already in the command scan and an existing target path.
 - `directory::prompts::update` — overwrite one EXISTING command template; the frontmatter must keep a non-empty `description` (a declared `name` renames it).
+- `directory::prompts::delete` — permanently remove one EXISTING command template by name.
 - `directory::system-prompts::list` — list the system prompts the chat picker offers (same shape as `prompts::list`, including the `prompts` field name).
 - `directory::system-prompts::get` — read one system prompt's body by name; `raw: true` as above.
 - `directory::system-prompts::create` — create a NEW system prompt at `<skills_folder>/system-prompts/<name>.md`; same rules and refusals as `prompts::create`, scoped to the system scan.

--- a/iii-directory/src/functions/mod.rs
+++ b/iii-directory/src/functions/mod.rs
@@ -68,8 +68,8 @@ pub fn register_all(
     engine_fn::register(iii);
     tracing::info!(
         "iii-directory registered 3 directory::skills::* reads (list + get + index), \
-         1 skills update, 4 directory::prompts::* (list + get + create + update), \
-         4 directory::system-prompts::* (list + get + create + update), \
+         1 skills update, 5 directory::prompts::* (list + get + create + update + delete), \
+         5 directory::system-prompts::* (list + get + create + update + delete), \
          3 downloads, 2 directory::registry::workers::*, \
          and 1 directory::engine::functions::info"
     );
@@ -91,8 +91,8 @@ pub fn register_all_with_cache(
     engine_fn::register(iii);
     tracing::info!(
         "iii-directory registered 3 directory::skills::* reads (list + get + index), \
-         1 skills update, 4 directory::prompts::* (list + get + create + update), \
-         4 directory::system-prompts::* (list + get + create + update), \
+         1 skills update, 5 directory::prompts::* (list + get + create + update + delete), \
+         5 directory::system-prompts::* (list + get + create + update + delete), \
          3 downloads, 2 directory::registry::workers::*, \
          and 1 directory::engine::functions::info"
     );

--- a/iii-directory/src/functions/update.rs
+++ b/iii-directory/src/functions/update.rs
@@ -194,14 +194,14 @@ pub struct PromptCreateOutput {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct PromptDeleteInput {
-    /// Existing system-prompt name, as returned by
-    /// `directory::system-prompts::list`.
+    /// Existing prompt name, as returned by the matching list function for
+    /// this kind (`directory::prompts::list` / `directory::system-prompts::list`).
     pub name: String,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct PromptDeleteOutput {
-    /// Name of the system prompt whose file was removed.
+    /// Name of the prompt whose file was removed.
     pub name: String,
 }
 
@@ -240,7 +240,20 @@ pub fn register(
         fs_source::PromptKind::System,
         "directory::system-prompts::create",
     );
-    register_delete_system_prompt(iii, cfg, &subscribers.system_prompts);
+    register_delete_prompt(
+        iii,
+        cfg,
+        &subscribers.prompts,
+        fs_source::PromptKind::Command,
+        "directory::prompts::delete",
+    );
+    register_delete_prompt(
+        iii,
+        cfg,
+        &subscribers.system_prompts,
+        fs_source::PromptKind::System,
+        "directory::system-prompts::delete",
+    );
 }
 
 fn register_update_skill(
@@ -391,35 +404,47 @@ fn register_create_prompt(
     );
 }
 
-fn register_delete_system_prompt(
+fn register_delete_prompt(
     iii: &Arc<IIIClient>,
     cfg: &SharedConfig,
     subs: &trigger_types::SubscriberSet,
+    kind: fs_source::PromptKind,
+    function_id: &str,
 ) {
     let cfg_inner = cfg.clone();
     let iii_inner = iii.clone();
     let subs_inner = subs.clone();
+    let (description, label): (&str, &str) = match kind {
+        fs_source::PromptKind::Command => (
+            "Permanently delete one EXISTING filesystem-backed command-template prompt \
+             by name. Resolves against the same merged scan as \
+             directory::prompts::list, removes only that prompt's markdown file, and \
+             fans out directory::prompts::on-change with { op: \"delete\" }.",
+            "Delete prompt",
+        ),
+        fs_source::PromptKind::System => (
+            "Permanently delete one EXISTING filesystem-backed system prompt by name. \
+             Resolves against the same merged scan as directory::system-prompts::list, \
+             removes only that prompt's markdown file, and fans out \
+             directory::system-prompts::on-change with { op: \"delete\" }.",
+            "Delete system prompt",
+        ),
+    };
     iii.register_function(
-        "directory::system-prompts::delete",
+        function_id,
         RegisterFunction::new_async(move |req: PromptDeleteInput| {
             let cfg = cfg_inner.load_full();
             let iii = iii_inner.clone();
             let subs = subs_inner.clone();
             async move {
-                let out = delete_prompt(&cfg, &req, fs_source::PromptKind::System)
-                    .map_err(Error::Handler)?;
+                let out = delete_prompt(&cfg, &req, kind).map_err(Error::Handler)?;
                 trigger_types::dispatch(&iii, &subs, json!({ "op": "delete", "name": out.name }))
                     .await;
                 Ok::<_, Error>(out)
             }
         })
-        .description(
-            "Permanently delete one EXISTING filesystem-backed system prompt by name. \
-             Resolves against the same merged scan as directory::system-prompts::list, \
-             removes only that prompt's markdown file, and fans out \
-             directory::system-prompts::on-change with { op: \"delete\" }.",
-        )
-        .metadata(json!({"tool": {"label": "Delete system prompt"}})),
+        .description(description)
+        .metadata(json!({"tool": {"label": label}})),
     );
 }
 

--- a/iii-directory/src/lib.rs
+++ b/iii-directory/src/lib.rs
@@ -35,7 +35,8 @@
 //! `<skills_folder>/<namespace>/...`; `directory::skills::update` /
 //! `directory::prompts::update` / `directory::system-prompts::update`
 //! overwrite one existing file with edited full-file content;
-//! `directory::system-prompts::{create,delete}` manage system-prompt files. After
+//! `directory::prompts::{create,delete}` and
+//! `directory::system-prompts::{create,delete}` manage prompt files per kind. After
 //! every successful write the worker fires `directory::skills::on-change`
 //! and/or `directory::prompts::on-change` and/or
 //! `directory::system-prompts::on-change` so subscribers can forward

--- a/iii-directory/src/main.rs
+++ b/iii-directory/src/main.rs
@@ -234,12 +234,12 @@ async fn main() -> Result<()> {
         }
     };
 
-    // 19 unconditional: 3 skills reads + 4 prompts reads (2 kinds) + 3 downloads +
-    // 5 updates/creates (skill update, prompt/system-prompt update, prompt/system-prompt
-    // create) + 2 registry proxy + 1 engine-functions-info + 1 configuration-change
+    // 21 unconditional: 3 skills reads + 4 prompts reads (2 kinds) + 3 downloads +
+    // 7 writes (skill update, prompt/system-prompt update, create, and delete) +
+    // 2 registry proxy + 1 engine-functions-info + 1 configuration-change
     // handler (registered above, outside functions::register_all_with_cache).
     // +1 when auto_download also registers directory::__on_worker_added.
-    let fn_count = if auto_download { 20 } else { 19 };
+    let fn_count = if auto_download { 22 } else { 21 };
     tracing::info!(
         "iii-directory ready: {} directory::* functions + 3 custom trigger types + \
          configuration hot-reload",

--- a/iii-directory/ui/src/function-trigger/UpdateViews.tsx
+++ b/iii-directory/ui/src/function-trigger/UpdateViews.tsx
@@ -62,7 +62,12 @@ export function SkillsUpdateView({ input, output, running }: ViewProps) {
 
 /* ---------------- directory::prompts::update ---------------- */
 
-export function PromptsUpdateView({ input, output, running }: ViewProps) {
+export function PromptsUpdateView({
+  input,
+  output,
+  running,
+  verb = 'updated',
+}: ViewProps & { verb?: string }) {
   const req = safeParseRequest(promptsUpdateRequestSchema, input)
 
   if (running) {
@@ -85,7 +90,7 @@ export function PromptsUpdateView({ input, output, running }: ViewProps) {
   return (
     <Card>
       <MetaRow>
-        <StatusPill label="updated" variant="accent" />
+        <StatusPill label={verb} variant="accent" />
         {renamed ? <KvChip label="was">{req.name}</KvChip> : null}
         <KvChip label="bytes">{formatBytes(resp.bytes)}</KvChip>
         <KvChip label="modified">{formatRelativeTime(resp.modified_at)}</KvChip>

--- a/iii-directory/ui/src/function-trigger/index.tsx
+++ b/iii-directory/ui/src/function-trigger/index.tsx
@@ -73,12 +73,27 @@ function render(
         <SkillsUpdateView input={input} output={output} running={running} />
       )
     case 'directory::prompts::list':
+    case 'directory::system-prompts::list':
       return <PromptsListView input={input} output={output} running={running} />
     case 'directory::prompts::get':
+    case 'directory::system-prompts::get':
       return <PromptsGetView input={input} output={output} running={running} />
     case 'directory::prompts::update':
+    case 'directory::system-prompts::update':
       return (
         <PromptsUpdateView input={input} output={output} running={running} />
+      )
+    /* create's wire shapes ({name, content} → {name, description, bytes,
+       modified_at}) are identical to update's, so the update view fits. */
+    case 'directory::prompts::create':
+    case 'directory::system-prompts::create':
+      return (
+        <PromptsUpdateView
+          input={input}
+          output={output}
+          running={running}
+          verb="created"
+        />
       )
     case 'directory::registry::workers::list':
       return (

--- a/iii-directory/ui/src/function-trigger/parsers.ts
+++ b/iii-directory/ui/src/function-trigger/parsers.ts
@@ -6,9 +6,14 @@
  * Wire source: `iii-directory/src/functions/*.rs`
  *   - skills.rs        — directory::skills::list / get / index
  *   - download.rs      — directory::skills::download (+ _from_registry / _from_repo)
- *   - update.rs        — directory::skills::update / directory::prompts::update
- *   - prompts.rs       — directory::prompts::list / get
+ *   - update.rs        — directory::skills::update, directory::prompts::update /
+ *                        create and the directory::system-prompts::* mirrors
+ *   - prompts.rs       — directory::prompts::list / get + system-prompts mirrors
  *   - registry.rs      — directory::registry::workers::list / info
+ *
+ * The two `::delete` ids are deliberately absent: their `{ name }` in/out
+ * shape has no dedicated view, and the console's generic JSON card is the
+ * right rendering for a delete confirmation.
  */
 import { z } from 'zod'
 import { unwrapEnvelope } from '../lib/envelope'
@@ -24,6 +29,11 @@ export const DIRECTORY_FUNCTION_IDS = [
   'directory::prompts::list',
   'directory::prompts::get',
   'directory::prompts::update',
+  'directory::prompts::create',
+  'directory::system-prompts::list',
+  'directory::system-prompts::get',
+  'directory::system-prompts::update',
+  'directory::system-prompts::create',
   'directory::registry::workers::list',
   'directory::registry::workers::info',
 ] as const

--- a/iii-directory/ui/src/page/index.tsx
+++ b/iii-directory/ui/src/page/index.tsx
@@ -92,6 +92,13 @@ const promptsAdapter: BrowserAdapter = {
     const out = await host.iii.trigger<{ name: string }>('directory::prompts::update', { name, content })
     return out.name ?? name
   },
+  async create(host, name, content) {
+    const out = await host.iii.trigger<{ name: string }>('directory::prompts::create', { name, content })
+    return out.name ?? name
+  },
+  async remove(host, name) {
+    await host.iii.trigger('directory::prompts::delete', { name })
+  },
 }
 
 const systemPromptsAdapter: BrowserAdapter = {


### PR DESCRIPTION
## Summary

Three features closing the gap between the iii-directory worker's filesystem-backed prompts/skills and the console chat:

**1. Prompt authoring on the directory page**
- New `directory::prompts::delete` — the kind-generic delete registration now serves both prompt families (`register_delete_prompt`), with kind-specific descriptions and `on-change { op: "delete" }` fan-out.
- The prompts tab gains create/delete, mirroring the system-prompts adapter; slug + required-description validation matches the server.
- Function-trigger cards un-staled: the `system-prompts::*` family and both `create` functions render proper cards (`created` pill) instead of generic JSON; both `::delete` ids intentionally stay on the JSON card.
- Fixed stale function-count logs and doc drift (README, SKILL.md, crate docs).

**2. Welcome-screen skills → system prompt**
- A multi-select skills picker on the new-session card; each selection resolves its body at pick time and rides the existing sticky first-send `system_prompt` (no harness changes). A blank base always ships as `enrich`, so addons can never override away the provider's built-in prompt.
- Selections persist in session metadata and restore across reloads; locked after the first message like the rest of the card.

**3. `/` slash commands in the composer**
- The palette lists directory prompts as `/name` and skills as `/skill:<id>` alongside built-ins (built-ins win collisions), refetched on every open.
- Submit-time expansion attaches the body as a `<command>`/`<skill>` block on the wire message — gated on palette-known entries so prose like `/etc is full` never fires an RPC — on both fresh sends and queued-message edits, with a warn notice when resolution fails.
- The chat never shows the body: blocks collapse into the user bubble as a command token (icon + name + size), the same collapse pattern `#file` attachments use.

Hardening from an adversarial review pass: 10s timeouts on all directory UI fetches, latest-value ref against addon toggle races, palette failure no longer pins built-ins-only, `SLASH_PATTERN` disarms on absolute paths.

## Testing

- `iii-directory`: `cargo test --lib` (279), clippy `--all-features`, fmt — clean.
- Worker UI: `tsc --noEmit` + esbuild + `node --test` — clean.
- Console: 1231 vitest tests, `tsc -b --noEmit`, biome scoped to touched files — clean.
- BDD suite untouched (pre-broken on main; `cargo test --lib` is the gate).

Linear: [MOT-4496](https://linear.app/motia/issue/MOT-4496)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added slash-command support for prompts and skills, including autocomplete, expansion, and inline attachment display.
  - Added a skill picker for selecting multiple skills in new conversations.
  - Added support for creating and deleting prompts and system prompts.
  - Improved attachment chips with specialized icons and clearer command/skill details.

- **Bug Fixes**
  - Preserved slash-command text and arguments when sending or editing queued messages.
  - Improved system-prompt and skill selection persistence across conversations.

- **Documentation**
  - Updated prompt management documentation to cover deletion and related events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
