### PR TITLE
(MOT-4466) feat(console): command palette over workers, functions, pages and chats

### DIFF
--- a/console/web/src/App.tsx
+++ b/console/web/src/App.tsx
@@ -2,6 +2,7 @@ import {
   CircleQuestionMark,
   Menu,
   Plus,
+  Search,
   SettingsIcon,
   SquarePen,
   X,
@@ -68,6 +69,9 @@ export function App() {
   const [view, setView] = useHashRoute()
   const extPageId = useExtPageRoute()
   const [shortcutsOpen, setShortcutsOpen] = useState(false)
+  // Held here, not in `PaletteHost`: ⌘K is one way in and the phone header's
+  // search affordance is the other, so the state has to sit above both.
+  const [paletteOpen, setPaletteOpen] = useState(false)
   const workspace = useWorkspaceTabs()
   const { activeTab, activeTabId } = workspace
   const [mobilePanelIndex, setMobilePanelIndex] = useState(0)
@@ -203,6 +207,7 @@ export function App() {
           settingsOpen={view === 'configuration'}
           onToggleSettings={toggleSettings}
           onOpenShortcuts={() => setShortcutsOpen(true)}
+          onOpenPalette={() => setPaletteOpen(true)}
         />
         <WorkspacePanes
           workspace={workspace}
@@ -219,6 +224,8 @@ export function App() {
         ) : null}
         <ShortcutsDialog open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
         <PaletteHost
+          open={paletteOpen}
+          onOpenChange={setPaletteOpen}
           openScreen={workspace.openScreen}
           onOpenSettings={() => setView('configuration')}
           onOpenShortcuts={() => setShortcutsOpen(true)}
@@ -564,6 +571,7 @@ interface HeaderProps {
   settingsOpen: boolean
   onToggleSettings: () => void
   onOpenShortcuts: () => void
+  onOpenPalette: () => void
 }
 
 function Header({
@@ -573,6 +581,7 @@ function Header({
   settingsOpen,
   onToggleSettings,
   onOpenShortcuts,
+  onOpenPalette,
 }: HeaderProps) {
   const { extPageTitles } = useScreenOptions()
   const { createNew } = useConversationsCtx()
@@ -622,23 +631,36 @@ function Header({
           ) : null}
         </div>
 
-        <button
-          type="button"
-          onClick={() => {
-            if (mobileScreen === CHAT_SCREEN) createNew()
-            else workspace.createTab({ columns: 1 })
-          }}
-          aria-label={
-            mobileScreen === CHAT_SCREEN ? 'new chat' : 'new workspace'
-          }
-          className="ml-auto flex size-12 items-center justify-center rounded-sm text-ink-faint hover:bg-surface-hover hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus"
-        >
-          {mobileScreen === CHAT_SCREEN ? (
-            <SquarePen className="size-6" aria-hidden />
-          ) : (
-            <Plus className="size-6" aria-hidden />
-          )}
-        </button>
+        <div className="flex items-center justify-end">
+          {/* A phone has no ⌘K. Search is the console's way of reaching
+              anything, so it gets a first-class affordance rather than a row
+              buried in the workspace menu. */}
+          <button
+            type="button"
+            onClick={onOpenPalette}
+            aria-label="search the console"
+            className="flex size-12 items-center justify-center rounded-sm text-ink-faint hover:bg-surface-hover hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus"
+          >
+            <Search className="size-6" aria-hidden />
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              if (mobileScreen === CHAT_SCREEN) createNew()
+              else workspace.createTab({ columns: 1 })
+            }}
+            aria-label={
+              mobileScreen === CHAT_SCREEN ? 'new chat' : 'new workspace'
+            }
+            className="flex size-12 items-center justify-center rounded-sm text-ink-faint hover:bg-surface-hover hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus"
+          >
+            {mobileScreen === CHAT_SCREEN ? (
+              <SquarePen className="size-6" aria-hidden />
+            ) : (
+              <Plus className="size-6" aria-hidden />
+            )}
+          </button>
+        </div>
       </header>
 
       <MobileWorkspaceMenu
@@ -653,6 +675,7 @@ function Header({
         }}
         onToggleSettings={onToggleSettings}
         onOpenShortcuts={onOpenShortcuts}
+        onOpenPalette={onOpenPalette}
       />
 
       <header className="hidden h-14 shrink-0 items-center justify-between gap-3 pr-6 pl-3 sm:flex">

--- a/console/web/src/App.tsx
+++ b/console/web/src/App.tsx
@@ -15,6 +15,7 @@ import {
   useState,
 } from 'react'
 import { ChatPanel } from '@/components/chat/ChatPanel'
+import { PaletteHost } from '@/components/PaletteHost'
 import {
   Dialog,
   DialogContent,
@@ -217,6 +218,13 @@ export function App() {
           />
         ) : null}
         <ShortcutsDialog open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
+        <PaletteHost
+          openScreen={workspace.openScreen}
+          onOpenSettings={() => setView('configuration')}
+          onOpenShortcuts={() => setShortcutsOpen(true)}
+          theme={theme}
+          onThemeChange={setTheme}
+        />
       </Sheet>
     </ConversationsProvider>
   )
@@ -746,6 +754,13 @@ interface ShortcutsDialogProps {
 }
 
 const SHORTCUTS: { combo: string; description: string }[] = [
+  {
+    combo: '⌘K / ctrl+K',
+    description: 'search workers, functions, pages, chats',
+  },
+  { combo: '↑ ↓', description: 'move through palette results' },
+  { combo: 'tab', description: 'cycle the palette filter' },
+  { combo: 'esc', description: 'close the palette' },
   { combo: '?', description: 'open this shortcut overlay' },
 ]
 

--- a/console/web/src/components/CommandPalette.stories.tsx
+++ b/console/web/src/components/CommandPalette.stories.tsx
@@ -1,0 +1,153 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Boxes, MessageSquareText, Radio, Terminal } from 'lucide-react'
+import type { EngineSnapshot, PaletteEntry } from '@/lib/palette/sources'
+import { CommandPalette } from './CommandPalette'
+
+/* A gallery has no engine behind it, so the inventory is a fixture. Stable
+   module-level identity on purpose: the palette re-reads whenever the reader
+   changes. */
+const INVENTORY: EngineSnapshot = {
+  workers: [
+    {
+      name: 'shell',
+      status: 'connected',
+      version: '0.4.1',
+      functionCount: 14,
+    },
+    {
+      name: 'harness',
+      status: 'connected',
+      version: '1.8.2',
+      functionCount: 31,
+    },
+    { name: 'iii-cron', status: 'available', version: '', functionCount: 4 },
+    {
+      name: 'database',
+      status: 'disconnected',
+      version: '0.4.0',
+      functionCount: 9,
+    },
+  ],
+  functions: [
+    {
+      id: 'shell::sessions::list',
+      worker: 'shell',
+      description: 'Every shell session the worker is holding open',
+    },
+    {
+      id: 'shell::exec',
+      worker: 'shell',
+      description: 'Run one command and stream its output',
+    },
+    {
+      id: 'engine::workers::list',
+      worker: 'engine',
+      description: 'Workers currently attached to the engine',
+    },
+  ],
+  error: null,
+}
+
+const readInventory = () => Promise.resolve(INVENTORY)
+const readEmptyInventory = () =>
+  Promise.resolve({ workers: [], functions: [], error: null })
+const readFailedInventory = () =>
+  Promise.resolve({
+    workers: [],
+    functions: [],
+    error: 'engine::workers::list timed out after 30000ms',
+  })
+
+const LOCAL_ENTRIES: PaletteEntry[] = [
+  {
+    id: 'action:new-chat',
+    kind: 'action',
+    title: 'New chat',
+    detail: 'Start a conversation',
+    run: () => {},
+  },
+  {
+    id: 'action:settings',
+    kind: 'action',
+    title: 'Open settings',
+    detail: 'Console and worker configuration',
+    run: () => {},
+  },
+  {
+    id: 'page:traces',
+    kind: 'page',
+    title: 'Traces',
+    detail: 'Every run the engine has recorded',
+    icon: Radio,
+    run: () => {},
+  },
+  {
+    id: 'page:workers',
+    kind: 'page',
+    title: 'Workers',
+    detail: 'What is attached, and what it registers',
+    icon: Boxes,
+    run: () => {},
+  },
+  {
+    id: 'page:shell',
+    kind: 'page',
+    title: 'Shell',
+    detail: 'A terminal the agent shares',
+    icon: Terminal,
+    run: () => {},
+  },
+  {
+    id: 'chat:1',
+    kind: 'chat',
+    title: 'why does the queue page show zero subscribers',
+    detail: 'claude-opus-5',
+    icon: MessageSquareText,
+    run: () => {},
+  },
+  {
+    id: 'chat:2',
+    kind: 'chat',
+    title: 'port the openwiki worker',
+    detail: 'deepseek-v4-flash',
+    icon: MessageSquareText,
+    run: () => {},
+  },
+]
+
+const meta = {
+  title: 'Console/CommandPalette',
+  component: CommandPalette,
+  parameters: { layout: 'fullscreen' },
+  args: {
+    open: true,
+    onClose: () => {},
+    localEntries: LOCAL_ENTRIES,
+    onOpenWorker: () => {},
+    onOpenFunction: () => {},
+    readInventory,
+  },
+} satisfies Meta<typeof CommandPalette>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Everything the console can reach, grouped. Narrow the browser under 640px
+ *  to see the phone layout: full-bleed sheet, scrollable filters, a close
+ *  affordance instead of `esc`. */
+export const Default: Story = {}
+
+/** Local rows only — the palette opens whether or not the engine answers. */
+export const WithoutEngine: Story = {
+  args: { readInventory: readEmptyInventory },
+}
+
+/** A read that failed says so and still shows what it does have. */
+export const EngineUnavailable: Story = {
+  args: { readInventory: readFailedInventory },
+}
+
+/** Nothing local either: the empty state has to carry the whole surface. */
+export const NoResults: Story = {
+  args: { localEntries: [], readInventory: readEmptyInventory },
+}

--- a/console/web/src/components/CommandPalette.tsx
+++ b/console/web/src/components/CommandPalette.tsx
@@ -9,6 +9,11 @@
  * The inventory is read when the palette opens, not cached at boot: a worker
  * that just disconnected should stop being searchable, and one that just
  * arrived should appear without a reload.
+ *
+ * Two layouts, one component. On a pointer screen it is a centred card the
+ * keyboard drives. On a phone it fills the visible viewport, opens from the
+ * header's search affordance, and sizes itself around the software keyboard —
+ * see `useKeyboardInset`.
  */
 
 import {
@@ -18,10 +23,20 @@ import {
   MessageSquareText,
   Search,
   Settings,
+  X,
   Zap,
 } from 'lucide-react'
-import { type KeyboardEvent, useEffect, useMemo, useRef, useState } from 'react'
 import {
+  type CSSProperties,
+  type KeyboardEvent,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import { useMediaQuery } from '@/hooks/use-media-query'
+import {
+  type EngineSnapshot,
   filterEntries,
   groupEntries,
   KIND_LABEL,
@@ -39,6 +54,13 @@ const FILTERS: Array<{ id: PaletteKind | 'all'; label: string }> = [
   { id: 'action', label: 'Actions' },
 ]
 
+/** The hint has to name the key the reader actually has. */
+const MODIFIER_LABEL =
+  typeof navigator !== 'undefined' &&
+  /Mac|iPhone|iPad|iPod/.test(navigator.platform || navigator.userAgent)
+    ? '⌘K'
+    : 'ctrl K'
+
 /** Icon plus the tint its chip carries. Colour is category, not severity —
  *  worker status gets its own dot below, where severity belongs. */
 const KIND_STYLE = {
@@ -49,13 +71,61 @@ const KIND_STYLE = {
   action: { Icon: Settings, chip: 'bg-accent-muted text-accent' },
 } as const
 
+/**
+ * The slice of the screen a phone keyboard leaves behind.
+ *
+ * iOS and Android pan the visual viewport rather than resizing the layout one,
+ * so a `fixed` overlay measured in `vh` (or even `dvh`) keeps its full height
+ * and puts its result rows under the keyboard. Reading `visualViewport` is the
+ * only way to know what is actually on screen. Pointer layouts have no keyboard
+ * to dodge, so above the `sm` breakpoint this stays null and the card keeps its
+ * own sizing.
+ */
+function useKeyboardInset(active: boolean): CSSProperties | undefined {
+  const [inset, setInset] = useState<{ top: number; height: number } | null>(
+    null,
+  )
+  const pointer = useMediaQuery('(min-width: 640px)')
+
+  useEffect(() => {
+    if (!active || pointer || typeof window === 'undefined') {
+      setInset(null)
+      return
+    }
+    const viewport = window.visualViewport
+    if (!viewport) return
+    // `scroll` fires per frame while iOS pans a focused field; only a real
+    // change should cost a render.
+    const read = () =>
+      setInset((previous) =>
+        previous?.top === viewport.offsetTop &&
+        previous?.height === viewport.height
+          ? previous
+          : { top: viewport.offsetTop, height: viewport.height },
+      )
+    read()
+    // `resize` covers the keyboard opening and rotation; `scroll` covers the
+    // pan that follows a focused field.
+    viewport.addEventListener('resize', read)
+    viewport.addEventListener('scroll', read)
+    return () => {
+      viewport.removeEventListener('resize', read)
+      viewport.removeEventListener('scroll', read)
+    }
+  }, [active, pointer])
+
+  if (!inset) return undefined
+  return { top: inset.top, height: inset.height, bottom: 'auto' }
+}
+
 /** `worker::rest-of-id` reads better with the owner dimmed, the way the
  *  console's own function labels render it. */
 function FunctionId({ id }: { id: string }) {
   const marker = id.indexOf('::')
-  if (marker <= 0) return <span className="font-mono text-[0.8rem]">{id}</span>
+  if (marker <= 0)
+    return <span className="font-mono text-sm sm:text-[0.8rem]">{id}</span>
   return (
-    <span className="font-mono text-[0.8rem]">
+    <span className="font-mono text-sm sm:text-[0.8rem]">
       <span className="text-ink-ghost">{id.slice(0, marker + 2)}</span>
       <span className="text-ink">{id.slice(marker + 2)}</span>
     </span>
@@ -79,6 +149,9 @@ export interface CommandPaletteProps {
   onOpenWorker: (name: string) => void
   /** Where a function row goes when chosen (its worker's row). */
   onOpenFunction: (functionId: string, worker: string) => void
+  /** Seam for the gallery, which has no engine to read. Must be a stable
+   *  reference: the palette re-reads whenever it changes. */
+  readInventory?: () => Promise<EngineSnapshot>
 }
 
 export function CommandPalette({
@@ -87,6 +160,7 @@ export function CommandPalette({
   localEntries,
   onOpenWorker,
   onOpenFunction,
+  readInventory = readEngine,
 }: CommandPaletteProps) {
   const [query, setQuery] = useState('')
   const [filter, setFilter] = useState<PaletteKind | 'all'>('all')
@@ -94,6 +168,8 @@ export function CommandPalette({
   const [engineEntries, setEngineEntries] = useState<PaletteEntry[]>([])
   const [engineError, setEngineError] = useState<string | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
+  const listRef = useRef<HTMLDivElement>(null)
+  const viewportStyle = useKeyboardInset(open)
 
   // Reset per opening: a palette that reopens on the last query is a palette
   // you have to clear before you can use it. Closing returns focus to whatever
@@ -119,7 +195,7 @@ export function CommandPalette({
     // not survive a read that fails.
     setEngineEntries([])
     setEngineError(null)
-    void readEngine().then((snapshot) => {
+    void readInventory().then((snapshot) => {
       if (cancelled) return
       setEngineError(snapshot.error)
       const workers: PaletteEntry[] = snapshot.workers.map((worker) => ({
@@ -147,7 +223,7 @@ export function CommandPalette({
     return () => {
       cancelled = true
     }
-  }, [open, onOpenWorker, onOpenFunction])
+  }, [open, onOpenWorker, onOpenFunction, readInventory])
 
   const results = useMemo(
     () => filterEntries([...localEntries, ...engineEntries], query, filter),
@@ -168,6 +244,18 @@ export function CommandPalette({
     entry.run()
   }
 
+  // Arrow keys walk past the visible window, so the row has to be dragged back
+  // into view. Only a keyboard move scrolls: pointing at a row already means
+  // you can see it, and scrolling under the cursor moves the target.
+  const move = (step: number) => {
+    if (!flat.length) return
+    const next = (active + step + flat.length) % flat.length
+    setActive(next)
+    listRef.current
+      ?.querySelector(`[data-palette-index="${next}"]`)
+      ?.scrollIntoView({ block: 'nearest' })
+  }
+
   const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if (event.key === 'Escape') {
       event.preventDefault()
@@ -176,14 +264,12 @@ export function CommandPalette({
     }
     if (event.key === 'ArrowDown' || (event.key === 'n' && event.ctrlKey)) {
       event.preventDefault()
-      setActive((current) => (flat.length ? (current + 1) % flat.length : 0))
+      move(1)
       return
     }
     if (event.key === 'ArrowUp' || (event.key === 'p' && event.ctrlKey)) {
       event.preventDefault()
-      setActive((current) =>
-        flat.length ? (current - 1 + flat.length) % flat.length : 0,
-      )
+      move(-1)
       return
     }
     if (event.key === 'Tab') {
@@ -204,9 +290,14 @@ export function CommandPalette({
   let cursor = -1
 
   return (
-    <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-[12vh] backdrop-blur-sm">
+    <div
+      style={viewportStyle}
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 sm:pt-[12vh] sm:backdrop-blur-sm"
+    >
       {/* The scrim is a real button so dismissing by click is reachable
-          without a mouse; the dialog below owns every other key. */}
+          without a mouse; the dialog below owns every other key. On a phone
+          the dialog covers it, which is why that layout carries its own
+          close affordance. */}
       <button
         type="button"
         aria-label="Close command palette"
@@ -218,10 +309,10 @@ export function CommandPalette({
         role="dialog"
         aria-modal="true"
         aria-label="Command palette"
-        className="flex max-h-[70vh] w-[min(44rem,92vw)] flex-col overflow-hidden rounded-lg border border-accent-border bg-panel shadow-2xl"
+        className="relative flex h-full w-full min-w-0 flex-col overflow-hidden border-edge bg-panel sm:h-auto sm:max-h-[70vh] sm:w-[min(44rem,92vw)] sm:rounded-lg sm:border sm:border-accent-border sm:shadow-2xl"
         onKeyDown={onKeyDown}
       >
-        <div className="flex items-center gap-3 border-b border-edge px-4">
+        <div className="flex shrink-0 items-center gap-2 border-b border-edge pr-1 pl-4 sm:gap-3 sm:pr-4">
           <Search aria-hidden className="size-4 shrink-0 text-ink-ghost" />
           <input
             ref={inputRef}
@@ -230,15 +321,34 @@ export function CommandPalette({
               setQuery(event.target.value)
               setActive(0)
             }}
-            placeholder="Search workers, functions, pages, chats, actions…"
+            placeholder="Search workers, functions, pages, chats…"
             aria-label="Search the console"
-            className="w-full bg-transparent py-3.5 text-sm text-ink outline-none placeholder:text-ink-ghost"
+            // Under 16px iOS Safari zooms the page on focus, which strands a
+            // fixed overlay off screen. Worker and function ids are not prose,
+            // so autocorrect and the automatic leading capital both mangle them.
+            className="w-full bg-transparent py-3.5 text-base text-ink outline-none placeholder:text-ink-ghost sm:text-sm"
+            inputMode="search"
+            enterKeyHint="go"
+            autoCapitalize="none"
+            autoCorrect="off"
+            autoComplete="off"
+            spellCheck={false}
           />
-          <kbd className="shrink-0 rounded border border-edge px-1.5 py-0.5 font-mono text-[0.65rem] text-ink-ghost">
-            ⌘K
+          <kbd className="hidden shrink-0 rounded border border-edge px-1.5 py-0.5 font-mono text-[0.65rem] text-ink-ghost sm:block">
+            {MODIFIER_LABEL}
           </kbd>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="close search"
+            className="flex size-12 shrink-0 items-center justify-center rounded-sm text-ink-faint hover:bg-surface-hover hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus sm:hidden"
+          >
+            <X className="size-5" aria-hidden />
+          </button>
         </div>
-        <div className="flex gap-1 border-b border-edge px-3 py-2">
+        {/* Six filters do not fit a phone's width; scrolling them beats
+            crushing them into unreadable slivers. */}
+        <div className="flex shrink-0 gap-1 overflow-x-auto border-b border-edge px-3 py-2">
           {FILTERS.map((option) => (
             <button
               key={option.id}
@@ -247,7 +357,7 @@ export function CommandPalette({
                 setFilter(option.id)
                 setActive(0)
               }}
-              className={`rounded-full border px-2.5 py-1 text-xs transition-colors ${
+              className={`min-h-11 shrink-0 rounded-full border px-3 text-sm transition-colors sm:min-h-0 sm:px-2.5 sm:py-1 sm:text-xs ${
                 filter === option.id
                   ? 'border-accent-border bg-accent-muted text-accent'
                   : 'border-transparent text-ink-faint hover:bg-surface-active hover:text-ink'
@@ -257,20 +367,23 @@ export function CommandPalette({
             </button>
           ))}
         </div>
-        <div className="min-h-0 flex-1 overflow-y-auto py-1">
+        <div
+          ref={listRef}
+          className="min-h-0 flex-1 overflow-y-auto overscroll-contain py-1"
+        >
           {engineError ? (
-            <p className="px-4 py-2 text-xs text-warn">
+            <p className="px-4 py-2 text-sm text-warn sm:text-xs">
               engine inventory unavailable: {engineError}
             </p>
           ) : null}
           {flat.length === 0 ? (
-            <p className="px-4 py-6 text-center text-sm text-ink-faint">
+            <p className="px-4 py-6 text-center text-base text-ink-faint sm:text-sm">
               no matches
             </p>
           ) : (
             groups.map(([kind, entries]) => (
               <div key={kind}>
-                <p className="flex items-center gap-2 px-4 pt-3 pb-1 text-[0.68rem] uppercase tracking-wider text-ink-ghost">
+                <p className="flex items-center gap-2 px-4 pt-3 pb-1 text-xs uppercase tracking-wider text-ink-ghost sm:text-[0.68rem]">
                   <span>{KIND_LABEL[kind]}</span>
                   <span className="rounded-full bg-surface-active px-1.5 py-px font-mono text-[0.62rem] normal-case tracking-normal">
                     {entries.length}
@@ -287,9 +400,10 @@ export function CommandPalette({
                     <button
                       key={entry.id}
                       type="button"
+                      data-palette-index={index}
                       onMouseEnter={() => setActive(index)}
                       onClick={() => choose(entry)}
-                      className={`flex w-full items-center gap-3 border-l-2 py-2 pr-4 pl-3.5 text-left transition-colors ${
+                      className={`flex min-h-12 w-full items-center gap-3 border-l-2 py-2.5 pr-4 pl-3.5 text-left transition-colors sm:min-h-0 sm:py-2 ${
                         selected
                           ? 'border-accent bg-accent-muted'
                           : 'border-transparent hover:bg-surface-active'
@@ -306,11 +420,11 @@ export function CommandPalette({
                             <FunctionId id={entry.title} />
                           ) : (
                             <span
-                              className={`truncate text-sm ${
+                              className={`truncate text-base text-ink sm:text-sm ${
                                 entry.kind === 'worker'
-                                  ? 'font-mono text-[0.82rem]'
+                                  ? 'font-mono sm:text-[0.82rem]'
                                   : ''
-                              } ${selected ? 'text-ink' : 'text-ink'}`}
+                              }`}
                             >
                               {entry.title}
                             </span>
@@ -323,13 +437,15 @@ export function CommandPalette({
                           ) : null}
                         </span>
                         {entry.detail ? (
-                          <span className="block truncate text-xs text-ink-faint">
+                          <span className="block truncate text-sm text-ink-faint sm:text-xs">
                             {entry.detail}
                           </span>
                         ) : null}
                       </span>
+                      {/* The right-hand tag is the first thing to give up when
+                          the row has to fit a phone. */}
                       {entry.meta ? (
-                        <span className="shrink-0 rounded border border-edge px-1.5 py-0.5 font-mono text-[0.65rem] text-ink-ghost">
+                        <span className="hidden shrink-0 rounded border border-edge px-1.5 py-0.5 font-mono text-[0.65rem] text-ink-ghost sm:block">
                           {entry.meta}
                         </span>
                       ) : null}
@@ -340,31 +456,34 @@ export function CommandPalette({
             ))
           )}
         </div>
-        <div className="flex items-center gap-3 border-t border-edge px-4 py-2 text-[0.68rem] text-ink-ghost">
-          <span className="flex items-center gap-1.5">
-            <kbd className="rounded border border-edge px-1 py-px font-mono">
-              <CornerDownLeft aria-hidden className="size-2.5" />
-            </kbd>
-            open
-          </span>
-          <span className="flex items-center gap-1.5">
-            <kbd className="rounded border border-edge px-1 py-px font-mono">
-              ↑↓
-            </kbd>
-            select
-          </span>
-          <span className="flex items-center gap-1.5">
-            <kbd className="rounded border border-edge px-1 py-px font-mono">
-              tab
-            </kbd>
-            filter
-          </span>
-          <span className="flex items-center gap-1.5">
-            <kbd className="rounded border border-edge px-1 py-px font-mono">
-              esc
-            </kbd>
-            close
-          </span>
+        <div className="flex shrink-0 items-center gap-3 border-t border-edge px-4 py-2 pb-[max(0.5rem,env(safe-area-inset-bottom))] text-[0.68rem] text-ink-ghost sm:pb-2">
+          {/* Key hints are noise on a surface with no keys to press. */}
+          <div className="hidden items-center gap-3 sm:flex">
+            <span className="flex items-center gap-1.5">
+              <kbd className="rounded border border-edge px-1 py-px font-mono">
+                <CornerDownLeft aria-hidden className="size-2.5" />
+              </kbd>
+              open
+            </span>
+            <span className="flex items-center gap-1.5">
+              <kbd className="rounded border border-edge px-1 py-px font-mono">
+                ↑↓
+              </kbd>
+              select
+            </span>
+            <span className="flex items-center gap-1.5">
+              <kbd className="rounded border border-edge px-1 py-px font-mono">
+                tab
+              </kbd>
+              filter
+            </span>
+            <span className="flex items-center gap-1.5">
+              <kbd className="rounded border border-edge px-1 py-px font-mono">
+                esc
+              </kbd>
+              close
+            </span>
+          </div>
           <span className="ml-auto font-mono">
             {flat.length} result{flat.length === 1 ? '' : 's'}
           </span>

--- a/console/web/src/components/CommandPalette.tsx
+++ b/console/web/src/components/CommandPalette.tsx
@@ -75,8 +75,8 @@ export interface CommandPaletteProps {
   onClose: () => void
   /** Rows the console can build without the engine: pages, chats, actions. */
   localEntries: PaletteEntry[]
-  /** Where a worker row goes when chosen (the workers screen). */
-  onOpenWorkers: () => void
+  /** Where a worker row goes when chosen, by worker name. */
+  onOpenWorker: (name: string) => void
   /** Where a function row goes when chosen (its worker's row). */
   onOpenFunction: (functionId: string, worker: string) => void
 }
@@ -85,7 +85,7 @@ export function CommandPalette({
   open,
   onClose,
   localEntries,
-  onOpenWorkers,
+  onOpenWorker,
   onOpenFunction,
 }: CommandPaletteProps) {
   const [query, setQuery] = useState('')
@@ -96,18 +96,29 @@ export function CommandPalette({
   const inputRef = useRef<HTMLInputElement>(null)
 
   // Reset per opening: a palette that reopens on the last query is a palette
-  // you have to clear before you can use it.
+  // you have to clear before you can use it. Closing returns focus to whatever
+  // had it — the palette can be opened from anywhere, so it must not strand
+  // the caret when it goes away.
   useEffect(() => {
     if (!open) return
+    const opener = document.activeElement as HTMLElement | null
     setQuery('')
     setFilter('all')
     setActive(0)
     inputRef.current?.focus()
+    return () => {
+      if (opener?.isConnected) opener.focus()
+    }
   }, [open])
 
   useEffect(() => {
     if (!open) return
     let cancelled = false
+    // Drop the previous opening's inventory first: a worker that disconnected
+    // since must not stay searchable while the new read is in flight, and must
+    // not survive a read that fails.
+    setEngineEntries([])
+    setEngineError(null)
     void readEngine().then((snapshot) => {
       if (cancelled) return
       setEngineError(snapshot.error)
@@ -120,7 +131,7 @@ export function CommandPalette({
           ? `${worker.status} · ${worker.version}`
           : worker.status,
         keywords: [worker.status],
-        run: onOpenWorkers,
+        run: () => onOpenWorker(worker.name),
       }))
       const functions: PaletteEntry[] = snapshot.functions.map((fn) => ({
         id: `function:${fn.id}`,
@@ -136,7 +147,7 @@ export function CommandPalette({
     return () => {
       cancelled = true
     }
-  }, [open, onOpenWorkers, onOpenFunction])
+  }, [open, onOpenWorker, onOpenFunction])
 
   const results = useMemo(
     () => filterEntries([...localEntries, ...engineEntries], query, filter),
@@ -193,9 +204,7 @@ export function CommandPalette({
   let cursor = -1
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-[12vh] backdrop-blur-sm"
-    >
+    <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-[12vh] backdrop-blur-sm">
       {/* The scrim is a real button so dismissing by click is reachable
           without a mouse; the dialog below owns every other key. */}
       <button

--- a/console/web/src/components/CommandPalette.tsx
+++ b/console/web/src/components/CommandPalette.tsx
@@ -1,0 +1,366 @@
+/**
+ * ⌘K — one keyboard surface over the whole console.
+ *
+ * The console's subject is the engine and whatever is attached to it, so that
+ * is what this searches: connected workers, the functions they register, every
+ * page the console can show, the open chats, and the console actions that have
+ * no other home. Selecting a row navigates; nothing here mutates the engine.
+ *
+ * The inventory is read when the palette opens, not cached at boot: a worker
+ * that just disconnected should stop being searchable, and one that just
+ * arrived should appear without a reload.
+ */
+
+import {
+  Boxes,
+  CornerDownLeft,
+  FunctionSquare,
+  MessageSquareText,
+  Search,
+  Settings,
+  Zap,
+} from 'lucide-react'
+import { type KeyboardEvent, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  filterEntries,
+  groupEntries,
+  KIND_LABEL,
+  type PaletteEntry,
+  type PaletteKind,
+  readEngine,
+} from '@/lib/palette/sources'
+
+const FILTERS: Array<{ id: PaletteKind | 'all'; label: string }> = [
+  { id: 'all', label: 'All' },
+  { id: 'worker', label: 'Workers' },
+  { id: 'function', label: 'Functions' },
+  { id: 'page', label: 'Pages' },
+  { id: 'chat', label: 'Chats' },
+  { id: 'action', label: 'Actions' },
+]
+
+/** Icon plus the tint its chip carries. Colour is category, not severity —
+ *  worker status gets its own dot below, where severity belongs. */
+const KIND_STYLE = {
+  worker: { Icon: Boxes, chip: 'bg-accent-muted text-accent' },
+  function: { Icon: FunctionSquare, chip: 'bg-ok-muted text-ok' },
+  page: { Icon: Zap, chip: 'bg-warn-muted text-warn' },
+  chat: { Icon: MessageSquareText, chip: 'bg-surface-active text-ink-faint' },
+  action: { Icon: Settings, chip: 'bg-accent-muted text-accent' },
+} as const
+
+/** `worker::rest-of-id` reads better with the owner dimmed, the way the
+ *  console's own function labels render it. */
+function FunctionId({ id }: { id: string }) {
+  const marker = id.indexOf('::')
+  if (marker <= 0) return <span className="font-mono text-[0.8rem]">{id}</span>
+  return (
+    <span className="font-mono text-[0.8rem]">
+      <span className="text-ink-ghost">{id.slice(0, marker + 2)}</span>
+      <span className="text-ink">{id.slice(marker + 2)}</span>
+    </span>
+  )
+}
+
+/** connected is the healthy state; `available` is a built-in that has no
+ *  process to connect. Anything else is worth noticing. */
+function statusTone(status: string): string {
+  if (status.startsWith('connected')) return 'bg-ok'
+  if (status.startsWith('available')) return 'bg-accent'
+  return 'bg-warn'
+}
+
+export interface CommandPaletteProps {
+  open: boolean
+  onClose: () => void
+  /** Rows the console can build without the engine: pages, chats, actions. */
+  localEntries: PaletteEntry[]
+  /** Where a worker row goes when chosen (the workers screen). */
+  onOpenWorkers: () => void
+  /** Where a function row goes when chosen (its worker's row). */
+  onOpenFunction: (functionId: string, worker: string) => void
+}
+
+export function CommandPalette({
+  open,
+  onClose,
+  localEntries,
+  onOpenWorkers,
+  onOpenFunction,
+}: CommandPaletteProps) {
+  const [query, setQuery] = useState('')
+  const [filter, setFilter] = useState<PaletteKind | 'all'>('all')
+  const [active, setActive] = useState(0)
+  const [engineEntries, setEngineEntries] = useState<PaletteEntry[]>([])
+  const [engineError, setEngineError] = useState<string | null>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  // Reset per opening: a palette that reopens on the last query is a palette
+  // you have to clear before you can use it.
+  useEffect(() => {
+    if (!open) return
+    setQuery('')
+    setFilter('all')
+    setActive(0)
+    inputRef.current?.focus()
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    let cancelled = false
+    void readEngine().then((snapshot) => {
+      if (cancelled) return
+      setEngineError(snapshot.error)
+      const workers: PaletteEntry[] = snapshot.workers.map((worker) => ({
+        id: `worker:${worker.name}`,
+        kind: 'worker',
+        title: worker.name,
+        detail: `${worker.functionCount} function${worker.functionCount === 1 ? '' : 's'}`,
+        meta: worker.version
+          ? `${worker.status} · ${worker.version}`
+          : worker.status,
+        keywords: [worker.status],
+        run: onOpenWorkers,
+      }))
+      const functions: PaletteEntry[] = snapshot.functions.map((fn) => ({
+        id: `function:${fn.id}`,
+        kind: 'function',
+        title: fn.id,
+        detail: fn.description,
+        meta: fn.worker,
+        keywords: fn.worker ? [fn.worker] : undefined,
+        run: () => onOpenFunction(fn.id, fn.worker),
+      }))
+      setEngineEntries([...workers, ...functions])
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [open, onOpenWorkers, onOpenFunction])
+
+  const results = useMemo(
+    () => filterEntries([...localEntries, ...engineEntries], query, filter),
+    [localEntries, engineEntries, query, filter],
+  )
+  const groups = useMemo(() => groupEntries(results), [results])
+  const flat = useMemo(() => groups.flatMap(([, entries]) => entries), [groups])
+
+  useEffect(() => {
+    setActive((current) => (current < flat.length ? current : 0))
+  }, [flat.length])
+
+  if (!open) return null
+
+  const choose = (entry: PaletteEntry | undefined) => {
+    if (!entry) return
+    onClose()
+    entry.run()
+  }
+
+  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      onClose()
+      return
+    }
+    if (event.key === 'ArrowDown' || (event.key === 'n' && event.ctrlKey)) {
+      event.preventDefault()
+      setActive((current) => (flat.length ? (current + 1) % flat.length : 0))
+      return
+    }
+    if (event.key === 'ArrowUp' || (event.key === 'p' && event.ctrlKey)) {
+      event.preventDefault()
+      setActive((current) =>
+        flat.length ? (current - 1 + flat.length) % flat.length : 0,
+      )
+      return
+    }
+    if (event.key === 'Tab') {
+      event.preventDefault()
+      const step = event.shiftKey ? -1 : 1
+      const index = FILTERS.findIndex((option) => option.id === filter)
+      const next = (index + step + FILTERS.length) % FILTERS.length
+      setFilter(FILTERS[next].id)
+      setActive(0)
+      return
+    }
+    if (event.key === 'Enter') {
+      event.preventDefault()
+      choose(flat[active])
+    }
+  }
+
+  let cursor = -1
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-[12vh] backdrop-blur-sm"
+    >
+      {/* The scrim is a real button so dismissing by click is reachable
+          without a mouse; the dialog below owns every other key. */}
+      <button
+        type="button"
+        aria-label="Close command palette"
+        tabIndex={-1}
+        className="absolute inset-0 cursor-default"
+        onClick={onClose}
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Command palette"
+        className="flex max-h-[70vh] w-[min(44rem,92vw)] flex-col overflow-hidden rounded-lg border border-accent-border bg-panel shadow-2xl"
+        onKeyDown={onKeyDown}
+      >
+        <div className="flex items-center gap-3 border-b border-edge px-4">
+          <Search aria-hidden className="size-4 shrink-0 text-ink-ghost" />
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={(event) => {
+              setQuery(event.target.value)
+              setActive(0)
+            }}
+            placeholder="Search workers, functions, pages, chats, actions…"
+            aria-label="Search the console"
+            className="w-full bg-transparent py-3.5 text-sm text-ink outline-none placeholder:text-ink-ghost"
+          />
+          <kbd className="shrink-0 rounded border border-edge px-1.5 py-0.5 font-mono text-[0.65rem] text-ink-ghost">
+            ⌘K
+          </kbd>
+        </div>
+        <div className="flex gap-1 border-b border-edge px-3 py-2">
+          {FILTERS.map((option) => (
+            <button
+              key={option.id}
+              type="button"
+              onClick={() => {
+                setFilter(option.id)
+                setActive(0)
+              }}
+              className={`rounded-full border px-2.5 py-1 text-xs transition-colors ${
+                filter === option.id
+                  ? 'border-accent-border bg-accent-muted text-accent'
+                  : 'border-transparent text-ink-faint hover:bg-surface-active hover:text-ink'
+              }`}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto py-1">
+          {engineError ? (
+            <p className="px-4 py-2 text-xs text-warn">
+              engine inventory unavailable: {engineError}
+            </p>
+          ) : null}
+          {flat.length === 0 ? (
+            <p className="px-4 py-6 text-center text-sm text-ink-faint">
+              no matches
+            </p>
+          ) : (
+            groups.map(([kind, entries]) => (
+              <div key={kind}>
+                <p className="flex items-center gap-2 px-4 pt-3 pb-1 text-[0.68rem] uppercase tracking-wider text-ink-ghost">
+                  <span>{KIND_LABEL[kind]}</span>
+                  <span className="rounded-full bg-surface-active px-1.5 py-px font-mono text-[0.62rem] normal-case tracking-normal">
+                    {entries.length}
+                  </span>
+                  <span className="h-px flex-1 bg-edge" />
+                </p>
+                {entries.map((entry) => {
+                  cursor += 1
+                  const index = cursor
+                  const { Icon: KindIcon, chip } = KIND_STYLE[entry.kind]
+                  const Icon = entry.icon ?? KindIcon
+                  const selected = index === active
+                  return (
+                    <button
+                      key={entry.id}
+                      type="button"
+                      onMouseEnter={() => setActive(index)}
+                      onClick={() => choose(entry)}
+                      className={`flex w-full items-center gap-3 border-l-2 py-2 pr-4 pl-3.5 text-left transition-colors ${
+                        selected
+                          ? 'border-accent bg-accent-muted'
+                          : 'border-transparent hover:bg-surface-active'
+                      }`}
+                    >
+                      <span
+                        className={`flex size-7 shrink-0 items-center justify-center rounded ${chip}`}
+                      >
+                        <Icon aria-hidden className="size-3.5" />
+                      </span>
+                      <span className="min-w-0 flex-1">
+                        <span className="flex items-center gap-2 truncate">
+                          {entry.kind === 'function' ? (
+                            <FunctionId id={entry.title} />
+                          ) : (
+                            <span
+                              className={`truncate text-sm ${
+                                entry.kind === 'worker'
+                                  ? 'font-mono text-[0.82rem]'
+                                  : ''
+                              } ${selected ? 'text-ink' : 'text-ink'}`}
+                            >
+                              {entry.title}
+                            </span>
+                          )}
+                          {entry.kind === 'worker' && entry.keywords?.[0] ? (
+                            <span
+                              aria-hidden
+                              className={`size-1.5 shrink-0 rounded-full ${statusTone(entry.keywords[0])}`}
+                            />
+                          ) : null}
+                        </span>
+                        {entry.detail ? (
+                          <span className="block truncate text-xs text-ink-faint">
+                            {entry.detail}
+                          </span>
+                        ) : null}
+                      </span>
+                      {entry.meta ? (
+                        <span className="shrink-0 rounded border border-edge px-1.5 py-0.5 font-mono text-[0.65rem] text-ink-ghost">
+                          {entry.meta}
+                        </span>
+                      ) : null}
+                    </button>
+                  )
+                })}
+              </div>
+            ))
+          )}
+        </div>
+        <div className="flex items-center gap-3 border-t border-edge px-4 py-2 text-[0.68rem] text-ink-ghost">
+          <span className="flex items-center gap-1.5">
+            <kbd className="rounded border border-edge px-1 py-px font-mono">
+              <CornerDownLeft aria-hidden className="size-2.5" />
+            </kbd>
+            open
+          </span>
+          <span className="flex items-center gap-1.5">
+            <kbd className="rounded border border-edge px-1 py-px font-mono">
+              ↑↓
+            </kbd>
+            select
+          </span>
+          <span className="flex items-center gap-1.5">
+            <kbd className="rounded border border-edge px-1 py-px font-mono">
+              tab
+            </kbd>
+            filter
+          </span>
+          <span className="flex items-center gap-1.5">
+            <kbd className="rounded border border-edge px-1 py-px font-mono">
+              esc
+            </kbd>
+            close
+          </span>
+          <span className="ml-auto font-mono">
+            {flat.length} result{flat.length === 1 ? '' : 's'}
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/console/web/src/components/PaletteHost.tsx
+++ b/console/web/src/components/PaletteHost.tsx
@@ -6,7 +6,7 @@
  * overlay, the theme) arrives as props from `App`.
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { CommandPalette } from '@/components/CommandPalette'
 import { useScreenOptions } from '@/components/workspace/use-screen-options'
 import { useConversationsCtx } from '@/lib/conversations-context'
@@ -15,6 +15,10 @@ import type { TabScreen } from '@/lib/workspace-tabs'
 import { setPendingWorkerSearch } from '@/pages/Workers/pending-selection'
 
 export interface PaletteHostProps {
+  /** Owned by `App`: the shortcut is one way in, the phone header's search
+   *  affordance is the other, and only one of them can live here. */
+  open: boolean
+  onOpenChange: (open: boolean) => void
   openScreen: (screen: TabScreen) => void
   onOpenSettings: () => void
   onOpenShortcuts: () => void
@@ -23,15 +27,21 @@ export interface PaletteHostProps {
 }
 
 export function PaletteHost({
+  open,
+  onOpenChange,
   openScreen,
   onOpenSettings,
   onOpenShortcuts,
   theme,
   onThemeChange,
 }: PaletteHostProps) {
-  const [open, setOpen] = useState(false)
   const { screenOptions } = useScreenOptions()
   const { conversations, select, createNew } = useConversationsCtx()
+
+  // Read through a ref so the global listener is bound once, not rebound on
+  // every open and close.
+  const openRef = useRef(open)
+  openRef.current = open
 
   // ⌘K / ctrl+K anywhere, including from inside the composer — the palette is
   // how you leave wherever you are, so it must not be shadowed by focus.
@@ -41,11 +51,11 @@ export function PaletteHost({
       if (event.key !== 'k' && event.key !== 'K') return
       if (!event.metaKey && !event.ctrlKey) return
       event.preventDefault()
-      setOpen((current) => !current)
+      onOpenChange(!openRef.current)
     }
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
-  }, [])
+  }, [onOpenChange])
 
   // Both land on the workers page, filtered to what was picked: a worker by
   // its name, a function by the worker that registers it, falling back to the
@@ -144,7 +154,7 @@ export function PaletteHost({
   return (
     <CommandPalette
       open={open}
-      onClose={() => setOpen(false)}
+      onClose={() => onOpenChange(false)}
       localEntries={localEntries}
       onOpenWorker={openWorker}
       onOpenFunction={openFunction}

--- a/console/web/src/components/PaletteHost.tsx
+++ b/console/web/src/components/PaletteHost.tsx
@@ -12,6 +12,7 @@ import { useScreenOptions } from '@/components/workspace/use-screen-options'
 import { useConversationsCtx } from '@/lib/conversations-context'
 import type { PaletteEntry } from '@/lib/palette/sources'
 import type { TabScreen } from '@/lib/workspace-tabs'
+import { setPendingWorkerSearch } from '@/pages/Workers/pending-selection'
 
 export interface PaletteHostProps {
   openScreen: (screen: TabScreen) => void
@@ -46,8 +47,23 @@ export function PaletteHost({
     return () => window.removeEventListener('keydown', onKeyDown)
   }, [])
 
-  const openWorkers = useCallback(() => openScreen('workers'), [openScreen])
-  const openFunction = useCallback(() => openScreen('workers'), [openScreen])
+  // Both land on the workers page, filtered to what was picked: a worker by
+  // its name, a function by the worker that registers it, falling back to the
+  // function id when the engine reported no owner.
+  const openWorker = useCallback(
+    (name: string) => {
+      setPendingWorkerSearch(name)
+      openScreen('workers')
+    },
+    [openScreen],
+  )
+  const openFunction = useCallback(
+    (functionId: string, worker: string) => {
+      setPendingWorkerSearch(worker || functionId)
+      openScreen('workers')
+    },
+    [openScreen],
+  )
 
   const localEntries = useMemo((): PaletteEntry[] => {
     const pages: PaletteEntry[] = screenOptions.map((option) => ({
@@ -130,7 +146,7 @@ export function PaletteHost({
       open={open}
       onClose={() => setOpen(false)}
       localEntries={localEntries}
-      onOpenWorkers={openWorkers}
+      onOpenWorker={openWorker}
       onOpenFunction={openFunction}
     />
   )

--- a/console/web/src/components/PaletteHost.tsx
+++ b/console/web/src/components/PaletteHost.tsx
@@ -1,0 +1,137 @@
+/**
+ * Owns ⌘K: the shortcut, the console-side rows, and where each row goes.
+ *
+ * It lives inside the conversations provider because chats are one of the
+ * things you search for; everything else it needs (the workspace, the settings
+ * overlay, the theme) arrives as props from `App`.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { CommandPalette } from '@/components/CommandPalette'
+import { useScreenOptions } from '@/components/workspace/use-screen-options'
+import { useConversationsCtx } from '@/lib/conversations-context'
+import type { PaletteEntry } from '@/lib/palette/sources'
+import type { TabScreen } from '@/lib/workspace-tabs'
+
+export interface PaletteHostProps {
+  openScreen: (screen: TabScreen) => void
+  onOpenSettings: () => void
+  onOpenShortcuts: () => void
+  theme: 'light' | 'dark'
+  onThemeChange: (theme: 'light' | 'dark') => void
+}
+
+export function PaletteHost({
+  openScreen,
+  onOpenSettings,
+  onOpenShortcuts,
+  theme,
+  onThemeChange,
+}: PaletteHostProps) {
+  const [open, setOpen] = useState(false)
+  const { screenOptions } = useScreenOptions()
+  const { conversations, select, createNew } = useConversationsCtx()
+
+  // ⌘K / ctrl+K anywhere, including from inside the composer — the palette is
+  // how you leave wherever you are, so it must not be shadowed by focus.
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'k' && event.key !== 'K') return
+      if (!event.metaKey && !event.ctrlKey) return
+      event.preventDefault()
+      setOpen((current) => !current)
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [])
+
+  const openWorkers = useCallback(() => openScreen('workers'), [openScreen])
+  const openFunction = useCallback(() => openScreen('workers'), [openScreen])
+
+  const localEntries = useMemo((): PaletteEntry[] => {
+    const pages: PaletteEntry[] = screenOptions.map((option) => ({
+      id: `page:${option.value}`,
+      kind: 'page',
+      title: option.label,
+      detail: option.description,
+      keywords: option.keywords,
+      icon: option.icon,
+      run: () => openScreen(option.value),
+    }))
+
+    const chats: PaletteEntry[] = conversations
+      .slice(0, 40)
+      .map((conversation) => ({
+        id: `chat:${conversation.id}`,
+        kind: 'chat',
+        title: conversation.title || 'untitled chat',
+        detail: conversation.model ?? undefined,
+        run: () => {
+          select(conversation.id)
+          openScreen('chat')
+        },
+      }))
+
+    const actions: PaletteEntry[] = [
+      {
+        id: 'action:new-chat',
+        kind: 'action',
+        title: 'New chat',
+        detail: 'Start a conversation',
+        keywords: ['conversation', 'session'],
+        run: () => {
+          createNew()
+          openScreen('chat')
+        },
+      },
+      {
+        id: 'action:settings',
+        kind: 'action',
+        title: 'Open settings',
+        detail: 'Console and worker configuration',
+        keywords: ['configuration', 'preferences'],
+        run: onOpenSettings,
+      },
+      {
+        id: 'action:shortcuts',
+        kind: 'action',
+        title: 'Keyboard shortcuts',
+        detail: 'Show the shortcut overlay',
+        keywords: ['keys', 'help'],
+        run: onOpenShortcuts,
+      },
+      {
+        id: 'action:theme',
+        kind: 'action',
+        title:
+          theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme',
+        detail: 'Toggle the console theme',
+        keywords: ['dark', 'light', 'appearance'],
+        run: () => onThemeChange(theme === 'dark' ? 'light' : 'dark'),
+      },
+    ]
+
+    return [...actions, ...pages, ...chats]
+  }, [
+    screenOptions,
+    conversations,
+    select,
+    createNew,
+    openScreen,
+    onOpenSettings,
+    onOpenShortcuts,
+    theme,
+    onThemeChange,
+  ])
+
+  return (
+    <CommandPalette
+      open={open}
+      onClose={() => setOpen(false)}
+      localEntries={localEntries}
+      onOpenWorkers={openWorkers}
+      onOpenFunction={openFunction}
+    />
+  )
+}

--- a/console/web/src/components/workspace/MobileWorkspaceMenu.tsx
+++ b/console/web/src/components/workspace/MobileWorkspaceMenu.tsx
@@ -3,6 +3,7 @@ import {
   CircleQuestionMark,
   PanelsTopLeft,
   Plus,
+  Search,
   Settings,
   X,
 } from 'lucide-react'
@@ -26,6 +27,7 @@ interface MobileWorkspaceMenuProps {
   onActivate: (tabId: string) => void
   onToggleSettings: () => void
   onOpenShortcuts: () => void
+  onOpenPalette: () => void
 }
 
 export function MobileWorkspaceMenu({
@@ -37,6 +39,7 @@ export function MobileWorkspaceMenu({
   onActivate,
   onToggleSettings,
   onOpenShortcuts,
+  onOpenPalette,
 }: MobileWorkspaceMenuProps) {
   return (
     <BottomSheet open={open} onOpenChange={onOpenChange}>
@@ -47,6 +50,20 @@ export function MobileWorkspaceMenu({
           contentClassName="flex flex-col overflow-hidden"
         >
           <div className="min-h-0 flex-1 overflow-y-auto px-3">
+            {/* The same search the header opens, repeated here because this
+                sheet is where a phone goes looking for everything else. */}
+            <button
+              type="button"
+              onClick={() => {
+                onOpenChange(false)
+                onOpenPalette()
+              }}
+              className="mb-3 flex min-h-12 w-full items-center gap-3 rounded-sm bg-surface px-3 font-sans text-base text-ink-faint hover:bg-surface-hover hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus"
+            >
+              <Search className="size-5" aria-hidden />
+              Search the console
+            </button>
+
             <ul className="space-y-1" aria-label="workspaces">
               {workspace.tabs.map((tab) => {
                 const active = tab.id === workspace.activeTabId

--- a/console/web/src/lib/palette/sources.test.ts
+++ b/console/web/src/lib/palette/sources.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+import {
+  filterEntries,
+  groupEntries,
+  KIND_ORDER,
+  type PaletteEntry,
+  type PaletteKind,
+  scoreEntry,
+} from './sources'
+
+function entry(
+  title: string,
+  kind: PaletteKind = 'action',
+  rest: Partial<PaletteEntry> = {},
+): PaletteEntry {
+  return { id: `${kind}:${title}`, kind, title, run: () => {}, ...rest }
+}
+
+describe('scoreEntry', () => {
+  it('keeps everything when there is nothing to match against', () => {
+    expect(scoreEntry(entry('shell'), '')).toBe(1)
+  })
+
+  it('ranks exact over prefix over word boundary over anywhere', () => {
+    const exact = scoreEntry(entry('shell'), 'shell')
+    const prefix = scoreEntry(entry('shell-agent'), 'shell')
+    const boundary = scoreEntry(entry('worker::shell'), 'shell')
+    const anywhere = scoreEntry(entry('reshell'), 'shell')
+    expect(exact).toBeGreaterThan(prefix)
+    expect(prefix).toBeGreaterThan(boundary)
+    expect(boundary).toBeGreaterThan(anywhere)
+    expect(anywhere).toBeGreaterThan(0)
+  })
+
+  it('falls back to a subsequence, below every literal match', () => {
+    const subsequence = scoreEntry(entry('engine::workers::list'), 'ewl')
+    expect(subsequence).toBeGreaterThan(0)
+    expect(subsequence).toBeLessThan(
+      scoreEntry(entry('engine::workers::list'), 'workers'),
+    )
+  })
+
+  it('rejects an entry it cannot match at all', () => {
+    expect(scoreEntry(entry('shell'), 'zzz')).toBe(0)
+  })
+
+  it('matches detail and keywords, not just the title', () => {
+    expect(
+      scoreEntry(
+        entry('Open settings', 'action', { detail: 'preferences' }),
+        'pref',
+      ),
+    ).toBeGreaterThan(0)
+    expect(
+      scoreEntry(
+        entry('Open settings', 'action', { keywords: ['config'] }),
+        'config',
+      ),
+    ).toBeGreaterThan(0)
+  })
+
+  it('ignores case on both sides', () => {
+    expect(scoreEntry(entry('Shell'), 'SHELL')).toBe(100)
+  })
+})
+
+describe('filterEntries', () => {
+  const entries = [
+    entry('shell', 'worker'),
+    entry('shell::exec', 'function'),
+    entry('New chat', 'action'),
+  ]
+
+  it('scopes to one kind without scoring', () => {
+    expect(
+      filterEntries(entries, '', 'worker').map((row) => row.title),
+    ).toEqual(['shell'])
+  })
+
+  it('sorts a query best-first', () => {
+    expect(
+      filterEntries(entries, 'shell', 'all').map((row) => row.title),
+    ).toEqual(['shell', 'shell::exec'])
+  })
+
+  it('treats a whitespace-only query as no query', () => {
+    expect(filterEntries(entries, '   ', 'all')).toHaveLength(entries.length)
+  })
+
+  it('drops everything that does not match', () => {
+    expect(filterEntries(entries, 'zzz', 'all')).toEqual([])
+  })
+})
+
+describe('groupEntries', () => {
+  it('emits groups in a fixed order, whatever the input order', () => {
+    const grouped = groupEntries([
+      entry('shell::exec', 'function'),
+      entry('New chat', 'action'),
+      entry('shell', 'worker'),
+    ])
+    expect(grouped.map(([kind]) => kind)).toEqual(
+      KIND_ORDER.filter((kind) =>
+        ['action', 'worker', 'function'].includes(kind),
+      ),
+    )
+  })
+
+  it('omits kinds with no rows', () => {
+    const grouped = groupEntries([entry('shell', 'worker')])
+    expect(grouped).toHaveLength(1)
+    expect(grouped[0][0]).toBe('worker')
+  })
+
+  it('keeps every entry exactly once', () => {
+    const input = [entry('a', 'page'), entry('b', 'page'), entry('c', 'chat')]
+    expect(groupEntries(input).flatMap(([, rows]) => rows)).toHaveLength(
+      input.length,
+    )
+  })
+})

--- a/console/web/src/lib/palette/sources.ts
+++ b/console/web/src/lib/palette/sources.ts
@@ -1,0 +1,198 @@
+/**
+ * What the command palette can reach.
+ *
+ * The console's subject is the engine and the workers attached to it, so the
+ * palette searches that: every connected worker, every function they register,
+ * every page the console can show (first-party and worker-injected), the open
+ * conversations, and the handful of console actions that have no other home.
+ *
+ * Worker and function rows come from the engine at open time rather than a
+ * cached list — a worker that just disconnected should not stay searchable, and
+ * a worker that just arrived should be there without a reload.
+ */
+
+import type { LucideIcon } from 'lucide-react'
+import { getIiiClient } from '@/lib/iii-client'
+
+export type PaletteKind = 'worker' | 'function' | 'page' | 'chat' | 'action'
+
+export interface PaletteEntry {
+  id: string
+  kind: PaletteKind
+  /** Primary line: what the user is looking for. */
+  title: string
+  /** Secondary line: where it is, or what it does. */
+  detail?: string
+  /** Right-aligned tag: the owning worker, the page's scope, a status. */
+  meta?: string
+  /** Extra words that should match without being displayed. */
+  keywords?: string[]
+  /** The row's own icon. Pages carry the icon the console already gives them,
+   *  so a page looks the same here as it does in the attach menu; anything
+   *  without one falls back to its category icon. */
+  icon?: LucideIcon
+  run: () => void
+}
+
+export interface EngineSnapshot {
+  workers: Array<{
+    name: string
+    status: string
+    version: string
+    functionCount: number
+  }>
+  functions: Array<{ id: string; worker: string; description: string }>
+  error: string | null
+}
+
+const EMPTY: EngineSnapshot = { workers: [], functions: [], error: null }
+
+function str(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback
+}
+
+function num(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0
+}
+
+/**
+ * Read the engine's own inventory. Both calls are best-effort: a palette that
+ * opens with pages and chats beats one that refuses to open because a worker
+ * list timed out.
+ */
+export async function readEngine(): Promise<EngineSnapshot> {
+  try {
+    const client = await getIiiClient()
+    const [workerResponse, functionResponse] = await Promise.all([
+      client.trigger<{ workers?: unknown }>('engine::workers::list', {}),
+      client.trigger<{ functions?: unknown }>('engine::functions::list', {}),
+    ])
+
+    const workerRows = Array.isArray(workerResponse?.workers)
+      ? workerResponse.workers
+      : []
+    const workers = workerRows
+      .map((raw) => {
+        const row = (raw ?? {}) as Record<string, unknown>
+        return {
+          name: str(row.name),
+          status: str(row.status, 'unknown'),
+          version: str(row.version),
+          functionCount: num(row.function_count),
+        }
+      })
+      .filter((worker) => worker.name !== '')
+
+    const functionRows = Array.isArray(functionResponse?.functions)
+      ? functionResponse.functions
+      : []
+    const functions = functionRows
+      .map((raw) => {
+        const row = (raw ?? {}) as Record<string, unknown>
+        const id = str(row.function_id) || str(row.id)
+        return {
+          id,
+          worker: str(row.worker_name),
+          description: str(row.description),
+        }
+      })
+      .filter((fn) => fn.id !== '')
+
+    return { workers, functions, error: null }
+  } catch (error) {
+    return {
+      ...EMPTY,
+      error: error instanceof Error ? error.message : String(error),
+    }
+  }
+}
+
+/**
+ * Rank matches the way a keyboard-first surface should: an exact prefix beats a
+ * word start, which beats a match anywhere. Subsequence matching (`ecw` finding
+ * `engine::workers::list`) comes last, because it is the loosest and would
+ * otherwise bury the obvious answers.
+ */
+export function scoreEntry(entry: PaletteEntry, query: string): number {
+  if (!query) return 1
+  const needle = query.toLowerCase()
+  const haystacks = [
+    entry.title,
+    entry.detail ?? '',
+    ...(entry.keywords ?? []),
+  ].map((value) => value.toLowerCase())
+
+  let best = 0
+  for (const hay of haystacks) {
+    if (!hay) continue
+    if (hay === needle) best = Math.max(best, 100)
+    else if (hay.startsWith(needle)) best = Math.max(best, 80)
+    else {
+      const at = hay.indexOf(needle)
+      if (at === 0) best = Math.max(best, 80)
+      else if (at > 0)
+        best = Math.max(
+          best,
+          hay[at - 1] === ' ' || hay[at - 1] === ':' ? 60 : 40,
+        )
+    }
+  }
+  if (best > 0) return best
+
+  // Subsequence: every needle character appears in order.
+  const title = haystacks[0]
+  let cursor = 0
+  for (const char of needle) {
+    cursor = title.indexOf(char, cursor)
+    if (cursor === -1) return 0
+    cursor += 1
+  }
+  return 20
+}
+
+export function filterEntries(
+  entries: PaletteEntry[],
+  query: string,
+  kind: PaletteKind | 'all',
+): PaletteEntry[] {
+  const scoped =
+    kind === 'all' ? entries : entries.filter((entry) => entry.kind === kind)
+  if (!query.trim()) return scoped
+  return scoped
+    .map((entry) => ({ entry, score: scoreEntry(entry, query.trim()) }))
+    .filter((row) => row.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .map((row) => row.entry)
+}
+
+export const KIND_LABEL: Record<PaletteKind, string> = {
+  worker: 'Workers',
+  function: 'Functions',
+  page: 'Pages',
+  chat: 'Chats',
+  action: 'Actions',
+}
+
+/** Group in a fixed order so the list does not reshuffle as scores change. */
+export const KIND_ORDER: PaletteKind[] = [
+  'action',
+  'page',
+  'chat',
+  'worker',
+  'function',
+]
+
+export function groupEntries(
+  entries: PaletteEntry[],
+): Array<[PaletteKind, PaletteEntry[]]> {
+  const groups = new Map<PaletteKind, PaletteEntry[]>()
+  for (const entry of entries) {
+    const bucket = groups.get(entry.kind)
+    if (bucket) bucket.push(entry)
+    else groups.set(entry.kind, [entry])
+  }
+  return KIND_ORDER.filter((kind) => groups.has(kind)).map((kind) => [
+    kind,
+    groups.get(kind) as PaletteEntry[],
+  ])
+}

--- a/console/web/src/lib/palette/sources.ts
+++ b/console/web/src/lib/palette/sources.ts
@@ -131,7 +131,7 @@ export async function readEngine(): Promise<EngineSnapshot> {
 
 /**
  * Rank matches the way a keyboard-first surface should: an exact prefix beats a
- * word start, which beats a match anywhere. Subsequence matching (`ecw` finding
+ * word start, which beats a match anywhere. Subsequence matching (`ewl` finding
  * `engine::workers::list`) comes last, because it is the loosest and would
  * otherwise bury the obvious answers.
  */

--- a/console/web/src/lib/palette/sources.ts
+++ b/console/web/src/lib/palette/sources.ts
@@ -51,6 +51,10 @@ function str(value: unknown, fallback = ''): string {
   return typeof value === 'string' ? value : fallback
 }
 
+function reasonText(reason: unknown): string {
+  return reason instanceof Error ? reason.message : String(reason)
+}
+
 function num(value: unknown): number {
   return typeof value === 'number' && Number.isFinite(value) ? value : 0
 }
@@ -63,10 +67,25 @@ function num(value: unknown): number {
 export async function readEngine(): Promise<EngineSnapshot> {
   try {
     const client = await getIiiClient()
-    const [workerResponse, functionResponse] = await Promise.all([
+    // Settled, not all: the two reads are independent, and a worker list that
+    // times out should not also cost you the function list.
+    const [workerResult, functionResult] = await Promise.allSettled([
       client.trigger<{ workers?: unknown }>('engine::workers::list', {}),
       client.trigger<{ functions?: unknown }>('engine::functions::list', {}),
     ])
+    const failures = [
+      workerResult.status === 'rejected'
+        ? reasonText(workerResult.reason)
+        : null,
+      functionResult.status === 'rejected'
+        ? reasonText(functionResult.reason)
+        : null,
+    ].filter((reason): reason is string => reason !== null)
+
+    const workerResponse =
+      workerResult.status === 'fulfilled' ? workerResult.value : undefined
+    const functionResponse =
+      functionResult.status === 'fulfilled' ? functionResult.value : undefined
 
     const workerRows = Array.isArray(workerResponse?.workers)
       ? workerResponse.workers
@@ -98,12 +117,15 @@ export async function readEngine(): Promise<EngineSnapshot> {
       })
       .filter((fn) => fn.id !== '')
 
-    return { workers, functions, error: null }
-  } catch (error) {
     return {
-      ...EMPTY,
-      error: error instanceof Error ? error.message : String(error),
+      workers,
+      functions,
+      error: failures.length > 0 ? failures.join('; ') : null,
     }
+  } catch (error) {
+    // Only a client that never connects lands here; the per-read failures
+    // above keep their own partial results.
+    return { ...EMPTY, error: reasonText(error) }
   }
 }
 

--- a/console/web/src/pages/Workers/hooks/useWorkersLive.ts
+++ b/console/web/src/pages/Workers/hooks/useWorkersLive.ts
@@ -4,6 +4,7 @@ import { useWorkerLifecycle } from '@/hooks/use-worker-lifecycle'
 import { getDefaultBackend } from '@/lib/backend'
 import { stopSupervisorWorker } from '../api/workers'
 import { fetchMergedWorkers } from '../lib/merge-workers'
+import { takePendingWorkerSearch } from '../pending-selection'
 import { filterWorkerRows, type WorkersFilterState } from '../types'
 
 export const workersKeys = {
@@ -27,11 +28,13 @@ const RUNTIME_STAGES = ['done', 'failed'] as const
 export function useWorkersLive() {
   const qc = useQueryClient()
   const enabled = getDefaultBackend().id === 'real'
-  const [filters, setFilters] = useState<WorkersFilterState>({
-    search: '',
+  // A caller (the command palette) can ask for this page filtered to one
+  // worker. It is consumed once, at mount, so a later visit opens unfiltered.
+  const [filters, setFilters] = useState<WorkersFilterState>(() => ({
+    search: takePendingWorkerSearch() ?? '',
     tag: null,
     runtime: null,
-  })
+  }))
   const [stoppingName, setStoppingName] = useState<string | null>(null)
 
   const query = useQuery({

--- a/console/web/src/pages/Workers/pending-selection.ts
+++ b/console/web/src/pages/Workers/pending-selection.ts
@@ -1,0 +1,23 @@
+/**
+ * A one-shot hand-off for "open the workers page, showing THIS worker".
+ *
+ * The workers page owns its filter state locally and takes no props, and the
+ * palette attaches it as a workspace screen rather than navigating by hash, so
+ * there is no route to carry a selection through. This is the smallest honest
+ * contract instead: the caller leaves a term, the page takes it once on mount,
+ * and it is gone — a later visit opens unfiltered.
+ */
+
+let pending: string | null = null
+
+/** Ask the workers page to open filtered to this worker (or function id). */
+export function setPendingWorkerSearch(term: string): void {
+  pending = term.trim() || null
+}
+
+/** Read and clear. Returns null when nothing asked for a selection. */
+export function takePendingWorkerSearch(): string | null {
+  const term = pending
+  pending = null
+  return term
+}


### PR DESCRIPTION
## What

Finding anything in the console meant knowing where it lived first: which tab shows workers, which page a worker injected, which chat had that run. The console's subject is the engine and whatever is attached to it, so `⌘K` (`ctrl+K` elsewhere) now searches exactly that.

Five sources, one list:

- **workers** — live from `engine::workers::list`, with status, version and function count
- **functions** — from `engine::functions::list`, showing the owning worker, with the `worker::` prefix dimmed the way function ids render elsewhere in the console
- **pages** — every screen a tab can attach, first-party and worker-injected, each carrying the icon the attach menu already gives it
- **chats** — jump straight to a conversation
- **actions** — the console-level ones with no other home: new chat, settings, shortcuts, theme

The engine inventory is read when the palette opens rather than cached at boot, so a worker that just disconnected stops being searchable and one that just arrived appears without a reload. Both reads are best effort: a palette that opens with pages and chats beats one that refuses to open because a worker list timed out.

Ranking is prefix-first (exact, starts-with, word boundary, anywhere) with a subsequence fallback last, so `sh` finds `shell` before `engine::functions::list` while a half-remembered id still resolves.

Keys: `⌘K` toggle, `↑↓` or `ctrl+n`/`ctrl+p` to move, `tab` / `shift+tab` to cycle the filter, `enter` to open, `esc` to close. All four are listed in the `?` shortcut overlay, which previously documented only itself.

Nothing here mutates the engine — every row navigates. Triggering a function or restarting a worker from a search box is a separate decision, not a default.

## Verification

- `pnpm exec tsc --noEmit` clean
- `pnpm test` — 116 files, 1294 tests, all passing
- biome clean on the touched files
- Live on a local rig against engine 0.22.1: 27 workers, 9 pages, all five groups populated; verified the worker rows show `connected` vs the built-ins' `available`, and that page rows carry their own icons

## Notes for review

- The palette lives in `console/web`, not an injectable worker UI: it spans the whole console, and the console already owns the global key handling (`?`).
- Function rows navigate to the workers screen. The console has no per-function route to land on yet, so the row is a finder that carries the id and owner, not a launcher.
- The scrim is a real `<button>` rather than an interactive `<div>` so dismissing by click stays reachable without a mouse.

Fixes MOT-4466


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a command palette accessible with ⌘K/Ctrl+K.
  - Search workspace pages, conversations, actions, workers, and functions from one interface.
  - Filter results by category with keyboard navigation and selection.
  - Added grouped results, status indicators, result counts, and loading/error states.
  - Added shortcuts for opening settings, viewing shortcuts, creating chats, switching themes, and navigating to workers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->