### PR TITLE
(MOT-4299) fix(release): keep stdio workers alive during publish

### DIFF
--- a/.github/scripts/tests/test_release_workflows.py
+++ b/.github/scripts/tests/test_release_workflows.py
@@ -250,6 +250,13 @@ def test_registry_publish_authenticates_iii_installer() -> None:
     assert "GITHUB_TOKEN: ${{ github.token }}" in body
 
 
+def test_registry_publish_keeps_stdio_workers_alive_for_interface_collection() -> None:
+    body = (WORKFLOWS / "_publish-registry.yml").read_text()
+    assert "start_worker_with_open_stdin" in body
+    assert "stdin=subprocess.PIPE" in body
+    assert "signal.signal(signal.SIGTERM" in body
+
+
 def test_rust_binary_cache_is_keyed_by_frontend_bundle_digest() -> None:
     jobs = workflow(WORKFLOWS / "_rust-binary.yml")["jobs"]
     web_build = jobs["web-build"]

--- a/.github/workflows/_publish-registry.yml
+++ b/.github/workflows/_publish-registry.yml
@@ -141,6 +141,40 @@ jobs:
           REPO_URL: ${{ format('https://github.com/{0}', github.repository) }}
         run: |
           set -euo pipefail
+
+          # Some binary workers use the stdio transport. A background process
+          # started directly by Actions inherits an EOF on stdin and exits
+          # before it can register its interface. Keep a pipe open for the
+          # worker and forward termination to the child so cleanup remains
+          # deterministic.
+          start_worker_with_open_stdin() {
+            local pidfile="$1"
+            local log="$2"
+            shift 2
+            python3 - "$@" >"$log" 2>&1 <<'PY' &
+          import signal
+          import subprocess
+          import sys
+
+          child = subprocess.Popen(sys.argv[1:], stdin=subprocess.PIPE)
+
+          def stop(signum, _frame):
+              if child.poll() is None:
+                  child.terminate()
+                  try:
+                      child.wait(timeout=10)
+                  except subprocess.TimeoutExpired:
+                      child.kill()
+                      child.wait()
+              raise SystemExit(128 + signum)
+
+          signal.signal(signal.SIGTERM, stop)
+          signal.signal(signal.SIGINT, stop)
+          raise SystemExit(child.wait())
+          PY
+            echo "$!" > "$pidfile"
+          }
+
           mode=$(python3 .github/scripts/manifest_version.py deploy-mode "$WORKER")
 
           case "$mode" in
@@ -172,8 +206,7 @@ jobs:
               worker_log="worker-$WORKER.log"
               pushd "$WORKER" >/dev/null
               echo "Starting local worker with: (cd $WORKER && $bin_path ${collect_args[*]})"
-              "$bin_path" "${collect_args[@]}" > "../$worker_log" 2>&1 &
-              echo "$!" > ../worker.pid
+              start_worker_with_open_stdin "../worker.pid" "../$worker_log" "$bin_path" "${collect_args[@]}"
               popd >/dev/null
 
               sleep 2
@@ -215,8 +248,7 @@ jobs:
                 sh -c "$install_cmd"
               fi
               echo "Starting local worker with: (cd $stage_dir && $start_cmd)"
-              sh -c "$start_cmd" > "$workspace_root/$worker_log" 2>&1 &
-              echo "$!" > "$workspace_root/worker.pid"
+              start_worker_with_open_stdin "$workspace_root/worker.pid" "$workspace_root/$worker_log" sh -c "$start_cmd"
               popd >/dev/null
 
               sleep 2
@@ -247,8 +279,7 @@ jobs:
               fi
 
               echo "Starting local worker with: (cd $WORKER && cargo ${cargo_args[*]})"
-              cargo "${cargo_args[@]}" > "../$worker_log" 2>&1 &
-              echo "$!" > ../worker.pid
+              start_worker_with_open_stdin "../worker.pid" "../$worker_log" cargo "${cargo_args[@]}"
               popd >/dev/null
 
               sleep 2


### PR DESCRIPTION
## Summary
- keep stdio workers connected while the Registry interface-collection process is running
- forward termination signals to the child process for deterministic cleanup
- add a workflow regression check for the wrapper

## Validation
- `python3 -m pytest -q .github/scripts/tests/test_release_workflows.py`
- workflow YAML parse
- extracted interface-collection shell `bash -n`
- `git diff --check`

Refs MOT-4299

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved registry publishing reliability by keeping interface-collection workers running correctly during the workflow.
  * Added graceful shutdown handling for worker processes, with forced termination as a fallback.

* **Tests**
  * Added regression coverage to verify workers remain active and handle termination signals properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->