### PR TITLE
(MOT-4463) fix(workers): allow shared dependency minor updates

### DIFF
--- a/.github/scripts/tests/test_worker_dependency_compatibility.py
+++ b/.github/scripts/tests/test_worker_dependency_compatibility.py
@@ -1,7 +1,6 @@
 """Regression tests for shared worker dependency ranges."""
 from __future__ import annotations
 
-import re
 import tomllib
 from pathlib import Path
 
@@ -9,10 +8,10 @@ import yaml
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
-BOUNDED_SHARED_DEPENDENCIES = {
-    "configuration": 0,
-    "llm-router": 1,
-    "state": 0,
+SHARED_DEPENDENCY_RANGES = {
+    "configuration": "0.x",
+    "llm-router": "1.x",
+    "state": "0.x",
 }
 
 
@@ -22,26 +21,21 @@ def dependencies(worker: str) -> dict[str, str]:
     return data.get("dependencies", {})
 
 
-def test_shared_dependencies_use_explicit_bounded_ranges() -> None:
+def test_shared_dependencies_use_major_wildcard_ranges() -> None:
     consumers: dict[str, list[str]] = {
-        dependency: [] for dependency in BOUNDED_SHARED_DEPENDENCIES
+        dependency: [] for dependency in SHARED_DEPENDENCY_RANGES
     }
 
     for manifest in sorted(REPO_ROOT.glob("*/iii.worker.yaml")):
         worker_dependencies = dependencies(manifest.parent.name)
-        for dependency, major in BOUNDED_SHARED_DEPENDENCIES.items():
+        for dependency, expected_range in SHARED_DEPENDENCY_RANGES.items():
             if dependency in worker_dependencies:
                 consumers[dependency].append(manifest.parent.name)
                 dependency_range = worker_dependencies[dependency]
-                next_major = major + 1
-                assert re.fullmatch(
-                    rf">={major}\.\d+\.\d+ <{next_major}\.0\.0",
-                    dependency_range,
-                ), (
+                assert dependency_range == expected_range, (
                     f"{manifest.relative_to(REPO_ROOT)} pins shared dependency "
-                    f"{dependency} to {dependency_range!r}; use a bounded range such as "
-                    f">={major}.0.0 <{next_major}.0.0 so compatible minor releases "
-                    f"remain allowed without crossing into {next_major}.x"
+                    f"{dependency} to {dependency_range!r}; use {expected_range!r} so "
+                    "compatible releases remain allowed without crossing majors"
                 )
 
     for dependency, workers in consumers.items():

--- a/.github/scripts/tests/test_worker_dependency_compatibility.py
+++ b/.github/scripts/tests/test_worker_dependency_compatibility.py
@@ -1,6 +1,7 @@
 """Regression tests for shared worker dependency ranges."""
 from __future__ import annotations
 
+import re
 import tomllib
 from pathlib import Path
 
@@ -8,12 +9,35 @@ import yaml
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
+BOUNDED_ZERO_MAJOR_DEPENDENCIES = ("configuration", "state")
 
 
 def dependencies(worker: str) -> dict[str, str]:
     manifest = REPO_ROOT / worker / "iii.worker.yaml"
     data = yaml.safe_load(manifest.read_text(encoding="utf-8"))
     return data.get("dependencies", {})
+
+
+def test_shared_zero_major_dependencies_keep_floor_and_allow_minor_updates() -> None:
+    consumers: dict[str, list[str]] = {
+        dependency: [] for dependency in BOUNDED_ZERO_MAJOR_DEPENDENCIES
+    }
+
+    for manifest in sorted(REPO_ROOT.glob("*/iii.worker.yaml")):
+        worker_dependencies = dependencies(manifest.parent.name)
+        for dependency in BOUNDED_ZERO_MAJOR_DEPENDENCIES:
+            if dependency in worker_dependencies:
+                consumers[dependency].append(manifest.parent.name)
+                dependency_range = worker_dependencies[dependency]
+                assert re.fullmatch(r">=0\.\d+\.\d+ <1\.0\.0", dependency_range), (
+                    f"{manifest.relative_to(REPO_ROOT)} pins shared dependency "
+                    f"{dependency} to {dependency_range!r}; use a bounded range such as "
+                    ">=0.22.0 <1.0.0 so new 0.x minor releases remain compatible "
+                    "without allowing 1.x"
+                )
+
+    for dependency, workers in consumers.items():
+        assert workers, f"expected at least one consumer of {dependency}"
 
 
 def test_approval_gate_uses_shared_runtime_dependency_ranges() -> None:

--- a/.github/scripts/tests/test_worker_dependency_compatibility.py
+++ b/.github/scripts/tests/test_worker_dependency_compatibility.py
@@ -9,7 +9,11 @@ import yaml
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
-BOUNDED_ZERO_MAJOR_DEPENDENCIES = ("configuration", "state")
+BOUNDED_SHARED_DEPENDENCIES = {
+    "configuration": 0,
+    "llm-router": 1,
+    "state": 0,
+}
 
 
 def dependencies(worker: str) -> dict[str, str]:
@@ -18,22 +22,26 @@ def dependencies(worker: str) -> dict[str, str]:
     return data.get("dependencies", {})
 
 
-def test_shared_zero_major_dependencies_keep_floor_and_allow_minor_updates() -> None:
+def test_shared_dependencies_use_explicit_bounded_ranges() -> None:
     consumers: dict[str, list[str]] = {
-        dependency: [] for dependency in BOUNDED_ZERO_MAJOR_DEPENDENCIES
+        dependency: [] for dependency in BOUNDED_SHARED_DEPENDENCIES
     }
 
     for manifest in sorted(REPO_ROOT.glob("*/iii.worker.yaml")):
         worker_dependencies = dependencies(manifest.parent.name)
-        for dependency in BOUNDED_ZERO_MAJOR_DEPENDENCIES:
+        for dependency, major in BOUNDED_SHARED_DEPENDENCIES.items():
             if dependency in worker_dependencies:
                 consumers[dependency].append(manifest.parent.name)
                 dependency_range = worker_dependencies[dependency]
-                assert re.fullmatch(r">=0\.\d+\.\d+ <1\.0\.0", dependency_range), (
+                next_major = major + 1
+                assert re.fullmatch(
+                    rf">={major}\.\d+\.\d+ <{next_major}\.0\.0",
+                    dependency_range,
+                ), (
                     f"{manifest.relative_to(REPO_ROOT)} pins shared dependency "
                     f"{dependency} to {dependency_range!r}; use a bounded range such as "
-                    ">=0.22.0 <1.0.0 so new 0.x minor releases remain compatible "
-                    "without allowing 1.x"
+                    f">={major}.0.0 <{next_major}.0.0 so compatible minor releases "
+                    f"remain allowed without crossing into {next_major}.x"
                 )
 
     for dependency, workers in consumers.items():

--- a/.github/scripts/tests/test_worker_dependency_compatibility.py
+++ b/.github/scripts/tests/test_worker_dependency_compatibility.py
@@ -10,7 +10,7 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[3]
 SHARED_DEPENDENCY_RANGES = {
     "configuration": "0.x",
-    "llm-router": "1.x",
+    "llm-router": "^1.0.0",
     "state": "0.x",
 }
 
@@ -21,7 +21,7 @@ def dependencies(worker: str) -> dict[str, str]:
     return data.get("dependencies", {})
 
 
-def test_shared_dependencies_use_major_wildcard_ranges() -> None:
+def test_shared_dependencies_use_compatible_ranges() -> None:
     consumers: dict[str, list[str]] = {
         dependency: [] for dependency in SHARED_DEPENDENCY_RANGES
     }

--- a/approval-gate/Cargo.lock
+++ b/approval-gate/Cargo.lock
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "harness"
-version = "1.8.1"
+version = "1.8.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/approval-gate/iii.worker.yaml
+++ b/approval-gate/iii.worker.yaml
@@ -9,7 +9,7 @@ tags: [approval, human-in-the-loop, permissions, policy, security]
 description: Policy and decision surface for human-held function calls — pre_trigger gate, pending inbox, per-session permission settings, and two notification trigger types.
 
 dependencies:
-  state: ">=0.22.0 <1.0.0"
-  configuration: ">=0.21.6 <1.0.0"
+  state: "0.x"
+  configuration: "0.x"
   iii-directory: "^1.0.0"
   session-manager: "^1.0.0"

--- a/approval-gate/iii.worker.yaml
+++ b/approval-gate/iii.worker.yaml
@@ -9,7 +9,7 @@ tags: [approval, human-in-the-loop, permissions, policy, security]
 description: Policy and decision surface for human-held function calls — pre_trigger gate, pending inbox, per-session permission settings, and two notification trigger types.
 
 dependencies:
-  state: "^0.22.0"
-  configuration: "^0.21.6"
+  state: ">=0.22.0 <1.0.0"
+  configuration: ">=0.21.6 <1.0.0"
   iii-directory: "^1.0.0"
   session-manager: "^1.0.0"

--- a/bridge/iii.worker.yaml
+++ b/bridge/iii.worker.yaml
@@ -12,4 +12,4 @@ config:
   expose: []
   forward: []
 dependencies:
-  configuration: ">=0.19.0 <1.0.0"
+  configuration: "0.x"

--- a/bridge/iii.worker.yaml
+++ b/bridge/iii.worker.yaml
@@ -12,4 +12,4 @@ config:
   expose: []
   forward: []
 dependencies:
-  configuration: "^0.19.0"
+  configuration: ">=0.19.0 <1.0.0"

--- a/canvas/iii.worker.yaml
+++ b/canvas/iii.worker.yaml
@@ -8,5 +8,5 @@ bin: canvas
 tags: [diagram, mermaid, flowchart, whiteboard, drawing, svg]
 description: Create, edit and render diagrams in the console — stored as editable source, drawn live in chat and on a canvas page.
 dependencies:
-  state: "^0.21.3"
-  configuration: "^0.21.6"
+  state: ">=0.21.3 <1.0.0"
+  configuration: ">=0.21.6 <1.0.0"

--- a/canvas/iii.worker.yaml
+++ b/canvas/iii.worker.yaml
@@ -8,5 +8,5 @@ bin: canvas
 tags: [diagram, mermaid, flowchart, whiteboard, drawing, svg]
 description: Create, edit and render diagrams in the console — stored as editable source, drawn live in chat and on a canvas page.
 dependencies:
-  state: ">=0.21.3 <1.0.0"
-  configuration: ">=0.21.6 <1.0.0"
+  state: "0.x"
+  configuration: "0.x"

--- a/claude-code/iii.worker.yaml
+++ b/claude-code/iii.worker.yaml
@@ -14,5 +14,5 @@ scripts:
   start: node ./index.mjs
 
 dependencies:
-  state: "^0.21.2"
+  state: ">=0.21.2 <1.0.0"
   iii-stream: "^0.21.6"

--- a/claude-code/iii.worker.yaml
+++ b/claude-code/iii.worker.yaml
@@ -14,5 +14,5 @@ scripts:
   start: node ./index.mjs
 
 dependencies:
-  state: ">=0.21.2 <1.0.0"
+  state: "0.x"
   iii-stream: "^0.21.6"

--- a/code-runner/iii.worker.yaml
+++ b/code-runner/iii.worker.yaml
@@ -7,7 +7,7 @@ bin: code-runner
 tags: [javascript, python, run, sandbox, v8, wasm]
 description: Run untrusted Node.js and Python in-process — V8 isolates and CPython-on-WebAssembly behind one run/register_function/teardown API, with no microVM and no /dev/kvm. Code gets a global `iii` and a private scratch directory.
 dependencies:
-  configuration: ">=0.21.6 <1.0.0"
+  configuration: "0.x"
 
 # Restricted for TWO independent reasons, both of which must hold before this
 # list can be widened — do not conclude it is liftable by dropping one

--- a/code-runner/iii.worker.yaml
+++ b/code-runner/iii.worker.yaml
@@ -7,7 +7,7 @@ bin: code-runner
 tags: [javascript, python, run, sandbox, v8, wasm]
 description: Run untrusted Node.js and Python in-process — V8 isolates and CPython-on-WebAssembly behind one run/register_function/teardown API, with no microVM and no /dev/kvm. Code gets a global `iii` and a private scratch directory.
 dependencies:
-  configuration: "^0.21.6"
+  configuration: ">=0.21.6 <1.0.0"
 
 # Restricted for TWO independent reasons, both of which must hold before this
 # list can be widened — do not conclude it is liftable by dropping one

--- a/context-manager/iii.worker.yaml
+++ b/context-manager/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [context, tokens, compaction, pruning, llm]
 description: Turns a raw conversation history plus a target model into a model-ready context — token counting, function-result pruning, and history compaction.
 
 dependencies:
-  configuration: ">=0.21.6 <1.0.0"
-  llm-router: ">=1.0.0 <2.0.0"
+  configuration: "0.x"
+  llm-router: "1.x"

--- a/context-manager/iii.worker.yaml
+++ b/context-manager/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [context, tokens, compaction, pruning, llm]
 description: Turns a raw conversation history plus a target model into a model-ready context — token counting, function-result pruning, and history compaction.
 
 dependencies:
-  configuration: "^0.21.6"
+  configuration: ">=0.21.6 <1.0.0"
   llm-router: "^1.0.0"

--- a/context-manager/iii.worker.yaml
+++ b/context-manager/iii.worker.yaml
@@ -10,4 +10,4 @@ description: Turns a raw conversation history plus a target model into a model-r
 
 dependencies:
   configuration: "0.x"
-  llm-router: "1.x"
+  llm-router: "^1.0.0"

--- a/context-manager/iii.worker.yaml
+++ b/context-manager/iii.worker.yaml
@@ -10,4 +10,4 @@ description: Turns a raw conversation history plus a target model into a model-r
 
 dependencies:
   configuration: ">=0.21.6 <1.0.0"
-  llm-router: "^1.0.0"
+  llm-router: ">=1.0.0 <2.0.0"

--- a/cron/iii.worker.yaml
+++ b/cron/iii.worker.yaml
@@ -11,4 +11,4 @@ config:
   adapter:
     name: local
 dependencies:
-  configuration: ">=0.21.6 <1.0.0"
+  configuration: "0.x"

--- a/cron/iii.worker.yaml
+++ b/cron/iii.worker.yaml
@@ -11,4 +11,4 @@ config:
   adapter:
     name: local
 dependencies:
-  configuration: "^0.21.6"
+  configuration: ">=0.21.6 <1.0.0"

--- a/docs/architecture/iii-worker-yaml.md
+++ b/docs/architecture/iii-worker-yaml.md
@@ -55,6 +55,13 @@ tags:
 
 Example: [`harness/iii.worker.yaml`](../../harness/iii.worker.yaml).
 
+Shared dependencies that are still on a `0.x` release line use a bounded range
+such as `>=0.22.0 <1.0.0`. Unlike a fully specified caret range such as
+`^0.22.0`, this preserves the minimum compatible version, accepts later minor
+releases, and still excludes `1.0.0` and above. This is the common form for
+`state` and `configuration`, whose compatible `0.x` releases are consumed by
+many workers.
+
 ## Example (minimal Rust binary)
 
 ```yaml

--- a/docs/architecture/iii-worker-yaml.md
+++ b/docs/architecture/iii-worker-yaml.md
@@ -55,11 +55,12 @@ tags:
 
 Example: [`harness/iii.worker.yaml`](../../harness/iii.worker.yaml).
 
-Shared dependencies use npm-style major wildcards. Workers declare `0.x` for
-`state` and `configuration`, accepting every stable `0.x` release while still
-excluding `1.0.0` and above. Consumers of `llm-router` use `1.x`, which accepts
-stable `1.x` releases and excludes `2.0.0` and above. These wildcard ranges are
-understood directly by both iii and the Registry.
+Shared dependencies that are still pre-1.0 use npm-style major wildcards.
+Workers declare `0.x` for `state` and `configuration`, accepting every stable
+`0.x` release while still excluding `1.0.0` and above. Consumers of
+`llm-router` retain `^1.0.0`: once a dependency is on a stable major, the caret
+already accepts compatible `1.x` releases and excludes `2.0.0` and above. Both
+forms are understood directly by iii and the Registry.
 
 ## Example (minimal Rust binary)
 

--- a/docs/architecture/iii-worker-yaml.md
+++ b/docs/architecture/iii-worker-yaml.md
@@ -55,16 +55,11 @@ tags:
 
 Example: [`harness/iii.worker.yaml`](../../harness/iii.worker.yaml).
 
-Shared dependencies that are still on a `0.x` release line use a bounded range
-such as `>=0.22.0 <1.0.0`. Unlike a fully specified caret range such as
-`^0.22.0`, this preserves the minimum compatible version, accepts later minor
-releases, and still excludes `1.0.0` and above. This is the common form for
-`state` and `configuration`, whose compatible `0.x` releases are consumed by
-many workers.
-
-Stable shared dependencies use the same explicit form. For example, consumers
-of `llm-router` declare `>=1.0.0 <2.0.0`, making the supported major boundary
-clear without relying on caret syntax.
+Shared dependencies use npm-style major wildcards. Workers declare `0.x` for
+`state` and `configuration`, accepting every stable `0.x` release while still
+excluding `1.0.0` and above. Consumers of `llm-router` use `1.x`, which accepts
+stable `1.x` releases and excludes `2.0.0` and above. These wildcard ranges are
+understood directly by both iii and the Registry.
 
 ## Example (minimal Rust binary)
 

--- a/docs/architecture/iii-worker-yaml.md
+++ b/docs/architecture/iii-worker-yaml.md
@@ -62,6 +62,10 @@ releases, and still excludes `1.0.0` and above. This is the common form for
 `state` and `configuration`, whose compatible `0.x` releases are consumed by
 many workers.
 
+Stable shared dependencies use the same explicit form. For example, consumers
+of `llm-router` declare `>=1.0.0 <2.0.0`, making the supported major boundary
+clear without relying on caret syntax.
+
 ## Example (minimal Rust binary)
 
 ```yaml

--- a/document/iii.worker.yaml
+++ b/document/iii.worker.yaml
@@ -8,4 +8,4 @@ bin: document
 tags: [document, markdown, docx, pptx, xlsx, epub, csv, attachments, text-extraction, ocr]
 description: Convert Word, PowerPoint, Excel, OpenDocument, RTF, EPUB, CSV and PDF documents to markdown on this machine, detect the format from the bytes, pull out the images embedded in them, and transcribe a scan by rendering its pages and reading them with a vision model.
 dependencies:
-  configuration: "^0.21.6"
+  configuration: ">=0.21.6 <1.0.0"

--- a/document/iii.worker.yaml
+++ b/document/iii.worker.yaml
@@ -8,4 +8,4 @@ bin: document
 tags: [document, markdown, docx, pptx, xlsx, epub, csv, attachments, text-extraction, ocr]
 description: Convert Word, PowerPoint, Excel, OpenDocument, RTF, EPUB, CSV and PDF documents to markdown on this machine, detect the format from the bytes, pull out the images embedded in them, and transcribe a scan by rendering its pages and reading them with a vision model.
 dependencies:
-  configuration: ">=0.21.6 <1.0.0"
+  configuration: "0.x"

--- a/editor/iii.worker.yaml
+++ b/editor/iii.worker.yaml
@@ -10,5 +10,5 @@ description: A shared code workspace — open buffers, a file tree, unified diff
 
 dependencies:
   shell: "^0.10.3"
-  state: "^0.21.3"
-  configuration: "^0.21.6"
+  state: ">=0.21.3 <1.0.0"
+  configuration: ">=0.21.6 <1.0.0"

--- a/editor/iii.worker.yaml
+++ b/editor/iii.worker.yaml
@@ -10,5 +10,5 @@ description: A shared code workspace — open buffers, a file tree, unified diff
 
 dependencies:
   shell: "^0.10.3"
-  state: ">=0.21.3 <1.0.0"
-  configuration: ">=0.21.6 <1.0.0"
+  state: "0.x"
+  configuration: "0.x"

--- a/eval/Cargo.lock
+++ b/eval/Cargo.lock
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "harness"
-version = "1.8.1"
+version = "1.8.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/eval/iii.worker.yaml
+++ b/eval/iii.worker.yaml
@@ -9,7 +9,7 @@ tags: [evaluation, benchmark, sessions, metrics, prompt, system-prompt]
 description: Compare live objective metrics for 2-5 root sessions; retain durable prompt experiments as an advanced surface.
 
 dependencies:
-  state: ">=0.21.3 <1.0.0"
+  state: "0.x"
   queue: "^0.2.0"
   cron: "^0.21.0"
   iii-observability: "^0.21.6"

--- a/eval/iii.worker.yaml
+++ b/eval/iii.worker.yaml
@@ -9,7 +9,7 @@ tags: [evaluation, benchmark, sessions, metrics, prompt, system-prompt]
 description: Compare live objective metrics for 2-5 root sessions; retain durable prompt experiments as an advanced surface.
 
 dependencies:
-  state: "^0.21.3"
+  state: ">=0.21.3 <1.0.0"
   queue: "^0.2.0"
   cron: "^0.21.0"
   iii-observability: "^0.21.6"

--- a/fp/iii.worker.yaml
+++ b/fp/iii.worker.yaml
@@ -9,4 +9,4 @@ tags: [fp, functional, pipeline, transform, lodash]
 description: Lodash-style value transforms (fp::get/pick/take/…) and fp::pipe — worker-side pipelines that move big values function→function without routing them through the model.
 
 dependencies:
-  configuration: ">=0.21.6 <1.0.0"
+  configuration: "0.x"

--- a/fp/iii.worker.yaml
+++ b/fp/iii.worker.yaml
@@ -9,4 +9,4 @@ tags: [fp, functional, pipeline, transform, lodash]
 description: Lodash-style value transforms (fp::get/pick/take/…) and fp::pipe — worker-side pipelines that move big values function→function without routing them through the model.
 
 dependencies:
-  configuration: "^0.21.6"
+  configuration: ">=0.21.6 <1.0.0"

--- a/harness/iii.worker.yaml
+++ b/harness/iii.worker.yaml
@@ -16,7 +16,7 @@ dependencies:
   iii-observability: "^0.21.6"
   iii-stream: "^0.21.6"
   iii-directory: "^1.2.0"
-  llm-router: "1.x"
+  llm-router: "^1.0.0"
   session-manager: "^1.0.0"
   context-manager: "^1.0.0"
   provider-anthropic: "^1.0.0"

--- a/harness/iii.worker.yaml
+++ b/harness/iii.worker.yaml
@@ -9,10 +9,10 @@ tags: [agent, harness, loop, autonomous]
 description: Thin durable turn loop that wires session-manager, context-manager, and llm-router into an agent loop; spawns sub-agents as child sessions.
 
 dependencies:
-  state: "^0.22.0"
+  state: ">=0.22.0 <1.0.0"
   queue: "^0.21.2"
   cron: "^0.21.0"
-  configuration: "^0.21.6"
+  configuration: ">=0.21.6 <1.0.0"
   iii-observability: "^0.21.6"
   iii-stream: "^0.21.6"
   iii-directory: "^1.2.0"

--- a/harness/iii.worker.yaml
+++ b/harness/iii.worker.yaml
@@ -16,7 +16,7 @@ dependencies:
   iii-observability: "^0.21.6"
   iii-stream: "^0.21.6"
   iii-directory: "^1.2.0"
-  llm-router: "^1.0.0"
+  llm-router: ">=1.0.0 <2.0.0"
   session-manager: "^1.0.0"
   context-manager: "^1.0.0"
   provider-anthropic: "^1.0.0"

--- a/harness/iii.worker.yaml
+++ b/harness/iii.worker.yaml
@@ -9,14 +9,14 @@ tags: [agent, harness, loop, autonomous]
 description: Thin durable turn loop that wires session-manager, context-manager, and llm-router into an agent loop; spawns sub-agents as child sessions.
 
 dependencies:
-  state: ">=0.22.0 <1.0.0"
+  state: "0.x"
   queue: "^0.21.2"
   cron: "^0.21.0"
-  configuration: ">=0.21.6 <1.0.0"
+  configuration: "0.x"
   iii-observability: "^0.21.6"
   iii-stream: "^0.21.6"
   iii-directory: "^1.2.0"
-  llm-router: ">=1.0.0 <2.0.0"
+  llm-router: "1.x"
   session-manager: "^1.0.0"
   context-manager: "^1.0.0"
   provider-anthropic: "^1.0.0"

--- a/harness/tests/manifest.rs
+++ b/harness/tests/manifest.rs
@@ -70,7 +70,7 @@ fn worker_manifest_uses_the_standalone_state_worker() {
 
     assert_eq!(
         dependencies.get(serde_yaml::Value::String("state".into())),
-        Some(&serde_yaml::Value::String("^0.22.0".into()))
+        Some(&serde_yaml::Value::String("0.x".into()))
     );
     assert!(!dependencies.contains_key(serde_yaml::Value::String("iii-state".into())));
 }

--- a/http/iii.worker.yaml
+++ b/http/iii.worker.yaml
@@ -16,4 +16,4 @@ config:
     allowed_origins: ['*']
     allowed_methods: [GET, POST, PUT, DELETE, OPTIONS]
 dependencies:
-  configuration: ">=0.21.6 <1.0.0"
+  configuration: "0.x"

--- a/http/iii.worker.yaml
+++ b/http/iii.worker.yaml
@@ -16,4 +16,4 @@ config:
     allowed_origins: ['*']
     allowed_methods: [GET, POST, PUT, DELETE, OPTIONS]
 dependencies:
-  configuration: "^0.21.6"
+  configuration: ">=0.21.6 <1.0.0"

--- a/iii-directory/iii.worker.yaml
+++ b/iii-directory/iii.worker.yaml
@@ -9,4 +9,4 @@ tags: [introspect, registry, skills, directory]
 description: Engine introspection (functions / triggers / workers), workers registry proxy, and filesystem-backed skill, prompt + system-prompt reader/editor.
 
 dependencies:
-  configuration: ">=0.21.6 <1.0.0"
+  configuration: "0.x"

--- a/iii-directory/iii.worker.yaml
+++ b/iii-directory/iii.worker.yaml
@@ -9,4 +9,4 @@ tags: [introspect, registry, skills, directory]
 description: Engine introspection (functions / triggers / workers), workers registry proxy, and filesystem-backed skill, prompt + system-prompt reader/editor.
 
 dependencies:
-  configuration: "^0.21.6"
+  configuration: ">=0.21.6 <1.0.0"

--- a/llm-router/iii.worker.yaml
+++ b/llm-router/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, router, models, providers]
 description: One front door + provider protocol in front of every LLM provider.
 
 dependencies:
-  state: ">=0.22.0 <1.0.0"
-  configuration: ">=0.21.6 <1.0.0"
+  state: "0.x"
+  configuration: "0.x"

--- a/llm-router/iii.worker.yaml
+++ b/llm-router/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, router, models, providers]
 description: One front door + provider protocol in front of every LLM provider.
 
 dependencies:
-  state: "^0.22.0"
-  configuration: "^0.21.6"
+  state: ">=0.22.0 <1.0.0"
+  configuration: ">=0.21.6 <1.0.0"

--- a/memory-consolidate/iii.worker.yaml
+++ b/memory-consolidate/iii.worker.yaml
@@ -10,5 +10,5 @@ description: Scheduled hygiene for the memory worker — deterministic dedup of 
 
 dependencies:
   memory: "^0.1.0"
-  configuration: ">=0.21.3 <1.0.0"
-  state: ">=0.21.2 <1.0.0"
+  configuration: "0.x"
+  state: "0.x"

--- a/memory-consolidate/iii.worker.yaml
+++ b/memory-consolidate/iii.worker.yaml
@@ -10,5 +10,5 @@ description: Scheduled hygiene for the memory worker — deterministic dedup of 
 
 dependencies:
   memory: "^0.1.0"
-  configuration: "^0.21.3"
-  state: "^0.21.2"
+  configuration: ">=0.21.3 <1.0.0"
+  state: ">=0.21.2 <1.0.0"

--- a/memory/iii.worker.yaml
+++ b/memory/iii.worker.yaml
@@ -11,6 +11,6 @@ description: Durable cross-session agent memory — named banks of always-inject
 dependencies:
   configuration: ">=0.21.3 <1.0.0"
   session-manager: "^1.0.0"
-  llm-router: "^1.0.0"
+  llm-router: ">=1.0.0 <2.0.0"
   state: ">=0.21.2 <1.0.0"
   queue: "^0.2.0"

--- a/memory/iii.worker.yaml
+++ b/memory/iii.worker.yaml
@@ -9,8 +9,8 @@ tags: [memory, rag, bm25, recall, agent, context]
 description: Durable cross-session agent memory — named banks of always-injected markdown rules and auto-extracted memories, hybrid BM25 + entity recall, pinning, and supersede-never-delete history. Plain files on disk; every operation is a traced function.
 
 dependencies:
-  configuration: ">=0.21.3 <1.0.0"
+  configuration: "0.x"
   session-manager: "^1.0.0"
-  llm-router: ">=1.0.0 <2.0.0"
-  state: ">=0.21.2 <1.0.0"
+  llm-router: "1.x"
+  state: "0.x"
   queue: "^0.2.0"

--- a/memory/iii.worker.yaml
+++ b/memory/iii.worker.yaml
@@ -9,8 +9,8 @@ tags: [memory, rag, bm25, recall, agent, context]
 description: Durable cross-session agent memory — named banks of always-injected markdown rules and auto-extracted memories, hybrid BM25 + entity recall, pinning, and supersede-never-delete history. Plain files on disk; every operation is a traced function.
 
 dependencies:
-  configuration: "^0.21.3"
+  configuration: ">=0.21.3 <1.0.0"
   session-manager: "^1.0.0"
   llm-router: "^1.0.0"
-  state: "^0.21.2"
+  state: ">=0.21.2 <1.0.0"
   queue: "^0.2.0"

--- a/memory/iii.worker.yaml
+++ b/memory/iii.worker.yaml
@@ -11,6 +11,6 @@ description: Durable cross-session agent memory — named banks of always-inject
 dependencies:
   configuration: "0.x"
   session-manager: "^1.0.0"
-  llm-router: "1.x"
+  llm-router: "^1.0.0"
   state: "0.x"
   queue: "^0.2.0"

--- a/opencode/iii.worker.yaml
+++ b/opencode/iii.worker.yaml
@@ -14,5 +14,5 @@ scripts:
   start: node ./index.mjs
 
 dependencies:
-  state: "^0.21.2"
+  state: ">=0.21.2 <1.0.0"
   iii-stream: "^0.21.6"

--- a/opencode/iii.worker.yaml
+++ b/opencode/iii.worker.yaml
@@ -14,5 +14,5 @@ scripts:
   start: node ./index.mjs
 
 dependencies:
-  state: ">=0.21.2 <1.0.0"
+  state: "0.x"
   iii-stream: "^0.21.6"

--- a/openwiki/iii.worker.yaml
+++ b/openwiki/iii.worker.yaml
@@ -16,4 +16,4 @@ scripts:
 dependencies:
   state: "0.x"
   cron: "^0.21.0"
-  llm-router: "1.x"
+  llm-router: "^1.0.0"

--- a/openwiki/iii.worker.yaml
+++ b/openwiki/iii.worker.yaml
@@ -16,4 +16,4 @@ scripts:
 dependencies:
   state: ">=0.21.2 <1.0.0"
   cron: "^0.21.0"
-  llm-router: "^1.0.0"
+  llm-router: ">=1.0.0 <2.0.0"

--- a/openwiki/iii.worker.yaml
+++ b/openwiki/iii.worker.yaml
@@ -14,6 +14,6 @@ scripts:
   start: node ./index.mjs
 
 dependencies:
-  state: "^0.21.2"
+  state: ">=0.21.2 <1.0.0"
   cron: "^0.21.0"
   llm-router: "^1.0.0"

--- a/openwiki/iii.worker.yaml
+++ b/openwiki/iii.worker.yaml
@@ -14,6 +14,6 @@ scripts:
   start: node ./index.mjs
 
 dependencies:
-  state: ">=0.21.2 <1.0.0"
+  state: "0.x"
   cron: "^0.21.0"
-  llm-router: ">=1.0.0 <2.0.0"
+  llm-router: "1.x"

--- a/pdf/iii.worker.yaml
+++ b/pdf/iii.worker.yaml
@@ -8,4 +8,4 @@ bin: pdf
 tags: [pdf, document, markdown, text-extraction, ocr-routing, tables]
 description: Read PDFs locally — classify text-based vs scanned, convert to markdown, extract positioned text and tables, and report which pages still need OCR.
 dependencies:
-  configuration: "^0.21.6"
+  configuration: ">=0.21.6 <1.0.0"

--- a/pdf/iii.worker.yaml
+++ b/pdf/iii.worker.yaml
@@ -8,4 +8,4 @@ bin: pdf
 tags: [pdf, document, markdown, text-extraction, ocr-routing, tables]
 description: Read PDFs locally — classify text-based vs scanned, convert to markdown, extract positioned text and tables, and report which pages still need OCR.
 dependencies:
-  configuration: ">=0.21.6 <1.0.0"
+  configuration: "0.x"

--- a/pi/iii.worker.yaml
+++ b/pi/iii.worker.yaml
@@ -14,5 +14,5 @@ scripts:
   start: node ./index.mjs
 
 dependencies:
-  state: "^0.21.2"
+  state: ">=0.21.2 <1.0.0"
   iii-stream: "^0.21.6"

--- a/pi/iii.worker.yaml
+++ b/pi/iii.worker.yaml
@@ -14,5 +14,5 @@ scripts:
   start: node ./index.mjs
 
 dependencies:
-  state: ">=0.21.2 <1.0.0"
+  state: "0.x"
   iii-stream: "^0.21.6"

--- a/provider-anthropic/iii.worker.yaml
+++ b/provider-anthropic/iii.worker.yaml
@@ -10,4 +10,4 @@ description: Anthropic Messages API provider worker; implements provider::anthro
 
 dependencies:
   state: "0.x"
-  llm-router: "1.x"
+  llm-router: "^1.0.0"

--- a/provider-anthropic/iii.worker.yaml
+++ b/provider-anthropic/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, anthropic, claude, messages, provider]
 description: Anthropic Messages API provider worker; implements provider::anthropic::stream and provider::anthropic::refresh_models behind llm-router.
 
 dependencies:
-  state: "^0.22.0"
+  state: ">=0.22.0 <1.0.0"
   llm-router: "^1.0.0"

--- a/provider-anthropic/iii.worker.yaml
+++ b/provider-anthropic/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, anthropic, claude, messages, provider]
 description: Anthropic Messages API provider worker; implements provider::anthropic::stream and provider::anthropic::refresh_models behind llm-router.
 
 dependencies:
-  state: ">=0.22.0 <1.0.0"
-  llm-router: ">=1.0.0 <2.0.0"
+  state: "0.x"
+  llm-router: "1.x"

--- a/provider-anthropic/iii.worker.yaml
+++ b/provider-anthropic/iii.worker.yaml
@@ -10,4 +10,4 @@ description: Anthropic Messages API provider worker; implements provider::anthro
 
 dependencies:
   state: ">=0.22.0 <1.0.0"
-  llm-router: "^1.0.0"
+  llm-router: ">=1.0.0 <2.0.0"

--- a/provider-claude-code/iii.worker.yaml
+++ b/provider-claude-code/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, anthropic, claude, claude-code, subscription, provider]
 description: Claude Code (Pro/Max subscription) Messages API provider worker; implements provider::claude-code::stream and provider::claude-code::refresh_models behind llm-router, using OAuth credentials from the auth-credentials vault or ~/.claude/.credentials.json.
 
 dependencies:
-  state: "^0.22.0"
+  state: ">=0.22.0 <1.0.0"
   llm-router: "^1.0.0"

--- a/provider-claude-code/iii.worker.yaml
+++ b/provider-claude-code/iii.worker.yaml
@@ -10,4 +10,4 @@ description: Claude Code (Pro/Max subscription) Messages API provider worker; im
 
 dependencies:
   state: "0.x"
-  llm-router: "1.x"
+  llm-router: "^1.0.0"

--- a/provider-claude-code/iii.worker.yaml
+++ b/provider-claude-code/iii.worker.yaml
@@ -10,4 +10,4 @@ description: Claude Code (Pro/Max subscription) Messages API provider worker; im
 
 dependencies:
   state: ">=0.22.0 <1.0.0"
-  llm-router: "^1.0.0"
+  llm-router: ">=1.0.0 <2.0.0"

--- a/provider-claude-code/iii.worker.yaml
+++ b/provider-claude-code/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, anthropic, claude, claude-code, subscription, provider]
 description: Claude Code (Pro/Max subscription) Messages API provider worker; implements provider::claude-code::stream and provider::claude-code::refresh_models behind llm-router, using OAuth credentials from the auth-credentials vault or ~/.claude/.credentials.json.
 
 dependencies:
-  state: ">=0.22.0 <1.0.0"
-  llm-router: ">=1.0.0 <2.0.0"
+  state: "0.x"
+  llm-router: "1.x"

--- a/provider-deepseek/iii.worker.yaml
+++ b/provider-deepseek/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, deepseek, chat-completions, provider]
 description: DeepSeek Chat Completions provider worker; implements provider::deepseek::stream and provider::deepseek::refresh_models behind llm-router.
 
 dependencies:
-  state: ">=0.22.0 <1.0.0"
-  llm-router: ">=1.0.0 <2.0.0"
+  state: "0.x"
+  llm-router: "1.x"

--- a/provider-deepseek/iii.worker.yaml
+++ b/provider-deepseek/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, deepseek, chat-completions, provider]
 description: DeepSeek Chat Completions provider worker; implements provider::deepseek::stream and provider::deepseek::refresh_models behind llm-router.
 
 dependencies:
-  state: "^0.22.0"
+  state: ">=0.22.0 <1.0.0"
   llm-router: "^1.0.0"

--- a/provider-deepseek/iii.worker.yaml
+++ b/provider-deepseek/iii.worker.yaml
@@ -10,4 +10,4 @@ description: DeepSeek Chat Completions provider worker; implements provider::dee
 
 dependencies:
   state: "0.x"
-  llm-router: "1.x"
+  llm-router: "^1.0.0"

--- a/provider-deepseek/iii.worker.yaml
+++ b/provider-deepseek/iii.worker.yaml
@@ -10,4 +10,4 @@ description: DeepSeek Chat Completions provider worker; implements provider::dee
 
 dependencies:
   state: ">=0.22.0 <1.0.0"
-  llm-router: "^1.0.0"
+  llm-router: ">=1.0.0 <2.0.0"

--- a/provider-github-copilot/iii.worker.yaml
+++ b/provider-github-copilot/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, github, copilot, subscription, chat-completions, provider]
 description: GitHub Copilot subscription provider worker; sign in with GitHub once and the models the plan grants appear in the picker. Implements provider::github-copilot::stream, refresh_models, and a device-flow login surface behind llm-router.
 
 dependencies:
-  state: "^0.22.0"
+  state: ">=0.22.0 <1.0.0"
   llm-router: "^1.0.0"

--- a/provider-github-copilot/iii.worker.yaml
+++ b/provider-github-copilot/iii.worker.yaml
@@ -10,4 +10,4 @@ description: GitHub Copilot subscription provider worker; sign in with GitHub on
 
 dependencies:
   state: "0.x"
-  llm-router: "1.x"
+  llm-router: "^1.0.0"

--- a/provider-github-copilot/iii.worker.yaml
+++ b/provider-github-copilot/iii.worker.yaml
@@ -10,4 +10,4 @@ description: GitHub Copilot subscription provider worker; sign in with GitHub on
 
 dependencies:
   state: ">=0.22.0 <1.0.0"
-  llm-router: "^1.0.0"
+  llm-router: ">=1.0.0 <2.0.0"

--- a/provider-github-copilot/iii.worker.yaml
+++ b/provider-github-copilot/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, github, copilot, subscription, chat-completions, provider]
 description: GitHub Copilot subscription provider worker; sign in with GitHub once and the models the plan grants appear in the picker. Implements provider::github-copilot::stream, refresh_models, and a device-flow login surface behind llm-router.
 
 dependencies:
-  state: ">=0.22.0 <1.0.0"
-  llm-router: ">=1.0.0 <2.0.0"
+  state: "0.x"
+  llm-router: "1.x"

--- a/provider-kimi/iii.worker.yaml
+++ b/provider-kimi/iii.worker.yaml
@@ -10,4 +10,4 @@ description: Moonshot (Kimi) Chat Completions provider worker; implements provid
 
 dependencies:
   state: "0.x"
-  llm-router: "1.x"
+  llm-router: "^1.0.0"

--- a/provider-kimi/iii.worker.yaml
+++ b/provider-kimi/iii.worker.yaml
@@ -10,4 +10,4 @@ description: Moonshot (Kimi) Chat Completions provider worker; implements provid
 
 dependencies:
   state: ">=0.22.0 <1.0.0"
-  llm-router: "^1.0.0"
+  llm-router: ">=1.0.0 <2.0.0"

--- a/provider-kimi/iii.worker.yaml
+++ b/provider-kimi/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, kimi, moonshot, chat-completions, provider]
 description: Moonshot (Kimi) Chat Completions provider worker; implements provider::kimi::stream and provider::kimi::refresh_models behind llm-router.
 
 dependencies:
-  state: "^0.22.0"
+  state: ">=0.22.0 <1.0.0"
   llm-router: "^1.0.0"

--- a/provider-kimi/iii.worker.yaml
+++ b/provider-kimi/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, kimi, moonshot, chat-completions, provider]
 description: Moonshot (Kimi) Chat Completions provider worker; implements provider::kimi::stream and provider::kimi::refresh_models behind llm-router.
 
 dependencies:
-  state: ">=0.22.0 <1.0.0"
-  llm-router: ">=1.0.0 <2.0.0"
+  state: "0.x"
+  llm-router: "1.x"

--- a/provider-llamacpp/iii.worker.yaml
+++ b/provider-llamacpp/iii.worker.yaml
@@ -10,4 +10,4 @@ description: llama.cpp server (llama-server) Chat Completions provider worker; i
 
 dependencies:
   state: "0.x"
-  llm-router: "1.x"
+  llm-router: "^1.0.0"

--- a/provider-llamacpp/iii.worker.yaml
+++ b/provider-llamacpp/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, llama.cpp, local, open-source, provider]
 description: llama.cpp server (llama-server) Chat Completions provider worker; implements provider::llamacpp::stream and provider::llamacpp::refresh_models behind llm-router.
 
 dependencies:
-  state: "^0.22.0"
+  state: ">=0.22.0 <1.0.0"
   llm-router: "^1.0.0"

--- a/provider-llamacpp/iii.worker.yaml
+++ b/provider-llamacpp/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, llama.cpp, local, open-source, provider]
 description: llama.cpp server (llama-server) Chat Completions provider worker; implements provider::llamacpp::stream and provider::llamacpp::refresh_models behind llm-router.
 
 dependencies:
-  state: ">=0.22.0 <1.0.0"
-  llm-router: ">=1.0.0 <2.0.0"
+  state: "0.x"
+  llm-router: "1.x"

--- a/provider-llamacpp/iii.worker.yaml
+++ b/provider-llamacpp/iii.worker.yaml
@@ -10,4 +10,4 @@ description: llama.cpp server (llama-server) Chat Completions provider worker; i
 
 dependencies:
   state: ">=0.22.0 <1.0.0"
-  llm-router: "^1.0.0"
+  llm-router: ">=1.0.0 <2.0.0"

--- a/provider-openai-codex/iii.worker.yaml
+++ b/provider-openai-codex/iii.worker.yaml
@@ -10,4 +10,4 @@ description: OpenAI Codex (ChatGPT subscription) provider; implements provider::
 
 dependencies:
   state: "0.x"
-  llm-router: "1.x"
+  llm-router: "^1.0.0"

--- a/provider-openai-codex/iii.worker.yaml
+++ b/provider-openai-codex/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, openai, codex, chatgpt, subscription, provider]
 description: OpenAI Codex (ChatGPT subscription) provider; implements provider::openai-codex::stream and provider::openai-codex::refresh_models behind llm-router, sourcing credentials from the auth-credentials vault.
 
 dependencies:
-  state: ">=0.22.0 <1.0.0"
-  llm-router: ">=1.0.0 <2.0.0"
+  state: "0.x"
+  llm-router: "1.x"

--- a/provider-openai-codex/iii.worker.yaml
+++ b/provider-openai-codex/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, openai, codex, chatgpt, subscription, provider]
 description: OpenAI Codex (ChatGPT subscription) provider; implements provider::openai-codex::stream and provider::openai-codex::refresh_models behind llm-router, sourcing credentials from the auth-credentials vault.
 
 dependencies:
-  state: "^0.22.0"
+  state: ">=0.22.0 <1.0.0"
   llm-router: "^1.0.0"

--- a/provider-openai-codex/iii.worker.yaml
+++ b/provider-openai-codex/iii.worker.yaml
@@ -10,4 +10,4 @@ description: OpenAI Codex (ChatGPT subscription) provider; implements provider::
 
 dependencies:
   state: ">=0.22.0 <1.0.0"
-  llm-router: "^1.0.0"
+  llm-router: ">=1.0.0 <2.0.0"

--- a/provider-openai/iii.worker.yaml
+++ b/provider-openai/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, openai, responses, chat-completions, provider]
 description: OpenAI Responses provider worker with Chat Completions compatibility; implements provider::openai::stream and provider::openai::refresh_models behind llm-router.
 
 dependencies:
-  state: ">=0.22.0 <1.0.0"
-  llm-router: ">=1.0.0 <2.0.0"
+  state: "0.x"
+  llm-router: "1.x"

--- a/provider-openai/iii.worker.yaml
+++ b/provider-openai/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, openai, responses, chat-completions, provider]
 description: OpenAI Responses provider worker with Chat Completions compatibility; implements provider::openai::stream and provider::openai::refresh_models behind llm-router.
 
 dependencies:
-  state: "^0.22.0"
+  state: ">=0.22.0 <1.0.0"
   llm-router: "^1.0.0"

--- a/provider-openai/iii.worker.yaml
+++ b/provider-openai/iii.worker.yaml
@@ -10,4 +10,4 @@ description: OpenAI Responses provider worker with Chat Completions compatibilit
 
 dependencies:
   state: ">=0.22.0 <1.0.0"
-  llm-router: "^1.0.0"
+  llm-router: ">=1.0.0 <2.0.0"

--- a/provider-openai/iii.worker.yaml
+++ b/provider-openai/iii.worker.yaml
@@ -10,4 +10,4 @@ description: OpenAI Responses provider worker with Chat Completions compatibilit
 
 dependencies:
   state: "0.x"
-  llm-router: "1.x"
+  llm-router: "^1.0.0"

--- a/provider-opencode-go/iii.worker.yaml
+++ b/provider-opencode-go/iii.worker.yaml
@@ -10,4 +10,4 @@ description: OpenCode Go Chat Completions provider worker; implements provider::
 
 dependencies:
   state: "0.x"
-  llm-router: "1.x"
+  llm-router: "^1.0.0"

--- a/provider-opencode-go/iii.worker.yaml
+++ b/provider-opencode-go/iii.worker.yaml
@@ -10,4 +10,4 @@ description: OpenCode Go Chat Completions provider worker; implements provider::
 
 dependencies:
   state: ">=0.22.0 <1.0.0"
-  llm-router: "^1.0.0"
+  llm-router: ">=1.0.0 <2.0.0"

--- a/provider-opencode-go/iii.worker.yaml
+++ b/provider-opencode-go/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, opencode, go, chat-completions, subscription, provider]
 description: OpenCode Go Chat Completions provider worker; implements provider::opencode_go::stream and provider::opencode_go::refresh_models behind llm-router.
 
 dependencies:
-  state: "^0.22.0"
+  state: ">=0.22.0 <1.0.0"
   llm-router: "^1.0.0"

--- a/provider-opencode-go/iii.worker.yaml
+++ b/provider-opencode-go/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, opencode, go, chat-completions, subscription, provider]
 description: OpenCode Go Chat Completions provider worker; implements provider::opencode_go::stream and provider::opencode_go::refresh_models behind llm-router.
 
 dependencies:
-  state: ">=0.22.0 <1.0.0"
-  llm-router: ">=1.0.0 <2.0.0"
+  state: "0.x"
+  llm-router: "1.x"

--- a/provider-openrouter/iii.worker.yaml
+++ b/provider-openrouter/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, openrouter, aggregator, chat-completions, provider]
 description: OpenRouter Chat Completions provider worker; one API key in front of every major vendor. Implements provider::openrouter::stream and provider::openrouter::refresh_models behind llm-router.
 
 dependencies:
-  state: ">=0.22.0 <1.0.0"
-  llm-router: ">=1.0.0 <2.0.0"
+  state: "0.x"
+  llm-router: "1.x"

--- a/provider-openrouter/iii.worker.yaml
+++ b/provider-openrouter/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, openrouter, aggregator, chat-completions, provider]
 description: OpenRouter Chat Completions provider worker; one API key in front of every major vendor. Implements provider::openrouter::stream and provider::openrouter::refresh_models behind llm-router.
 
 dependencies:
-  state: "^0.22.0"
+  state: ">=0.22.0 <1.0.0"
   llm-router: "^1.0.0"

--- a/provider-openrouter/iii.worker.yaml
+++ b/provider-openrouter/iii.worker.yaml
@@ -10,4 +10,4 @@ description: OpenRouter Chat Completions provider worker; one API key in front o
 
 dependencies:
   state: ">=0.22.0 <1.0.0"
-  llm-router: "^1.0.0"
+  llm-router: ">=1.0.0 <2.0.0"

--- a/provider-openrouter/iii.worker.yaml
+++ b/provider-openrouter/iii.worker.yaml
@@ -10,4 +10,4 @@ description: OpenRouter Chat Completions provider worker; one API key in front o
 
 dependencies:
   state: "0.x"
-  llm-router: "1.x"
+  llm-router: "^1.0.0"

--- a/provider-xai/iii.worker.yaml
+++ b/provider-xai/iii.worker.yaml
@@ -10,4 +10,4 @@ description: xAI Chat Completions provider worker; implements provider::xai::str
 
 dependencies:
   state: "0.x"
-  llm-router: "1.x"
+  llm-router: "^1.0.0"

--- a/provider-xai/iii.worker.yaml
+++ b/provider-xai/iii.worker.yaml
@@ -10,4 +10,4 @@ description: xAI Chat Completions provider worker; implements provider::xai::str
 
 dependencies:
   state: ">=0.22.0 <1.0.0"
-  llm-router: "^1.0.0"
+  llm-router: ">=1.0.0 <2.0.0"

--- a/provider-xai/iii.worker.yaml
+++ b/provider-xai/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, xai, grok, chat-completions, provider]
 description: xAI Chat Completions provider worker; implements provider::xai::stream and provider::xai::refresh_models behind llm-router.
 
 dependencies:
-  state: "^0.22.0"
+  state: ">=0.22.0 <1.0.0"
   llm-router: "^1.0.0"

--- a/provider-xai/iii.worker.yaml
+++ b/provider-xai/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, xai, grok, chat-completions, provider]
 description: xAI Chat Completions provider worker; implements provider::xai::stream and provider::xai::refresh_models behind llm-router.
 
 dependencies:
-  state: ">=0.22.0 <1.0.0"
-  llm-router: ">=1.0.0 <2.0.0"
+  state: "0.x"
+  llm-router: "1.x"

--- a/provider-zai/iii.worker.yaml
+++ b/provider-zai/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, zai, glm, chat-completions, provider]
 description: Z.AI Chat Completions provider worker; implements provider::zai::stream and provider::zai::refresh_models behind llm-router.
 
 dependencies:
-  state: "^0.22.0"
+  state: ">=0.22.0 <1.0.0"
   llm-router: "^1.0.0"

--- a/provider-zai/iii.worker.yaml
+++ b/provider-zai/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, zai, glm, chat-completions, provider]
 description: Z.AI Chat Completions provider worker; implements provider::zai::stream and provider::zai::refresh_models behind llm-router.
 
 dependencies:
-  state: ">=0.22.0 <1.0.0"
-  llm-router: ">=1.0.0 <2.0.0"
+  state: "0.x"
+  llm-router: "1.x"

--- a/provider-zai/iii.worker.yaml
+++ b/provider-zai/iii.worker.yaml
@@ -10,4 +10,4 @@ description: Z.AI Chat Completions provider worker; implements provider::zai::st
 
 dependencies:
   state: "0.x"
-  llm-router: "1.x"
+  llm-router: "^1.0.0"

--- a/provider-zai/iii.worker.yaml
+++ b/provider-zai/iii.worker.yaml
@@ -10,4 +10,4 @@ description: Z.AI Chat Completions provider worker; implements provider::zai::st
 
 dependencies:
   state: ">=0.22.0 <1.0.0"
-  llm-router: "^1.0.0"
+  llm-router: ">=1.0.0 <2.0.0"

--- a/pubsub/iii.worker.yaml
+++ b/pubsub/iii.worker.yaml
@@ -11,4 +11,4 @@ config:
   adapter:
     name: local
 dependencies:
-  configuration: ">=0.21.6 <1.0.0"
+  configuration: "0.x"

--- a/pubsub/iii.worker.yaml
+++ b/pubsub/iii.worker.yaml
@@ -11,4 +11,4 @@ config:
   adapter:
     name: local
 dependencies:
-  configuration: "^0.21.6"
+  configuration: ">=0.21.6 <1.0.0"

--- a/queue/iii.worker.yaml
+++ b/queue/iii.worker.yaml
@@ -40,4 +40,4 @@ config:
       file_path: ./data/queue
       save_interval_ms: 5000
 dependencies:
-  configuration: "^0.21.6"
+  configuration: ">=0.21.6 <1.0.0"

--- a/queue/iii.worker.yaml
+++ b/queue/iii.worker.yaml
@@ -40,4 +40,4 @@ config:
       file_path: ./data/queue
       save_interval_ms: 5000
 dependencies:
-  configuration: ">=0.21.6 <1.0.0"
+  configuration: "0.x"

--- a/rbac-proxy/iii.worker.yaml
+++ b/rbac-proxy/iii.worker.yaml
@@ -9,4 +9,4 @@ tags: [rbac, authorization, security, proxy, middleware]
 description: "RBAC boundary proxy for the iii worker protocol — auth, gating, namespacing, middleware, and engine:: result filtering on its own port."
 
 dependencies:
-  configuration: "^0.21.6"
+  configuration: ">=0.21.6 <1.0.0"

--- a/rbac-proxy/iii.worker.yaml
+++ b/rbac-proxy/iii.worker.yaml
@@ -9,4 +9,4 @@ tags: [rbac, authorization, security, proxy, middleware]
 description: "RBAC boundary proxy for the iii worker protocol — auth, gating, namespacing, middleware, and engine:: result filtering on its own port."
 
 dependencies:
-  configuration: ">=0.21.6 <1.0.0"
+  configuration: "0.x"

--- a/sandbox-code-runner/iii.worker.yaml
+++ b/sandbox-code-runner/iii.worker.yaml
@@ -8,7 +8,7 @@ tags: [nodejs, python, run, sandbox, microvm]
 description: Run Node.js and Python in iii-sandbox microVMs — run code, register bus functions from working source, and tear down runtimes on demand. Guest code gets the real iii-sdk client as a global `iii`, lazily connected to the engine.
 
 dependencies:
-  configuration: ">=0.21.6 <1.0.0"
+  configuration: "0.x"
 
 # sandbox-code-runner has no V8 (or any other platform-restricted)
 # dependency — everything it links (iii-sdk, tokio, serde, schemars, clap,

--- a/sandbox-code-runner/iii.worker.yaml
+++ b/sandbox-code-runner/iii.worker.yaml
@@ -8,7 +8,7 @@ tags: [nodejs, python, run, sandbox, microvm]
 description: Run Node.js and Python in iii-sandbox microVMs — run code, register bus functions from working source, and tear down runtimes on demand. Guest code gets the real iii-sdk client as a global `iii`, lazily connected to the engine.
 
 dependencies:
-  configuration: "^0.21.6"
+  configuration: ">=0.21.6 <1.0.0"
 
 # sandbox-code-runner has no V8 (or any other platform-restricted)
 # dependency — everything it links (iii-sdk, tokio, serde, schemars, clap,

--- a/scrapling/iii.worker.yaml
+++ b/scrapling/iii.worker.yaml
@@ -20,7 +20,7 @@ env:
   III_URL: "ws://localhost:49134"
 
 dependencies:
-  configuration: "^0.21.6"
+  configuration: ">=0.21.6 <1.0.0"
 
 # Must name an engine-preset image ref verbatim: bundle workers may not pull
 # arbitrary base images, and this is how a non-node bundle picks its rootfs

--- a/scrapling/iii.worker.yaml
+++ b/scrapling/iii.worker.yaml
@@ -20,7 +20,7 @@ env:
   III_URL: "ws://localhost:49134"
 
 dependencies:
-  configuration: ">=0.21.6 <1.0.0"
+  configuration: "0.x"
 
 # Must name an engine-preset image ref verbatim: bundle workers may not pull
 # arbitrary base images, and this is how a non-node bundle picks its rootfs

--- a/session-manager/iii.worker.yaml
+++ b/session-manager/iii.worker.yaml
@@ -9,4 +9,4 @@ tags: [session, conversation, chat, history]
 description: Durable, reactive, branching store of typed conversation entries with six emitted trigger types.
 
 dependencies:
-  configuration: "^0.21.6"
+  configuration: ">=0.21.6 <1.0.0"

--- a/session-manager/iii.worker.yaml
+++ b/session-manager/iii.worker.yaml
@@ -9,4 +9,4 @@ tags: [session, conversation, chat, history]
 description: Durable, reactive, branching store of typed conversation entries with six emitted trigger types.
 
 dependencies:
-  configuration: ">=0.21.6 <1.0.0"
+  configuration: "0.x"

--- a/slack/iii.worker.yaml
+++ b/slack/iii.worker.yaml
@@ -9,7 +9,7 @@ tags: [slack, messaging, chat, bot, approvals]
 description: Slack as an iii worker — exposes the Slack Web API as slack::* functions, plus a harness bridge (inbound events → harness::send, native streaming, approvals). Configurable from the console.
 
 dependencies:
-  configuration: ">=0.21.6 <1.0.0"
-  state: ">=0.21.2 <1.0.0"
+  configuration: "0.x"
+  state: "0.x"
   harness: "^1.0.0"
   session-manager: "^1.0.0"

--- a/slack/iii.worker.yaml
+++ b/slack/iii.worker.yaml
@@ -9,7 +9,7 @@ tags: [slack, messaging, chat, bot, approvals]
 description: Slack as an iii worker — exposes the Slack Web API as slack::* functions, plus a harness bridge (inbound events → harness::send, native streaming, approvals). Configurable from the console.
 
 dependencies:
-  configuration: "^0.21.6"
-  state: "^0.21.2"
+  configuration: ">=0.21.6 <1.0.0"
+  state: ">=0.21.2 <1.0.0"
   harness: "^1.0.0"
   session-manager: "^1.0.0"

--- a/state/iii.worker.yaml
+++ b/state/iii.worker.yaml
@@ -13,4 +13,4 @@ config:
     config:
       store_method: in_memory
 dependencies:
-  configuration: "^0.21.6"
+  configuration: ">=0.21.6 <1.0.0"

--- a/state/iii.worker.yaml
+++ b/state/iii.worker.yaml
@@ -13,4 +13,4 @@ config:
     config:
       store_method: in_memory
 dependencies:
-  configuration: ">=0.21.6 <1.0.0"
+  configuration: "0.x"

--- a/telegram-bot/iii.worker.yaml
+++ b/telegram-bot/iii.worker.yaml
@@ -9,8 +9,8 @@ tags: [telegram, bot, messaging, chat, webhook]
 description: Telegram bridge to the harness stack — polling or webhook ingress, live message edits, approvals, and configurable verbosity.
 
 dependencies:
-  state: ">=0.21.2 <1.0.0"
+  state: "0.x"
   queue: "^0.2.0"
-  configuration: ">=0.21.6 <1.0.0"
+  configuration: "0.x"
   session-manager: "^1.0.0"
   harness: "^1.0.0"

--- a/telegram-bot/iii.worker.yaml
+++ b/telegram-bot/iii.worker.yaml
@@ -9,8 +9,8 @@ tags: [telegram, bot, messaging, chat, webhook]
 description: Telegram bridge to the harness stack — polling or webhook ingress, live message edits, approvals, and configurable verbosity.
 
 dependencies:
-  state: "^0.21.2"
+  state: ">=0.21.2 <1.0.0"
   queue: "^0.2.0"
-  configuration: "^0.21.6"
+  configuration: ">=0.21.6 <1.0.0"
   session-manager: "^1.0.0"
   harness: "^1.0.0"

--- a/web/iii.worker.yaml
+++ b/web/iii.worker.yaml
@@ -9,4 +9,4 @@ tags: [http, client, fetch, rest, api]
 description: Outbound HTTP client on the iii bus (web::fetch).
 
 dependencies:
-  configuration: "^0.21.6"
+  configuration: ">=0.21.6 <1.0.0"

--- a/web/iii.worker.yaml
+++ b/web/iii.worker.yaml
@@ -9,4 +9,4 @@ tags: [http, client, fetch, rest, api]
 description: Outbound HTTP client on the iii bus (web::fetch).
 
 dependencies:
-  configuration: ">=0.21.6 <1.0.0"
+  configuration: "0.x"

--- a/workflow/iii.worker.yaml
+++ b/workflow/iii.worker.yaml
@@ -9,4 +9,4 @@ tags: [workflow, orchestration, multi-agent, durable, automation]
 description: Deterministic, crash-resumable multi-agent workflow orchestrator over harness turns.
 
 dependencies:
-  configuration: ">=0.21.6 <1.0.0"
+  configuration: "0.x"

--- a/workflow/iii.worker.yaml
+++ b/workflow/iii.worker.yaml
@@ -9,4 +9,4 @@ tags: [workflow, orchestration, multi-agent, durable, automation]
 description: Deterministic, crash-resumable multi-agent workflow orchestrator over harness turns.
 
 dependencies:
-  configuration: "^0.21.6"
+  configuration: ">=0.21.6 <1.0.0"

--- a/worktree/iii.worker.yaml
+++ b/worktree/iii.worker.yaml
@@ -9,6 +9,6 @@ tags: [git, worktree, parallel, agents, branches, ci]
 description: Git worktree lifecycle for parallel agents — mint, claim, and track isolated worktrees per repo, emit lifecycle trigger types, and land branches back through a per-repo FIFO queue (rebase, test gate, ff-only merge).
 
 dependencies:
-  configuration: ">=0.21.6 <1.0.0"
-  state: ">=0.21.2 <1.0.0"
+  configuration: "0.x"
+  state: "0.x"
   shell: "^0.7.0"

--- a/worktree/iii.worker.yaml
+++ b/worktree/iii.worker.yaml
@@ -9,6 +9,6 @@ tags: [git, worktree, parallel, agents, branches, ci]
 description: Git worktree lifecycle for parallel agents — mint, claim, and track isolated worktrees per repo, emit lifecycle trigger types, and land branches back through a per-repo FIFO queue (rebase, test gate, ff-only merge).
 
 dependencies:
-  configuration: "^0.21.6"
-  state: "^0.21.2"
+  configuration: ">=0.21.6 <1.0.0"
+  state: ">=0.21.2 <1.0.0"
   shell: "^0.7.0"


### PR DESCRIPTION
## Summary

- use `0.x` for shared `state` and `configuration` dependencies across all consumers
- retain `^1.0.0` for `llm-router`, where caret already allows compatible minor updates
- add regression coverage and document the shared dependency contract

## Why

A fully specified caret range on a `0.x` dependency stays within that minor line, preventing workers from resolving later compatible minor releases. The `0.x` wildcard is already supported by both iii and the Registry, so those manifests can express the intended compatibility without changing the worker resolver. For `llm-router`, `^1.0.0` already spans stable `1.x` releases and remains unchanged.

`0.x` intentionally accepts every stable pre-1.0 release; the Registry continues to select the highest compatible published version.

## Validation

- `pytest -q .github/scripts/tests` — 199 passed, 3 subtests passed
- 45/45 affected worker manifests validated
- npm semver checks for the `0.x` wildcard and `^1.0.0` caret bounds
- `git diff --check`

Fixes MOT-4463
