### PR TITLE
Disable telemetry in the harness integration engine

### DIFF
--- a/harness/tests/integration/src/stack/supervisor.rs
+++ b/harness/tests/integration/src/stack/supervisor.rs
@@ -9,6 +9,7 @@ use super::{EarlyExit, RunLayout, StackBins};
 
 const ENGINE_STARTUP_TIMEOUT: Duration = Duration::from_secs(10);
 const ENGINE_CONNECT_INTERVAL: Duration = Duration::from_millis(25);
+const INTEGRATION_TELEMETRY_ENV: (&str, &str) = ("III_TELEMETRY_ENABLED", "false");
 
 pub struct Stack {
     pub ws_url: String,
@@ -80,9 +81,7 @@ impl Stack {
             engine_restarts: 0,
         };
 
-        if let Err(error) =
-            stack.spawn_child("engine", &bins.engine, &engine_args, &paths.engine_dir)
-        {
+        if let Err(error) = stack.spawn_engine(&bins.engine, &engine_args, &paths.engine_dir) {
             let teardown = stack.teardown().await;
             return Err(BootError::Other { error, teardown });
         }
@@ -195,7 +194,7 @@ impl Stack {
             .ok_or_else(|| anyhow::anyhow!("stack has no engine recipe"))?;
         self.engine_restarts += 1;
         let log_name = format!("engine.restart{}", self.engine_restarts);
-        self.spawn_child_logged_with_env("engine", &log_name, &bin, &args, &cwd, &[])
+        self.spawn_engine_logged(&log_name, &bin, &args, &cwd)
     }
 
     pub fn respawn_worker(&mut self, bins: &StackBins, worker: &str) -> anyhow::Result<()> {
@@ -222,6 +221,27 @@ impl Stack {
             args.push(seed_path.to_string_lossy().into_owned());
         }
         self.spawn_child_with_env(worker, bin, &args, &paths.root, extra_env)
+    }
+
+    fn spawn_engine(&mut self, bin: &Path, args: &[String], cwd: &Path) -> anyhow::Result<()> {
+        self.spawn_engine_logged("engine", bin, args, cwd)
+    }
+
+    pub(super) fn spawn_engine_logged(
+        &mut self,
+        log_name: &str,
+        bin: &Path,
+        args: &[String],
+        cwd: &Path,
+    ) -> anyhow::Result<()> {
+        // Integration engines are test processes. Their inherited environment
+        // is intentionally cleared below, so disable product telemetry
+        // explicitly instead of relying on CI detection in the child.
+        let extra_env = [(
+            INTEGRATION_TELEMETRY_ENV.0.to_string(),
+            INTEGRATION_TELEMETRY_ENV.1.to_string(),
+        )];
+        self.spawn_child_logged_with_env("engine", log_name, bin, args, cwd, &extra_env)
     }
 
     #[doc(hidden)]

--- a/harness/tests/integration/src/stack/tests.rs
+++ b/harness/tests/integration/src/stack/tests.rs
@@ -101,3 +101,29 @@ async fn boot_failure_carries_a_complete_typed_teardown() {
     assert!(failure.teardown.complete());
     assert!(format!("{:#}", failure.error).contains("missing --worker-bin"));
 }
+
+#[tokio::test]
+async fn integration_engine_receives_telemetry_opt_out() {
+    let artifacts = tempfile::tempdir().unwrap();
+    let layout = RunLayout::allocate(artifacts.path(), "run-engine-env").unwrap();
+    let marker = layout.root.join("engine-telemetry-env.txt");
+    let args = vec![
+        "-c".to_string(),
+        "printf '%s' \"$III_TELEMETRY_ENABLED\" > \"$1\"".to_string(),
+        "engine-test".to_string(),
+        marker.to_string_lossy().into_owned(),
+    ];
+    let mut stack = Stack::for_tests(layout.clone());
+
+    stack
+        .spawn_engine_logged(
+            "engine",
+            PathBuf::from("/bin/sh").as_path(),
+            &args,
+            &layout.root,
+        )
+        .unwrap();
+    stack.wait_for_early_exit().await.unwrap();
+
+    assert_eq!(std::fs::read_to_string(marker).unwrap(), "false");
+}


### PR DESCRIPTION
## What changed
- pass `III_TELEMETRY_ENABLED=false` explicitly to every integration engine launch, including restarts
- add a regression test that verifies the child process receives the opt-out

## Why
The integration supervisor clears the inherited environment before spawning children. That removed `CI`/`GITHUB_ACTIONS`, so pinned iii engines classified themselves as user sessions and emitted heartbeat events to analytics from CI runners.

## Validation
- `cargo test --locked --manifest-path harness/Cargo.toml -p harness-integration`
- 89 unit tests, integration crate tests, determinism, schema, supervisor, and doc tests passed