### PR TITLE
fix: sync provider lockfiles with llm-router 1.4.9

### DIFF
--- a/.github/scripts/tests/test_worker_dependency_compatibility.py
+++ b/.github/scripts/tests/test_worker_dependency_compatibility.py
@@ -1,6 +1,7 @@
 """Regression tests for shared worker dependency ranges."""
 from __future__ import annotations
 
+import tomllib
 from pathlib import Path
 
 import yaml
@@ -36,3 +37,23 @@ def test_harness_llm_stack_uses_shared_state_range() -> None:
 
     for worker in ("llm-router", *providers):
         assert dependencies(worker)["state"] == expected
+
+
+def test_provider_lockfiles_track_llm_router_version() -> None:
+    router_manifest = tomllib.loads(
+        (REPO_ROOT / "llm-router" / "Cargo.toml").read_text(encoding="utf-8"),
+    )
+    expected = router_manifest["package"]["version"]
+
+    for lockfile in sorted(REPO_ROOT.glob("provider-*/Cargo.lock")):
+        lock = tomllib.loads(lockfile.read_text(encoding="utf-8"))
+        locked_versions = [
+            package["version"]
+            for package in lock["package"]
+            if package["name"] == "llm-router"
+        ]
+        if locked_versions:
+            assert locked_versions == [expected], (
+                f"{lockfile.relative_to(REPO_ROOT)} pins llm-router "
+                f"{locked_versions}, expected {expected}"
+            )

--- a/.github/scripts/tests/test_worker_dependency_compatibility.py
+++ b/.github/scripts/tests/test_worker_dependency_compatibility.py
@@ -39,13 +39,16 @@ def test_harness_llm_stack_uses_shared_state_range() -> None:
         assert dependencies(worker)["state"] == expected
 
 
-def test_provider_lockfiles_track_llm_router_version() -> None:
+def test_provider_related_lockfiles_track_llm_router_version() -> None:
     router_manifest = tomllib.loads(
         (REPO_ROOT / "llm-router" / "Cargo.toml").read_text(encoding="utf-8"),
     )
     expected = router_manifest["package"]["version"]
 
-    for lockfile in sorted(REPO_ROOT.glob("provider-*/Cargo.lock")):
+    lockfiles = sorted(REPO_ROOT.glob("provider-*/Cargo.lock"))
+    lockfiles.append(REPO_ROOT / "crates" / "provider-integration-testkit" / "Cargo.lock")
+
+    for lockfile in lockfiles:
         lock = tomllib.loads(lockfile.read_text(encoding="utf-8"))
         locked_versions = [
             package["version"]

--- a/crates/provider-integration-testkit/Cargo.lock
+++ b/crates/provider-integration-testkit/Cargo.lock
@@ -1048,7 +1048,7 @@ checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "llm-router"
-version = "1.4.8"
+version = "1.4.9"
 dependencies = [
  "async-trait",
  "clap",
@@ -1326,7 +1326,7 @@ dependencies = [
 
 [[package]]
 name = "provider-anthropic"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "clap",
  "futures",
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "provider-claude-code"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "clap",
  "futures",
@@ -1360,7 +1360,7 @@ dependencies = [
 
 [[package]]
 name = "provider-deepseek"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "clap",
  "futures",
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "provider-kimi"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "clap",
  "futures",
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "provider-openai"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "clap",
  "futures",
@@ -1435,7 +1435,7 @@ dependencies = [
 
 [[package]]
 name = "provider-openai-codex"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -1472,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "provider-xai"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "clap",
  "futures",
@@ -1489,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "provider-zai"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "clap",
  "futures",

--- a/provider-anthropic/Cargo.lock
+++ b/provider-anthropic/Cargo.lock
@@ -1017,7 +1017,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.8"
+version = "1.4.9"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-claude-code/Cargo.lock
+++ b/provider-claude-code/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.8"
+version = "1.4.9"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-deepseek/Cargo.lock
+++ b/provider-deepseek/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.8"
+version = "1.4.9"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-github-copilot/Cargo.lock
+++ b/provider-github-copilot/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.8"
+version = "1.4.9"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-kimi/Cargo.lock
+++ b/provider-kimi/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.8"
+version = "1.4.9"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-llamacpp/Cargo.lock
+++ b/provider-llamacpp/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.8"
+version = "1.4.9"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-openai-codex/Cargo.lock
+++ b/provider-openai-codex/Cargo.lock
@@ -1029,7 +1029,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.8"
+version = "1.4.9"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-openai/Cargo.lock
+++ b/provider-openai/Cargo.lock
@@ -1017,7 +1017,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.8"
+version = "1.4.9"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-opencode-go/Cargo.lock
+++ b/provider-opencode-go/Cargo.lock
@@ -976,7 +976,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.8"
+version = "1.4.9"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-openrouter/Cargo.lock
+++ b/provider-openrouter/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.8"
+version = "1.4.9"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-xai/Cargo.lock
+++ b/provider-xai/Cargo.lock
@@ -1017,7 +1017,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.8"
+version = "1.4.9"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-zai/Cargo.lock
+++ b/provider-zai/Cargo.lock
@@ -1017,7 +1017,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.8"
+version = "1.4.9"
 dependencies = [
  "async-trait",
  "clap",


### PR DESCRIPTION
## Summary

- update every provider lockfile that still recorded `llm-router 1.4.8` to `1.4.9`
- cover all 12 affected providers, including four that were not selected in the failed release operation
- add a repository test that keeps provider lockfiles aligned with the local `llm-router` package version

## Root cause

The `llm-router` manifest had advanced to `1.4.9`, while provider lockfiles still recorded the path dependency as `1.4.8`. Provider release builds run Cargo with `--locked`, so Cargo refused to update each stale lockfile and the binary matrices failed before Registry publication.

## Impact

Provider releases can build from committed lockfiles again. The regression test prevents a future router version bump from leaving provider lockfiles stale.

## Validation

- full `cargo metadata --locked` completed for all 12 affected providers
- `python3 -m pytest .github/scripts/tests/test_worker_dependency_compatibility.py -q` — 3 passed
- `python3 -m pytest .github/scripts/tests -q` — 196 passed, 3 subtests passed
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage to verify provider integrations use the declared `llm-router` version consistently across lockfiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->