### PR TITLE
(MOT-4299) feat(release): add immutable worker release train

### DIFF
--- a/.github/scripts/_lib.py
+++ b/.github/scripts/_lib.py
@@ -16,9 +16,9 @@ RELEASE_VERSION_RE = re.compile(
     r"^(?P<major>0|[1-9][0-9]*)\."
     r"(?P<minor>0|[1-9][0-9]*)\."
     r"(?P<patch>0|[1-9][0-9]*)"
-    r"(?:-(?P<maturity>experimental|alpha|beta))?$"
+    r"(?:-(?:(?P<rc>rc)\.(?P<rc_number>[1-9][0-9]*)|(?P<maturity>experimental|alpha|beta)))?$"
 )
-RELEASE_MATURITIES = ("experimental", "alpha", "beta", "stable")
+RELEASE_MATURITIES = ("experimental", "alpha", "beta", "rc", "stable")
 RELEASE_SUFFIXES = ("none", "experimental", "alpha", "beta")
 _MATURITY_RANK = {name: idx for idx, name in enumerate(RELEASE_MATURITIES)}
 
@@ -31,6 +31,7 @@ class ReleaseVersion:
     minor: int
     patch: int
     maturity: str
+    rc: int | None = None
 
     @property
     def core(self) -> tuple[int, int, int]:
@@ -45,20 +46,22 @@ def parse_release_version(version: str) -> ReleaseVersion:
     """Parse a worker release version and reject unsupported SemVer shapes.
 
     Release Control intentionally exposes only the product maturity ladder.
-    Build metadata, arbitrary prerelease labels and numbered prereleases are
-    excluded so the workflow and UI share one unambiguous contract.
+    Build metadata and arbitrary prerelease labels are excluded; numbered RCs
+    are represented explicitly so the workflow and UI share one unambiguous
+    contract.
     """
     match = RELEASE_VERSION_RE.fullmatch(version.strip())
     if not match:
         raise ValueError(
             "version must be MAJOR.MINOR.PATCH with an optional "
-            "-experimental, -alpha, or -beta suffix"
+            "-rc.N, -experimental, -alpha, or -beta suffix"
         )
     return ReleaseVersion(
         major=int(match.group("major")),
         minor=int(match.group("minor")),
         patch=int(match.group("patch")),
-        maturity=match.group("maturity") or "stable",
+        maturity=("rc" if match.group("rc") else match.group("maturity") or "stable"),
+        rc=int(match.group("rc_number")) if match.group("rc_number") else None,
     )
 
 
@@ -77,9 +80,14 @@ def validate_release_transition(current: str, target: str) -> None:
     after = parse_release_version(target)
     if after.core < before.core:
         raise ValueError(f"version core cannot move backwards: {current} -> {target}")
-    if after.core == before.core and target != current and before.maturity != "stable":
-        if _MATURITY_RANK[after.maturity] <= _MATURITY_RANK[before.maturity]:
+    if after.core == before.core and target != current:
+        # A manifest at an unreleased stable core is the bootstrap point for
+        # its first candidate. Once a prerelease exists, movement is forward
+        # only through the maturity ladder and RC counter.
+        if before.maturity != "stable" and _MATURITY_RANK[after.maturity] < _MATURITY_RANK[before.maturity]:
             raise ValueError(f"maturity cannot repeat or move backwards: {current} -> {target}")
+        if after.maturity == before.maturity == "rc" and (after.rc or 0) <= (before.rc or 0):
+            raise ValueError(f"rc number cannot repeat or move backwards: {current} -> {target}")
 
 
 def list_tagged_versions(worker: str) -> list[str]:
@@ -121,6 +129,8 @@ def validate_release_history(target: str, existing: list[str]) -> None:
         if version.core != wanted.core:
             continue
         same_version = version.maturity == wanted.maturity
+        if same_version and version.maturity == "rc" and (version.rc or 0) >= (wanted.rc or 0):
+            raise ValueError(f"rc {wanted.rc} cannot follow rc {version.rc} for {wanted.core_text}")
         if not same_version and _MATURITY_RANK[version.maturity] >= _MATURITY_RANK[wanted.maturity]:
             raise ValueError(
                 f"maturity {wanted.maturity} cannot follow {version.maturity} "
@@ -161,7 +171,11 @@ def parse_semver(v: str) -> SemverKey:
     parts = [int(x) for x in core.split(".")]
     while len(parts) < 3:
         parts.append(0)
-    return (tuple(parts), 0 if pre else 1, pre)
+    if not pre:
+        return (tuple(parts), 1, "")
+    if pre.startswith("rc.") and pre[3:].isdigit():
+        return (tuple(parts), 0, f"rc.{int(pre[3:]):020d}")
+    return (tuple(parts), 0, pre)
 
 
 def bump(current: str, kind: BumpKind) -> str:

--- a/.github/scripts/build_publish_payload.py
+++ b/.github/scripts/build_publish_payload.py
@@ -287,7 +287,6 @@ def build_payload(
     worker: str,
     version: str,
     registry_tag: str,
-    expected_current_version: str = "",
     deploy: str,
     repo_url: str,
     interface: dict[str, Any],
@@ -341,10 +340,6 @@ def build_payload(
     # mutable `next`/`latest` assignment, so `none` must omit the tag field.
     if registry_tag and registry_tag != "none":
         payload["tag"] = registry_tag
-        if expected_current_version == "none":
-            payload["expected_current_version"] = None
-        elif expected_current_version:
-            payload["expected_current_version"] = expected_current_version
 
     tags = normalize_tags(meta.get("tags"))
     if tags:
@@ -382,7 +377,6 @@ def main() -> int:
     parser.add_argument("--worker", required=True)
     parser.add_argument("--version", required=True)
     parser.add_argument("--registry-tag", default="latest")
-    parser.add_argument("--expected-current-version", default="none")
     parser.add_argument("--deploy", required=True, choices=["binary", "image", "bundle"])
     parser.add_argument("--repo-url", required=True)
     parser.add_argument("--interface-json", required=True)
@@ -414,7 +408,6 @@ def main() -> int:
         worker=args.worker,
         version=args.version,
         registry_tag=args.registry_tag,
-        expected_current_version=args.expected_current_version,
         deploy=args.deploy,
         repo_url=args.repo_url,
         interface=interface,

--- a/.github/scripts/build_publish_payload.py
+++ b/.github/scripts/build_publish_payload.py
@@ -287,6 +287,7 @@ def build_payload(
     worker: str,
     version: str,
     registry_tag: str,
+    expected_current_version: str = "",
     deploy: str,
     repo_url: str,
     interface: dict[str, Any],
@@ -314,7 +315,6 @@ def build_payload(
     payload: dict[str, Any] = {
         "worker_name": worker,
         "version": version,
-        "tag": registry_tag or "latest",
         "type": deploy,
         "readme": readme,
         "repo": repo_url,
@@ -336,6 +336,15 @@ def build_payload(
         # registry rejects a string here, hence the explicit bool.
         "experimental": bool(experimental),
     }
+    # Stable finalization first creates an immutable version without moving a
+    # channel. The Registry distinguishes that bootstrap-safe state from a
+    # mutable `next`/`latest` assignment, so `none` must omit the tag field.
+    if registry_tag and registry_tag != "none":
+        payload["tag"] = registry_tag
+        if expected_current_version == "none":
+            payload["expected_current_version"] = None
+        elif expected_current_version:
+            payload["expected_current_version"] = expected_current_version
 
     tags = normalize_tags(meta.get("tags"))
     if tags:
@@ -373,6 +382,7 @@ def main() -> int:
     parser.add_argument("--worker", required=True)
     parser.add_argument("--version", required=True)
     parser.add_argument("--registry-tag", default="latest")
+    parser.add_argument("--expected-current-version", default="none")
     parser.add_argument("--deploy", required=True, choices=["binary", "image", "bundle"])
     parser.add_argument("--repo-url", required=True)
     parser.add_argument("--interface-json", required=True)
@@ -404,6 +414,7 @@ def main() -> int:
         worker=args.worker,
         version=args.version,
         registry_tag=args.registry_tag,
+        expected_current_version=args.expected_current_version,
         deploy=args.deploy,
         repo_url=args.repo_url,
         interface=interface,

--- a/.github/scripts/cleanup_release_attempt_refs.py
+++ b/.github/scripts/cleanup_release_attempt_refs.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Remove terminal release-attempt refs after their evidence retention window.
+
+Only refs below the exact release-control namespace are eligible. A missing or
+unreadable commit timestamp is treated as unsafe and leaves the ref in place;
+the Release Control ledger and GitHub artifacts remain the source of evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from datetime import datetime, timedelta, timezone
+from urllib.parse import quote
+
+
+PREFIXES = ("heads/release-control", "tags/release-control")
+ALLOWED_REF_PREFIXES = ("refs/heads/release-control/", "refs/tags/release-control/")
+
+
+def gh_lines(*args: str) -> list[str]:
+    output = subprocess.check_output(["gh", "api", *args], text=True)
+    return [line for line in output.splitlines() if line]
+
+
+def candidate_refs(repository: str) -> list[str]:
+    refs: list[str] = []
+    for prefix in PREFIXES:
+        try:
+            refs.extend(gh_lines("--paginate", "--jq", ".[].ref", f"repos/{repository}/git/matching-refs/{prefix}"))
+        except subprocess.CalledProcessError as error:
+            print(f"warning: could not list {prefix}: {error}")
+    return sorted(set(refs))
+
+
+def ref_commit_date(repository: str, ref: str) -> datetime | None:
+    endpoint = f"repos/{repository}/commits?sha={quote(ref, safe='')}&per_page=1"
+    try:
+        values = gh_lines("--jq", ".[0].commit.committer.date // empty", endpoint)
+    except subprocess.CalledProcessError as error:
+        print(f"warning: could not inspect {ref}: {error}")
+        return None
+    if not values:
+        return None
+    try:
+        return datetime.fromisoformat(values[0].replace("Z", "+00:00")).astimezone(timezone.utc)
+    except ValueError:
+        return None
+
+
+def delete_ref(repository: str, ref: str) -> None:
+    if not ref.startswith(ALLOWED_REF_PREFIXES):
+        raise ValueError(f"ref outside cleanup namespace: {ref}")
+    subprocess.run(["gh", "api", "--method", "DELETE", f"repos/{repository}/git/refs/{ref.removeprefix('refs/')}"], check=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--older-than-days", type=int, default=7)
+    args = parser.parse_args()
+    if args.older_than_days < 1:
+        parser.error("--older-than-days must be positive")
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=args.older_than_days)
+    removed = 0
+    for ref in candidate_refs(args.repository):
+        if not ref.startswith(ALLOWED_REF_PREFIXES):
+            print(f"preserve unexpected ref: {ref}")
+            continue
+        updated_at = ref_commit_date(args.repository, ref)
+        if updated_at is None or updated_at >= cutoff:
+            print(f"preserve recent or unverifiable ref: {ref}")
+            continue
+        print(f"delete terminal release-attempt ref: {ref} (last commit {updated_at.isoformat()})")
+        delete_ref(args.repository, ref)
+        removed += 1
+    print(f"removed {removed} release-attempt refs")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/release_control_contract.py
+++ b/.github/scripts/release_control_contract.py
@@ -13,6 +13,10 @@ from uuid import UUID
 
 
 KINDS = {
+    "prepare_release",
+    "publish_candidate",
+    "publish_stable",
+    "registry_finalize",
     "create_tag",
     "release",
     "registry_promotion",
@@ -35,6 +39,12 @@ def _uuid(value: str, field: str) -> str:
     return str(parsed)
 
 
+def _optional_uuid(value: str | None, field: str) -> str | None:
+    if value in (None, ""):
+        return None
+    return _uuid(value, field)
+
+
 def validate_dispatch(args: argparse.Namespace) -> int:
     expected_bot = args.expected_bot.strip()
     if not expected_bot:
@@ -50,6 +60,20 @@ def validate_dispatch(args: argparse.Namespace) -> int:
         raise ValueError("GITHUB_RUN_ATTEMPT or --run-attempt is required")
     if args.mutating and args.run_attempt != 1:
         raise ValueError("mutating Release Control executors cannot be rerun; create a recovery operation")
+    if args.plan_hash and not re.fullmatch(r"[0-9a-f]{64}", args.plan_hash):
+        raise ValueError("plan_hash must be a 64-char lowercase SHA-256")
+    if args.dispatch_nonce:
+        _uuid(args.dispatch_nonce, "dispatch_nonce")
+    for value, field in ((args.source_sha, "source_sha"), (args.prepared_sha, "prepared_sha")):
+        if value and not re.fullmatch(r"[0-9a-f]{40}", value):
+            raise ValueError(f"{field} must be a full lowercase commit SHA")
+    candidate_pattern = r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)-rc\.[1-9][0-9]*"
+    if args.candidate_version and not re.fullmatch(candidate_pattern, args.candidate_version):
+        raise ValueError("candidate_version must be x.y.z-rc.N")
+    if args.stable_version and not re.fullmatch(r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)", args.stable_version):
+        raise ValueError("stable_version must be x.y.z")
+    if args.candidate_version and args.stable_version and args.candidate_version.split("-", 1)[0] != args.stable_version:
+        raise ValueError("candidate_version and stable_version must share the same core")
     return 0
 
 
@@ -88,6 +112,24 @@ def write_result(args: argparse.Namespace) -> int:
         "effects": _json(args.effects, "effects", list),
         "outputs": _json(args.outputs, "outputs", dict),
     }
+    release_identity = {
+        key: value
+        for key, value in {
+            "release_intent_id": _optional_uuid(args.release_intent_id, "release_intent_id"),
+            "candidate_id": _optional_uuid(args.candidate_id, "candidate_id"),
+            "attempt_id": _optional_uuid(args.attempt_id, "attempt_id"),
+            "plan_hash": args.plan_hash or None,
+            "dispatch_nonce": args.dispatch_nonce or None,
+            "candidate_version": args.candidate_version or None,
+            "stable_version": args.stable_version or None,
+            "source_sha": args.source_sha or None,
+            "prepared_sha": args.prepared_sha or None,
+            "digests": json.loads(args.digests_json) if args.digests_json else None,
+        }.items()
+        if value is not None
+    }
+    if release_identity:
+        payload["release"] = release_identity
     args.output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
     print(json.dumps(payload, sort_keys=True))
     return 0
@@ -105,6 +147,12 @@ def parser() -> argparse.ArgumentParser:
     validate.add_argument("--expected-bot", default=os.environ.get("RELEASE_CONTROL_BOT_LOGIN", ""))
     validate.add_argument("--run-attempt", type=int, default=os.environ.get("GITHUB_RUN_ATTEMPT"))
     validate.add_argument("--mutating", action="store_true")
+    validate.add_argument("--plan-hash")
+    validate.add_argument("--dispatch-nonce")
+    validate.add_argument("--candidate-version")
+    validate.add_argument("--stable-version")
+    validate.add_argument("--source-sha")
+    validate.add_argument("--prepared-sha")
     validate.set_defaults(handler=validate_dispatch)
 
     write = commands.add_parser("write-result")
@@ -122,6 +170,16 @@ def parser() -> argparse.ArgumentParser:
     write.add_argument("--effects", required=True)
     write.add_argument("--outputs", required=True)
     write.add_argument("--output", type=Path, required=True)
+    write.add_argument("--release-intent-id")
+    write.add_argument("--candidate-id")
+    write.add_argument("--attempt-id")
+    write.add_argument("--plan-hash")
+    write.add_argument("--dispatch-nonce")
+    write.add_argument("--candidate-version")
+    write.add_argument("--stable-version")
+    write.add_argument("--source-sha")
+    write.add_argument("--prepared-sha")
+    write.add_argument("--digests-json")
     write.set_defaults(handler=write_result)
     return root
 

--- a/.github/scripts/release_train.py
+++ b/.github/scripts/release_train.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Build and package one immutable Release Train attempt.
+
+The script deliberately has no GitHub Release, Registry, or final tag logic.
+Those effects belong to the publish workflows, which consume this attempt's
+artifact and prepared commit identity.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import tarfile
+from pathlib import Path
+
+import _lib
+
+
+def run(*command: str, cwd: Path | None = None) -> None:
+    print("+", " ".join(command))
+    subprocess.run(command, cwd=cwd, check=True)
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def manifest_for(worker: str) -> tuple[Path, _lib.WorkerManifest]:
+    root = Path(worker)
+    return root, _lib.read_iii_worker_yaml(root)
+
+
+def package_source(worker: str, out: Path) -> Path:
+    archive = out / f"{worker}.tar.gz"
+    with tarfile.open(archive, "w:gz") as handle:
+        handle.add(worker, arcname=".", filter=lambda item: None if ".git" in item.name.split("/") else item)
+    return archive
+
+
+def build_attempt(worker: str, out: Path) -> list[Path]:
+    root, manifest = manifest_for(worker)
+    out.mkdir(parents=True, exist_ok=True)
+    artifacts: list[Path] = []
+    if manifest.deploy == "binary":
+        cargo = root / "Cargo.toml"
+        if not cargo.exists():
+            raise SystemExit(f"{worker}: deploy=binary requires Cargo.toml")
+        locked = (root / "Cargo.lock").exists()
+        test_command = ["cargo", "test"]
+        build_command = ["cargo", "build", "--release"]
+        if locked:
+            test_command.append("--locked")
+            build_command.append("--locked")
+        test_command += ["--manifest-path", str(cargo)]
+        build_command += ["--manifest-path", str(cargo)]
+        run(*test_command)
+        run(*build_command)
+        binary = manifest.bin or manifest.name
+        binary_path = Path("target/release") / binary
+        if not binary_path.exists():
+            raise SystemExit(f"{worker}: built binary not found at {binary_path}")
+        archive = out / f"{binary}-x86_64-unknown-linux-gnu.tar.gz"
+        with tarfile.open(archive, "w:gz") as handle:
+            handle.add(binary_path, arcname=binary)
+        artifacts.append(archive)
+    elif manifest.deploy == "image":
+        image = f"release-attempt/{worker}:{os.environ.get('RELEASE_ATTEMPT_ID', 'local')}"
+        run("docker", "build", "--tag", image, str(root))
+        image_tar = out / f"{worker}-image.tar"
+        run("docker", "save", "--output", str(image_tar), image)
+        artifacts.append(image_tar)
+    elif manifest.deploy == "bundle":
+        package = root / "package.json"
+        if package.exists():
+            lock = Path("pnpm-lock.yaml")
+            if lock.exists():
+                run("pnpm", "install", "--frozen-lockfile", "--ignore-workspace", cwd=root)
+            else:
+                run("pnpm", "install", "--ignore-workspace", cwd=root)
+            package_json = json.loads(package.read_text(encoding="utf-8"))
+            if "build:bundle" in (package_json.get("scripts") or {}):
+                run("pnpm", "run", "build:bundle", cwd=root)
+        archive = package_source(worker, out)
+        artifacts.append(archive)
+    else:
+        raise SystemExit(f"{worker}: unsupported deploy mode {manifest.deploy}")
+    return artifacts
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--worker", required=True)
+    parser.add_argument("--source-sha", required=True)
+    parser.add_argument("--candidate-version", required=True)
+    parser.add_argument("--intent-id", required=True)
+    parser.add_argument("--attempt-id", required=True)
+    parser.add_argument("--branch", required=True)
+    parser.add_argument("--out", type=Path, default=Path("release-prepared"))
+    args = parser.parse_args()
+
+    actual = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+    if actual != args.source_sha:
+        raise SystemExit(f"source SHA mismatch: checkout={actual}, requested={args.source_sha}")
+    if not _lib.RELEASE_VERSION_RE.fullmatch(args.candidate_version):
+        raise SystemExit(f"invalid candidate version: {args.candidate_version}")
+
+    root, manifest = manifest_for(args.worker)
+    run(
+        "python3",
+        ".github/scripts/manifest_version.py",
+        "bump",
+        str(root / manifest.manifest),
+        "--kind",
+        "none",
+        "--target",
+        args.candidate_version,
+    )
+    run("python3", ".github/scripts/manifest_version.py", "verify", str(root / manifest.manifest), "--expected", args.candidate_version)
+    run("python3", ".github/scripts/manifest_version.py", "sync-lock", str(root / manifest.manifest))
+    run("git", "config", "user.name", "workers-ci[bot]")
+    run("git", "config", "user.email", "workers-ci[bot]@users.noreply.github.com")
+    run("git", "add", str(root))
+    if subprocess.run(["git", "diff", "--cached", "--quiet"], check=False).returncode != 0:
+        run("git", "commit", "-m", f"chore({args.worker}): prepare v{args.candidate_version}")
+    prepared_sha = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+    run("git", "push", "origin", f"HEAD:{args.branch}")
+
+    artifacts = build_attempt(args.worker, args.out)
+    metadata = {
+        "schema_version": 1,
+        "worker": args.worker,
+        "source_sha": args.source_sha,
+        "prepared_sha": prepared_sha,
+        "candidate_version": args.candidate_version,
+        "release_intent_id": args.intent_id,
+        "release_attempt_id": args.attempt_id,
+        "deploy": manifest.deploy,
+        "artifacts": [
+            {"name": artifact.name, "sha256": sha256(artifact), "path": artifact.name}
+            for artifact in artifacts
+        ],
+    }
+    (args.out / "prepared.json").write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(metadata, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_lib.py
+++ b/.github/scripts/tests/test_lib.py
@@ -16,7 +16,7 @@ class TestParseSemver:
         assert _lib.parse_semver("1.2") == ((1, 2, 0), 1, "")
 
     def test_prerelease_strips_core_keeps_suffix(self):
-        assert _lib.parse_semver("1.2.3-rc.1") == ((1, 2, 3), 0, "rc.1")
+        assert _lib.parse_semver("1.2.3-rc.1") == ((1, 2, 3), 0, "rc.00000000000000000001")
 
     def test_stable_greater_than_prerelease_same_core(self):
         # 1.2.3 must rank above 1.2.3-rc.1 (the audit bug).
@@ -28,6 +28,7 @@ class TestParseSemver:
 
     def test_two_prereleases_sort_lexicographically(self):
         assert _lib.parse_semver("1.2.3-rc.1") < _lib.parse_semver("1.2.3-rc.2")
+        assert _lib.parse_semver("1.2.3-rc.2") < _lib.parse_semver("1.2.3-rc.10")
 
     def test_build_metadata_is_ignored(self):
         # SemVer 2.0.0 §10: build metadata after `+` MUST NOT affect precedence.

--- a/.github/scripts/tests/test_release_control_contract.py
+++ b/.github/scripts/tests/test_release_control_contract.py
@@ -54,6 +54,58 @@ def test_strict_dispatch_rejects_user_and_rerun():
         assert result.returncode == 2
 
 
+def test_release_dispatch_validates_frozen_identity_inputs():
+    valid = run(
+        "validate-dispatch",
+        "--operation-id",
+        OPERATION_ID,
+        "--step-id",
+        STEP_ID,
+        "--actor",
+        "iii-release-control[bot]",
+        "--triggering-actor",
+        "iii-release-control[bot]",
+        "--expected-bot",
+        "iii-release-control[bot]",
+        "--run-attempt",
+        "1",
+        "--mutating",
+        "--plan-hash",
+        "b" * 64,
+        "--dispatch-nonce",
+        "66666666-6666-4666-8666-666666666666",
+        "--candidate-version",
+        "1.2.3-rc.1",
+        "--stable-version",
+        "1.2.3",
+        "--source-sha",
+        "a" * 40,
+        "--prepared-sha",
+        "c" * 40,
+    )
+    assert valid.returncode == 0, valid.stderr
+
+    invalid = run(
+        "validate-dispatch",
+        "--operation-id",
+        OPERATION_ID,
+        "--step-id",
+        STEP_ID,
+        "--actor",
+        "iii-release-control[bot]",
+        "--triggering-actor",
+        "iii-release-control[bot]",
+        "--expected-bot",
+        "iii-release-control[bot]",
+        "--run-attempt",
+        "1",
+        "--mutating",
+        "--plan-hash",
+        "not-a-plan",
+    )
+    assert invalid.returncode == 2
+
+
 def test_result_contains_only_factual_sections(tmp_path: pathlib.Path):
     output = tmp_path / "execution-result.json"
     result = run(
@@ -84,6 +136,26 @@ def test_result_contains_only_factual_sections(tmp_path: pathlib.Path):
         '[{"surface":"registry","status":"changed"}]',
         "--outputs",
         '{"tag":"eval/v1.2.3"}',
+        "--release-intent-id",
+        "33333333-3333-4333-8333-333333333333",
+        "--candidate-id",
+        "44444444-4444-4444-8444-444444444444",
+        "--attempt-id",
+        "55555555-5555-4555-8555-555555555555",
+        "--plan-hash",
+        "b" * 64,
+        "--dispatch-nonce",
+        "nonce-1",
+        "--candidate-version",
+        "1.2.3-rc.1",
+        "--stable-version",
+        "1.2.3",
+        "--source-sha",
+        "a" * 40,
+        "--prepared-sha",
+        "c" * 40,
+        "--digests-json",
+        '[{"name":"worker.tar.gz","sha256":"d"}]',
         "--output",
         str(output),
     )
@@ -93,3 +165,5 @@ def test_result_contains_only_factual_sections(tmp_path: pathlib.Path):
     assert payload["run"]["attempt"] == 1
     assert "status" not in payload
     assert "promotable" not in payload
+    assert payload["release"]["candidate_id"] == "44444444-4444-4444-8444-444444444444"
+    assert payload["release"]["digests"] == [{"name": "worker.tar.gz", "sha256": "d"}]

--- a/.github/scripts/tests/test_release_workflows.py
+++ b/.github/scripts/tests/test_release_workflows.py
@@ -11,6 +11,66 @@ COMMON = {"operation_id", "step_id"}
 
 EXPECTED_INPUTS = {
     "harness-e2e-shadow.yml": {"campaign_id", "execution_id", "attempt", "execution_contract"},
+    "prepare-release.yml": COMMON
+    | {
+        "release_intent_id",
+        "candidate_id",
+        "release_attempt_id",
+        "worker",
+        "stable_version",
+        "candidate_version",
+        "source_sha",
+        "plan_hash",
+        "dispatch_nonce",
+    },
+    "publish-candidate.yml": COMMON
+    | {
+        "release_intent_id",
+        "candidate_id",
+        "release_attempt_id",
+        "worker",
+        "stable_version",
+        "candidate_version",
+        "source_sha",
+        "prepared_sha",
+        "prepared_run_id",
+        "prepared_artifact",
+        "plan_hash",
+        "expected_next_version",
+        "dispatch_nonce",
+    },
+    "publish-stable.yml": COMMON
+    | {
+        "release_intent_id",
+        "candidate_id",
+        "release_attempt_id",
+        "worker",
+        "candidate_version",
+        "stable_version",
+        "source_operation_id",
+        "source_sha",
+        "plan_hash",
+        "expected_next_version",
+        "expected_latest_version",
+        "recovery_run_id",
+        "recovery_operation_id",
+        "recovery_step_id",
+        "dispatch_nonce",
+    },
+    "finalize-registry.yml": COMMON
+    | {
+        "release_intent_id",
+        "candidate_id",
+        "release_attempt_id",
+        "worker",
+        "candidate_version",
+        "stable_version",
+        "source_sha",
+        "plan_hash",
+        "expected_next_version",
+        "expected_latest_version",
+        "dispatch_nonce",
+    },
     "create-tag.yml": COMMON | {"worker", "target_version", "registry_tag", "experimental", "expected_current_version", "source_sha"},
     "create-prerelease-tag.yml": COMMON | {"worker", "target_version", "source_sha", "experimental"},
     "release.yml": COMMON | {"source_tag_step_id", "tag", "publish_registry"},
@@ -83,6 +143,10 @@ EXPECTED_INPUTS = {
 }
 
 MUTATING = {
+    "prepare-release.yml",
+    "publish-candidate.yml",
+    "publish-stable.yml",
+    "finalize-registry.yml",
     "create-tag.yml",
     "create-prerelease-tag.yml",
     "release.yml",
@@ -117,7 +181,19 @@ def test_release_control_workflow_input_contract_is_exact() -> None:
         dispatch = workflow(WORKFLOWS / name)["on"]["workflow_dispatch"]
         inputs = dispatch.get("inputs", {}) if isinstance(dispatch, dict) else {}
         assert set(inputs) == expected, name
-        assert all(input_definition.get("required") == "true" for input_definition in inputs.values()), name
+        optional_defaults = {
+            "publish-stable.yml": {
+                "recovery_run_id": "0",
+                "recovery_operation_id": "none",
+                "recovery_step_id": "none",
+            },
+        }
+        for input_name, definition in inputs.items():
+            if input_name in optional_defaults.get(name, {}):
+                assert definition.get("required") == "false", (name, input_name)
+                assert definition.get("default") == optional_defaults[name][input_name], (name, input_name)
+            else:
+                assert definition.get("required") == "true", (name, input_name)
 
 
 def test_every_dispatch_is_actor_gated_and_emits_factual_evidence() -> None:
@@ -152,8 +228,21 @@ def test_reusable_release_executors_have_no_implicit_inputs() -> None:
     for name in RELEASE_EXECUTORS:
         inputs = workflow(WORKFLOWS / name)["on"]["workflow_call"]["inputs"]
         assert inputs, name
-        assert all(definition.get("required") == "true" for definition in inputs.values()), name
-        assert all("default" not in definition for definition in inputs.values()), name
+        optional_defaults = {
+            "_publish-registry.yml": {"expected_current_version": ""},
+            "publish-stable.yml": {
+                "recovery_run_id": "0",
+                "recovery_operation_id": "none",
+                "recovery_step_id": "none",
+            },
+        }
+        for input_name, definition in inputs.items():
+            if input_name in optional_defaults.get(name, {}):
+                assert definition.get("required") == "false", (name, input_name)
+                assert definition.get("default") == optional_defaults[name][input_name], (name, input_name)
+            else:
+                assert definition.get("required") == "true", (name, input_name)
+                assert "default" not in definition, (name, input_name)
 
 
 def test_registry_publish_authenticates_iii_installer() -> None:

--- a/.github/workflows/_publish-registry.yml
+++ b/.github/workflows/_publish-registry.yml
@@ -323,12 +323,13 @@ jobs:
           printf '{}\n' > bundle.json
 
       - name: Build payload
+        # Keep immutable publication separate from mutable channel assignment.
+        # The Registry already exposes the latter as PUT /w/:slug/tags/:tag
+        # with an optional compare-and-swap precondition.
         env:
           WORKER: ${{ inputs.worker }}
           VERSION: ${{ inputs.version }}
           DEPLOY: ${{ inputs.deploy }}
-          REGISTRY_TAG: ${{ inputs.registry_tag }}
-          EXPECTED_CURRENT_VERSION: ${{ inputs.expected_current_version }}
           IMAGE_TAG: ${{ inputs.image_tag }}
           REPO_URL: ${{ format('https://github.com/{0}', github.repository) }}
           EXPERIMENTAL: ${{ inputs.experimental }}
@@ -336,8 +337,7 @@ jobs:
           python3 .github/scripts/build_publish_payload.py \
             --worker "$WORKER" \
             --version "$VERSION" \
-            --registry-tag "$REGISTRY_TAG" \
-            --expected-current-version "$EXPECTED_CURRENT_VERSION" \
+            --registry-tag none \
             --experimental "$EXPERIMENTAL" \
             --deploy "$DEPLOY" \
             --repo-url "$REPO_URL" \
@@ -368,22 +368,16 @@ jobs:
           echo "HTTP $http"
           cat response.json
           if [[ "$http" == "409" ]]; then
-            resolve_version="$REGISTRY_TAG"
-            if [[ "$REGISTRY_TAG" == "none" ]]; then
-              resolve_version="$VERSION"
-            fi
             resolve_http=$(curl -sS -o resolve-response.json -w '%{http_code}' \
               -H "Content-Type: application/json" \
               -X POST "$API_URL/resolve" \
-              --data "$(jq -cn --arg worker "$WORKER" --arg version "$resolve_version" \
+              --data "$(jq -cn --arg worker "$WORKER" --arg version "$VERSION" \
                 '{worker: $worker, version: $version}')")
             resolved=$(jq -r '.root.version // empty' resolve-response.json)
-            if [[ "$REGISTRY_TAG" == "none" && "$resolve_http" == "200" && "$resolved" == "$VERSION" ]]; then
-              echo "::notice::$WORKER@$VERSION already exists without a mutable Registry channel; continuing idempotently"
-            elif [[ "$resolve_http" == "200" && "$resolved" == "$VERSION" ]]; then
-              echo "::notice::$WORKER@$VERSION already exists and $REGISTRY_TAG still points to it; continuing idempotently"
+            if [[ "$resolve_http" == "200" && "$resolved" == "$VERSION" ]]; then
+              echo "::notice::$WORKER@$VERSION already exists; continuing idempotently"
             else
-              echo "::error::duplicate publish is not a safe retry: $WORKER@$resolve_version resolved ${resolved:-nothing} (HTTP $resolve_http), expected $VERSION"
+              echo "::error::duplicate publish is not a safe retry: $WORKER@$VERSION resolved ${resolved:-nothing} (HTTP $resolve_http), expected $VERSION"
               cat resolve-response.json
               exit 1
             fi
@@ -391,6 +385,44 @@ jobs:
             echo "::error::publish failed with HTTP $http"
             exit 1
           fi
+
+      - name: Assign Registry tag with existing CAS
+        if: inputs.registry_tag != 'none'
+        env:
+          API_URL: https://api.workers.iii.dev
+          API_KEY: ${{ secrets.WORKERS_REGISTRY_API_KEY }}
+          WORKER: ${{ inputs.worker }}
+          VERSION: ${{ inputs.version }}
+          REGISTRY_TAG: ${{ inputs.registry_tag }}
+          EXPECTED_CURRENT_VERSION: ${{ inputs.expected_current_version }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$API_KEY" ]]; then
+            echo "::error::WORKERS_REGISTRY_API_KEY secret is not set"
+            exit 1
+          fi
+          if [[ "$EXPECTED_CURRENT_VERSION" == "none" ]]; then
+            payload=$(jq -cn --arg version "$VERSION" \
+              '{version:$version,expected_current_version:null}')
+          elif [[ -n "$EXPECTED_CURRENT_VERSION" ]]; then
+            payload=$(jq -cn --arg version "$VERSION" --arg expected "$EXPECTED_CURRENT_VERSION" \
+              '{version:$version,expected_current_version:$expected}')
+          else
+            payload=$(jq -cn --arg version "$VERSION" '{version:$version}')
+          fi
+          http=$(curl -sS -o tag-response.json -w '%{http_code}' \
+            -H "X-API-Key: $API_KEY" \
+            -H "Content-Type: application/json" \
+            -X PUT "$API_URL/w/$WORKER/tags/$REGISTRY_TAG" \
+            --data "$payload")
+          echo "HTTP $http"
+          cat tag-response.json
+          if [[ "$http" != "200" ]]; then
+            echo "::error::Registry tag assignment failed with HTTP $http"
+            exit 1
+          fi
+          assigned=$(jq -r '.tag.version // empty' tag-response.json)
+          test "$assigned" = "$VERSION"
 
       - name: Build skills payload
         id: skills_payload

--- a/.github/workflows/_publish-registry.yml
+++ b/.github/workflows/_publish-registry.yml
@@ -23,6 +23,11 @@ on:
         description: 'Registry tag (latest, next, ...)'
         required: true
         type: string
+      expected_current_version:
+        description: Current destination tag version, or none for an unassigned tag
+        required: false
+        default: ''
+        type: string
       tag:
         description: 'Git tag (e.g., image-resize/v1.0.0)'
         required: true
@@ -323,6 +328,7 @@ jobs:
           VERSION: ${{ inputs.version }}
           DEPLOY: ${{ inputs.deploy }}
           REGISTRY_TAG: ${{ inputs.registry_tag }}
+          EXPECTED_CURRENT_VERSION: ${{ inputs.expected_current_version }}
           IMAGE_TAG: ${{ inputs.image_tag }}
           REPO_URL: ${{ format('https://github.com/{0}', github.repository) }}
           EXPERIMENTAL: ${{ inputs.experimental }}
@@ -331,6 +337,7 @@ jobs:
             --worker "$WORKER" \
             --version "$VERSION" \
             --registry-tag "$REGISTRY_TAG" \
+            --expected-current-version "$EXPECTED_CURRENT_VERSION" \
             --experimental "$EXPERIMENTAL" \
             --deploy "$DEPLOY" \
             --repo-url "$REPO_URL" \
@@ -361,16 +368,22 @@ jobs:
           echo "HTTP $http"
           cat response.json
           if [[ "$http" == "409" ]]; then
+            resolve_version="$REGISTRY_TAG"
+            if [[ "$REGISTRY_TAG" == "none" ]]; then
+              resolve_version="$VERSION"
+            fi
             resolve_http=$(curl -sS -o resolve-response.json -w '%{http_code}' \
               -H "Content-Type: application/json" \
               -X POST "$API_URL/resolve" \
-              --data "$(jq -cn --arg worker "$WORKER" --arg version "$REGISTRY_TAG" \
+              --data "$(jq -cn --arg worker "$WORKER" --arg version "$resolve_version" \
                 '{worker: $worker, version: $version}')")
             resolved=$(jq -r '.root.version // empty' resolve-response.json)
-            if [[ "$resolve_http" == "200" && "$resolved" == "$VERSION" ]]; then
+            if [[ "$REGISTRY_TAG" == "none" && "$resolve_http" == "200" && "$resolved" == "$VERSION" ]]; then
+              echo "::notice::$WORKER@$VERSION already exists without a mutable Registry channel; continuing idempotently"
+            elif [[ "$resolve_http" == "200" && "$resolved" == "$VERSION" ]]; then
               echo "::notice::$WORKER@$VERSION already exists and $REGISTRY_TAG still points to it; continuing idempotently"
             else
-              echo "::error::duplicate publish is not a safe retry: $WORKER@$REGISTRY_TAG resolved ${resolved:-nothing} (HTTP $resolve_http), expected $VERSION"
+              echo "::error::duplicate publish is not a safe retry: $WORKER@$resolve_version resolved ${resolved:-nothing} (HTTP $resolve_http), expected $VERSION"
               cat resolve-response.json
               exit 1
             fi

--- a/.github/workflows/cleanup-release-attempt-refs.yml
+++ b/.github/workflows/cleanup-release-attempt-refs.yml
@@ -1,0 +1,24 @@
+name: Cleanup terminal release attempt refs
+run-name: Cleanup release attempt refs older than seven days
+
+on:
+  schedule:
+    - cron: '23 3 * * *'
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Remove expired internal refs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          python3 .github/scripts/cleanup_release_attempt_refs.py
+          --repository '${{ github.repository }}'
+          --older-than-days 7

--- a/.github/workflows/finalize-registry.yml
+++ b/.github/workflows/finalize-registry.yml
@@ -1,0 +1,150 @@
+name: Commit exact stable Registry release
+run-name: RC · registry_finalize · ${{ inputs.operation_id }} · ${{ inputs.step_id }} · ${{ inputs.dispatch_nonce }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      operation_id:
+        required: true
+        type: string
+      step_id:
+        required: true
+        type: string
+      release_intent_id:
+        required: true
+        type: string
+      candidate_id:
+        required: true
+        type: string
+      release_attempt_id:
+        required: true
+        type: string
+      worker:
+        required: true
+        type: string
+      candidate_version:
+        required: true
+        type: string
+      stable_version:
+        required: true
+        type: string
+      source_sha:
+        required: true
+        type: string
+      plan_hash:
+        required: true
+        type: string
+      expected_next_version:
+        required: true
+        type: string
+      expected_latest_version:
+        required: true
+        type: string
+      dispatch_nonce:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  finalize:
+    name: Commit ${{ inputs.worker }} latest and next
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Validate exact dispatch and CAS identity
+        env:
+          RELEASE_CONTROL_BOT_LOGIN: ${{ vars.RELEASE_CONTROL_BOT_LOGIN }}
+        run: >-
+          python3 .github/scripts/release_control_contract.py validate-dispatch
+          --operation-id '${{ inputs.operation_id }}'
+          --step-id '${{ inputs.step_id }}'
+          --plan-hash '${{ inputs.plan_hash }}'
+          --dispatch-nonce '${{ inputs.dispatch_nonce }}'
+          --candidate-version '${{ inputs.candidate_version }}'
+          --stable-version '${{ inputs.stable_version }}'
+          --source-sha '${{ inputs.source_sha }}'
+          --mutating
+
+      - name: Commit Registry point or confirm an already committed retry
+        id: commit
+        env:
+          API_KEY: ${{ secrets.WORKERS_REGISTRY_API_KEY }}
+          WORKER: ${{ inputs.worker }}
+          CANDIDATE: ${{ inputs.candidate_version }}
+          STABLE: ${{ inputs.stable_version }}
+          EXPECTED_NEXT: ${{ inputs.expected_next_version }}
+          EXPECTED_LATEST: ${{ inputs.expected_latest_version }}
+        run: |
+          set -euo pipefail
+          resolve() {
+            local channel="$1" response http
+            response=$(mktemp)
+            http=$(curl -sS -o "$response" -w '%{http_code}' \
+              -H 'Content-Type: application/json' -X POST 'https://api.workers.iii.dev/resolve' \
+              --data "$(jq -cn --arg worker "$WORKER" --arg version "$channel" '{worker:$worker,version:$version}')")
+            if [[ "$http" == "200" ]]; then jq -r '.root.version // empty' "$response"; else echo; fi
+          }
+
+          next=$(resolve next)
+          latest=$(resolve latest)
+          if [[ "$next" == "$STABLE" && "$latest" == "$STABLE" ]]; then
+            echo 'state=unchanged' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          expected_latest_json=null
+          if [[ "$EXPECTED_LATEST" != 'none' ]]; then
+            expected_latest_json=$(jq -cn --arg value "$EXPECTED_LATEST" '$value')
+          fi
+          payload=$(jq -cn \
+            --arg candidate "$CANDIDATE" --arg stable "$STABLE" --arg next "$EXPECTED_NEXT" \
+            --argjson latest "$expected_latest_json" \
+            '{candidate_version:$candidate,stable_version:$stable,expected_next_version:$next,expected_latest_version:$latest}')
+          http=$(curl -sS -o finalize-response.json -w '%{http_code}' \
+            -H "X-API-Key: $API_KEY" -H 'Content-Type: application/json' \
+            -H 'Idempotency-Key: ${{ inputs.operation_id }}-${{ inputs.worker }}' \
+            -X POST "https://api.workers.iii.dev/w/$WORKER/releases/finalize" \
+            --data "$payload")
+          cat finalize-response.json
+          test "$http" = 200
+          echo 'state=changed' >> "$GITHUB_OUTPUT"
+
+      - name: Write factual Registry result
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATE: ${{ steps.commit.outputs.state }}
+        run: |
+          set -euo pipefail
+          state="$STATE"
+          if [[ "$JOB_STATUS" != 'success' ]]; then state='failed'; fi
+          checks=$(jq -cn --arg status "$JOB_STATUS" '[{name:"registry_commit_point",status:$status}]')
+          effects=$(jq -cn --arg state "$state" --arg worker '${{ inputs.worker }}' --arg version '${{ inputs.stable_version }}' \
+            '[{surface:"registry_commit_point",status:(if $state == "changed" then "changed" else (if $state == "unchanged" then "unchanged" else "failed" end) end),immutable_id:($worker + "@" + $version)}]')
+          outputs=$(jq -cn --arg state "$state" '{registry_state:$state}')
+          subject=$(jq -cn \
+            --arg worker '${{ inputs.worker }}' --arg candidate '${{ inputs.candidate_version }}' \
+            --arg stable '${{ inputs.stable_version }}' --arg source '${{ inputs.source_sha }}' \
+            '{worker:$worker,version:$stable,candidate_version:$candidate,stable_version:$stable,source_sha:$source}')
+          python3 .github/scripts/release_control_contract.py write-result \
+            --kind registry_finalize --repository '${{ github.repository }}' \
+            --operation-id '${{ inputs.operation_id }}' --step-id '${{ inputs.step_id }}' \
+            --run-id '${{ github.run_id }}' --run-attempt '${{ github.run_attempt }}' \
+            --workflow finalize-registry.yml --event '${{ github.event_name }}' --sha '${{ github.sha }}' \
+            --subject "$subject" --checks "$checks" --effects "$effects" --outputs "$outputs" \
+            --release-intent-id '${{ inputs.release_intent_id }}' --candidate-id '${{ inputs.candidate_id }}' --attempt-id '${{ inputs.release_attempt_id }}' \
+            --plan-hash '${{ inputs.plan_hash }}' --dispatch-nonce '${{ inputs.dispatch_nonce }}' \
+            --candidate-version '${{ inputs.candidate_version }}' --stable-version '${{ inputs.stable_version }}' \
+            --source-sha '${{ inputs.source_sha }}' --output execution-result.json
+
+      - uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: execution-result-${{ inputs.operation_id }}-${{ inputs.step_id }}
+          path: execution-result.json
+          retention-days: 30
+          if-no-files-found: error

--- a/.github/workflows/finalize-registry.yml
+++ b/.github/workflows/finalize-registry.yml
@@ -49,7 +49,7 @@ permissions:
 
 jobs:
   finalize:
-    name: Commit ${{ inputs.worker }} latest and next
+    name: Set ${{ inputs.worker }} latest tag
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -91,7 +91,16 @@ jobs:
 
           next=$(resolve next)
           latest=$(resolve latest)
-          if [[ "$next" == "$STABLE" && "$latest" == "$STABLE" ]]; then
+          if [[ "$next" != "$EXPECTED_NEXT" ]]; then
+            echo "::error::next points to ${next:-nothing}, expected $EXPECTED_NEXT"
+            exit 1
+          fi
+          stable=$(resolve "$STABLE")
+          if [[ "$stable" != "$STABLE" ]]; then
+            echo "::error::stable version $STABLE is not present in the Registry"
+            exit 1
+          fi
+          if [[ "$next" == "$EXPECTED_NEXT" && "$latest" == "$STABLE" ]]; then
             echo 'state=unchanged' >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -100,17 +109,16 @@ jobs:
           if [[ "$EXPECTED_LATEST" != 'none' ]]; then
             expected_latest_json=$(jq -cn --arg value "$EXPECTED_LATEST" '$value')
           fi
-          payload=$(jq -cn \
-            --arg candidate "$CANDIDATE" --arg stable "$STABLE" --arg next "$EXPECTED_NEXT" \
-            --argjson latest "$expected_latest_json" \
-            '{candidate_version:$candidate,stable_version:$stable,expected_next_version:$next,expected_latest_version:$latest}')
+          payload=$(jq -cn --arg stable "$STABLE" --argjson latest "$expected_latest_json" \
+            '{version:$stable} + (if $latest == null then {expected_current_version:null} else {expected_current_version:$latest} end)')
           http=$(curl -sS -o finalize-response.json -w '%{http_code}' \
             -H "X-API-Key: $API_KEY" -H 'Content-Type: application/json' \
-            -H 'Idempotency-Key: ${{ inputs.operation_id }}-${{ inputs.worker }}' \
-            -X POST "https://api.workers.iii.dev/w/$WORKER/releases/finalize" \
+            -X PUT "https://api.workers.iii.dev/w/$WORKER/tags/latest" \
             --data "$payload")
           cat finalize-response.json
           test "$http" = 200
+          test "$(resolve latest)" = "$STABLE"
+          test "$(resolve next)" = "$EXPECTED_NEXT"
           echo 'state=changed' >> "$GITHUB_OUTPUT"
 
       - name: Write factual Registry result

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,146 @@
+name: Prepare exact release attempt
+run-name: RC · prepare_release · ${{ inputs.operation_id }} · ${{ inputs.step_id }} · ${{ inputs.dispatch_nonce }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      operation_id:
+        description: Release Control operation UUID
+        required: true
+        type: string
+      step_id:
+        description: Release Control step UUID
+        required: true
+        type: string
+      release_intent_id:
+        required: true
+        type: string
+      candidate_id:
+        required: true
+        type: string
+      release_attempt_id:
+        required: true
+        type: string
+      worker:
+        required: true
+        type: string
+      stable_version:
+        required: true
+        type: string
+      candidate_version:
+        required: true
+        type: string
+      source_sha:
+        description: Immutable source commit used by the plan
+        required: true
+        type: string
+      plan_hash:
+        required: true
+        type: string
+      dispatch_nonce:
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-prepare-${{ inputs.worker }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Build ${{ inputs.worker }} ${{ inputs.candidate_version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Generate token
+        id: token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.III_CI_APP_ID }}
+          private-key: ${{ secrets.III_CI_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.source_sha }}
+          fetch-depth: 0
+          fetch-tags: true
+          token: ${{ steps.token.outputs.token }}
+
+      - name: Validate exact dispatch and inputs
+        env:
+          RELEASE_CONTROL_BOT_LOGIN: ${{ vars.RELEASE_CONTROL_BOT_LOGIN }}
+        run: >-
+          python3 .github/scripts/release_control_contract.py validate-dispatch
+          --operation-id '${{ inputs.operation_id }}'
+          --step-id '${{ inputs.step_id }}'
+          --plan-hash '${{ inputs.plan_hash }}'
+          --dispatch-nonce '${{ inputs.dispatch_nonce }}'
+          --candidate-version '${{ inputs.candidate_version }}'
+          --stable-version '${{ inputs.stable_version }}'
+          --source-sha '${{ inputs.source_sha }}'
+          --mutating
+
+      - name: Prepare, test and package without publishing
+        env:
+          RELEASE_ATTEMPT_ID: ${{ inputs.release_attempt_id }}
+        run: >-
+          python3 .github/scripts/release_train.py
+          --worker '${{ inputs.worker }}'
+          --source-sha '${{ inputs.source_sha }}'
+          --candidate-version '${{ inputs.candidate_version }}'
+          --intent-id '${{ inputs.release_intent_id }}'
+          --attempt-id '${{ inputs.release_attempt_id }}'
+          --branch 'refs/heads/release-control/${{ inputs.release_intent_id }}/${{ inputs.release_attempt_id }}'
+          --out release-prepared
+
+      - name: Upload prepared artifacts
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-prepared-${{ inputs.operation_id }}-${{ inputs.step_id }}
+          path: release-prepared/
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Write factual preparation result
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          PREPARED: ${{ inputs.candidate_version }}
+        run: |
+          set -euo pipefail
+          prepared_sha=$(jq -r '.prepared_sha // empty' release-prepared/prepared.json 2>/dev/null || true)
+          artifact_sha=$(jq -c '[.artifacts[]? | {name,sha256}]' release-prepared/prepared.json 2>/dev/null || echo '[]')
+          subject=$(jq -cn \
+            --arg worker '${{ inputs.worker }}' --arg candidate '${{ inputs.candidate_version }}' \
+            --arg stable '${{ inputs.stable_version }}' --arg source '${{ inputs.source_sha }}' \
+            --arg prepared "$prepared_sha" \
+            '{worker:$worker,version:$candidate,candidate_version:$candidate,stable_version:$stable,source_sha:$source,prepared_sha:(if $prepared == "" then null else $prepared end)}')
+          checks=$(jq -cn --arg status "$JOB_STATUS" '[{name:"prepare_build_and_tests",status:$status}]')
+          effects=$(jq -cn --arg status "$JOB_STATUS" --arg prepared "$prepared_sha" \
+            '[{surface:"internal_attempt_ref",status:(if $prepared == "" then "unknown" else (if $status == "success" then "changed" else "present" end) end),immutable_id:$prepared}]')
+          outputs=$(jq -cn --arg prepared "$prepared_sha" --argjson digests "$artifact_sha" \
+            --arg artifact "release-prepared-${{ inputs.operation_id }}-${{ inputs.step_id }}" \
+            '{prepared_sha:(if $prepared == "" then null else $prepared end),prepared_run_id:(${{ github.run_id }}),prepared_artifact:$artifact,digests:$digests}')
+          python3 .github/scripts/release_control_contract.py write-result \
+            --kind prepare_release --repository '${{ github.repository }}' \
+            --operation-id '${{ inputs.operation_id }}' --step-id '${{ inputs.step_id }}' \
+            --run-id '${{ github.run_id }}' --run-attempt '${{ github.run_attempt }}' \
+            --workflow prepare-release.yml --event '${{ github.event_name }}' --sha '${{ github.sha }}' \
+            --subject "$subject" --checks "$checks" --effects "$effects" --outputs "$outputs" \
+            --release-intent-id '${{ inputs.release_intent_id }}' --candidate-id '${{ inputs.candidate_id }}' --attempt-id '${{ inputs.release_attempt_id }}' \
+            --plan-hash '${{ inputs.plan_hash }}' --dispatch-nonce '${{ inputs.dispatch_nonce }}' \
+            --candidate-version '${{ inputs.candidate_version }}' --stable-version '${{ inputs.stable_version }}' \
+            --source-sha '${{ inputs.source_sha }}' --prepared-sha "$prepared_sha" \
+            --digests-json "$artifact_sha" --output execution-result.json
+
+      - name: Upload factual result
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: execution-result-${{ inputs.operation_id }}-${{ inputs.step_id }}
+          path: execution-result.json
+          retention-days: 30
+          if-no-files-found: error

--- a/.github/workflows/publish-candidate.yml
+++ b/.github/workflows/publish-candidate.yml
@@ -1,0 +1,314 @@
+name: Publish exact release candidate
+run-name: RC · publish_candidate · ${{ inputs.operation_id }} · ${{ inputs.step_id }} · ${{ inputs.dispatch_nonce }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      operation_id:
+        required: true
+        type: string
+      step_id:
+        required: true
+        type: string
+      release_intent_id:
+        required: true
+        type: string
+      candidate_id:
+        required: true
+        type: string
+      release_attempt_id:
+        required: true
+        type: string
+      worker:
+        required: true
+        type: string
+      stable_version:
+        required: true
+        type: string
+      candidate_version:
+        required: true
+        type: string
+      source_sha:
+        required: true
+        type: string
+      expected_next_version:
+        description: Exact current next version, or none during Registry bootstrap
+        required: true
+        type: string
+      prepared_sha:
+        required: true
+        type: string
+      prepared_run_id:
+        required: true
+        type: string
+      prepared_artifact:
+        required: true
+        type: string
+      plan_hash:
+        required: true
+        type: string
+      dispatch_nonce:
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: write
+  packages: write
+
+concurrency:
+  group: release-candidate-${{ inputs.worker }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish ${{ inputs.worker }} ${{ inputs.candidate_version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      tag: ${{ steps.meta.outputs.tag }}
+      deploy: ${{ steps.meta.outputs.deploy }}
+      bin: ${{ steps.meta.outputs.bin }}
+      image_tag: ${{ steps.image.outputs.image_tag }}
+    steps:
+      - name: Generate token
+        id: token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.III_CI_APP_ID }}
+          private-key: ${{ secrets.III_CI_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.prepared_sha }}
+          fetch-depth: 0
+          fetch-tags: true
+          token: ${{ steps.token.outputs.token }}
+
+      - name: Validate exact dispatch and prepared identity
+        env:
+          RELEASE_CONTROL_BOT_LOGIN: ${{ vars.RELEASE_CONTROL_BOT_LOGIN }}
+        run: >-
+          python3 .github/scripts/release_control_contract.py validate-dispatch
+          --operation-id '${{ inputs.operation_id }}'
+          --step-id '${{ inputs.step_id }}'
+          --plan-hash '${{ inputs.plan_hash }}'
+          --dispatch-nonce '${{ inputs.dispatch_nonce }}'
+          --candidate-version '${{ inputs.candidate_version }}'
+          --stable-version '${{ inputs.stable_version }}'
+          --source-sha '${{ inputs.source_sha }}'
+          --prepared-sha '${{ inputs.prepared_sha }}'
+          --mutating
+
+      - name: Download prepared artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: ${{ inputs.prepared_artifact }}
+          path: release-prepared
+          run-id: ${{ inputs.prepared_run_id }}
+          github-token: ${{ steps.token.outputs.token }}
+
+      - name: Install pyyaml
+        run: python3 -m pip install --quiet pyyaml
+
+      - name: Verify prepared artifact and release metadata
+        id: meta
+        env:
+          WORKER: ${{ inputs.worker }}
+          CANDIDATE: ${{ inputs.candidate_version }}
+          PREPARED_SHA: ${{ inputs.prepared_sha }}
+        run: |
+          set -euo pipefail
+          jq -e --arg sha "$PREPARED_SHA" --arg worker "$WORKER" --arg version "$CANDIDATE" \
+            '.prepared_sha == $sha and .worker == $worker and .candidate_version == $version' \
+            release-prepared/prepared.json
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import os, yaml
+          worker = os.environ["WORKER"]
+          manifest = yaml.safe_load(open(f"{worker}/iii.worker.yaml", encoding="utf-8"))
+          print(f"tag={worker}/v{os.environ['CANDIDATE']}")
+          print(f"deploy={manifest['deploy']}")
+          print(f"bin={manifest.get('bin') or worker}")
+          PY
+          git fetch origin main --quiet
+          main_sha=$(git rev-parse origin/main)
+          test "$main_sha" = '${{ inputs.source_sha }}' || test "$main_sha" = "$PREPARED_SHA"
+          test "$(git rev-parse HEAD)" = "$PREPARED_SHA"
+
+      - name: Push candidate commit and annotated tag atomically
+        env:
+          TAG: ${{ steps.meta.outputs.tag }}
+          PREPARED_SHA: ${{ inputs.prepared_sha }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          WORKER: ${{ inputs.worker }}
+          VERSION: ${{ inputs.candidate_version }}
+          PLAN_HASH: ${{ inputs.plan_hash }}
+        run: |
+          set -euo pipefail
+          git config user.name "workers-ci[bot]"
+          git config user.email "workers-ci[bot]@users.noreply.github.com"
+          git fetch origin main --quiet
+          git fetch origin "refs/tags/$TAG:refs/tags/$TAG" --quiet || true
+          if git rev-parse --verify --quiet "refs/tags/$TAG" >/dev/null; then
+            test "$(git rev-list -n 1 "$TAG^{}")" = "$PREPARED_SHA"
+            annotation=$(git tag -l --format='%(contents)' "$TAG")
+            for field in \
+              "worker: $WORKER" "version: $VERSION" "managed-by: release-control" \
+              "plan-hash: $PLAN_HASH" "source-sha: $SOURCE_SHA" "prepared-sha: $PREPARED_SHA"; do
+              grep -Fx "$field" <<<"$annotation" >/dev/null
+            done
+            main_sha=$(git rev-parse origin/main)
+            if [[ "$main_sha" == "$SOURCE_SHA" ]]; then
+              git push origin "$PREPARED_SHA:refs/heads/main"
+            else
+              test "$main_sha" = "$PREPARED_SHA"
+            fi
+            exit 0
+          fi
+          git tag -a "$TAG" -m "Release $TAG
+
+          worker: ${{ inputs.worker }}
+          version: ${{ inputs.candidate_version }}
+          managed-by: release-control
+          operation-id: ${{ inputs.operation_id }}
+          step-id: ${{ inputs.step_id }}
+          release-intent-id: ${{ inputs.release_intent_id }}
+          release-attempt-id: ${{ inputs.release_attempt_id }}
+          plan-hash: ${{ inputs.plan_hash }}
+          dispatch-nonce: ${{ inputs.dispatch_nonce }}
+          source-sha: ${{ inputs.source_sha }}
+          prepared-sha: ${{ inputs.prepared_sha }}
+          maturity: rc
+          registry-tag: next
+          experimental: false
+          "
+          main_sha=$(git rev-parse origin/main)
+          if [[ "$main_sha" == "$SOURCE_SHA" ]]; then
+            git push --atomic origin \
+            "$PREPARED_SHA:refs/heads/main" \
+            "refs/tags/$TAG"
+          elif [[ "$main_sha" == "$PREPARED_SHA" ]]; then
+            git push origin "refs/tags/$TAG"
+          else
+            echo "::error::main moved from the planned source and cannot be reconciled safely"
+            exit 1
+          fi
+
+      - name: Create draft prerelease and upload prepared assets
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            gh release create "$TAG" --draft --prerelease --title "${{ inputs.worker }} ${{ inputs.candidate_version }}" --notes "Release candidate managed by Release Control."
+          fi
+          existing_assets=$(gh release view "$TAG" --json assets --jq '.assets[].name' 2>/dev/null || true)
+          while IFS= read -r asset; do
+            [[ -z "$asset" ]] && continue
+            if grep -Fx "$asset" <<<"$existing_assets" >/dev/null; then continue; fi
+            gh release upload "$TAG" "release-prepared/$asset"
+          done < <(find release-prepared -maxdepth 1 -type f ! -name prepared.json -printf '%f\n')
+          gh release edit "$TAG" --draft=false --prerelease=true
+
+      - name: Materialize image digest from prepared image (image workers only)
+        id: image
+        if: steps.meta.outputs.deploy == 'image'
+        env:
+          GHCR_TOKEN: ${{ steps.token.outputs.token }}
+          WORKER: ${{ inputs.worker }}
+          VERSION: ${{ inputs.candidate_version }}
+        run: |
+          set -euo pipefail
+          image_tar=$(jq -r '.artifacts[] | select(.name | endswith("-image.tar")) | .name' release-prepared/prepared.json)
+          docker load --input "release-prepared/$image_tar"
+          image="ghcr.io/${{ github.repository_owner }}/${WORKER}:${VERSION}"
+          echo "$GHCR_TOKEN" | docker login ghcr.io --username github-actions --password-stdin
+          docker tag "release-attempt/${WORKER}:${{ inputs.release_attempt_id }}" "$image"
+          push_log=$(mktemp)
+          docker push "$image" | tee "$push_log"
+          digest=$(sed -n 's/^digest: //p' "$push_log" | tail -1)
+          test -n "$digest"
+          echo "image_tag=ghcr.io/${{ github.repository_owner }}/${WORKER}@${digest}" >> "$GITHUB_OUTPUT"
+
+  registry-publish:
+    name: Publish immutable candidate to Registry
+    needs: [publish]
+    uses: ./.github/workflows/_publish-registry.yml
+    with:
+      ref: ${{ needs.publish.outputs.tag }}
+      worker: ${{ inputs.worker }}
+      version: ${{ inputs.candidate_version }}
+      deploy: ${{ needs.publish.outputs.deploy }}
+      registry_tag: next
+      expected_current_version: ${{ inputs.expected_next_version }}
+      tag: ${{ needs.publish.outputs.tag }}
+      bin: ${{ needs.publish.outputs.bin }}
+      image_tag: ${{ needs.publish.outputs.image_tag }}
+      experimental: false
+    secrets: inherit
+
+  evidence:
+    name: Record candidate effects
+    needs: [publish, registry-publish]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.III_CI_APP_ID }}
+          private-key: ${{ secrets.III_CI_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+          token: ${{ steps.token.outputs.token }}
+
+      - name: Download prepared artifact metadata
+        uses: actions/download-artifact@v7
+        with:
+          name: ${{ inputs.prepared_artifact }}
+          path: release-prepared
+          run-id: ${{ inputs.prepared_run_id }}
+          github-token: ${{ steps.token.outputs.token }}
+
+      - name: Write factual result
+        env:
+          PUBLISH: ${{ needs.publish.result }}
+          REGISTRY: ${{ needs.registry-publish.result }}
+        run: |
+          set -euo pipefail
+          tag='${{ needs.publish.outputs.tag }}'
+          git fetch origin "refs/tags/$tag:refs/tags/$tag" --quiet || true
+          tag_sha=$(git rev-list -n 1 "$tag^{}" 2>/dev/null || true)
+          prepared_digests=$(jq -c '([.artifacts[]? | {(.name): .sha256}] | add) // {}' release-prepared/prepared.json 2>/dev/null || echo '{}')
+          subject=$(jq -cn --arg worker '${{ inputs.worker }}' --arg version '${{ inputs.candidate_version }}' \
+            --arg stable '${{ inputs.stable_version }}' --arg source '${{ inputs.source_sha }}' \
+            --arg prepared '${{ inputs.prepared_sha }}' --arg tag_sha "$tag_sha" \
+            '{worker:$worker,version:$version,candidate_version:$version,stable_version:$stable,source_sha:$source,prepared_sha:$prepared,tag_sha:$tag_sha}')
+          checks=$(jq -cn --arg publish "$PUBLISH" --arg registry "$REGISTRY" \
+            '[{name:"atomic_git_publication",status:$publish},{name:"registry_next",status:$registry}]')
+          effects=$(jq -cn --arg publish "$PUBLISH" --arg registry "$REGISTRY" --arg tag "$tag" \
+            '[{surface:"git_main_and_tag",status:$publish,immutable_id:$tag},{surface:"github_prerelease",status:$publish,immutable_id:$tag},{surface:"registry_next",status:$registry,immutable_id:$tag}]')
+          outputs=$(jq -cn --arg deploy '${{ needs.publish.outputs.deploy }}' --arg digest '${{ needs.publish.outputs.image_tag }}' \
+            --argjson digests "$prepared_digests" '{deploy:$deploy,image_digest:(if $digest == "" then null else $digest end),digests:$digests}')
+          python3 .github/scripts/release_control_contract.py write-result \
+            --kind publish_candidate --repository '${{ github.repository }}' \
+            --operation-id '${{ inputs.operation_id }}' --step-id '${{ inputs.step_id }}' \
+            --run-id '${{ github.run_id }}' --run-attempt '${{ github.run_attempt }}' \
+            --workflow publish-candidate.yml --event '${{ github.event_name }}' --sha '${{ github.sha }}' \
+            --subject "$subject" --checks "$checks" --effects "$effects" --outputs "$outputs" \
+            --release-intent-id '${{ inputs.release_intent_id }}' --candidate-id '${{ inputs.candidate_id }}' --attempt-id '${{ inputs.release_attempt_id }}' \
+            --plan-hash '${{ inputs.plan_hash }}' --dispatch-nonce '${{ inputs.dispatch_nonce }}' \
+            --candidate-version '${{ inputs.candidate_version }}' --stable-version '${{ inputs.stable_version }}' \
+            --source-sha '${{ inputs.source_sha }}' --prepared-sha '${{ inputs.prepared_sha }}' --digests-json "$prepared_digests" \
+            --output execution-result.json
+
+      - uses: actions/upload-artifact@v6
+        with:
+          name: execution-result-${{ inputs.operation_id }}-${{ inputs.step_id }}
+          path: execution-result.json
+          retention-days: 30
+          if-no-files-found: error

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -1,0 +1,356 @@
+name: Publish exact stable release
+run-name: RC · publish_stable · ${{ inputs.operation_id }} · ${{ inputs.step_id }} · ${{ inputs.dispatch_nonce }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      operation_id:
+        required: true
+        type: string
+      step_id:
+        required: true
+        type: string
+      release_intent_id:
+        required: true
+        type: string
+      candidate_id:
+        required: true
+        type: string
+      release_attempt_id:
+        required: true
+        type: string
+      worker:
+        required: true
+        type: string
+      candidate_version:
+        required: true
+        type: string
+      stable_version:
+        required: true
+        type: string
+      source_operation_id:
+        required: true
+        type: string
+      source_sha:
+        required: true
+        type: string
+      plan_hash:
+        required: true
+        type: string
+      expected_next_version:
+        required: true
+        type: string
+      expected_latest_version:
+        description: Current latest version or none
+        required: true
+        type: string
+      recovery_run_id:
+        description: Original stable executor run to reuse, or 0 for a fresh build
+        required: false
+        default: '0'
+        type: string
+      recovery_operation_id:
+        description: Original operation that produced the reusable stable artifact
+        required: false
+        default: none
+        type: string
+      recovery_step_id:
+        description: Original stable step that produced the reusable artifact
+        required: false
+        default: none
+        type: string
+      dispatch_nonce:
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: write
+  packages: write
+
+concurrency:
+  group: release-stable-${{ inputs.worker }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Rebuild and publish ${{ inputs.worker }} ${{ inputs.stable_version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    outputs:
+      tag: ${{ steps.meta.outputs.tag }}
+      prepared_sha: ${{ steps.meta.outputs.prepared_sha }}
+      deploy: ${{ steps.meta.outputs.deploy }}
+      bin: ${{ steps.meta.outputs.bin }}
+      image_tag: ${{ steps.image.outputs.image_tag }}
+    steps:
+      - name: Generate token
+        id: token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.III_CI_APP_ID }}
+          private-key: ${{ secrets.III_CI_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.source_sha }}
+          fetch-depth: 0
+          fetch-tags: true
+          token: ${{ steps.token.outputs.token }}
+
+      - name: Validate exact dispatch
+        env:
+          RELEASE_CONTROL_BOT_LOGIN: ${{ vars.RELEASE_CONTROL_BOT_LOGIN }}
+        run: >-
+          python3 .github/scripts/release_control_contract.py validate-dispatch
+          --operation-id '${{ inputs.operation_id }}'
+          --step-id '${{ inputs.step_id }}'
+          --plan-hash '${{ inputs.plan_hash }}'
+          --dispatch-nonce '${{ inputs.dispatch_nonce }}'
+          --candidate-version '${{ inputs.candidate_version }}'
+          --stable-version '${{ inputs.stable_version }}'
+          --source-sha '${{ inputs.source_sha }}'
+          --mutating
+
+      - name: Download stable artifacts from the original executor
+        if: inputs.recovery_run_id != '0'
+        uses: actions/download-artifact@v7
+        with:
+          name: release-stable-${{ inputs.recovery_operation_id }}-${{ inputs.recovery_step_id }}
+          path: release-stable
+          run-id: ${{ inputs.recovery_run_id }}
+          github-token: ${{ steps.token.outputs.token }}
+
+      - name: Checkout the recovered prepared commit
+        if: inputs.recovery_run_id != '0'
+        run: |
+          set -euo pipefail
+          prepared_sha=$(jq -r '.prepared_sha' release-stable/prepared.json)
+          test -n "$prepared_sha" && test "$prepared_sha" != null
+          git fetch origin "$prepared_sha" --quiet
+          git checkout --detach "$prepared_sha"
+
+      - name: Rebuild stable artifacts from the exact stable commit
+        if: inputs.recovery_run_id == '0'
+        env:
+          RELEASE_ATTEMPT_ID: ${{ inputs.release_attempt_id }}
+        run: >-
+          python3 .github/scripts/release_train.py
+          --worker '${{ inputs.worker }}'
+          --source-sha '${{ inputs.source_sha }}'
+          --candidate-version '${{ inputs.stable_version }}'
+          --intent-id '${{ inputs.release_intent_id }}'
+          --attempt-id '${{ inputs.release_attempt_id }}'
+          --branch 'refs/heads/release-control/${{ inputs.release_intent_id }}/${{ inputs.release_attempt_id }}'
+          --out release-stable
+
+      - name: Install pyyaml
+        run: python3 -m pip install --quiet pyyaml
+
+      - name: Verify stable metadata and source drift
+        id: meta
+        env:
+          WORKER: ${{ inputs.worker }}
+          STABLE: ${{ inputs.stable_version }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
+        run: |
+          set -euo pipefail
+          jq -e --arg worker "$WORKER" --arg version "$STABLE" \
+            '.worker == $worker and .candidate_version == $version' release-stable/prepared.json
+          prepared_sha=$(jq -r .prepared_sha release-stable/prepared.json)
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import os, yaml, json
+          worker = os.environ["WORKER"]
+          meta = yaml.safe_load(open(f"{worker}/iii.worker.yaml", encoding="utf-8"))
+          prepared = json.load(open("release-stable/prepared.json", encoding="utf-8"))
+          print(f"tag={worker}/v{os.environ['STABLE']}")
+          print(f"prepared_sha={prepared['prepared_sha']}")
+          print(f"deploy={meta['deploy']}")
+          print(f"bin={meta.get('bin') or worker}")
+          PY
+          git fetch origin main --quiet
+          main_sha=$(git rev-parse origin/main)
+          if [[ '${{ inputs.recovery_run_id }}' == '0' ]]; then
+            test "$main_sha" = "$SOURCE_SHA"
+          else
+            prepared_sha=$(jq -r .prepared_sha release-stable/prepared.json)
+            test "$main_sha" = "$SOURCE_SHA" || test "$main_sha" = "$prepared_sha"
+          fi
+
+      - name: Push stable manifest commit and tag atomically
+        env:
+          TAG: ${{ steps.meta.outputs.tag }}
+          PREPARED_SHA: ${{ steps.meta.outputs.prepared_sha }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          WORKER: ${{ inputs.worker }}
+          VERSION: ${{ inputs.stable_version }}
+          PLAN_HASH: ${{ inputs.plan_hash }}
+        run: |
+          set -euo pipefail
+          git config user.name "workers-ci[bot]"
+          git config user.email "workers-ci[bot]@users.noreply.github.com"
+          git fetch origin main --quiet
+          git fetch origin "refs/tags/$TAG:refs/tags/$TAG" --quiet || true
+          if git rev-parse --verify --quiet "refs/tags/$TAG" >/dev/null; then
+            test "$(git rev-list -n 1 "$TAG^{}")" = "$PREPARED_SHA"
+            annotation=$(git tag -l --format='%(contents)' "$TAG")
+            for field in \
+              "worker: $WORKER" "version: $VERSION" "managed-by: release-control" \
+              "plan-hash: $PLAN_HASH" "source-sha: $SOURCE_SHA" "prepared-sha: $PREPARED_SHA"; do
+              grep -Fx "$field" <<<"$annotation" >/dev/null
+            done
+            main_sha=$(git rev-parse origin/main)
+            if [[ "$main_sha" == "$SOURCE_SHA" ]]; then
+              git push origin "$PREPARED_SHA:refs/heads/main"
+            else
+              test "$main_sha" = "$PREPARED_SHA"
+            fi
+            exit 0
+          fi
+          git tag -a "$TAG" -m "Release $TAG
+
+          worker: ${{ inputs.worker }}
+          version: ${{ inputs.stable_version }}
+          managed-by: release-control
+          operation-id: ${{ inputs.operation_id }}
+          step-id: ${{ inputs.step_id }}
+          release-intent-id: ${{ inputs.release_intent_id }}
+          release-attempt-id: ${{ inputs.release_attempt_id }}
+          source-operation-id: ${{ inputs.source_operation_id }}
+          plan-hash: ${{ inputs.plan_hash }}
+          dispatch-nonce: ${{ inputs.dispatch_nonce }}
+          source-sha: ${{ inputs.source_sha }}
+          prepared-sha: $PREPARED_SHA
+          maturity: stable
+          registry-tag: latest
+          experimental: false
+          "
+          main_sha=$(git rev-parse origin/main)
+          if [[ "$main_sha" == "$SOURCE_SHA" ]]; then
+            git push --atomic origin \
+              "$PREPARED_SHA:refs/heads/main" \
+              "refs/tags/$TAG"
+          elif [[ "$main_sha" == "$PREPARED_SHA" ]]; then
+            git push origin "refs/tags/$TAG"
+          else
+            echo "::error::main moved from the planned source and cannot be reconciled safely"
+            exit 1
+          fi
+
+      - name: Create final draft and upload stable assets
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            gh release create "$TAG" --draft --title "${{ inputs.worker }} ${{ inputs.stable_version }}" --notes "Stable release managed by Release Control."
+          fi
+          existing_assets=$(gh release view "$TAG" --json assets --jq '.assets[].name' 2>/dev/null || true)
+          while IFS= read -r asset; do
+            [[ -z "$asset" ]] && continue
+            if grep -Fx "$asset" <<<"$existing_assets" >/dev/null; then continue; fi
+            gh release upload "$TAG" "release-stable/$asset"
+          done < <(find release-stable -maxdepth 1 -type f ! -name prepared.json -printf '%f\n')
+          gh release edit "$TAG" --draft=false --prerelease=false
+
+      - name: Push immutable image by digest (image workers only)
+        id: image
+        if: steps.meta.outputs.deploy == 'image'
+        env:
+          GHCR_TOKEN: ${{ steps.token.outputs.token }}
+          WORKER: ${{ inputs.worker }}
+          VERSION: ${{ inputs.stable_version }}
+        run: |
+          set -euo pipefail
+          image_tar=$(jq -r '.artifacts[] | select(.name | endswith("-image.tar")) | .name' release-stable/prepared.json)
+          docker load --input "release-stable/$image_tar"
+          image="ghcr.io/${{ github.repository_owner }}/${WORKER}:${VERSION}"
+          echo "$GHCR_TOKEN" | docker login ghcr.io --username github-actions --password-stdin
+          docker tag "release-attempt/${WORKER}:${{ inputs.release_attempt_id }}" "$image"
+          push_log=$(mktemp)
+          docker push "$image" | tee "$push_log"
+          digest=$(sed -n 's/^digest: //p' "$push_log" | tail -1)
+          test -n "$digest"
+          echo "image_tag=ghcr.io/${{ github.repository_owner }}/${WORKER}@${digest}" >> "$GITHUB_OUTPUT"
+
+      - name: Retain stable build metadata for factual evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-stable-${{ inputs.operation_id }}-${{ inputs.step_id }}
+          path: release-stable/
+          retention-days: 30
+          if-no-files-found: warn
+
+  registry-publish:
+    name: Publish stable immutable version without a channel
+    needs: [publish]
+    uses: ./.github/workflows/_publish-registry.yml
+    with:
+      ref: ${{ needs.publish.outputs.tag }}
+      worker: ${{ inputs.worker }}
+      version: ${{ inputs.stable_version }}
+      deploy: ${{ needs.publish.outputs.deploy }}
+      registry_tag: none
+      tag: ${{ needs.publish.outputs.tag }}
+      bin: ${{ needs.publish.outputs.bin }}
+      image_tag: ${{ needs.publish.outputs.image_tag }}
+      experimental: false
+    secrets: inherit
+
+  evidence:
+    name: Record stable effects
+    needs: [publish, registry-publish]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+      - name: Download stable build metadata
+        uses: actions/download-artifact@v7
+        continue-on-error: true
+        with:
+          name: release-stable-${{ inputs.operation_id }}-${{ inputs.step_id }}
+          path: release-stable
+          run-id: ${{ github.run_id }}
+          github-token: ${{ github.token }}
+      - name: Write factual result
+        env:
+          PUBLISH: ${{ needs.publish.result }}
+          REGISTRY: ${{ needs.registry-publish.result }}
+        run: |
+          set -euo pipefail
+          tag='${{ needs.publish.outputs.tag }}'
+          git fetch origin "refs/tags/$tag:refs/tags/$tag" --quiet || true
+          tag_sha=$(git rev-list -n 1 "$tag^{}" 2>/dev/null || true)
+          prepared_digests=$(jq -c '([.artifacts[]? | {(.name): .sha256}] | add) // {}' release-stable/prepared.json 2>/dev/null || echo '{}')
+          subject=$(jq -cn --arg worker '${{ inputs.worker }}' --arg version '${{ inputs.stable_version }}' \
+            --arg candidate '${{ inputs.candidate_version }}' --arg source '${{ inputs.source_sha }}' \
+            --arg prepared '${{ needs.publish.outputs.prepared_sha }}' --arg tag_sha "$tag_sha" \
+            '{worker:$worker,version:$version,stable_version:$version,candidate_version:$candidate,source_sha:$source,prepared_sha:$prepared,tag_sha:$tag_sha}')
+          checks=$(jq -cn --arg publish "$PUBLISH" --arg registry "$REGISTRY" \
+            '[{name:"stable_rebuild_and_publication",status:$publish},{name:"registry_immutable",status:$registry}]')
+          effects=$(jq -cn --arg publish "$PUBLISH" --arg registry "$REGISTRY" --arg tag "$tag" \
+            '[{surface:"git_main_and_stable_tag",status:$publish,immutable_id:$tag},{surface:"github_release",status:$publish,immutable_id:$tag},{surface:"registry_immutable",status:$registry,immutable_id:$tag}]')
+          outputs=$(jq -cn --arg deploy '${{ needs.publish.outputs.deploy }}' --arg digest '${{ needs.publish.outputs.image_tag }}' \
+            '{deploy:$deploy,image_digest:(if $digest == "" then null else $digest end)}')
+          python3 .github/scripts/release_control_contract.py write-result \
+            --kind publish_stable --repository '${{ github.repository }}' \
+            --operation-id '${{ inputs.operation_id }}' --step-id '${{ inputs.step_id }}' \
+            --run-id '${{ github.run_id }}' --run-attempt '${{ github.run_attempt }}' \
+            --workflow publish-stable.yml --event '${{ github.event_name }}' --sha '${{ github.sha }}' \
+            --subject "$subject" --checks "$checks" --effects "$effects" --outputs "$outputs" \
+            --release-intent-id '${{ inputs.release_intent_id }}' --candidate-id '${{ inputs.candidate_id }}' --attempt-id '${{ inputs.release_attempt_id }}' \
+            --plan-hash '${{ inputs.plan_hash }}' --dispatch-nonce '${{ inputs.dispatch_nonce }}' \
+            --candidate-version '${{ inputs.candidate_version }}' --stable-version '${{ inputs.stable_version }}' \
+            --source-sha '${{ inputs.source_sha }}' --prepared-sha '${{ needs.publish.outputs.prepared_sha }}' \
+            --digests-json "$prepared_digests" \
+            --output execution-result.json
+      - uses: actions/upload-artifact@v6
+        with:
+          name: execution-result-${{ inputs.operation_id }}-${{ inputs.step_id }}
+          path: execution-result.json
+          retention-days: 30
+          if-no-files-found: error

--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -10,6 +10,8 @@ trap 'rm -f "$headers_file"' EXIT
 ignore=(
   'https://api.workers.iii.dev'            # API base, only POST routes
   'https://api.workers.iii.dev/workers'    # ditto
+  'https://api.workers.iii.dev/resolve'    # workflow action endpoint, POST only
+  'https://api.workers.iii.dev/w/$WORKER/tags/latest' # workflow action endpoint, PUT only
   'https://workers.iii.dev/workers/'       # URL prefix in a test assertion, not a link
   'https://workers.iii.dev/workers/skills' # published (badge.svg 200) but registry page missing
 )


### PR DESCRIPTION
## Summary

- Add exact prepare, candidate publication and stable publication workflows.
- Keep Git, GitHub Releases, GHCR and Registry effects idempotent and factually identifiable.
- Add immutable artifact reuse for recovery and a separate Registry finalization executor.
- Add RC semver, CAS inputs, dispatch identity validation and cleanup of terminal attempt refs.

## Validation

- Release script suite: 204 tests passed, plus 3 subtests.
- Python bytecode compilation passed.
- All workflow YAML files parsed successfully.

Refs MOT-4299


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added end-to-end workflows for preparing, publishing, and finalizing candidate and stable releases.
  - Added automated cleanup of outdated release-attempt references.
  - Added safer registry tag assignment with version checks and retry support.

- **Improvements**
  - Release candidates now support numbered versions such as `rc.10`, with correct numeric ordering.
  - Release operations validate release identity, source versions, checksums, and execution metadata more thoroughly.

- **Bug Fixes**
  - Prevented incorrect registry tags from being included in immutable publication payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->