### PR TITLE
(MOT-4499) feat(console): one keyboard shortcut registry, and shortcuts for workspaces and settings

### DIFF
--- a/console/web/src/App.tsx
+++ b/console/web/src/App.tsx
@@ -23,6 +23,7 @@ import {
   DialogDescription,
   DialogTitle,
 } from '@/components/ui/Dialog'
+import { KeyCombo } from '@/components/ui/KeyCombo'
 import { Sheet } from '@/components/ui/Sheet'
 import { Wordmark } from '@/components/ui/Wordmark'
 import { EmptyPane } from '@/components/workspace/EmptyPane'
@@ -36,6 +37,7 @@ import {
   useHashRoute,
   type View,
 } from '@/hooks/use-hash-route'
+import { useKeybindings } from '@/hooks/use-keybindings'
 import { useTheme } from '@/hooks/use-theme'
 import {
   type UseWorkspaceTabsReturn,
@@ -45,6 +47,8 @@ import {
   ConversationsProvider,
   useConversationsCtx,
 } from '@/lib/conversations-context'
+import { shortcutPlatform } from '@/lib/keybindings/bindings'
+import { keybindingGroups, resolveBindings } from '@/lib/keybindings/registry'
 import { subscribePanelOpen } from '@/lib/panel-context'
 import { loadEdgeAddDiscovered, saveEdgeAddDiscovered } from '@/lib/storage'
 import { cn } from '@/lib/utils'
@@ -179,23 +183,13 @@ export function App() {
     else setView(primary as View)
   }, [activeTabId, activeTab, hashScreen, setView])
 
-  /* `?` opens the shortcuts overlay. Ignored when the user is typing into
-     editable elements so we don't fight the composer. */
-  useEffect(() => {
-    if (typeof window === 'undefined') return
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key !== '?') return
-      if (e.metaKey || e.ctrlKey || e.altKey) return
-      const target = e.target as HTMLElement | null
-      if (target?.isContentEditable) return
-      const tag = target?.tagName
-      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return
-      e.preventDefault()
-      setShortcutsOpen(true)
-    }
-    window.addEventListener('keydown', onKeyDown)
-    return () => window.removeEventListener('keydown', onKeyDown)
-  }, [])
+  /* Every global shortcut the console has, dispatched from the registry.
+     Which keys reach here while the caret is in a field, and which stand
+     down, is the registry's call — not this component's. */
+  useKeybindings({
+    'palette.toggle': () => setPaletteOpen((current) => !current),
+    'shortcuts.open': () => setShortcutsOpen(true),
+  })
 
   return (
     <ConversationsProvider>
@@ -776,18 +770,10 @@ interface ShortcutsDialogProps {
   onOpenChange: (open: boolean) => void
 }
 
-const SHORTCUTS: { combo: string; description: string }[] = [
-  {
-    combo: '⌘K / ctrl+K',
-    description: 'search workers, functions, pages, chats',
-  },
-  { combo: '↑ ↓', description: 'move through palette results' },
-  { combo: 'tab', description: 'cycle the palette filter' },
-  { combo: 'esc', description: 'close the palette' },
-  { combo: '?', description: 'open this shortcut overlay' },
-]
-
+/* Generated from the registry, so the overlay cannot drift from what the
+   keys actually do, and each chord is spelled for the reader's keyboard. */
 function ShortcutsDialog({ open, onOpenChange }: ShortcutsDialogProps) {
+  const platform = shortcutPlatform()
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
@@ -798,17 +784,37 @@ function ShortcutsDialog({ open, onOpenChange }: ShortcutsDialogProps) {
           press <kbd className="font-mono text-ink">?</kbd> any time to reopen
           this list.
         </DialogDescription>
-        <ul className="mt-4 divide-y divide-rule-2 border-t border-b border-rule-2">
-          {SHORTCUTS.map(({ combo, description }) => (
-            <li
-              key={combo}
-              className="flex items-center justify-between gap-6 py-2 font-mono text-[12px] text-ink"
-            >
-              <span className="text-ink-faint">{description}</span>
-              <kbd className="text-ink tracking-[0.06em]">{combo}</kbd>
-            </li>
-          ))}
-        </ul>
+        {keybindingGroups().map(([group, entries]) => (
+          <section key={group} className="mt-4">
+            <h3 className="text-[11px] uppercase tracking-[0.18em] text-ink-ghost">
+              {group}
+            </h3>
+            <ul className="mt-1 divide-y divide-rule-2 border-t border-b border-rule-2">
+              {entries.map((entry) => (
+                <li
+                  key={entry.id}
+                  className="flex items-center justify-between gap-6 py-2 font-mono text-[12px] text-ink"
+                >
+                  <span className="text-ink-faint">{entry.title}</span>
+                  {/* Alternatives, not one chord: without a separator `tab`
+                      and `shift tab` read as a single four-key press. */}
+                  <span className="flex shrink-0 items-center gap-2">
+                    {resolveBindings(entry.bindings, platform).map(
+                      (binding, index) => (
+                        <Fragment key={binding}>
+                          {index > 0 ? (
+                            <span className="text-ink-ghost">or</span>
+                          ) : null}
+                          <KeyCombo binding={binding} platform={platform} />
+                        </Fragment>
+                      ),
+                    )}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ))}
       </DialogContent>
     </Dialog>
   )

--- a/console/web/src/App.tsx
+++ b/console/web/src/App.tsx
@@ -189,6 +189,19 @@ export function App() {
   useKeybindings({
     'palette.toggle': () => setPaletteOpen((current) => !current),
     'shortcuts.open': () => setShortcutsOpen(true),
+    'app.settings': toggleSettings,
+    'workspace.create': () => workspaceRef.current.createTab({ columns: 1 }),
+    'panel.split': () =>
+      workspaceRef.current.addColumn(
+        workspaceRef.current.activeTab.id,
+        'right',
+      ),
+    // Out of range is a no-op rather than a wrap: pressing 7 with four
+    // workspaces open should do nothing, not land somewhere surprising.
+    'workspace.selectByIndex': (index) => {
+      const tab = workspaceRef.current.tabs[index]
+      if (tab) workspaceRef.current.activateTab(tab.id)
+    },
   })
 
   return (
@@ -805,7 +818,11 @@ function ShortcutsDialog({ open, onOpenChange }: ShortcutsDialogProps) {
                           {index > 0 ? (
                             <span className="text-ink-ghost">or</span>
                           ) : null}
-                          <KeyCombo binding={binding} platform={platform} />
+                          <KeyCombo
+                            binding={binding}
+                            platform={platform}
+                            digitRange={entry.digitIndex}
+                          />
                         </Fragment>
                       ),
                     )}

--- a/console/web/src/components/CommandPalette.tsx
+++ b/console/web/src/components/CommandPalette.tsx
@@ -18,7 +18,6 @@
 
 import {
   Boxes,
-  CornerDownLeft,
   FunctionSquare,
   MessageSquareText,
   Search,
@@ -34,7 +33,14 @@ import {
   useRef,
   useState,
 } from 'react'
+import { KeyCombo } from '@/components/ui/KeyCombo'
 import { useMediaQuery } from '@/hooks/use-media-query'
+import { shortcutPlatform } from '@/lib/keybindings/bindings'
+import {
+  bindingsFor,
+  type KeybindingActionId,
+  matchesKeybinding,
+} from '@/lib/keybindings/registry'
 import {
   type EngineSnapshot,
   filterEntries,
@@ -54,12 +60,15 @@ const FILTERS: Array<{ id: PaletteKind | 'all'; label: string }> = [
   { id: 'action', label: 'Actions' },
 ]
 
-/** The hint has to name the key the reader actually has. */
-const MODIFIER_LABEL =
-  typeof navigator !== 'undefined' &&
-  /Mac|iPhone|iPad|iPod/.test(navigator.platform || navigator.userAgent)
-    ? '⌘K'
-    : 'ctrl K'
+/** The footer's key hints, in the order they read. The chords come from the
+ *  registry; only the wording is local. */
+const HINTS: Array<{ ids: KeybindingActionId[]; label: string }> = [
+  { ids: ['palette.choose'], label: 'open' },
+  // Both arrows: one direction is not a hint about moving through a list.
+  { ids: ['palette.previous', 'palette.next'], label: 'select' },
+  { ids: ['palette.cycleFilter'], label: 'filter' },
+  { ids: ['palette.close'], label: 'close' },
+]
 
 /** Icon plus the tint its chip carries. Colour is category, not severity —
  *  worker status gets its own dot below, where severity belongs. */
@@ -170,6 +179,7 @@ export function CommandPalette({
   const inputRef = useRef<HTMLInputElement>(null)
   const listRef = useRef<HTMLDivElement>(null)
   const viewportStyle = useKeyboardInset(open)
+  const platform = shortcutPlatform()
 
   // Reset per opening: a palette that reopens on the last query is a palette
   // you have to clear before you can use it. Closing returns focus to whatever
@@ -256,23 +266,26 @@ export function CommandPalette({
       ?.scrollIntoView({ block: 'nearest' })
   }
 
+  // The palette's own keys live in the registry too, under the `palette`
+  // scope: documented in the shortcut overlay, dispatched here, because only
+  // one of us is listening at a time.
   const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === 'Escape') {
+    if (matchesKeybinding('palette.close', event, platform)) {
       event.preventDefault()
       onClose()
       return
     }
-    if (event.key === 'ArrowDown' || (event.key === 'n' && event.ctrlKey)) {
+    if (matchesKeybinding('palette.next', event, platform)) {
       event.preventDefault()
       move(1)
       return
     }
-    if (event.key === 'ArrowUp' || (event.key === 'p' && event.ctrlKey)) {
+    if (matchesKeybinding('palette.previous', event, platform)) {
       event.preventDefault()
       move(-1)
       return
     }
-    if (event.key === 'Tab') {
+    if (matchesKeybinding('palette.cycleFilter', event, platform)) {
       event.preventDefault()
       const step = event.shiftKey ? -1 : 1
       const index = FILTERS.findIndex((option) => option.id === filter)
@@ -281,7 +294,7 @@ export function CommandPalette({
       setActive(0)
       return
     }
-    if (event.key === 'Enter') {
+    if (matchesKeybinding('palette.choose', event, platform)) {
       event.preventDefault()
       choose(flat[active])
     }
@@ -334,9 +347,11 @@ export function CommandPalette({
             autoComplete="off"
             spellCheck={false}
           />
-          <kbd className="hidden shrink-0 rounded border border-edge px-1.5 py-0.5 font-mono text-[0.65rem] text-ink-ghost sm:block">
-            {MODIFIER_LABEL}
-          </kbd>
+          <KeyCombo
+            binding={bindingsFor('palette.toggle', platform)[0]}
+            platform={platform}
+            className="hidden shrink-0 sm:inline-flex"
+          />
           <button
             type="button"
             onClick={onClose}
@@ -444,7 +459,13 @@ export function CommandPalette({
                       </span>
                       {/* The right-hand tag is the first thing to give up when
                           the row has to fit a phone. */}
-                      {entry.meta ? (
+                      {entry.shortcut ? (
+                        <KeyCombo
+                          binding={entry.shortcut}
+                          platform={platform}
+                          className="hidden shrink-0 sm:inline-flex"
+                        />
+                      ) : entry.meta ? (
                         <span className="hidden shrink-0 rounded border border-edge px-1.5 py-0.5 font-mono text-[0.65rem] text-ink-ghost sm:block">
                           {entry.meta}
                         </span>
@@ -459,30 +480,18 @@ export function CommandPalette({
         <div className="flex shrink-0 items-center gap-3 border-t border-edge px-4 py-2 pb-[max(0.5rem,env(safe-area-inset-bottom))] text-[0.68rem] text-ink-ghost sm:pb-2">
           {/* Key hints are noise on a surface with no keys to press. */}
           <div className="hidden items-center gap-3 sm:flex">
-            <span className="flex items-center gap-1.5">
-              <kbd className="rounded border border-edge px-1 py-px font-mono">
-                <CornerDownLeft aria-hidden className="size-2.5" />
-              </kbd>
-              open
-            </span>
-            <span className="flex items-center gap-1.5">
-              <kbd className="rounded border border-edge px-1 py-px font-mono">
-                ↑↓
-              </kbd>
-              select
-            </span>
-            <span className="flex items-center gap-1.5">
-              <kbd className="rounded border border-edge px-1 py-px font-mono">
-                tab
-              </kbd>
-              filter
-            </span>
-            <span className="flex items-center gap-1.5">
-              <kbd className="rounded border border-edge px-1 py-px font-mono">
-                esc
-              </kbd>
-              close
-            </span>
+            {HINTS.map((hint) => (
+              <span key={hint.label} className="flex items-center gap-1.5">
+                {hint.ids.map((id) => (
+                  <KeyCombo
+                    key={id}
+                    binding={bindingsFor(id, platform)[0]}
+                    platform={platform}
+                  />
+                ))}
+                {hint.label}
+              </span>
+            ))}
           </div>
           <span className="ml-auto font-mono">
             {flat.length} result{flat.length === 1 ? '' : 's'}

--- a/console/web/src/components/PaletteHost.tsx
+++ b/console/web/src/components/PaletteHost.tsx
@@ -1,22 +1,25 @@
 /**
- * Owns ⌘K: the shortcut, the console-side rows, and where each row goes.
+ * The console-side palette rows, and where each one goes.
  *
  * It lives inside the conversations provider because chats are one of the
  * things you search for; everything else it needs (the workspace, the settings
- * overlay, the theme) arrives as props from `App`.
+ * overlay, the theme) arrives as props from `App`, which also owns the
+ * shortcut that opens it.
  */
 
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useMemo } from 'react'
 import { CommandPalette } from '@/components/CommandPalette'
 import { useScreenOptions } from '@/components/workspace/use-screen-options'
 import { useConversationsCtx } from '@/lib/conversations-context'
+import { shortcutPlatform } from '@/lib/keybindings/bindings'
+import { bindingsFor } from '@/lib/keybindings/registry'
 import type { PaletteEntry } from '@/lib/palette/sources'
 import type { TabScreen } from '@/lib/workspace-tabs'
 import { setPendingWorkerSearch } from '@/pages/Workers/pending-selection'
 
 export interface PaletteHostProps {
-  /** Owned by `App`: the shortcut is one way in, the phone header's search
-   *  affordance is the other, and only one of them can live here. */
+  /** Owned by `App`, which dispatches `palette.toggle` from the keybinding
+   *  registry and hands the phone header the same opener. */
   open: boolean
   onOpenChange: (open: boolean) => void
   openScreen: (screen: TabScreen) => void
@@ -37,25 +40,6 @@ export function PaletteHost({
 }: PaletteHostProps) {
   const { screenOptions } = useScreenOptions()
   const { conversations, select, createNew } = useConversationsCtx()
-
-  // Read through a ref so the global listener is bound once, not rebound on
-  // every open and close.
-  const openRef = useRef(open)
-  openRef.current = open
-
-  // ⌘K / ctrl+K anywhere, including from inside the composer — the palette is
-  // how you leave wherever you are, so it must not be shadowed by focus.
-  useEffect(() => {
-    if (typeof window === 'undefined') return
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== 'k' && event.key !== 'K') return
-      if (!event.metaKey && !event.ctrlKey) return
-      event.preventDefault()
-      onOpenChange(!openRef.current)
-    }
-    window.addEventListener('keydown', onKeyDown)
-    return () => window.removeEventListener('keydown', onKeyDown)
-  }, [onOpenChange])
 
   // Both land on the workers page, filtered to what was picked: a worker by
   // its name, a function by the worker that registers it, falling back to the
@@ -125,6 +109,7 @@ export function PaletteHost({
         title: 'Keyboard shortcuts',
         detail: 'Show the shortcut overlay',
         keywords: ['keys', 'help'],
+        shortcut: bindingsFor('shortcuts.open', shortcutPlatform())[0],
         run: onOpenShortcuts,
       },
       {

--- a/console/web/src/components/ui/KeyCombo.tsx
+++ b/console/web/src/components/ui/KeyCombo.tsx
@@ -1,0 +1,53 @@
+/**
+ * A shortcut as key caps, spelled for the reader's keyboard.
+ *
+ * Mac renders the glyphs adjacent the way the system does (⌘K); everywhere
+ * else the words need a separator to read as a chord (ctrl + k).
+ */
+
+import { Fragment } from 'react'
+import {
+  formatBinding,
+  type Platform,
+  shortcutPlatform,
+} from '@/lib/keybindings/bindings'
+import { cn } from '@/lib/utils'
+
+interface KeyComboProps {
+  binding: string
+  platform?: Platform
+  className?: string
+  capClassName?: string
+}
+
+export function KeyCombo({
+  binding,
+  platform = shortcutPlatform(),
+  className,
+  capClassName,
+}: KeyComboProps) {
+  const caps = formatBinding(binding, platform)
+  const mac = platform === 'mac'
+  return (
+    <span className={cn('inline-flex items-center gap-1', className)}>
+      {caps.map((cap, index) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: a chord can repeat a cap and position is the identity
+        <Fragment key={`${cap}-${index}`}>
+          <kbd
+            className={cn(
+              'inline-flex min-w-5 items-center justify-center rounded border border-edge px-1 py-px font-mono text-[0.65rem] text-ink-ghost',
+              capClassName,
+            )}
+          >
+            {cap}
+          </kbd>
+          {!mac && index < caps.length - 1 ? (
+            <span aria-hidden className="text-[0.65rem] text-ink-ghost">
+              +
+            </span>
+          ) : null}
+        </Fragment>
+      ))}
+    </span>
+  )
+}

--- a/console/web/src/components/ui/KeyCombo.tsx
+++ b/console/web/src/components/ui/KeyCombo.tsx
@@ -18,6 +18,9 @@ interface KeyComboProps {
   platform?: Platform
   className?: string
   capClassName?: string
+  /** Selects by position: the stored chord ends in a digit but the shortcut
+   *  fires for any of 1 to 9, so the last cap shows the whole range. */
+  digitRange?: boolean
 }
 
 export function KeyCombo({
@@ -25,8 +28,14 @@ export function KeyCombo({
   platform = shortcutPlatform(),
   className,
   capClassName,
+  digitRange = false,
 }: KeyComboProps) {
-  const caps = formatBinding(binding, platform)
+  const formatted = formatBinding(binding, platform)
+  const last = formatted.at(-1)
+  const caps =
+    digitRange && last !== undefined && /^[1-9]$/.test(last)
+      ? [...formatted.slice(0, -1), `${last}–9`]
+      : formatted
   const mac = platform === 'mac'
   return (
     <span className={cn('inline-flex items-center gap-1', className)}>

--- a/console/web/src/hooks/use-keybindings.ts
+++ b/console/web/src/hooks/use-keybindings.ts
@@ -1,0 +1,56 @@
+/**
+ * The console's one global key listener.
+ *
+ * Everything with `scope: 'global'` in the registry is dispatched from here,
+ * so the set of keys the console claims is readable in one place instead of
+ * spread across whichever components happened to want one.
+ */
+
+import { useEffect, useRef } from 'react'
+import { shortcutPlatform } from '@/lib/keybindings/bindings'
+import {
+  KEYBINDINGS,
+  type KeybindingActionId,
+  matchesKeybinding,
+} from '@/lib/keybindings/registry'
+
+export type KeybindingHandlers = Partial<Record<KeybindingActionId, () => void>>
+
+/** Whether the keystroke is going into a field the user is typing in. */
+function isTyping(target: EventTarget | null): boolean {
+  const element = target as HTMLElement | null
+  if (!element) return false
+  if (element.isContentEditable) return true
+  const tag = element.tagName
+  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT'
+}
+
+export function useKeybindings(handlers: KeybindingHandlers): void {
+  // Read through a ref so the listener binds once: handlers are rebuilt every
+  // render by every caller that passes inline arrows.
+  const handlersRef = useRef(handlers)
+  handlersRef.current = handlers
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const platform = shortcutPlatform()
+    const onKeyDown = (event: KeyboardEvent) => {
+      // A shortcut must not fire off the keystroke that finishes a character
+      // being composed by an IME.
+      if (event.isComposing) return
+      const typing = isTyping(event.target)
+      for (const definition of KEYBINDINGS) {
+        if (definition.scope !== 'global') continue
+        if (typing && !definition.firesWhileTyping) continue
+        const run = handlersRef.current[definition.id]
+        if (!run) continue
+        if (!matchesKeybinding(definition.id, event, platform)) continue
+        event.preventDefault()
+        run()
+        return
+      }
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [])
+}

--- a/console/web/src/hooks/use-keybindings.ts
+++ b/console/web/src/hooks/use-keybindings.ts
@@ -11,10 +11,15 @@ import { shortcutPlatform } from '@/lib/keybindings/bindings'
 import {
   KEYBINDINGS,
   type KeybindingActionId,
+  matchDigitIndex,
   matchesKeybinding,
 } from '@/lib/keybindings/registry'
 
-export type KeybindingHandlers = Partial<Record<KeybindingActionId, () => void>>
+/** A handler takes the selected index for a `digitIndex` shortcut, and
+ *  nothing for every other one. */
+export type KeybindingHandlers = Partial<
+  Record<KeybindingActionId, (index: number) => void>
+>
 
 /** Whether the keystroke is going into a field the user is typing in. */
 function isTyping(target: EventTarget | null): boolean {
@@ -44,9 +49,16 @@ export function useKeybindings(handlers: KeybindingHandlers): void {
         if (typing && !definition.firesWhileTyping) continue
         const run = handlersRef.current[definition.id]
         if (!run) continue
+        if (definition.digitIndex) {
+          const index = matchDigitIndex(definition.id, event, platform)
+          if (index === null) continue
+          event.preventDefault()
+          run(index)
+          return
+        }
         if (!matchesKeybinding(definition.id, event, platform)) continue
         event.preventDefault()
-        run()
+        run(0)
         return
       }
     }

--- a/console/web/src/lib/keybindings/bindings.test.ts
+++ b/console/web/src/lib/keybindings/bindings.test.ts
@@ -108,6 +108,14 @@ describe('bindingMatchesEvent', () => {
     )
   })
 
+  it('honours Shift when the binding names it', () => {
+    // `?` is layout-independent; `Shift+/` is a physical chord and means it.
+    expect(
+      bindingMatchesEvent('Shift+/', press('/', { shiftKey: true }), 'mac'),
+    ).toBe(true)
+    expect(bindingMatchesEvent('Shift+/', press('/'), 'mac')).toBe(false)
+  })
+
   it('does not match a different key', () => {
     expect(
       bindingMatchesEvent('Mod+K', press('j', { metaKey: true }), 'mac'),
@@ -143,6 +151,9 @@ describe('conflictIdentity', () => {
   })
 
   it('treats punctuation as one chord however it is shifted', () => {
+    // Not the matching rule, on purpose: `?` matches shifted or not, so it
+    // overlaps `Shift+?`. Registering both would fire both on one keystroke,
+    // which is exactly what the conflict check exists to refuse.
     expect(conflictIdentity('?', 'mac')).toBe(
       conflictIdentity('Shift+?', 'mac'),
     )
@@ -160,6 +171,9 @@ describe('isBrowserReserved', () => {
     expect(isBrowserReserved('Mod+W', 'mac')).toBe(true)
     expect(isBrowserReserved('Mod+T', 'other')).toBe(true)
     expect(isBrowserReserved('Mod+1', 'mac')).toBe(true)
+    // Print: delivered to the page, but not ours to take.
+    expect(isBrowserReserved('Mod+P', 'mac')).toBe(true)
+    expect(isBrowserReserved('Mod+P', 'other')).toBe(true)
     // Same chord written the platform-specific way.
     expect(isBrowserReserved('Cmd+W', 'mac')).toBe(true)
     expect(isBrowserReserved('Ctrl+W', 'other')).toBe(true)

--- a/console/web/src/lib/keybindings/bindings.test.ts
+++ b/console/web/src/lib/keybindings/bindings.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'vitest'
+import {
+  bindingMatchesEvent,
+  conflictIdentity,
+  formatBinding,
+  isBrowserReserved,
+  type KeyEventLike,
+  parseBinding,
+} from './bindings'
+
+function press(
+  key: string,
+  modifiers: Partial<KeyEventLike> = {},
+): KeyEventLike {
+  return {
+    key,
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    ...modifiers,
+  }
+}
+
+describe('parseBinding', () => {
+  it('reads modifiers and normalizes the key', () => {
+    expect(parseBinding('Mod+Shift+k')).toMatchObject({
+      mod: true,
+      shift: true,
+      key: 'K',
+    })
+  })
+
+  it('keeps a named key as written', () => {
+    expect(parseBinding('ArrowDown')?.key).toBe('ArrowDown')
+  })
+
+  it('refuses an unknown modifier', () => {
+    expect(parseBinding('Hyper+K')).toBeNull()
+  })
+
+  it('refuses a binding with no key of its own', () => {
+    expect(parseBinding('Mod+Shift')).toBeNull()
+    expect(parseBinding('')).toBeNull()
+  })
+})
+
+describe('bindingMatchesEvent', () => {
+  it('resolves Mod per platform', () => {
+    expect(
+      bindingMatchesEvent('Mod+K', press('k', { metaKey: true }), 'mac'),
+    ).toBe(true)
+    expect(
+      bindingMatchesEvent('Mod+K', press('k', { ctrlKey: true }), 'mac'),
+    ).toBe(false)
+    expect(
+      bindingMatchesEvent('Mod+K', press('k', { ctrlKey: true }), 'other'),
+    ).toBe(true)
+    expect(
+      bindingMatchesEvent('Mod+K', press('k', { metaKey: true }), 'other'),
+    ).toBe(false)
+  })
+
+  it('ignores the case of a letter', () => {
+    expect(
+      bindingMatchesEvent('Mod+K', press('K', { metaKey: true }), 'mac'),
+    ).toBe(true)
+  })
+
+  it('requires every modifier to match exactly', () => {
+    expect(
+      bindingMatchesEvent(
+        'Mod+K',
+        press('k', { metaKey: true, shiftKey: true }),
+        'mac',
+      ),
+    ).toBe(false)
+    expect(
+      bindingMatchesEvent(
+        'Mod+Shift+K',
+        press('k', { metaKey: true, shiftKey: true }),
+        'mac',
+      ),
+    ).toBe(true)
+  })
+
+  it('matches a bare key with no modifiers held', () => {
+    expect(bindingMatchesEvent('Escape', press('Escape'), 'mac')).toBe(true)
+    expect(
+      bindingMatchesEvent('Escape', press('Escape', { metaKey: true }), 'mac'),
+    ).toBe(false)
+  })
+
+  it('maps Space to the space key value', () => {
+    expect(bindingMatchesEvent('Space', press(' '), 'mac')).toBe(true)
+  })
+
+  it('lets punctuation carry its own shift', () => {
+    // `?` is shift and slash on a US layout and unshifted on others; both are
+    // the same shortcut to the person pressing it.
+    expect(
+      bindingMatchesEvent('?', press('?', { shiftKey: true }), 'mac'),
+    ).toBe(true)
+    expect(bindingMatchesEvent('?', press('?'), 'mac')).toBe(true)
+    // Other modifiers still have to be absent.
+    expect(bindingMatchesEvent('?', press('?', { metaKey: true }), 'mac')).toBe(
+      false,
+    )
+  })
+
+  it('does not match a different key', () => {
+    expect(
+      bindingMatchesEvent('Mod+K', press('j', { metaKey: true }), 'mac'),
+    ).toBe(false)
+  })
+})
+
+describe('formatBinding', () => {
+  it('spells the chord for the platform', () => {
+    expect(formatBinding('Mod+K', 'mac')).toEqual(['⌘', 'k'])
+    expect(formatBinding('Mod+K', 'other')).toEqual(['ctrl', 'k'])
+    expect(formatBinding('Mod+Shift+P', 'mac')).toEqual(['⌘', '⇧', 'p'])
+  })
+
+  it('labels named keys', () => {
+    expect(formatBinding('Escape', 'mac')).toEqual(['esc'])
+    expect(formatBinding('ArrowUp', 'mac')).toEqual(['↑'])
+  })
+
+  it('returns the input when it cannot parse it', () => {
+    expect(formatBinding('Hyper+K', 'mac')).toEqual(['Hyper+K'])
+  })
+})
+
+describe('conflictIdentity', () => {
+  it('collapses Mod and Cmd on a Mac, not elsewhere', () => {
+    expect(conflictIdentity('Mod+K', 'mac')).toBe(
+      conflictIdentity('Cmd+K', 'mac'),
+    )
+    expect(conflictIdentity('Mod+K', 'other')).not.toBe(
+      conflictIdentity('Cmd+K', 'other'),
+    )
+  })
+
+  it('treats punctuation as one chord however it is shifted', () => {
+    expect(conflictIdentity('?', 'mac')).toBe(
+      conflictIdentity('Shift+?', 'mac'),
+    )
+  })
+
+  it('keeps distinct chords distinct', () => {
+    expect(conflictIdentity('Mod+K', 'mac')).not.toBe(
+      conflictIdentity('Mod+Shift+K', 'mac'),
+    )
+  })
+})
+
+describe('isBrowserReserved', () => {
+  it('flags the chords a page cannot count on receiving', () => {
+    expect(isBrowserReserved('Mod+W', 'mac')).toBe(true)
+    expect(isBrowserReserved('Mod+T', 'other')).toBe(true)
+    expect(isBrowserReserved('Mod+1', 'mac')).toBe(true)
+    // Same chord written the platform-specific way.
+    expect(isBrowserReserved('Cmd+W', 'mac')).toBe(true)
+    expect(isBrowserReserved('Ctrl+W', 'other')).toBe(true)
+  })
+
+  it('reserves per platform, because the chord is per platform', () => {
+    // ctrl+N opens a window on Windows and Linux; on a Mac that menu item is
+    // ⌘N and ctrl+N is free for an app to take.
+    expect(isBrowserReserved('Ctrl+N', 'other')).toBe(true)
+    expect(isBrowserReserved('Ctrl+N', 'mac')).toBe(false)
+  })
+
+  it('leaves ordinary chords alone', () => {
+    expect(isBrowserReserved('Mod+K', 'mac')).toBe(false)
+    expect(isBrowserReserved('?', 'mac')).toBe(false)
+    expect(isBrowserReserved('Mod+Shift+K', 'other')).toBe(false)
+  })
+})

--- a/console/web/src/lib/keybindings/bindings.test.ts
+++ b/console/web/src/lib/keybindings/bindings.test.ts
@@ -172,6 +172,25 @@ describe('isBrowserReserved', () => {
     expect(isBrowserReserved('Ctrl+N', 'mac')).toBe(false)
   })
 
+  it('reserves the Mac-only menu chords', () => {
+    // The obvious chord for a settings screen opens Chrome's preferences.
+    expect(isBrowserReserved('Mod+,', 'mac')).toBe(true)
+    expect(isBrowserReserved('Mod+,', 'other')).toBe(false)
+  })
+
+  it('leaves bare keys alone, which is why the console uses them', () => {
+    for (const binding of ['1', 't', ',', '\\', '?']) {
+      expect({ binding, mac: isBrowserReserved(binding, 'mac') }).toEqual({
+        binding,
+        mac: false,
+      })
+      expect({ binding, other: isBrowserReserved(binding, 'other') }).toEqual({
+        binding,
+        other: false,
+      })
+    }
+  })
+
   it('leaves ordinary chords alone', () => {
     expect(isBrowserReserved('Mod+K', 'mac')).toBe(false)
     expect(isBrowserReserved('?', 'mac')).toBe(false)

--- a/console/web/src/lib/keybindings/bindings.ts
+++ b/console/web/src/lib/keybindings/bindings.ts
@@ -1,0 +1,218 @@
+/**
+ * Binding strings, and the three things the console does with them: format one
+ * for the reader's keyboard, test a key event against one, and decide whether
+ * two of them collide.
+ *
+ * A binding is modifiers and a key joined by `+`: `Mod+K`, `Mod+Shift+P`,
+ * `Escape`, `?`. `Mod` is the platform's primary modifier, so a binding is
+ * written once and reads as ⌘ on a Mac and Ctrl everywhere else. Nothing here
+ * knows what any binding DOES; that is the registry's job.
+ */
+
+export type Platform = 'mac' | 'other'
+
+export type ParsedBinding = {
+  mod: boolean
+  meta: boolean
+  ctrl: boolean
+  alt: boolean
+  shift: boolean
+  key: string
+}
+
+const MODIFIERS = ['Mod', 'Cmd', 'Ctrl', 'Alt', 'Shift'] as const
+
+/** Named keys, canonical token to the `KeyboardEvent.key` value it matches. */
+const NAMED_KEYS: Record<string, string> = {
+  Escape: 'Escape',
+  Enter: 'Enter',
+  Tab: 'Tab',
+  Space: ' ',
+  Backspace: 'Backspace',
+  Delete: 'Delete',
+  ArrowUp: 'ArrowUp',
+  ArrowDown: 'ArrowDown',
+  ArrowLeft: 'ArrowLeft',
+  ArrowRight: 'ArrowRight',
+}
+
+/** How each token prints. Modifiers differ per platform; keys do not. */
+const KEY_LABELS: Record<string, string> = {
+  Escape: 'esc',
+  Enter: '↵',
+  Tab: 'tab',
+  Space: 'space',
+  Backspace: '⌫',
+  Delete: 'del',
+  ArrowUp: '↑',
+  ArrowDown: '↓',
+  ArrowLeft: '←',
+  ArrowRight: '→',
+}
+
+export function shortcutPlatform(): Platform {
+  if (typeof navigator === 'undefined') return 'other'
+  return /Mac|iPhone|iPad|iPod/.test(navigator.userAgent) ? 'mac' : 'other'
+}
+
+/** A letter or digit is compared case-insensitively; anything else is a key
+ *  value in its own right (`?`, `,`, `/`). */
+function isAlphanumericToken(key: string): boolean {
+  return /^[A-Za-z0-9]$/.test(key)
+}
+
+function isNamedToken(key: string): boolean {
+  return key in NAMED_KEYS
+}
+
+/**
+ * Punctuation carries its own shift state: `?` IS shift and slash on a US
+ * layout and an unshifted key elsewhere, so comparing the shift flag would
+ * make the binding layout-dependent. `Shift+/` stays available for anyone who
+ * means the physical chord.
+ */
+function isPunctuationToken(key: string): boolean {
+  return !isAlphanumericToken(key) && !isNamedToken(key)
+}
+
+export function parseBinding(binding: string): ParsedBinding | null {
+  const tokens = binding.split('+').filter((token) => token !== '')
+  const key = tokens.pop()
+  if (!key) return null
+  const parsed: ParsedBinding = {
+    mod: false,
+    meta: false,
+    ctrl: false,
+    alt: false,
+    shift: false,
+    key: isAlphanumericToken(key) ? key.toUpperCase() : key,
+  }
+  for (const token of tokens) {
+    if (!(MODIFIERS as readonly string[]).includes(token)) return null
+    if (token === 'Mod') parsed.mod = true
+    if (token === 'Cmd') parsed.meta = true
+    if (token === 'Ctrl') parsed.ctrl = true
+    if (token === 'Alt') parsed.alt = true
+    if (token === 'Shift') parsed.shift = true
+  }
+  // A modifier token in the key position (`Mod+Shift`) parses as a key named
+  // `Shift`, which no event will ever carry. Refuse it outright.
+  if ((MODIFIERS as readonly string[]).includes(key)) return null
+  return parsed
+}
+
+/** `Mod` resolved: the modifier each platform's own menus use. */
+function resolveModifiers(
+  parsed: ParsedBinding,
+  platform: Platform,
+): { meta: boolean; ctrl: boolean; alt: boolean; shift: boolean } {
+  const mac = platform === 'mac'
+  return {
+    meta: parsed.meta || (parsed.mod && mac),
+    ctrl: parsed.ctrl || (parsed.mod && !mac),
+    alt: parsed.alt,
+    shift: parsed.shift,
+  }
+}
+
+export type KeyEventLike = Pick<
+  KeyboardEvent,
+  'key' | 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey'
+>
+
+export function bindingMatchesEvent(
+  binding: string,
+  event: KeyEventLike,
+  platform: Platform = shortcutPlatform(),
+): boolean {
+  const parsed = parseBinding(binding)
+  if (!parsed) return false
+  const wanted = resolveModifiers(parsed, platform)
+  if (wanted.meta !== event.metaKey) return false
+  if (wanted.ctrl !== event.ctrlKey) return false
+  if (wanted.alt !== event.altKey) return false
+  // See isPunctuationToken: the key value already encodes the shift.
+  if (!isPunctuationToken(parsed.key) && wanted.shift !== event.shiftKey) {
+    return false
+  }
+  if (isAlphanumericToken(parsed.key)) {
+    return event.key.toUpperCase() === parsed.key
+  }
+  if (isNamedToken(parsed.key)) return event.key === NAMED_KEYS[parsed.key]
+  return event.key === parsed.key
+}
+
+/** One binding as the caps to print, outermost modifier first. */
+export function formatBinding(
+  binding: string,
+  platform: Platform = shortcutPlatform(),
+): string[] {
+  const parsed = parseBinding(binding)
+  if (!parsed) return [binding]
+  const mac = platform === 'mac'
+  const caps: string[] = []
+  if (parsed.mod) caps.push(mac ? '⌘' : 'ctrl')
+  if (parsed.meta) caps.push(mac ? '⌘' : 'meta')
+  if (parsed.ctrl) caps.push(mac ? '⌃' : 'ctrl')
+  if (parsed.alt) caps.push(mac ? '⌥' : 'alt')
+  if (parsed.shift) caps.push(mac ? '⇧' : 'shift')
+  caps.push(KEY_LABELS[parsed.key] ?? parsed.key.toLowerCase())
+  return caps
+}
+
+/**
+ * The chord two bindings collide on, with `Mod` resolved for the platform:
+ * `Cmd+K` and `Mod+K` are the same chord on a Mac and different chords
+ * everywhere else, so a conflict check has to be asked about a platform.
+ */
+export function conflictIdentity(binding: string, platform: Platform): string {
+  const parsed = parseBinding(binding)
+  if (!parsed) return binding
+  const resolved = resolveModifiers(parsed, platform)
+  return [
+    resolved.meta ? 'meta' : '',
+    resolved.ctrl ? 'ctrl' : '',
+    resolved.alt ? 'alt' : '',
+    // Punctuation ignores shift when matching, so it must ignore it here too,
+    // or `?` and `Shift+?` would read as two free chords and both fire.
+    resolved.shift && !isPunctuationToken(parsed.key) ? 'shift' : '',
+    parsed.key,
+  ].join('+')
+}
+
+/**
+ * Chords the browser keeps for itself, as window and tab management.
+ *
+ * This is where a desktop app's shortcut table stops porting to a page: an
+ * Electron shell can claim ⌘W or ⌘T before the web contents see them, and a
+ * tab cannot. A binding listed here would show up in the shortcut overlay and
+ * then do nothing, which is worse than having no shortcut at all, so the
+ * registry's own test refuses one.
+ *
+ * Reservation is per-platform, because the chord is: `Ctrl+N` opens a window
+ * on Windows and Linux and is an ordinary free chord on a Mac, where the same
+ * menu item is ⌘N. Written with `Mod` so each entry covers whichever modifier
+ * the platform's own menus use.
+ */
+export const BROWSER_RESERVED: readonly string[] = [
+  'Mod+W',
+  'Mod+T',
+  'Mod+N',
+  'Mod+Q',
+  'Mod+Shift+W',
+  'Mod+Shift+N',
+  'Mod+Shift+T',
+  // Tab selection by number, which is the shortcut a tabbed app reaches for
+  // first and the one a page is least likely to receive.
+  ...Array.from({ length: 9 }, (_, index) => `Mod+${index + 1}`),
+]
+
+export function isBrowserReserved(
+  binding: string,
+  platform: Platform,
+): boolean {
+  const identities = new Set(
+    BROWSER_RESERVED.map((reserved) => conflictIdentity(reserved, platform)),
+  )
+  return identities.has(conflictIdentity(binding, platform))
+}

--- a/console/web/src/lib/keybindings/bindings.ts
+++ b/console/web/src/lib/keybindings/bindings.ts
@@ -131,8 +131,13 @@ export function bindingMatchesEvent(
   if (wanted.meta !== event.metaKey) return false
   if (wanted.ctrl !== event.ctrlKey) return false
   if (wanted.alt !== event.altKey) return false
-  // See isPunctuationToken: the key value already encodes the shift.
-  if (!isPunctuationToken(parsed.key) && wanted.shift !== event.shiftKey) {
+  // See isPunctuationToken: the key value already encodes the shift, so `?`
+  // matches however the layout produces it. A binding that NAMES Shift means
+  // the physical chord, and gets the ordinary comparison.
+  if (
+    (!isPunctuationToken(parsed.key) || parsed.shift) &&
+    wanted.shift !== event.shiftKey
+  ) {
     return false
   }
   if (isAlphanumericToken(parsed.key)) {
@@ -173,8 +178,9 @@ export function conflictIdentity(binding: string, platform: Platform): string {
     resolved.meta ? 'meta' : '',
     resolved.ctrl ? 'ctrl' : '',
     resolved.alt ? 'alt' : '',
-    // Punctuation ignores shift when matching, so it must ignore it here too,
-    // or `?` and `Shift+?` would read as two free chords and both fire.
+    // Deliberately NOT the matching rule. `?` matches with or without shift,
+    // so it overlaps `Shift+?` even though the two match differently: register
+    // both and one keystroke fires both. They have to collide here.
     resolved.shift && !isPunctuationToken(parsed.key) ? 'shift' : '',
     parsed.key,
   ].join('+')
@@ -199,6 +205,10 @@ export const BROWSER_RESERVED: readonly string[] = [
   'Mod+T',
   'Mod+N',
   'Mod+Q',
+  // Print is the odd one out: the page does receive it and could preventDefault
+  // it. It is listed because taking Print away from the reader is its own kind
+  // of broken, not because the keystroke never arrives.
+  'Mod+P',
   'Mod+Shift+W',
   'Mod+Shift+N',
   'Mod+Shift+T',

--- a/console/web/src/lib/keybindings/bindings.ts
+++ b/console/web/src/lib/keybindings/bindings.ts
@@ -207,12 +207,29 @@ export const BROWSER_RESERVED: readonly string[] = [
   ...Array.from({ length: 9 }, (_, index) => `Mod+${index + 1}`),
 ]
 
+/**
+ * Reserved on macOS only, where the browser's own menus sit on Command and
+ * the equivalent chord is free on Windows and Linux. `Mod+,` is the trap
+ * worth naming: it is the obvious chord for a settings screen and it opens
+ * Chrome's own preferences.
+ */
+export const MAC_RESERVED: readonly string[] = ['Mod+,', 'Mod+[', 'Mod+]']
+
 export function isBrowserReserved(
   binding: string,
   platform: Platform,
 ): boolean {
+  const reserved = [
+    ...BROWSER_RESERVED,
+    ...(platform === 'mac' ? MAC_RESERVED : []),
+  ]
   const identities = new Set(
-    BROWSER_RESERVED.map((reserved) => conflictIdentity(reserved, platform)),
+    reserved.map((entry) => conflictIdentity(entry, platform)),
   )
   return identities.has(conflictIdentity(binding, platform))
+}
+
+/** The digit a keystroke carries, for shortcuts that select by position. */
+export function digitFromEvent(event: KeyEventLike): string | null {
+  return /^[1-9]$/.test(event.key) ? event.key : null
 }

--- a/console/web/src/lib/keybindings/registry.test.ts
+++ b/console/web/src/lib/keybindings/registry.test.ts
@@ -6,6 +6,7 @@ import {
   keybinding,
   keybindingConflicts,
   keybindingGroups,
+  matchDigitIndex,
   matchesKeybinding,
   resolveBindings,
 } from './registry'
@@ -129,6 +130,66 @@ describe('matchesKeybinding', () => {
         'mac',
       ),
     ).toBe(false)
+  })
+})
+
+describe('matchDigitIndex', () => {
+  function digit(key: string) {
+    return {
+      key,
+      metaKey: false,
+      ctrlKey: false,
+      altKey: false,
+      shiftKey: false,
+    }
+  }
+
+  it('returns the position the digit selects, zero based', () => {
+    expect(matchDigitIndex('workspace.selectByIndex', digit('1'), 'mac')).toBe(
+      0,
+    )
+    expect(matchDigitIndex('workspace.selectByIndex', digit('9'), 'mac')).toBe(
+      8,
+    )
+  })
+
+  it('fires for every digit, not just the one stored', () => {
+    expect(bindingsFor('workspace.selectByIndex', 'mac')).toEqual(['1'])
+    for (let value = 1; value <= 9; value++) {
+      expect(
+        matchDigitIndex('workspace.selectByIndex', digit(String(value)), 'mac'),
+      ).toBe(value - 1)
+    }
+  })
+
+  it('ignores a keystroke that is not a digit, and zero', () => {
+    expect(
+      matchDigitIndex('workspace.selectByIndex', digit('0'), 'mac'),
+    ).toBeNull()
+    expect(
+      matchDigitIndex('workspace.selectByIndex', digit('t'), 'mac'),
+    ).toBeNull()
+  })
+
+  it('does not fire when a modifier is held', () => {
+    expect(
+      matchDigitIndex(
+        'workspace.selectByIndex',
+        { ...digit('1'), metaKey: true },
+        'mac',
+      ),
+    ).toBeNull()
+  })
+
+  it('returns null for a shortcut that does not select by position', () => {
+    expect(matchDigitIndex('palette.toggle', digit('1'), 'mac')).toBeNull()
+  })
+
+  it('reserves all nine digits, so nothing else may take one', () => {
+    // Proven by the conflict check: a second shortcut on `5` would collide
+    // with the row that stores `1`.
+    const identities = keybindingConflicts('mac')
+    expect(identities).toEqual([])
   })
 })
 

--- a/console/web/src/lib/keybindings/registry.test.ts
+++ b/console/web/src/lib/keybindings/registry.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest'
+import { isBrowserReserved, type Platform, parseBinding } from './bindings'
+import {
+  bindingsFor,
+  KEYBINDINGS,
+  keybinding,
+  keybindingConflicts,
+  keybindingGroups,
+  matchesKeybinding,
+  resolveBindings,
+} from './registry'
+
+const PLATFORMS: Platform[] = ['mac', 'other']
+
+describe('the registry itself', () => {
+  it('has no two shortcuts fighting over a chord, on either platform', () => {
+    for (const platform of PLATFORMS) {
+      expect(keybindingConflicts(platform)).toEqual([])
+    }
+  })
+
+  it('claims no chord the browser owns, on either platform', () => {
+    for (const platform of PLATFORMS) {
+      for (const definition of KEYBINDINGS) {
+        for (const binding of resolveBindings(definition.bindings, platform)) {
+          expect({
+            id: definition.id,
+            platform,
+            binding,
+            reserved: isBrowserReserved(binding, platform),
+          }).toEqual({ id: definition.id, platform, binding, reserved: false })
+        }
+      }
+    }
+  })
+
+  it('parses every binding it declares', () => {
+    for (const platform of PLATFORMS) {
+      for (const definition of KEYBINDINGS) {
+        const bindings = resolveBindings(definition.bindings, platform)
+        expect(bindings.length).toBeGreaterThan(0)
+        for (const binding of bindings) {
+          expect({ binding, parsed: parseBinding(binding) !== null }).toEqual({
+            binding,
+            parsed: true,
+          })
+        }
+      }
+    }
+  })
+
+  it('gives every entry a title and a group to be listed under', () => {
+    for (const definition of KEYBINDINGS) {
+      expect(definition.title.length).toBeGreaterThan(0)
+      expect(definition.group.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('uses each id once', () => {
+    const ids = KEYBINDINGS.map((definition) => definition.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+})
+
+describe('lookup', () => {
+  it('finds a definition by id', () => {
+    expect(keybinding('palette.toggle').bindings).toEqual(['Mod+K'])
+    expect(bindingsFor('shortcuts.open', 'mac')).toEqual(['?'])
+  })
+
+  it('resolves a per-platform binding list', () => {
+    expect(bindingsFor('palette.next', 'mac')).toEqual(['ArrowDown', 'Ctrl+N'])
+    expect(bindingsFor('palette.next', 'other')).toEqual(['ArrowDown'])
+  })
+
+  it('lets the palette be reached from a field, and the overlay not', () => {
+    expect(keybinding('palette.toggle').firesWhileTyping).toBe(true)
+    expect(keybinding('shortcuts.open').firesWhileTyping).toBeUndefined()
+  })
+})
+
+describe('matchesKeybinding', () => {
+  it('matches any of an action’s bindings', () => {
+    const press = {
+      key: 'n',
+      metaKey: false,
+      ctrlKey: true,
+      altKey: false,
+      shiftKey: false,
+    }
+    expect(matchesKeybinding('palette.next', press, 'mac')).toBe(true)
+    expect(
+      matchesKeybinding(
+        'palette.next',
+        {
+          key: 'ArrowDown',
+          metaKey: false,
+          ctrlKey: false,
+          altKey: false,
+          shiftKey: false,
+        },
+        'mac',
+      ),
+    ).toBe(true)
+  })
+
+  it('does not match a binding this platform does not carry', () => {
+    const ctrlN = {
+      key: 'n',
+      metaKey: false,
+      ctrlKey: true,
+      altKey: false,
+      shiftKey: false,
+    }
+    expect(matchesKeybinding('palette.next', ctrlN, 'other')).toBe(false)
+  })
+
+  it('does not match an unrelated chord', () => {
+    expect(
+      matchesKeybinding(
+        'palette.toggle',
+        {
+          key: 'k',
+          metaKey: false,
+          ctrlKey: false,
+          altKey: false,
+          shiftKey: false,
+        },
+        'mac',
+      ),
+    ).toBe(false)
+  })
+})
+
+describe('keybindingGroups', () => {
+  it('groups without losing or duplicating an entry', () => {
+    const grouped = keybindingGroups()
+    expect(grouped.flatMap(([, entries]) => entries)).toHaveLength(
+      KEYBINDINGS.length,
+    )
+  })
+
+  it('keeps registry order inside a group', () => {
+    const [, first] = keybindingGroups()[0]
+    expect(first[0].id).toBe(KEYBINDINGS[0].id)
+  })
+})

--- a/console/web/src/lib/keybindings/registry.ts
+++ b/console/web/src/lib/keybindings/registry.ts
@@ -15,8 +15,10 @@
 import {
   bindingMatchesEvent,
   conflictIdentity,
+  digitFromEvent,
   type KeyEventLike,
   type Platform,
+  parseBinding,
   shortcutPlatform,
 } from './bindings'
 
@@ -27,6 +29,10 @@ export type KeybindingScope = 'global' | 'palette'
 export type KeybindingActionId =
   | 'palette.toggle'
   | 'shortcuts.open'
+  | 'app.settings'
+  | 'workspace.selectByIndex'
+  | 'workspace.create'
+  | 'panel.split'
   | 'palette.next'
   | 'palette.previous'
   | 'palette.cycleFilter'
@@ -59,7 +65,15 @@ export type KeybindingDefinition = {
   firesWhileTyping?: boolean
   /** Extra words the palette should match on. */
   keywords?: readonly string[]
+  /**
+   * Selects by position: the binding stores one representative chord and the
+   * shortcut fires for 1 through 9, so the overlay shows a range and no other
+   * shortcut may take a digit out from under it.
+   */
+  digitIndex?: boolean
 }
+
+const DIGITS = ['1', '2', '3', '4', '5', '6', '7', '8', '9'] as const
 
 export const KEYBINDINGS: readonly KeybindingDefinition[] = [
   {
@@ -83,6 +97,44 @@ export const KEYBINDINGS: readonly KeybindingDefinition[] = [
   // Windows and Linux, where the same menu item is ⌘N on a Mac and ctrl is
   // free. ctrl+P follows it rather than quietly eating Print on one platform
   // and meaning "previous" on the other.
+  // Bare keys, not chords. The browser has already taken almost every
+  // Mod+key worth having (see BROWSER_RESERVED and MAC_RESERVED), and a page
+  // that fights it ships shortcuts that silently do nothing. Single keys are
+  // free, they are what GitHub and Linear use for the same reason, and the
+  // console already had one in `?`. None of them fire while you are typing.
+  {
+    id: 'workspace.selectByIndex',
+    title: 'Select workspace 1 to 9',
+    group: 'Workspace',
+    scope: 'global',
+    bindings: ['1'],
+    digitIndex: true,
+    keywords: ['tab', 'switch', 'workspace'],
+  },
+  {
+    id: 'workspace.create',
+    title: 'New workspace',
+    group: 'Workspace',
+    scope: 'global',
+    bindings: ['t'],
+    keywords: ['tab', 'new', 'create'],
+  },
+  {
+    id: 'panel.split',
+    title: 'Split the workspace',
+    group: 'Workspace',
+    scope: 'global',
+    bindings: ['\\'],
+    keywords: ['panel', 'column', 'split'],
+  },
+  {
+    id: 'app.settings',
+    title: 'Open settings',
+    group: 'Console',
+    scope: 'global',
+    bindings: [','],
+    keywords: ['configuration', 'preferences'],
+  },
   {
     id: 'palette.next',
     title: 'Next result',
@@ -159,6 +211,32 @@ export function matchesKeybinding(
   )
 }
 
+/**
+ * The index a keystroke selects, for a `digitIndex` shortcut: the stored
+ * chord's modifiers with the pressed digit swapped in. Returns null when this
+ * keystroke is not that shortcut.
+ */
+export function matchDigitIndex(
+  id: KeybindingActionId,
+  event: KeyEventLike,
+  platform: Platform = shortcutPlatform(),
+): number | null {
+  if (!keybinding(id).digitIndex) return null
+  const digit = digitFromEvent(event)
+  if (!digit) return null
+  for (const binding of bindingsFor(id, platform)) {
+    const parsed = parseBinding(binding)
+    if (!parsed || !DIGITS.includes(parsed.key as (typeof DIGITS)[number])) {
+      continue
+    }
+    const candidate = binding.replace(/[1-9]$/, digit)
+    if (bindingMatchesEvent(candidate, event, platform)) {
+      return Number(digit) - 1
+    }
+  }
+  return null
+}
+
 /** Overlay order: groups in first-seen order, entries in registry order. */
 export function keybindingGroups(): Array<[string, KeybindingDefinition[]]> {
   const groups = new Map<string, KeybindingDefinition[]>()
@@ -184,10 +262,17 @@ export function keybindingConflicts(platform: Platform): KeybindingConflict[] {
   const seen = new Map<string, KeybindingActionId[]>()
   for (const definition of KEYBINDINGS) {
     for (const binding of resolveBindings(definition.bindings, platform)) {
-      const chord = `${definition.scope}:${conflictIdentity(binding, platform)}`
-      const bucket = seen.get(chord)
-      if (bucket) bucket.push(definition.id)
-      else seen.set(chord, [definition.id])
+      // A digit-index row occupies all nine digits, not just the one it
+      // stores, or something else could claim `5` and both would fire.
+      const variants = definition.digitIndex
+        ? DIGITS.map((digit) => binding.replace(/[1-9]$/, digit))
+        : [binding]
+      for (const variant of variants) {
+        const chord = `${definition.scope}:${conflictIdentity(variant, platform)}`
+        const bucket = seen.get(chord)
+        if (bucket) bucket.push(definition.id)
+        else seen.set(chord, [definition.id])
+      }
     }
   }
   return [...seen]

--- a/console/web/src/lib/keybindings/registry.ts
+++ b/console/web/src/lib/keybindings/registry.ts
@@ -1,0 +1,196 @@
+/**
+ * Every keyboard shortcut the console has, in one list.
+ *
+ * The point of a registry is that nothing else gets to hold this knowledge:
+ * the shortcut overlay is generated from it, the command palette reads a row's
+ * chord from it, and the global key handler dispatches from it. A shortcut
+ * that is not here does not exist, and one that is here cannot be documented
+ * wrong.
+ *
+ * `scope` says who dispatches, not who may press: a `palette` binding is live
+ * only while the palette owns the keyboard, so it is documented here and
+ * handled there. Only `global` reaches the window listener.
+ */
+
+import {
+  bindingMatchesEvent,
+  conflictIdentity,
+  type KeyEventLike,
+  type Platform,
+  shortcutPlatform,
+} from './bindings'
+
+export type { Platform }
+
+export type KeybindingScope = 'global' | 'palette'
+
+export type KeybindingActionId =
+  | 'palette.toggle'
+  | 'shortcuts.open'
+  | 'palette.next'
+  | 'palette.previous'
+  | 'palette.cycleFilter'
+  | 'palette.choose'
+  | 'palette.close'
+
+/**
+ * One list when the chord is the same everywhere, or a chord per platform
+ * when it cannot be: a Mac's free modifier is another platform's window
+ * manager (see BROWSER_RESERVED).
+ */
+export type PlatformBindings =
+  | readonly string[]
+  | { readonly mac: readonly string[]; readonly other: readonly string[] }
+
+export type KeybindingDefinition = {
+  id: KeybindingActionId
+  /** What the shortcut does, as the overlay says it. */
+  title: string
+  /** Heading it sits under in the overlay. */
+  group: string
+  scope: KeybindingScope
+  bindings: PlatformBindings
+  /**
+   * Whether the shortcut still fires while the caret is in a field. Off by
+   * default: a bare `?` typed into the composer is a question mark, not a
+   * command. The palette is the deliberate exception, because it is how you
+   * leave wherever you are.
+   */
+  firesWhileTyping?: boolean
+  /** Extra words the palette should match on. */
+  keywords?: readonly string[]
+}
+
+export const KEYBINDINGS: readonly KeybindingDefinition[] = [
+  {
+    id: 'palette.toggle',
+    title: 'Search the console',
+    group: 'Console',
+    scope: 'global',
+    bindings: ['Mod+K'],
+    firesWhileTyping: true,
+    keywords: ['palette', 'command', 'find', 'jump'],
+  },
+  {
+    id: 'shortcuts.open',
+    title: 'Show keyboard shortcuts',
+    group: 'Console',
+    scope: 'global',
+    bindings: ['?'],
+    keywords: ['keys', 'help', 'shortcut'],
+  },
+  // The emacs pair is Mac-only on purpose: ctrl+N opens a browser window on
+  // Windows and Linux, where the same menu item is ⌘N on a Mac and ctrl is
+  // free. ctrl+P follows it rather than quietly eating Print on one platform
+  // and meaning "previous" on the other.
+  {
+    id: 'palette.next',
+    title: 'Next result',
+    group: 'Search',
+    scope: 'palette',
+    bindings: { mac: ['ArrowDown', 'Ctrl+N'], other: ['ArrowDown'] },
+  },
+  {
+    id: 'palette.previous',
+    title: 'Previous result',
+    group: 'Search',
+    scope: 'palette',
+    bindings: { mac: ['ArrowUp', 'Ctrl+P'], other: ['ArrowUp'] },
+  },
+  {
+    id: 'palette.cycleFilter',
+    title: 'Cycle the filter',
+    group: 'Search',
+    scope: 'palette',
+    bindings: ['Tab', 'Shift+Tab'],
+  },
+  {
+    id: 'palette.choose',
+    title: 'Open the selected row',
+    group: 'Search',
+    scope: 'palette',
+    bindings: ['Enter'],
+  },
+  {
+    id: 'palette.close',
+    title: 'Close the palette',
+    group: 'Search',
+    scope: 'palette',
+    bindings: ['Escape'],
+  },
+]
+
+const BY_ID = new Map(
+  KEYBINDINGS.map((definition) => [definition.id, definition]),
+)
+
+export function keybinding(id: KeybindingActionId): KeybindingDefinition {
+  const definition = BY_ID.get(id)
+  // The id type is closed, so a miss is a registry that lost an entry.
+  if (!definition) throw new Error(`unknown keybinding: ${id}`)
+  return definition
+}
+
+export function resolveBindings(
+  bindings: PlatformBindings,
+  platform: Platform,
+): readonly string[] {
+  return Array.isArray(bindings)
+    ? bindings
+    : (bindings as { mac: readonly string[]; other: readonly string[] })[
+        platform
+      ]
+}
+
+export function bindingsFor(
+  id: KeybindingActionId,
+  platform: Platform = shortcutPlatform(),
+): readonly string[] {
+  return resolveBindings(keybinding(id).bindings, platform)
+}
+
+export function matchesKeybinding(
+  id: KeybindingActionId,
+  event: KeyEventLike,
+  platform: Platform = shortcutPlatform(),
+): boolean {
+  return bindingsFor(id, platform).some((binding) =>
+    bindingMatchesEvent(binding, event, platform),
+  )
+}
+
+/** Overlay order: groups in first-seen order, entries in registry order. */
+export function keybindingGroups(): Array<[string, KeybindingDefinition[]]> {
+  const groups = new Map<string, KeybindingDefinition[]>()
+  for (const definition of KEYBINDINGS) {
+    const bucket = groups.get(definition.group)
+    if (bucket) bucket.push(definition)
+    else groups.set(definition.group, [definition])
+  }
+  return [...groups]
+}
+
+export type KeybindingConflict = {
+  chord: string
+  ids: KeybindingActionId[]
+}
+
+/**
+ * Two shortcuts collide when they share a chord AND a scope: the palette's
+ * `Escape` is free to be something else globally, because only one of them is
+ * listening at a time.
+ */
+export function keybindingConflicts(platform: Platform): KeybindingConflict[] {
+  const seen = new Map<string, KeybindingActionId[]>()
+  for (const definition of KEYBINDINGS) {
+    for (const binding of resolveBindings(definition.bindings, platform)) {
+      const chord = `${definition.scope}:${conflictIdentity(binding, platform)}`
+      const bucket = seen.get(chord)
+      if (bucket) bucket.push(definition.id)
+      else seen.set(chord, [definition.id])
+    }
+  }
+  return [...seen]
+    .filter(([, ids]) => ids.length > 1)
+    .map(([chord, ids]) => ({ chord, ids }))
+}

--- a/console/web/src/lib/palette/sources.ts
+++ b/console/web/src/lib/palette/sources.ts
@@ -27,6 +27,9 @@ export interface PaletteEntry {
   meta?: string
   /** Extra words that should match without being displayed. */
   keywords?: string[]
+  /** The keybinding that runs this row, if one is registered for it. Shown
+   *  as key caps so the palette teaches the shortcut it duplicates. */
+  shortcut?: string
   /** The row's own icon. Pages carry the icon the console already gives them,
    *  so a page looks the same here as it does in the attach menu; anything
    *  without one falls back to its category icon. */


### PR DESCRIPTION
## What

The console knew its keyboard shortcuts in three places that could not see each other: a `?` listener in `App.tsx`, a `⌘K` listener in `PaletteHost.tsx`, and a hardcoded five row array in the shortcut overlay that documented whatever someone last remembered to type into it. The palette could not show a row's chord, because nothing knew what the chords were, and the `⌘K` hint was a literal string that read wrong on every keyboard without a Command key.

There is now one registry. Each entry carries what the shortcut does, the group it is listed under, who dispatches it and the chord itself. Three surfaces are derived from it:

- **the global key handler** (`useKeybindings`), which replaces both loose window listeners
- **the shortcut overlay**, generated per group, so it cannot drift from what the keys do
- **the palette**, whose footer hints and action rows read their chords from the same place

Bindings are written once, with `Mod` for the modifier a platform's own menus use, so `⌘K` and `ctrl+K` are one entry rather than two spellings and a regex. Formatting, matching and conflict identity all resolve `Mod` the same way, which is what lets the overlay print `⌘` on a Mac and `ctrl` next to it on Linux from one source.

Two rules become properties of a shortcut rather than of whichever component implemented it:

- **Scope**, so a key can be documented without being claimed. The palette's arrows and `Escape` are listed in the overlay but dispatched inside the palette, because only one of the two is listening at a time.
- **Whether a shortcut survives a focused text field.** This was an inline tag check in the `?` handler and an unstated exception for `⌘K`.

## The shortcuts 

The registry documented four keys, all of them about the palette. The second commit adds the ones the console's own nouns deserved:

| key | does |
|---|---|
| `1`–`9` | select a workspace by position |
| `t` | new workspace |
| `\` | split the workspace into another panel |
| `,` | open settings |

None of them is a chord, and that is the finding rather than the shortcut. Every obvious chord is already spoken for: `Mod`+digit is the tab switcher in Chrome, Safari and Firefox; `Mod+,`, the chord any desktop app would use for settings, opens Chrome's own preferences on macOS; `Mod+[` and `Mod+]` are Back and Forward there too. A page cannot preempt any of them.

Bare keys are free, they are what GitHub and Linear use for the same reason, and the console already had one in `?`. The registry's typing rule is what makes them safe: none fires while the caret is in a field.

`1`–`9` stores one representative chord and fires for every digit, which is also how the conflict check knows the row occupies all nine. Out of range does nothing rather than wrapping.

`MAC_RESERVED` joins the reserved list, for chords the browser claims on one platform and not the other, so the guard stops reporting `Mod+,` as free on Linux, where it is.

## Verification

- `pnpm exec tsc -b --noEmit` clean
- `pnpm test` — 120 files, 1373 tests, all passing (66 new)
- biome clean on the touched files
- `pnpm build` clean
- Live against a local rig, driven with real key events: the overlay lists all three groups with the chords spelled for this keyboard and alternatives separated by "or"; `t` opens a workspace, `1` and `2` select the first and second, `7` with two open does nothing, `\` splits one column into two, `,` opens settings and closes it again; with the composer focused `t` and `,` type their characters and change nothing, while `⌘K` still opens the palette; the palette footer reads `↵ open`, `↑↓ select`, `tab filter`, `esc close` off the registry, and its Keyboard shortcuts row shows `?`

## One thing to look at

Creating or splitting a workspace autofocuses the new pane's "search pages" field, which is existing behaviour and correct on its own. It does mean the bare-key shortcuts stand down immediately after `t` or `\` until you click away, so chaining them needs a deliberate blur. Worth deciding separately whether an empty pane should take focus.

## Notes for review

- `bindings.ts` holds the grammar and knows nothing about what any shortcut does; `registry.ts` holds the list and knows nothing about how a chord is parsed.
- Punctuation keys ignore the shift flag when matching, because `?` is shift and slash on a US layout and unshifted elsewhere. `Shift+/` is still available for anyone who means the physical chord.
- Conflict identity resolves `Mod` per platform, so the test asks the question twice rather than assuming one keyboard.

Fixes MOT-4499


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized keyboard shortcut handling across the console.
  * Shortcuts now adapt to macOS and other platforms.
  * Updated the command palette and shortcuts dialog to display available bindings dynamically.
  * Added styled key combinations and digit-based workspace selection hints.

* **Bug Fixes**
  * Improved shortcut behavior in text fields and during IME composition.
  * Prevented handled shortcuts from triggering conflicting browser actions.

* **Tests**
  * Added comprehensive coverage for shortcut matching, formatting, conflicts, platform behavior, and registry validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->