### PR TITLE
feat(e2e): run shadow observations on ephemeral GitHub workers

### DIFF
--- a/.github/scripts/harness_e2e_shadow_contract.py
+++ b/.github/scripts/harness_e2e_shadow_contract.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Validate and materialize Release Control shadow E2E contracts."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+
+SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
+VERSION = re.compile(
+    r"^[0-9]+\.[0-9]+\.[0-9]+"
+    r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
+
+
+def load_object(path: Path, label: str) -> dict[str, Any]:
+    value = json.loads(path.read_text())
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be a JSON object")
+    return value
+
+
+def canonical(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def require_uuid(value: Any, label: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{label} must be a UUID")
+    parsed = UUID(value)
+    if str(parsed) != value.lower():
+        raise ValueError(f"{label} must use canonical UUID form")
+    return str(parsed)
+
+
+def require_text(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{label} must be a non-empty string")
+    return value
+
+
+def require_digest(value: Any, label: str) -> str:
+    value = require_text(value, label)
+    if not SHA256.fullmatch(value):
+        raise ValueError(f"{label} must be sha256:<64 lowercase hex>")
+    return value
+
+
+def validate_contract(contract: dict[str, Any]) -> dict[str, Any]:
+    if contract.get("schema_version") != 1:
+        raise ValueError("execution contract schema_version must be 1")
+    require_uuid(contract.get("campaign_id"), "campaign_id")
+    require_uuid(contract.get("execution_id"), "execution_id")
+    attempt = contract.get("attempt")
+    if not isinstance(attempt, int) or attempt < 1:
+        raise ValueError("attempt must be a positive integer")
+    key = require_text(contract.get("idempotency_key"), "idempotency_key")
+    if not re.fullmatch(r"rc:d0:[0-9a-f]{64}", key):
+        raise ValueError("idempotency_key must be rc:d0:<sha256>")
+
+    target = contract.get("target")
+    if not isinstance(target, dict) or target.get("application") != "harness":
+        raise ValueError("target application must be harness")
+    require_text(target.get("version"), "target.version")
+    source_sha = require_text(target.get("source_sha"), "target.source_sha")
+    if not re.fullmatch(r"[0-9a-f]{40}", source_sha):
+        raise ValueError("target.source_sha must be a full lowercase git SHA")
+    require_uuid(target.get("deployment_id"), "target.deployment_id")
+    stack = target.get("stack_versions")
+    if not isinstance(stack, dict) or not stack:
+        raise ValueError("target.stack_versions must be a non-empty object")
+    for worker, version in stack.items():
+        if not isinstance(worker, str) or not re.fullmatch(r"[a-z0-9][a-z0-9_-]*", worker):
+            raise ValueError("target.stack_versions contains an invalid worker name")
+        if not isinstance(version, str) or not VERSION.fullmatch(version):
+            raise ValueError(f"target.stack_versions contains an invalid version for {worker}")
+    if stack.get("harness") != target.get("version"):
+        raise ValueError("target version must match stack_versions.harness")
+    require_digest(target.get("stack_digest"), "target.stack_digest")
+
+    plan = contract.get("plan")
+    if not isinstance(plan, dict):
+        raise ValueError("plan must be an object")
+    require_uuid(plan.get("id"), "plan.id")
+    revision = plan.get("revision")
+    if not isinstance(revision, int) or revision < 1:
+        raise ValueError("plan.revision must be a positive integer")
+    require_digest(plan.get("sha256"), "plan.sha256")
+    definition = plan.get("definition")
+    if not isinstance(definition, dict):
+        raise ValueError("plan.definition must be an object")
+    if definition.get("mode") != "demonstrative" or definition.get("entrypoint") != "e2e::run":
+        raise ValueError("plan must be demonstrative and use e2e::run")
+    scenarios = definition.get("scenarios")
+    if not isinstance(scenarios, list) or not scenarios or len(set(scenarios)) != len(scenarios):
+        raise ValueError("plan scenarios must be a non-empty unique list")
+    if not all(isinstance(item, str) and item for item in scenarios):
+        raise ValueError("plan scenarios must contain non-empty strings")
+    for field in ("runs", "seed", "technicalRetries", "progressIntervalSeconds"):
+        if not isinstance(definition.get(field), int) or definition[field] < 1:
+            raise ValueError(f"plan.definition.{field} must be a positive integer")
+    for role in ("subject", "judge"):
+        identity = definition.get(role)
+        if not isinstance(identity, dict):
+            raise ValueError(f"plan.definition.{role} must be an object")
+        require_text(identity.get("provider"), f"plan.definition.{role}.provider")
+        require_text(identity.get("model"), f"plan.definition.{role}.model")
+
+    runner = contract.get("runner")
+    if not isinstance(runner, dict):
+        raise ValueError("runner must be an object")
+    if require_text(runner.get("registry_worker"), "runner.registry_worker") != "harness-e2e":
+        raise ValueError("runner.registry_worker must be harness-e2e")
+    runner_ref = require_text(runner.get("registry_ref"), "runner.registry_ref")
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", runner_ref):
+        raise ValueError("runner.registry_ref is invalid")
+    return contract
+
+
+def materialize_request(contract: dict[str, Any], catalog: dict[str, Any]) -> dict[str, Any]:
+    validate_contract(contract)
+    if catalog.get("schema") != "e2e-scenario-catalog/v1":
+        raise ValueError("unsupported scenario catalog schema")
+    runner = catalog.get("runner")
+    if not isinstance(runner, dict):
+        raise ValueError("scenario catalog has no runner identity")
+    for field in ("name", "version", "revision"):
+        require_text(runner.get(field), f"catalog.runner.{field}")
+    catalog_sha256 = require_digest(catalog.get("catalog_sha256"), "catalog.catalog_sha256")
+    descriptors = catalog.get("scenarios")
+    if not isinstance(descriptors, list):
+        raise ValueError("scenario catalog scenarios must be a list")
+    by_id: dict[str, dict[str, Any]] = {}
+    for item in descriptors:
+        if isinstance(item, dict) and isinstance(item.get("scenario_id"), str):
+            by_id[item["scenario_id"]] = item
+
+    definition = contract["plan"]["definition"]
+    selected_cases: list[dict[str, Any]] = []
+    for scenario_id in definition["scenarios"]:
+        descriptor = by_id.get(scenario_id)
+        if descriptor is None:
+            raise ValueError(f"scenario catalog is missing {scenario_id}")
+        scenario_version = descriptor.get("scenario_version")
+        seed = descriptor.get("seed")
+        if not isinstance(scenario_version, int) or scenario_version < 1:
+            raise ValueError(f"scenario {scenario_id} has an invalid version")
+        if seed != definition["seed"]:
+            raise ValueError(f"scenario {scenario_id} seed does not match the plan")
+        selected_cases.append(
+            {
+                "scenario_id": scenario_id,
+                "scenario_version": scenario_version,
+                "case_id": require_text(descriptor.get("case_id"), f"{scenario_id}.case_id"),
+                "seed": seed,
+                "inputs_sha256": require_digest(
+                    descriptor.get("inputs_sha256"), f"{scenario_id}.inputs_sha256"
+                ),
+                "contract_sha256": require_digest(
+                    descriptor.get("contract_sha256"), f"{scenario_id}.contract_sha256"
+                ),
+            }
+        )
+
+    run_contract = {
+        "schema_version": 1,
+        "mode": {"environment": "demonstration", "decision": "observe_only"},
+        "target": {
+            "application": "harness",
+            "version": contract["target"]["version"],
+            "stack": {
+                "mode": "registry",
+                "stack_versions": contract["target"]["stack_versions"],
+                "stack_lock_digest": contract["target"]["stack_digest"],
+            },
+        },
+        "plan": {
+            "id": contract["plan"]["id"],
+            "revision": str(contract["plan"]["revision"]),
+            "sha256": contract["plan"]["sha256"],
+            "catalog_sha256": catalog_sha256,
+        },
+        "runner": runner,
+        "attempt": contract["attempt"],
+        "selected_cases": selected_cases,
+        "correlation": {
+            "system": "release-control",
+            "deployment_id": contract["target"]["deployment_id"],
+            "operation_id": contract["campaign_id"],
+        },
+    }
+    return {
+        "idempotency_key": contract["idempotency_key"],
+        "label": f"{definition['label']} · Harness {contract['target']['version']}",
+        "lane": definition["lane"],
+        "model": definition["subject"]["model"],
+        "provider": definition["subject"]["provider"],
+        "judge_model": definition["judge"]["model"],
+        "judge_provider": definition["judge"]["provider"],
+        "scenarios": definition["scenarios"],
+        "runs": definition["runs"],
+        "seed": definition["seed"],
+        "rotating_seeds": [],
+        "technical_retries": definition["technicalRetries"],
+        "progress_interval_seconds": definition["progressIntervalSeconds"],
+        "run_contract": run_contract,
+    }
+
+
+def package_bundle(root: Path, contract: dict[str, Any], workflow: dict[str, Any]) -> dict[str, Any]:
+    validate_contract(contract)
+    files = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or path.name == "bundle-manifest.json":
+            continue
+        relative = path.relative_to(root).as_posix()
+        payload = path.read_bytes()
+        files.append(
+            {
+                "path": relative,
+                "sha256": f"sha256:{hashlib.sha256(payload).hexdigest()}",
+                "size_bytes": len(payload),
+            }
+        )
+    terminal = root / "results.json"
+    failure = root / "failure.json"
+    return {
+        "schema": "e2e-observation-bundle/v1",
+        "campaign_id": contract["campaign_id"],
+        "execution_id": contract["execution_id"],
+        "attempt": contract["attempt"],
+        "workflow": workflow,
+        "terminal_payload": "results.json" if terminal.is_file() else None,
+        "failure_payload": "failure.json" if failure.is_file() else None,
+        "files": files,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    commands = parser.add_subparsers(dest="command", required=True)
+    validate = commands.add_parser("validate")
+    validate.add_argument("--contract", type=Path, required=True)
+    materialize = commands.add_parser("materialize")
+    materialize.add_argument("--contract", type=Path, required=True)
+    materialize.add_argument("--catalog", type=Path, required=True)
+    materialize.add_argument("--output", type=Path, required=True)
+    package = commands.add_parser("package")
+    package.add_argument("--root", type=Path, required=True)
+    package.add_argument("--contract", type=Path, required=True)
+    package.add_argument("--workflow", required=True)
+    package.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        contract = validate_contract(load_object(args.contract, "execution contract"))
+        if args.command == "validate":
+            print(canonical(contract))
+        elif args.command == "materialize":
+            request = materialize_request(contract, load_object(args.catalog, "scenario catalog"))
+            args.output.write_text(json.dumps(request, indent=2, sort_keys=True) + "\n")
+        else:
+            workflow = json.loads(args.workflow)
+            if not isinstance(workflow, dict):
+                raise ValueError("workflow must be a JSON object")
+            manifest = package_bundle(args.root, contract, workflow)
+            args.output.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+        return 0
+    except (ValueError, json.JSONDecodeError) as error:
+        print(f"error: {error}")
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_harness_e2e_shadow_contract.py
+++ b/.github/scripts/tests/test_harness_e2e_shadow_contract.py
@@ -1,0 +1,98 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parents[1] / "harness_e2e_shadow_contract.py"
+SPEC = importlib.util.spec_from_file_location("shadow_contract", SCRIPT)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def contract():
+    return {
+        "schema_version": 1,
+        "campaign_id": "11111111-1111-4111-8111-111111111111",
+        "execution_id": "22222222-2222-4222-8222-222222222222",
+        "attempt": 1,
+        "idempotency_key": f"rc:d0:{'a' * 64}",
+        "target": {
+            "application": "harness",
+            "version": "1.9.0",
+            "source_sha": "b" * 40,
+            "deployment_id": "33333333-3333-4333-8333-333333333333",
+            "stack_versions": {"harness": "1.9.0", "database": "0.5.1"},
+            "stack_digest": f"sha256:{'c' * 64}",
+        },
+        "plan": {
+            "id": "44444444-4444-4444-8444-444444444444",
+            "revision": 1,
+            "sha256": f"sha256:{'d' * 64}",
+            "definition": {
+                "mode": "demonstrative",
+                "entrypoint": "e2e::run",
+                "label": "Shadow",
+                "lane": "release-control-shadow",
+                "subject": {"provider": "anthropic", "model": "claude-sonnet-4-6"},
+                "judge": {"provider": "anthropic", "model": "claude-sonnet-4-6"},
+                "scenarios": ["direct_answer"],
+                "runs": 1,
+                "seed": 4404,
+                "technicalRetries": 1,
+                "progressIntervalSeconds": 15,
+            },
+        },
+        "runner": {"registry_worker": "harness-e2e", "registry_ref": "next"},
+    }
+
+
+def catalog():
+    return {
+        "schema": "e2e-scenario-catalog/v1",
+        "runner": {"name": "harness-e2e", "version": "0.4.0", "revision": "e" * 40},
+        "catalog_sha256": f"sha256:{'f' * 64}",
+        "scenarios": [
+            {
+                "scenario_id": "direct_answer",
+                "scenario_version": 2,
+                "case_id": "direct_answer:4404",
+                "seed": 4404,
+                "inputs_sha256": f"sha256:{'1' * 64}",
+                "contract_sha256": f"sha256:{'2' * 64}",
+            }
+        ],
+    }
+
+
+class ShadowContractTest(unittest.TestCase):
+    def test_materializes_observe_only_request(self):
+        request = MODULE.materialize_request(contract(), catalog())
+        self.assertEqual(request["run_contract"]["mode"]["decision"], "observe_only")
+        self.assertEqual(request["run_contract"]["runner"]["revision"], "e" * 40)
+        self.assertEqual(request["run_contract"]["selected_cases"][0]["scenario_version"], 2)
+
+    def test_rejects_catalog_seed_drift(self):
+        changed = catalog()
+        changed["scenarios"][0]["seed"] = 9
+        with self.assertRaisesRegex(ValueError, "seed does not match"):
+            MODULE.materialize_request(contract(), changed)
+
+    def test_accepts_exact_registry_prerelease_versions(self):
+        changed = contract()
+        changed["target"]["stack_versions"]["database"] = "0.11.0-next.5"
+        MODULE.validate_contract(changed)
+
+    def test_packages_raw_file_digests(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "results.json").write_text("{}\n")
+            manifest = MODULE.package_bundle(root, contract(), {"run_id": 7, "run_attempt": 1})
+        self.assertEqual(manifest["terminal_payload"], "results.json")
+        self.assertRegex(manifest["files"][0]["sha256"], r"^sha256:[0-9a-f]{64}$")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_release_workflows.py
+++ b/.github/scripts/tests/test_release_workflows.py
@@ -10,6 +10,7 @@ WORKFLOWS = ROOT / "workflows"
 COMMON = {"operation_id", "step_id"}
 
 EXPECTED_INPUTS = {
+    "harness-e2e-shadow.yml": {"campaign_id", "execution_id", "attempt", "execution_contract"},
     "create-tag.yml": COMMON | {"worker", "target_version", "registry_tag", "experimental", "expected_current_version", "source_sha"},
     "create-prerelease-tag.yml": COMMON | {"worker", "target_version", "source_sha", "experimental"},
     "release.yml": COMMON | {"source_tag_step_id", "tag", "publish_registry"},
@@ -124,7 +125,11 @@ def test_every_dispatch_is_actor_gated_and_emits_factual_evidence() -> None:
         body = (WORKFLOWS / name).read_text()
         assert "release_control_contract.py validate-dispatch" in body, name
         assert "RELEASE_CONTROL_BOT_LOGIN" in body, name
-        assert "execution-result-${{ inputs.operation_id }}-${{ inputs.step_id }}" in body, name
+        if name == "harness-e2e-shadow.yml":
+            assert "e2e-observation-${{ inputs.campaign_id }}-${{ inputs.execution_id }}" in body, name
+            assert "ACTIONS_ID_TOKEN_REQUEST_TOKEN" in body, name
+        else:
+            assert "execution-result-${{ inputs.operation_id }}-${{ inputs.step_id }}" in body, name
         assert ("--mutating" in body) == (name in MUTATING), name
 
 

--- a/.github/workflows/harness-e2e-shadow.yml
+++ b/.github/workflows/harness-e2e-shadow.yml
@@ -1,0 +1,144 @@
+name: Observe deployed Harness with ephemeral E2E
+run-name: RC · e2e_shadow · ${{ inputs.campaign_id }} · ${{ inputs.execution_id }} · ${{ inputs.attempt }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      campaign_id:
+        description: Release Control shadow campaign UUID
+        required: true
+        type: string
+      execution_id:
+        description: Release Control execution UUID
+        required: true
+        type: string
+      attempt:
+        description: Explicit Release Control attempt
+        required: true
+        type: number
+      execution_contract:
+        description: Canonical execution contract JSON
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+
+concurrency:
+  group: harness-e2e-shadow-${{ inputs.execution_id }}
+  cancel-in-progress: false
+
+jobs:
+  observe:
+    name: Run observe-only plan
+    runs-on: ubuntu-latest
+    timeout-minutes: 210
+    environment: harness-e2e-trusted
+    env:
+      HARNESS_E2E_ARTIFACTS_DIR: ${{ github.workspace }}/target/harness-e2e-shadow
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Validate Release Control dispatch
+        env:
+          RELEASE_CONTROL_BOT_LOGIN: ${{ vars.RELEASE_CONTROL_BOT_LOGIN }}
+        run: >-
+          python3 .github/scripts/release_control_contract.py validate-dispatch
+          --operation-id '${{ inputs.campaign_id }}'
+          --step-id '${{ inputs.execution_id }}'
+
+      - name: Prepare execution contract
+        env:
+          EXECUTION_CONTRACT: ${{ inputs.execution_contract }}
+        run: |
+          set -euo pipefail
+          mkdir -p target/harness-e2e-shadow
+          printf '%s\n' "$EXECUTION_CONTRACT" > target/harness-e2e-shadow/execution-contract.json
+          python3 .github/scripts/harness_e2e_shadow_contract.py validate \
+            --contract target/harness-e2e-shadow/execution-contract.json >/dev/null
+          jq -e \
+            --arg campaign '${{ inputs.campaign_id }}' \
+            --arg execution '${{ inputs.execution_id }}' \
+            --argjson attempt '${{ inputs.attempt }}' \
+            '.campaign_id == $campaign and .execution_id == $execution and .attempt == $attempt' \
+            target/harness-e2e-shadow/execution-contract.json >/dev/null
+
+      - name: Install stack verification tooling
+        run: python3 -m pip install --quiet pyyaml
+
+      - name: Acquire single-use execution admission
+        id: admission
+        continue-on-error: true
+        env:
+          RELEASE_CONTROL_API_URL: ${{ vars.RELEASE_CONTROL_API_URL }}
+        run: |
+          set -euo pipefail
+          test -n "$RELEASE_CONTROL_API_URL"
+          token_response=$(curl -fsSL \
+            -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=release-control-harness-e2e")
+          oidc_token=$(jq -er '.value' <<<"$token_response")
+          response=$(curl -fsSL \
+            -H "Authorization: Bearer $oidc_token" \
+            -H 'Content-Type: application/json' \
+            -X POST "${RELEASE_CONTROL_API_URL%/}/internal/test-executions/${{ inputs.execution_id }}/admit" \
+            --data "$(jq -cn \
+              --arg campaign_id '${{ inputs.campaign_id }}' \
+              --argjson run_id '${{ github.run_id }}' \
+              --argjson run_attempt '${{ github.run_attempt }}' \
+              --arg workflow_sha '${{ github.sha }}' \
+              '{campaign_id:$campaign_id,run_id:$run_id,run_attempt:$run_attempt,workflow_sha:$workflow_sha}')")
+          printf '%s\n' "$response" > target/harness-e2e-shadow/admission.json
+          jq -e '.admitted == true' target/harness-e2e-shadow/admission.json >/dev/null
+
+      - name: Run ephemeral E2E control plane
+        id: execute
+        if: steps.admission.outcome == 'success'
+        continue-on-error: true
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ZAI_API_KEY: ${{ secrets.ZAI_API_KEY }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          HARNESS_E2E_EXECUTION_CONTRACT: ${{ inputs.execution_contract }}
+          III_CLI_CHANNEL: latest
+        run: harness/tests/e2e/run-shadow-control-ci.sh
+
+      - name: Record admission failure
+        if: steps.admission.outcome != 'success'
+        run: |
+          set -euo pipefail
+          mkdir -p target/harness-e2e-shadow
+          jq -n \
+            '{schema:"e2e-shadow-failure/v1",phase:"admission",outcome:"infra_failed",error:"execution admission was rejected"}' \
+            > target/harness-e2e-shadow/failure.json
+
+      - name: Package factual evidence
+        if: always()
+        env:
+          WORKFLOW_IDENTITY: >-
+            {"repository":"${{ github.repository }}","workflow":"harness-e2e-shadow.yml","workflow_sha":"${{ github.sha }}","run_id":${{ github.run_id }},"run_attempt":${{ github.run_attempt }}}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/harness_e2e_shadow_contract.py package \
+            --root target/harness-e2e-shadow \
+            --contract target/harness-e2e-shadow/execution-contract.json \
+            --workflow "$WORKFLOW_IDENTITY" \
+            --output target/harness-e2e-shadow/bundle-manifest.json
+
+      - name: Upload observation bundle
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: e2e-observation-${{ inputs.campaign_id }}-${{ inputs.execution_id }}-${{ inputs.attempt }}-gh-${{ github.run_attempt }}
+          path: target/harness-e2e-shadow/
+          retention-days: 90
+          if-no-files-found: error
+
+      - name: Preserve factual job conclusion
+        if: always() && (steps.admission.outcome != 'success' || steps.execute.outcome != 'success')
+        run: exit 1

--- a/harness/tests/e2e/README.md
+++ b/harness/tests/e2e/README.md
@@ -205,6 +205,15 @@ zero.
 | Pull-request CI | Relevant pull-request changes | 0 | Deterministic integration only |
 | Harness source validation | Release Control operation with an immutable SHA | Policy-defined | Empty reports, hard-gate and technical failures are blocking |
 | Harness Registry validation | Release Control operation with an exact `latest` or `next` stack | Policy-defined | Empty reports, hard-gate and technical failures are blocking; promotion requires exact evidence |
+| Deployment shadow observation | Successful Harness deployment | Plan-defined | Never blocks deployment or promotion |
+
+`harness-e2e-shadow.yml` is intentionally separate from the legacy validation
+matrix. It starts an isolated iii engine on a GitHub-hosted runner, installs the
+exact deployment stack, then installs the independent
+`harness-e2e@<plan-ref>` worker from Registry. The job materializes and invokes
+the local `e2e::*` control plane and uploads an
+`e2e-observation-bundle/v1`. Release Control admits the job through GitHub OIDC
+and ingests the Artifact; it does not host the E2E worker.
 
 Release Control owns the schedule, source/Registry choice, exact stack,
 profiles, selected and required scenarios, repetitions, subjects, judge and

--- a/harness/tests/e2e/run-shadow-control-ci.sh
+++ b/harness/tests/e2e/run-shadow-control-ci.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+: "${HARNESS_E2E_EXECUTION_CONTRACT:?HARNESS_E2E_EXECUTION_CONTRACT is required}"
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd -- "$script_dir/../../.." && pwd)
+contract_tool="$repo_root/.github/scripts/harness_e2e_shadow_contract.py"
+artifact_dir=${HARNESS_E2E_ARTIFACTS_DIR:-"$repo_root/target/harness-e2e-shadow"}
+install_url=${III_INSTALL_URL:-https://install.iii.dev/iii/main/install.sh}
+cli_channel=${III_CLI_CHANNEL:-latest}
+engine_port=${HARNESS_E2E_ENGINE_PORT:-49134}
+wait_seconds=${HARNESS_E2E_WAIT_SECONDS:-180}
+run_timeout_seconds=${HARNESS_E2E_RUN_TIMEOUT_SECONDS:-10800}
+
+case "$artifact_dir" in
+  "$repo_root"/target/*) ;;
+  *) echo "HARNESS_E2E_ARTIFACTS_DIR must be below $repo_root/target" >&2; exit 2 ;;
+esac
+case "$cli_channel" in latest | next) ;; *) echo "III_CLI_CHANNEL must be latest or next" >&2; exit 2 ;; esac
+
+mkdir -p "$artifact_dir"
+artifact_dir=$(cd "$artifact_dir" && pwd)
+contract_path="$artifact_dir/execution-contract.json"
+printf '%s\n' "$HARNESS_E2E_EXECUTION_CONTRACT" >"$contract_path"
+python3 "$contract_tool" validate --contract "$contract_path" >/dev/null
+
+stack_versions=$(jq -c '.target.stack_versions' "$contract_path")
+stack_digest=$(jq -r '.target.stack_digest' "$contract_path")
+runner_worker=$(jq -r '.runner.registry_worker' "$contract_path")
+runner_ref=$(jq -r '.runner.registry_ref' "$contract_path")
+subject_provider=$(jq -r '.plan.definition.subject.provider' "$contract_path")
+judge_provider=$(jq -r '.plan.definition.judge.provider' "$contract_path")
+seed=$(jq -r '.plan.definition.seed' "$contract_path")
+
+run_root=$(mktemp -d "${TMPDIR:-/tmp}/harness-e2e-shadow.XXXXXX")
+project_dir="$run_root/project"
+e2e_home="$run_root/home"
+mkdir -p "$project_dir" "$e2e_home" "$artifact_dir/logs" "$artifact_dir/stack"
+
+export HOME="$e2e_home"
+export XDG_CONFIG_HOME="$e2e_home/.config"
+export PATH="$e2e_home/.local/bin:$e2e_home/.iii/bin:$PATH"
+export HARNESS_E2E_STACK_MODE=registry
+export HARNESS_E2E_STACK_VERSIONS="$stack_versions"
+export HARNESS_E2E_STACK_DIGEST="$stack_digest"
+export HARNESS_E2E_DATA_DIR="$run_root/e2e-data"
+export HARNESS_E2E_RUN_DIR="$project_dir"
+export HARNESS_E2E_LANE=release-control-shadow
+
+iii_bin=""
+engine_pid=""
+failure_phase=bootstrap
+failure_reason=""
+
+log() {
+  printf '\n[%s] %s\n' "$(date -u +%H:%M:%S)" "$*" >&2
+}
+
+fail() {
+  failure_reason=$1
+  printf '[FAIL] %s\n' "$failure_reason" >&2
+  return 1
+}
+
+snapshot_stack() {
+  for file in config.yaml iii.lock workers.json; do
+    [[ -f "$project_dir/$file" ]] && cp "$project_dir/$file" "$artifact_dir/stack/$file"
+  done
+  if [[ -f "$project_dir/iii.lock" ]]; then
+    sha256sum "$project_dir/iii.lock" | awk '{print "sha256:" $1}' >"$artifact_dir/stack/iii-lock.sha256"
+  fi
+}
+
+cleanup() {
+  local status=$?
+  trap - EXIT INT TERM ERR
+  set +e
+  snapshot_stack
+  if [[ -n "$engine_pid" ]] && kill -0 "$engine_pid" 2>/dev/null; then
+    kill -- "-$engine_pid" 2>/dev/null || kill "$engine_pid" 2>/dev/null || true
+    wait "$engine_pid" 2>/dev/null || true
+  fi
+  if ((status != 0)); then
+    [[ -n "$failure_reason" ]] || failure_reason="shadow execution failed during $failure_phase (exit $status)"
+    jq -n --arg phase "$failure_phase" --arg error "$failure_reason" --argjson exit_code "$status" \
+      '{schema:"e2e-shadow-failure/v1",phase:$phase,outcome:"infra_failed",error:$error,exit_code:$exit_code}' \
+      >"$artifact_dir/failure.json"
+  fi
+  rm -rf "$run_root"
+  exit "$status"
+}
+
+on_error() {
+  local status=$? line=$1
+  [[ -n "$failure_reason" ]] || failure_reason="command failed during $failure_phase at line $line (exit $status)"
+  return "$status"
+}
+
+trap 'on_error "$LINENO"' ERR
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+wait_for_engine() {
+  local response
+  for ((attempt = 0; attempt < wait_seconds; attempt++)); do
+    kill -0 "$engine_pid" 2>/dev/null || fail "iii engine exited before becoming ready"
+    response=$("$iii_bin" trigger engine::workers::list --port "$engine_port" --json '{}' 2>/dev/null || true)
+    jq -e '.workers != null' <<<"$response" >/dev/null 2>&1 && return 0
+    sleep 1
+  done
+  fail "iii engine did not become ready within ${wait_seconds}s"
+}
+
+wait_for_functions() {
+  local required response missing
+  required=$(printf '%s\n' "$@" | jq -R . | jq -s .)
+  for ((attempt = 0; attempt < wait_seconds; attempt++)); do
+    response=$("$iii_bin" trigger engine::functions::list --port "$engine_port" \
+      --json '{"include_internal":true}' 2>/dev/null || true)
+    missing=$(jq -r --argjson required "$required" \
+      '(.functions // [] | map(.function_id)) as $available | ($required - $available) | join(" ")' \
+      <<<"$response" 2>/dev/null || printf 'function discovery failed')
+    [[ -z "$missing" ]] && return 0
+    sleep 1
+  done
+  fail "required functions did not register: $missing"
+}
+
+add_with_retry() {
+  local label=$1
+  shift
+  for attempt in 1 2 3; do
+    if (cd "$project_dir" && timeout --signal=TERM --kill-after=15s 600 "$iii_bin" worker add -y "$@") \
+      2>&1 | tee -a "$artifact_dir/logs/$label.log"; then
+      return 0
+    fi
+    log "worker add ($label) failed on attempt $attempt"
+    sleep 15
+  done
+  return 1
+}
+
+log "Installing iii CLI from $cli_channel"
+curl -fsSL --retry 3 --retry-all-errors --retry-delay 5 "$install_url" -o "$run_root/install.sh"
+if [[ "$cli_channel" == next ]]; then
+  sh "$run_root/install.sh" --next 2>&1 | tee "$artifact_dir/logs/install.log"
+else
+  sh "$run_root/install.sh" 2>&1 | tee "$artifact_dir/logs/install.log"
+fi
+iii_bin=$(command -v iii)
+cli_version=$("$iii_bin" --version 2>&1)
+printf '%s\n' "$cli_version" >"$artifact_dir/iii-version.txt"
+export HARNESS_E2E_ENGINE_REVISION="$cli_version"
+
+printf 'workers: []\n' >"$project_dir/config.yaml"
+(cd "$project_dir" && exec setsid "$iii_bin" -c config.yaml --no-update-check) \
+  >"$artifact_dir/logs/engine.log" 2>&1 &
+engine_pid=$!
+wait_for_engine
+
+failure_phase=registry
+support=("database@latest" "storage@latest" "fp@latest" "web@latest")
+declare -A providers=()
+for provider in "$subject_provider" "$judge_provider"; do
+  [[ -n "${providers[$provider]:-}" ]] && continue
+  support+=("provider-$provider@latest")
+  providers[$provider]=1
+done
+log "Installing E2E support workers"
+add_with_retry support "${support[@]}"
+
+while IFS=$'\t' read -r worker version; do
+  log "Installing exact target stack: $worker@$version"
+  add_with_retry "stack-$worker" "$worker@$version" --force
+done < <(jq -r 'to_entries | sort_by(.key)[] | [.key,.value] | @tsv' <<<"$stack_versions")
+
+log "Installing ephemeral runner: $runner_worker@$runner_ref"
+add_with_retry runner "$runner_worker@$runner_ref" --force
+
+# A runner dependency may resolve a different version of a target worker. The
+# target stack is authoritative, so reapply every exact pin after the runner.
+while IFS=$'\t' read -r worker version; do
+  add_with_retry "repin-$worker" "$worker@$version" --force
+done < <(jq -r 'to_entries | sort_by(.key)[] | [.key,.value] | @tsv' <<<"$stack_versions")
+
+target_harness_version=$(jq -r '.target.version' "$contract_path")
+python3 "$repo_root/.github/scripts/verify_registry_lock.py" \
+  --lock "$project_dir/iii.lock" \
+  --worker harness \
+  --version "$target_harness_version" \
+  --required harness \
+  --required "$runner_worker" \
+  --required database \
+  --required storage \
+  --expected-versions-json "$stack_versions" \
+  --output "$artifact_dir/stack/lock-verification.json" >/dev/null
+
+wait_for_functions \
+  e2e::scenarios-list e2e::run e2e::status e2e::results-get \
+  harness::send harness::status router::models::get
+"$iii_bin" trigger engine::workers::list --port "$engine_port" --json '{}' >"$project_dir/workers.json"
+
+failure_phase=materialization
+"$iii_bin" trigger e2e::scenarios-list --port "$engine_port" \
+  --json "$(jq -cn --argjson seed "$seed" '{seed:$seed}')" >"$artifact_dir/catalog.json"
+python3 "$contract_tool" materialize \
+  --contract "$contract_path" \
+  --catalog "$artifact_dir/catalog.json" \
+  --output "$artifact_dir/run-request.json"
+
+failure_phase=execution
+timeout --signal=TERM --kill-after=30s 60 \
+  "$iii_bin" trigger e2e::run --port "$engine_port" \
+  --json "$(jq -c . "$artifact_dir/run-request.json")" >"$artifact_dir/accepted.json"
+remote_execution_id=$(jq -er '.execution_id | select(type == "string" and length > 0)' "$artifact_dir/accepted.json")
+printf '%s\n' "$remote_execution_id" >"$artifact_dir/remote-execution-id.txt"
+
+started_at=$SECONDS
+poll_index=0
+while true; do
+  timeout --signal=TERM --kill-after=30s 60 \
+    "$iii_bin" trigger e2e::status --port "$engine_port" \
+    --json "$(jq -cn --arg execution_id "$remote_execution_id" '{execution_id:$execution_id}')" \
+    >"$artifact_dir/status.json"
+  jq -e --arg id "$remote_execution_id" '.execution_id == $id' "$artifact_dir/status.json" >/dev/null
+  [[ "$(jq -r '.terminal // false' "$artifact_dir/status.json")" == true ]] && break
+  if ((SECONDS - started_at >= run_timeout_seconds)); then
+    fail "E2E execution exceeded ${run_timeout_seconds}s"
+  fi
+  case "$poll_index" in 0) delay=2 ;; 1) delay=5 ;; 2) delay=10 ;; *) delay=30 ;; esac
+  poll_index=$((poll_index + 1))
+  sleep "$delay"
+done
+
+failure_phase=results
+timeout --signal=TERM --kill-after=30s 120 \
+  "$iii_bin" trigger e2e::results-get --port "$engine_port" \
+  --json "$(jq -cn --arg execution_id "$remote_execution_id" '{execution_id:$execution_id}')" \
+  >"$artifact_dir/results.json"
+jq -e --arg id "$remote_execution_id" '.execution_id == $id' "$artifact_dir/results.json" >/dev/null
+
+# This proves the archive contract while the runner is alive. GitHub Artifact,
+# not this ephemeral local storage, is the D0 retention boundary.
+if "$iii_bin" trigger e2e::archive --port "$engine_port" \
+  --json "$(jq -cn --arg execution_id "$remote_execution_id" '{execution_id:$execution_id,retention_class:"longitudinal"}')" \
+  >"$artifact_dir/archive.json" 2>"$artifact_dir/logs/archive.log"; then
+  "$iii_bin" trigger e2e::archive-head --port "$engine_port" \
+    --json "$(jq -cn --arg execution_id "$remote_execution_id" '{execution_id:$execution_id}')" \
+    >"$artifact_dir/archive-head.json" 2>>"$artifact_dir/logs/archive.log" || true
+fi
+
+failure_phase=complete


### PR DESCRIPTION
## Summary

- add a trusted `workflow_dispatch` executor for Release Control shadow E2E campaigns
- authenticate each execution with a single-use GitHub Actions OIDC admission before any model call
- install the exact deployed Harness stack and `harness-e2e` independently from the Registry on an ephemeral GitHub runner
- materialize and run the native `e2e::*` control plane, then upload a digest-verified terminal observation bundle
- keep GitHub Artifact as the D0 retention boundary and preserve factual infrastructure failures

## Safety

- this workflow is observational and never changes deployment or promotion state
- native GitHub reruns are rejected; an explicit Release Control rerun creates a new attempt
- provider credentials stay in the protected `harness-e2e-trusted` environment
- the target stack is re-pinned after installing the runner and verified against `iii.lock`

## Validation

- `bash -n harness/tests/e2e/run-shadow-control-ci.sh`
- `python3 .github/scripts/tests/test_harness_e2e_shadow_contract.py` — 4 passed
- `python3 -m py_compile .github/scripts/harness_e2e_shadow_contract.py`
- workflow YAML parse
- `git diff --check`

## Related PRs and rollout order

1. iii-hq/harness-e2e#19 publishes the versioned observation contract and Registry runner.
2. This PR provides the ephemeral GitHub execution environment.
3. iii-hq/release-control#21 dispatches, admits, reconciles, persists, and displays the observations.

The Release Control feature flag remains off until all three changes are deployed and a Registry smoke succeeds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an observe-only Harness E2E workflow for deployment shadow observations.
  * Added contract validation, request materialization, execution monitoring, and evidence packaging.
  * Added factual observation bundles with file manifests and SHA-256 digests.
  * Added isolated E2E control-plane execution with retries, timeouts, logging, and cleanup.

* **Documentation**
  * Documented the deployment shadow observation workflow and its non-blocking behavior.

* **Tests**
  * Added coverage for contract validation, catalog consistency, prerelease versions, workflow inputs, and evidence packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->