### PR TITLE
(MOT-4509) feat(shell): review pane rich preview, shared toolbar, file-type icons

### DIFF
--- a/shell/ui/src/page/EditorPane.tsx
+++ b/shell/ui/src/page/EditorPane.tsx
@@ -149,6 +149,9 @@ export function EditorPane({
   const absPath = joinPath(root, relPath)
   const previewable = isRichPreviewPath(relPath)
   const [previewChoice, setPreviewChoice] = useState<boolean | null>(null)
+  useEffect(() => {
+    setPreviewChoice(null)
+  }, [richPreview, relPath])
   const showPreview = previewable && (previewChoice ?? richPreview)
   const [pane, setPane] = useState<PaneState>({ phase: 'loading' })
   const [draft, setDraftState] = useState('')

--- a/shell/ui/src/page/EditorPane.tsx
+++ b/shell/ui/src/page/EditorPane.tsx
@@ -7,7 +7,8 @@
    remounted per file (key=path) and rehydrates from the cache instead
    of re-reading. */
 
-import { CodeEditor, type Host } from '@iii-dev/console-ui'
+import { CodeEditor, type Host, IconButton } from '@iii-dev/console-ui'
+import { Code, Eye } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { errorMessage, formatBytes } from '../lib/format'
 import {
@@ -16,6 +17,7 @@ import {
   coderWriteFile,
   joinPath,
 } from './coder'
+import { isRichPreviewPath, richPreviewNode } from './rich-preview'
 
 /** File-extension → Monaco language id (unknown ids render plain). */
 export function monacoLangFromPath(path: string): string {
@@ -131,6 +133,8 @@ interface EditorPaneProps {
   onSaved: () => void
   /** Dirty-flag transitions — the page pins the tab on first edit. */
   onDirtyChange: (relPath: string, dirty: boolean) => void
+  /** Global review-pane preference; the header toggle overrides it per file. */
+  richPreview?: boolean
 }
 
 export function EditorPane({
@@ -138,10 +142,14 @@ export function EditorPane({
   root,
   relPath,
   cache,
+  richPreview = false,
   onSaved,
   onDirtyChange,
 }: EditorPaneProps) {
   const absPath = joinPath(root, relPath)
+  const previewable = isRichPreviewPath(relPath)
+  const [previewChoice, setPreviewChoice] = useState<boolean | null>(null)
+  const showPreview = previewable && (previewChoice ?? richPreview)
   const [pane, setPane] = useState<PaneState>({ phase: 'loading' })
   const [draft, setDraftState] = useState('')
   const [savedContent, setSavedContent] = useState('')
@@ -296,6 +304,15 @@ export function EditorPane({
         ) : null}
         <span className="spacer" />
         {saveError ? <span className="shui-ro-note warn">{saveError}</span> : null}
+        {previewable ? (
+          <IconButton
+            label={showPreview ? 'Show source' : 'Show preview'}
+            aria-pressed={showPreview}
+            onClick={() => setPreviewChoice(!showPreview)}
+          >
+            {showPreview ? <Code aria-hidden /> : <Eye aria-hidden />}
+          </IconButton>
+        ) : null}
         <button
           type="button"
           className="shui-save-btn"
@@ -316,6 +333,8 @@ export function EditorPane({
           <div className="shui-image-wrap">
             <img src={entry.image} alt={relPath} />
           </div>
+        ) : showPreview ? (
+          <div className="shui-editor-preview">{richPreviewNode(relPath, draft)}</div>
         ) : (
           <CodeEditor
             value={draft}

--- a/shell/ui/src/page/FilesTab.tsx
+++ b/shell/ui/src/page/FilesTab.tsx
@@ -74,6 +74,7 @@ export function FilesTab({
   const { model } = useFileTree({
     fileTreeSearchMode: 'hide-non-matches',
     flattenEmptyDirectories: true,
+    icons: { set: 'complete', colored: true },
     itemHeight: 29,
     paths: tree?.paths ?? [],
     search: false,

--- a/shell/ui/src/page/ReviewPane.tsx
+++ b/shell/ui/src/page/ReviewPane.tsx
@@ -2,6 +2,7 @@ import {
   FileDiff,
   type FileDiffEditState,
   type Host,
+  Markdown,
 } from '@iii-dev/console-ui'
 import {
   ChevronDown,
@@ -15,10 +16,12 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { errorMessage } from '../lib/format'
 import {
   coderReadFile,
+  coderReadFileBase64,
   coderWriteFile,
   joinPath,
   type ReadFileResponse,
 } from './coder'
+import { imageMimeFromPath } from './EditorPane'
 import { diffLines, diffTotals } from './diff'
 import { gitHeadBaseline, gitReadSource, gitShowHead } from './git'
 import type { ReviewEntry } from './review'
@@ -350,6 +353,9 @@ export interface ReviewContents {
   newContents: string
   worktreeRevision?: string
   mode?: number | null
+  /** Raster image rows: data URL of the working copy, `null` once deleted.
+      Text fields stay empty because the bytes are not diffable. */
+  image?: string | null
   /** Set when the old side is the last commit rather than this turn's
       pre-turn snapshot. */
   baselineSource?: 'committed'
@@ -382,11 +388,31 @@ async function loadCommittedFallback(
   }
 }
 
+async function loadImageContents(
+  host: Host,
+  root: string,
+  entry: ReviewEntry,
+  mime: string,
+): Promise<ReviewContents> {
+  const path = reviewEntryWorktreePath(entry)
+  if (path === null) return { oldContents: '', newContents: '', image: null }
+  const out = await coderReadFileBase64(host, joinPath(root, path))
+  return {
+    oldContents: '',
+    newContents: '',
+    worktreeRevision: out.revision ?? undefined,
+    mode: out.mode,
+    image: `data:${mime};base64,${out.content ?? ''}`,
+  }
+}
+
 export async function loadReviewContents(
   host: Host,
   root: string,
   entry: ReviewEntry,
 ): Promise<ReviewContents> {
+  const mime = imageMimeFromPath(entry.path)
+  if (mime !== null) return loadImageContents(host, root, entry, mime)
   if (entry.before !== undefined && entry.after !== undefined) {
     const oldSide = gitReadSource(host, root, entry.before)
     if (entry.after.kind === 'worktree') {
@@ -934,7 +960,8 @@ function ReviewFile({
   const editable =
     reviewEntryWorktreePath(entry) !== null &&
     state.phase === 'ready' &&
-    state.worktreeRevision !== undefined
+    state.worktreeRevision !== undefined &&
+    state.image === undefined
   const dirty = editing && draft !== editBaseContents
   const changedOnDisk =
     editing &&
@@ -1058,9 +1085,7 @@ function ReviewFile({
   const editStatus = reviewEditStatus(editing, editorState, saving)
 
   const rich =
-    renderBody && state.phase === 'ready'
-      ? richPreviewFor(entry.path, state.newContents)
-      : null
+    renderBody && state.phase === 'ready' ? richPreviewFor(entry.path, state) : null
   return (
     <section
       ref={sectionRef}
@@ -1174,6 +1199,10 @@ function ReviewFile({
         <div className="shui-review-message warn">{state.message}</div>
       ) : !editing && options.richPreview && rich !== null ? (
         rich
+      ) : !editing && state.image !== undefined ? (
+        <div className="shui-review-message">
+          {state.image === null ? 'image deleted' : 'binary image; enable rich preview to view it'}
+        </div>
       ) : !editing && totals?.add === 0 && totals.del === 0 ? (
         <div className="shui-review-message">no line changes</div>
       ) : (
@@ -1200,7 +1229,16 @@ function ReviewFile({
   )
 }
 
-function richPreviewFor(path: string, contents: string): React.ReactNode | null {
+function richPreviewFor(
+  path: string,
+  state: Extract<FileState, { phase: 'ready' }>,
+): React.ReactNode | null {
+  if (state.image !== undefined) {
+    return state.image === null ? null : (
+      <img className="shui-rich-preview-image" src={state.image} alt={`preview ${path}`} />
+    )
+  }
+  const contents = state.newContents
   const lower = path.toLowerCase()
   if (lower.endsWith('.html') || lower.endsWith('.htm')) {
     return <iframe className="shui-rich-preview" title={`preview ${path}`} sandbox="" srcDoc={contents} />
@@ -1210,28 +1248,11 @@ function richPreviewFor(path: string, contents: string): React.ReactNode | null 
     return <img className="shui-rich-preview-image" src={src} alt={`preview ${path}`} />
   }
   if (lower.endsWith('.md') || lower.endsWith('.markdown')) {
-    return <MarkdownPreview contents={contents} />
+    return (
+      <article className="shui-markdown-preview">
+        <Markdown>{contents}</Markdown>
+      </article>
+    )
   }
   return null
-}
-
-function MarkdownPreview({ contents }: { contents: string }) {
-  return (
-    <article className="shui-markdown-preview">
-      {contents.split('\n').map((line, index) => {
-        const heading = /^(#{1,4})\s+(.*)$/.exec(line)
-        if (heading) {
-          const level = heading[1].length
-          const text = heading[2]
-          if (level === 1) return <h1 key={index}>{text}</h1>
-          if (level === 2) return <h2 key={index}>{text}</h2>
-          if (level === 3) return <h3 key={index}>{text}</h3>
-          return <h4 key={index}>{text}</h4>
-        }
-        if (/^[-*]\s+/.test(line)) return <li key={index}>{line.slice(2)}</li>
-        if (line.trim() === '') return <br key={index} />
-        return <p key={index}>{line}</p>
-      })}
-    </article>
-  )
 }

--- a/shell/ui/src/page/ReviewPane.tsx
+++ b/shell/ui/src/page/ReviewPane.tsx
@@ -2,7 +2,6 @@ import {
   FileDiff,
   type FileDiffEditState,
   type Host,
-  Markdown,
 } from '@iii-dev/console-ui'
 import {
   ChevronRight,
@@ -21,6 +20,7 @@ import {
 } from './coder'
 import { imageMimeFromPath } from './EditorPane'
 import { FileTypeIcon } from './file-type-icon'
+import { richPreviewNode } from './rich-preview'
 import { diffLines, diffTotals } from './diff'
 import { gitHeadBaseline, gitReadSource, gitShowHead } from './git'
 import type { ReviewEntry } from './review'
@@ -1206,6 +1206,7 @@ function ReviewFile({
         <div className="shui-review-message">no line changes</div>
       ) : (
         <FileDiff
+          key={options.diffStyle}
           oldFile={{ name: entry.change.from ?? entry.path, contents: state.oldContents }}
           newFile={{ name: entry.path, contents: editing ? draft : state.newContents }}
           diffStyle={options.diffStyle}
@@ -1237,21 +1238,5 @@ function richPreviewFor(
       <img className="shui-rich-preview-image" src={state.image} alt={`preview ${path}`} />
     )
   }
-  const contents = state.newContents
-  const lower = path.toLowerCase()
-  if (lower.endsWith('.html') || lower.endsWith('.htm')) {
-    return <iframe className="shui-rich-preview" title={`preview ${path}`} sandbox="" srcDoc={contents} />
-  }
-  if (lower.endsWith('.svg')) {
-    const src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(contents)}`
-    return <img className="shui-rich-preview-image" src={src} alt={`preview ${path}`} />
-  }
-  if (lower.endsWith('.md') || lower.endsWith('.markdown')) {
-    return (
-      <article className="shui-markdown-preview">
-        <Markdown>{contents}</Markdown>
-      </article>
-    )
-  }
-  return null
+  return richPreviewNode(path, state.newContents)
 }

--- a/shell/ui/src/page/ReviewPane.tsx
+++ b/shell/ui/src/page/ReviewPane.tsx
@@ -5,9 +5,7 @@ import {
   Markdown,
 } from '@iii-dev/console-ui'
 import {
-  ChevronDown,
   ChevronRight,
-  FileCode2,
   Pencil,
   Save,
   X,
@@ -22,6 +20,7 @@ import {
   type ReadFileResponse,
 } from './coder'
 import { imageMimeFromPath } from './EditorPane'
+import { FileTypeIcon } from './file-type-icon'
 import { diffLines, diffTotals } from './diff'
 import { gitHeadBaseline, gitReadSource, gitShowHead } from './git'
 import type { ReviewEntry } from './review'
@@ -1110,8 +1109,8 @@ function ReviewFile({
           onClick={onToggle}
           aria-expanded={!collapsed}
         >
-          {collapsed ? <ChevronRight aria-hidden /> : <ChevronDown aria-hidden />}
-          <FileCode2 aria-hidden className="file-icon" />
+          <ChevronRight aria-hidden className={collapsed ? 'chevron' : 'chevron open'} />
+          <FileTypeIcon path={entry.path} className="file-icon" />
           <span className="path" title={entry.path}>
             {entry.change.from ? `${entry.change.from} → ${entry.path}` : entry.path}
           </span>

--- a/shell/ui/src/page/ReviewPane.tsx
+++ b/shell/ui/src/page/ReviewPane.tsx
@@ -355,6 +355,9 @@ export interface ReviewContents {
   /** Raster image rows: data URL of the working copy, `null` once deleted.
       Text fields stay empty because the bytes are not diffable. */
   image?: string | null
+  /** Raster image rows whose new side is a committed revision: the bytes
+      only stream as text, so the row explains instead of previewing. */
+  imageUnavailable?: true
   /** Set when the old side is the last commit rather than this turn's
       pre-turn snapshot. */
   baselineSource?: 'committed'
@@ -393,8 +396,11 @@ async function loadImageContents(
   entry: ReviewEntry,
   mime: string,
 ): Promise<ReviewContents> {
+  if (entry.change.status === 'deleted') {
+    return { oldContents: '', newContents: '', image: null }
+  }
   const path = reviewEntryWorktreePath(entry)
-  if (path === null) return { oldContents: '', newContents: '', image: null }
+  if (path === null) return { oldContents: '', newContents: '', imageUnavailable: true }
   const out = await coderReadFileBase64(host, joinPath(root, path))
   return {
     oldContents: '',
@@ -1198,6 +1204,10 @@ function ReviewFile({
         <div className="shui-review-message warn">{state.message}</div>
       ) : !editing && options.richPreview && rich !== null ? (
         rich
+      ) : !editing && state.imageUnavailable ? (
+        <div className="shui-review-message">
+          binary image; preview is available for working-tree files only
+        </div>
       ) : !editing && state.image !== undefined ? (
         <div className="shui-review-message">
           {state.image === null ? 'image deleted' : 'binary image; enable rich preview to view it'}

--- a/shell/ui/src/page/ReviewScopePicker.tsx
+++ b/shell/ui/src/page/ReviewScopePicker.tsx
@@ -3,8 +3,12 @@ import {
   ChevronDown,
   ChevronLeft,
   ChevronRight,
+  FilePen,
   GitBranch,
   GitCommitHorizontal,
+  History,
+  Layers,
+  ListChecks,
 } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 
@@ -41,6 +45,23 @@ export function reviewScopeLabel(scope: ReviewScopeSelection): string {
       return scope.subject || scope.sha.slice(0, 8)
     case 'branch':
       return scope.name
+  }
+}
+
+function scopeIcon(scope: ReviewScopeSelection) {
+  switch (scope.kind) {
+    case 'last-turn':
+      return <History aria-hidden className="menu-icon" />
+    case 'uncommitted':
+      return <FilePen aria-hidden className="menu-icon" />
+    case 'unstaged':
+      return <ListChecks aria-hidden className="menu-icon" />
+    case 'staged':
+      return <Layers aria-hidden className="menu-icon" />
+    case 'commit':
+      return <GitCommitHorizontal aria-hidden className="menu-icon" />
+    case 'branch':
+      return <GitBranch aria-hidden className="menu-icon" />
   }
 }
 
@@ -120,6 +141,7 @@ export function ReviewScopePicker({
           if (next) onOpen()
         }}
       >
+        {scopeIcon(value)}
         <span>{reviewScopeLabel(value)}</span>
         <ChevronDown aria-hidden />
       </button>
@@ -136,6 +158,7 @@ export function ReviewScopePicker({
                     aria-checked={scopeMatches(value, scope)}
                     onClick={() => choose(scope)}
                   >
+                    {scopeIcon(scope)}
                     <span>{reviewScopeLabel(scope)}</span>
                     {scopeMatches(value, scope) ? <Check aria-hidden /> : <span className="menu-icon-gap" />}
                   </button>
@@ -143,10 +166,12 @@ export function ReviewScopePicker({
               ))}
               <div className="shui-review-menu-separator" />
               <button type="button" role="menuitem" onClick={() => setSubMenu('committed')}>
+                <GitCommitHorizontal aria-hidden className="menu-icon" />
                 <span>Committed</span>
                 <ChevronRight aria-hidden />
               </button>
               <button type="button" role="menuitem" onClick={() => setSubMenu('branch')}>
+                <GitBranch aria-hidden className="menu-icon" />
                 <span>Branch</span>
                 <ChevronRight aria-hidden />
               </button>

--- a/shell/ui/src/page/__tests__/ReviewPane.test.ts
+++ b/shell/ui/src/page/__tests__/ReviewPane.test.ts
@@ -547,6 +547,23 @@ describe('loadReviewContents for raster images', () => {
     expect(trigger).toHaveBeenCalledTimes(1)
   })
 
+  it('flags a committed image as unavailable instead of deleted', async () => {
+    const { host, trigger } = execHost({})
+    const committed: ReviewEntry = {
+      path: 'docs/logo.png',
+      change: { path: 'docs/logo.png', status: 'modified', staged: false },
+      before: { kind: 'revision', revision: 'aaaa', path: 'docs/logo.png' },
+      after: { kind: 'revision', revision: 'bbbb', path: 'docs/logo.png' },
+    }
+
+    await expect(loadReviewContents(host, '/root', committed)).resolves.toEqual({
+      oldContents: '',
+      newContents: '',
+      imageUnavailable: true,
+    })
+    expect(trigger).not.toHaveBeenCalled()
+  })
+
   it('marks a deleted image without reading anything', async () => {
     const { host, trigger } = execHost({})
     const deleted: ReviewEntry = {

--- a/shell/ui/src/page/__tests__/ReviewPane.test.ts
+++ b/shell/ui/src/page/__tests__/ReviewPane.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 vi.mock('@iii-dev/console-ui', () => ({
   FileDiff: () => null,
+  Markdown: () => null,
 }))
 vi.mock('react', () => ({
   useCallback: (callback: unknown) => callback,
@@ -518,5 +519,47 @@ describe('loadReviewContents without a captured baseline', () => {
       newContents: '',
       baselineSource: 'committed',
     })
+  })
+})
+
+describe('loadReviewContents for raster images', () => {
+  it('loads the working copy as a data URL instead of a text diff', async () => {
+    const { host, trigger } = execHost({
+      'coder::read-file': { content: 'iVBORw0KGgo=', revision: 'r9', mode: 420, size: 8 },
+    })
+    const image: ReviewEntry = {
+      path: 'docs/logo.png',
+      change: { path: 'docs/logo.png', status: 'modified', staged: false },
+      baseline: 'old bytes',
+    }
+
+    await expect(loadReviewContents(host, '/root', image)).resolves.toEqual({
+      oldContents: '',
+      newContents: '',
+      worktreeRevision: 'r9',
+      mode: 420,
+      image: 'data:image/png;base64,iVBORw0KGgo=',
+    })
+    expect(trigger).toHaveBeenCalledWith(
+      'coder::read-file',
+      expect.objectContaining({ path: '/root/docs/logo.png', encoding: 'base64' }),
+    )
+    expect(trigger).toHaveBeenCalledTimes(1)
+  })
+
+  it('marks a deleted image without reading anything', async () => {
+    const { host, trigger } = execHost({})
+    const deleted: ReviewEntry = {
+      path: 'docs/logo.png',
+      change: { path: 'docs/logo.png', status: 'deleted', staged: false },
+      baseline: 'old bytes',
+    }
+
+    await expect(loadReviewContents(host, '/root', deleted)).resolves.toEqual({
+      oldContents: '',
+      newContents: '',
+      image: null,
+    })
+    expect(trigger).not.toHaveBeenCalled()
   })
 })

--- a/shell/ui/src/page/file-type-icon.tsx
+++ b/shell/ui/src/page/file-type-icon.tsx
@@ -1,0 +1,41 @@
+import { createFileTreeIconResolver, getBuiltInSpriteSheet } from '@pierre/trees'
+import { useEffect } from 'react'
+
+const ICON_SET = 'complete'
+const SPRITE_HOST_ID = 'shui-file-type-sprite'
+const BUILTIN_PREFIX = 'file-tree-builtin-'
+const FILE_SLOT = 'file-tree-icon-file'
+
+const resolver = createFileTreeIconResolver({ set: ICON_SET, colored: true })
+
+export function fileTypeToken(path: string): string {
+  const name = resolver.resolveIcon(FILE_SLOT, path).name
+  return name.startsWith(BUILTIN_PREFIX) ? name.slice(BUILTIN_PREFIX.length) : 'default'
+}
+
+function ensureSprite(): void {
+  if (typeof document === 'undefined' || document.getElementById(SPRITE_HOST_ID)) return
+  const host = document.createElement('div')
+  host.id = SPRITE_HOST_ID
+  host.hidden = true
+  host.innerHTML = getBuiltInSpriteSheet(ICON_SET)
+  document.body.append(host)
+}
+
+export function FileTypeIcon({ path, className }: { path: string; className?: string }) {
+  useEffect(ensureSprite, [])
+  const icon = resolver.resolveIcon(FILE_SLOT, path)
+  return (
+    <svg
+      className={className ? `shui-file-type-icon ${className}` : 'shui-file-type-icon'}
+      data-token={fileTypeToken(path)}
+      viewBox={icon.viewBox ?? '0 0 16 16'}
+      width={icon.width ?? 16}
+      height={icon.height ?? 16}
+      aria-hidden="true"
+      focusable="false"
+    >
+      <use href={`#${icon.name}`} />
+    </svg>
+  )
+}

--- a/shell/ui/src/page/git.ts
+++ b/shell/ui/src/page/git.ts
@@ -1079,6 +1079,39 @@ function parseRefs(stdout: string): GitRefSummary[] | string {
 
 /** Local and remote-tracking branch refs. Symbolic aliases such as
     `refs/remotes/origin/HEAD` are omitted so menu entries are unique. */
+export type GitPatchScope =
+  | { kind: 'uncommitted' }
+  | { kind: 'unstaged' }
+  | { kind: 'staged' }
+  | { kind: 'commit'; sha: string }
+  | { kind: 'branch'; ref: string }
+
+function patchArgs(scope: GitPatchScope): string[] {
+  switch (scope.kind) {
+    case 'uncommitted':
+      return ['diff', 'HEAD']
+    case 'unstaged':
+      return ['diff']
+    case 'staged':
+      return ['diff', '--cached']
+    case 'commit':
+      return ['show', '--format=', scope.sha]
+    case 'branch':
+      return ['diff', `${scope.ref}...HEAD`]
+  }
+}
+
+/** Unified patch for a git-backed scope, ready for `git apply` at the
+    repository root. Untracked files are outside every `git diff`. */
+export async function gitPatch(host: Host, root: string, scope: GitPatchScope): Promise<string> {
+  const out = await git(host, root, [...patchArgs(scope), '--no-color'])
+  if (out.exit_code !== 0) {
+    throw new Error(out.stderr.trim() || `git exited with ${out.exit_code}`)
+  }
+  if (out.stdout_truncated) throw new Error('patch is larger than the shell output cap')
+  return out.stdout
+}
+
 export async function gitRefs(host: Host, root: string): Promise<GitRefsState> {
   const repository = await probeRepository(host, root)
   if (repository.kind !== 'ready') return repository

--- a/shell/ui/src/page/git.ts
+++ b/shell/ui/src/page/git.ts
@@ -1086,7 +1086,10 @@ export type GitPatchScope =
   | { kind: 'commit'; sha: string }
   | { kind: 'branch'; ref: string }
 
-function patchArgs(scope: GitPatchScope): string[] {
+/** The same bases the comparisons use: a commit against its first parent
+    (`diff-tree --root` for a root commit), a branch's merge base against the
+    working tree. */
+async function patchArgs(host: Host, root: string, scope: GitPatchScope): Promise<string[]> {
   switch (scope.kind) {
     case 'uncommitted':
       return ['diff', 'HEAD']
@@ -1094,17 +1097,38 @@ function patchArgs(scope: GitPatchScope): string[] {
       return ['diff']
     case 'staged':
       return ['diff', '--cached']
-    case 'commit':
-      return ['show', '--format=', scope.sha]
-    case 'branch':
-      return ['diff', `${scope.ref}...HEAD`]
+    case 'commit': {
+      const sha = await resolveCommit(host, root, scope.sha)
+      const parentsOut = await checkedGit(
+        host,
+        root,
+        ['rev-list', '--parents', '--max-count=1', sha],
+        'git rev-list parents',
+      )
+      const parentSha = parseParents(parentsOut.stdout, sha)[0] ?? null
+      return parentSha === null
+        ? ['diff-tree', '--root', '--no-commit-id', '-p', sha]
+        : ['diff', parentSha, sha]
+    }
+    case 'branch': {
+      const baseSha = await resolveCommit(host, root, scope.ref)
+      const headSha = await resolveCommit(host, root, 'HEAD')
+      const mergeBaseOut = await checkedGit(
+        host,
+        root,
+        ['merge-base', baseSha, headSha],
+        'git merge-base',
+      )
+      return ['diff', parseObjectId(mergeBaseOut.stdout, 'git merge-base')]
+    }
   }
 }
 
 /** Unified patch for a git-backed scope, ready for `git apply` at the
     repository root. Untracked files are outside every `git diff`. */
 export async function gitPatch(host: Host, root: string, scope: GitPatchScope): Promise<string> {
-  const out = await git(host, root, [...patchArgs(scope), '--no-color'])
+  const args = await patchArgs(host, root, scope)
+  const out = await git(host, root, [...args, '--no-color', '--no-ext-diff', '--no-textconv'])
   if (out.exit_code !== 0) {
     throw new Error(out.stderr.trim() || `git exited with ${out.exit_code}`)
   }

--- a/shell/ui/src/page/index.tsx
+++ b/shell/ui/src/page/index.tsx
@@ -2897,6 +2897,7 @@ export function ShellExplorerPage({
               </div>
             ) : tabs.active !== null ? (
               <EditorPane
+                richPreview={reviewOptions.richPreview}
                 // fileBump remounts after an agent-side write to the active
                 // file: the pane rehydrates from the refreshed cache entry.
                 key={`${tabs.active}:${fileBump}`}

--- a/shell/ui/src/page/index.tsx
+++ b/shell/ui/src/page/index.tsx
@@ -2688,7 +2688,7 @@ export function ShellExplorerPage({
                     />
                   </DropdownMenuContent>
                 </DropdownMenu>
-                {orderedReviewEntries.length > 1 ? (
+                {orderedReviewEntries.length > 0 ? (
                   <HoverTip label="Jump to file">
                     <div className="shui-review-jump-wrap">
                       <Selector

--- a/shell/ui/src/page/index.tsx
+++ b/shell/ui/src/page/index.tsx
@@ -11,34 +11,51 @@
  */
 
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
   type Host,
+  IconButton,
   PageBody,
   PageHeader,
   PageMain,
   type PageRenderProps,
   PageShell,
   PageSidebar,
+  Selector,
 } from '@iii-dev/console-ui'
 import type { GitStatusEntry } from '@pierre/trees'
 import {
   Check,
   ChevronsDownUp,
   ChevronsUpDown,
+  ClipboardCopy,
   Columns2,
   Eye,
   EyeOff,
+  FileSearch,
+  FileStack,
   FolderTree,
+  Image,
   MoreHorizontal,
   PanelLeft,
   PanelRight,
+  PanelRightClose,
+  PanelRightOpen,
   RefreshCw,
   Rows3,
   Search,
+  Space,
   SquareTerminal,
   Terminal,
+  WholeWord,
+  WrapText,
   X,
 } from 'lucide-react'
 import {
+  type ReactNode,
   useCallback,
   useEffect,
   useMemo,
@@ -87,6 +104,7 @@ import {
   gitChanges,
   gitCommitComparison,
   gitComparison,
+  gitPatch,
   gitRecentCommits,
   gitRefs,
 } from './git'
@@ -189,26 +207,54 @@ type RootChangeOutcome = RootTargetValidation['outcome'] | 'declined'
 
 function ReviewOption({
   label,
+  icon,
   checked,
   onChange,
 }: {
   label: string
+  icon: ReactNode
   checked: boolean
   onChange: (checked: boolean) => void
 }) {
   return (
-    <button
-      type="button"
+    <DropdownMenuItem
       className="shui-review-option"
       role="menuitemcheckbox"
       aria-checked={checked}
-      onClick={() => onChange(!checked)}
+      onSelect={(event) => {
+        event.preventDefault()
+        onChange(!checked)
+      }}
     >
+      <span className="menu-icon" aria-hidden>
+        {icon}
+      </span>
       <span>{label}</span>
       <span className="check" aria-hidden>
         {checked ? <Check /> : null}
       </span>
-    </button>
+    </DropdownMenuItem>
+  )
+}
+
+function ReviewMenuAction({
+  label,
+  icon,
+  disabled,
+  onSelect,
+}: {
+  label: string
+  icon: ReactNode
+  disabled?: boolean
+  onSelect: () => void
+}) {
+  return (
+    <DropdownMenuItem className="shui-review-option" disabled={disabled} onSelect={onSelect}>
+      <span className="menu-icon" aria-hidden>
+        {icon}
+      </span>
+      <span>{label}</span>
+    </DropdownMenuItem>
   )
 }
 
@@ -389,6 +435,28 @@ export function ShellExplorerPage({
   const [reviewCollapseEpoch, setReviewCollapseEpoch] = useState(0)
   const [reviewExpandEpoch, setReviewExpandEpoch] = useState(0)
   const [reviewMenuOpen, setReviewMenuOpen] = useState(false)
+  const [copyingPatch, setCopyingPatch] = useState(false)
+  const reloadReview = () => {
+    refreshTree()
+    void refreshGit()
+    if (reviewScope.kind === 'last-turn') {
+      setReviewRefreshEpoch((value) => value + 1)
+    } else {
+      loadReviewScope(reviewScope)
+    }
+  }
+  const copyApplyCommand = async () => {
+    if (reviewScope.kind === 'last-turn' || copyingPatch || root === null) return
+    setCopyingPatch(true)
+    try {
+      const patch = await gitPatch(host, root, reviewScope)
+      await navigator.clipboard.writeText(`git apply <<'PATCH'\n${patch}\nPATCH\n`)
+    } catch (error: unknown) {
+      setScopeError(errorMessage(error))
+    } finally {
+      setCopyingPatch(false)
+    }
+  }
   const [reviewScope, setReviewScope] =
     useState<ReviewScopeSelection>(LAST_TURN_SCOPE)
   const reviewScopeRef = useRef(reviewScope)
@@ -2520,137 +2588,145 @@ export function ShellExplorerPage({
                   </span>
                 ) : null}
                 <span className="spacer" />
-                <HoverTip label="Reload this review">
-                  <button
-                    type="button"
-                    className="shui-review-action"
-                    onClick={() => {
-                      refreshTree()
-                      void refreshGit()
-                      if (reviewScope.kind === 'last-turn') {
-                        setReviewRefreshEpoch((value) => value + 1)
-                      } else {
-                        loadReviewScope(reviewScope)
-                      }
-                    }}
-                    aria-label="Reload this review"
-                  >
-                    <RefreshCw aria-hidden />
-                  </button>
-                </HoverTip>
-                <HoverTip label="Expand all diffs">
-                  <button
-                    type="button"
-                    className="shui-review-action"
-                    onClick={() => setReviewExpandEpoch((value) => value + 1)}
-                    aria-label="Expand all diffs"
-                  >
-                    <ChevronsUpDown aria-hidden />
-                  </button>
-                </HoverTip>
-                <HoverTip label="Collapse all diffs">
-                  <button
-                    type="button"
-                    className="shui-review-action"
-                    onClick={() => setReviewCollapseEpoch((value) => value + 1)}
-                    aria-label="Collapse all diffs"
-                  >
-                    <ChevronsDownUp aria-hidden />
-                  </button>
-                </HoverTip>
-                <HoverTip
-                  label={
-                    reviewOptions.diffStyle === 'unified'
-                      ? 'Show split diff (side by side)'
-                      : 'Show unified diff (one column)'
-                  }
-                >
-                  <button
-                    type="button"
-                    className="shui-review-action"
-                    onClick={() =>
-                      setReviewOptions((previous) => ({
-                        ...previous,
-                        diffStyle:
-                          previous.diffStyle === 'unified'
-                            ? 'split'
-                            : 'unified',
-                      }))
-                    }
-                    aria-label={
-                      reviewOptions.diffStyle === 'unified'
-                        ? 'Show split diff'
-                        : 'Show unified diff'
-                    }
-                  >
-                    {reviewOptions.diffStyle === 'unified' ? (
-                      <Columns2 aria-hidden />
-                    ) : (
-                      <Rows3 aria-hidden />
-                    )}
-                  </button>
-                </HoverTip>
-                <div className="shui-review-menu-wrap">
-                  <HoverTip label="Diff display options">
-                    <button
-                      type="button"
-                      className={`shui-review-action${reviewMenuOpen ? ' active' : ''}`}
-                      onClick={() => setReviewMenuOpen((value) => !value)}
-                      aria-expanded={reviewMenuOpen}
-                      aria-label="Diff display options"
-                    >
-                      <MoreHorizontal aria-hidden />
-                    </button>
-                  </HoverTip>
-                  {reviewMenuOpen ? (
-                    <div className="shui-review-menu" role="menu">
-                      <ReviewOption
-                        label="Enable word wrap"
-                        checked={reviewOptions.wordWrap}
-                        onChange={(wordWrap) =>
-                          setReviewOptions((value) => ({ ...value, wordWrap }))
-                        }
-                      />
-                      <ReviewOption
-                        label="Enable word diffs"
-                        checked={reviewOptions.wordDiffs}
-                        onChange={(wordDiffs) =>
-                          setReviewOptions((value) => ({ ...value, wordDiffs }))
-                        }
-                      />
-                      <ReviewOption
-                        label="Hide whitespace"
-                        checked={reviewOptions.hideWhitespace}
-                        onChange={(hideWhitespace) =>
-                          setReviewOptions((value) => ({
-                            ...value,
-                            hideWhitespace,
-                          }))
-                        }
-                      />
-                      <ReviewOption
-                        label="Load full files"
-                        checked={reviewOptions.expandUnchanged}
-                        onChange={(expandUnchanged) =>
-                          setReviewOptions((value) => ({
-                            ...value,
-                            expandUnchanged,
-                          }))
-                        }
-                      />
-                      <ReviewOption
-                        label="Enable rich preview"
-                        checked={reviewOptions.richPreview}
-                        onChange={(richPreview) =>
-                          setReviewOptions((value) => ({
-                            ...value,
-                            richPreview,
-                          }))
-                        }
+                {orderedReviewEntries.length > 1 ? (
+                  <HoverTip label="Jump to file">
+                    <div className="shui-review-jump-wrap">
+                      <Selector
+                        aria-label="Jump to file"
+                        className="shui-review-jump"
+                        contentClassName="shui-review-jump-list"
+                        value={undefined}
+                        options={orderedReviewEntries.map((entry) => ({
+                          value: entry.path,
+                          label: entry.path,
+                        }))}
+                        placeholder=""
+                        searchPlaceholder="Jump to file…"
+                        emptyMessage="no matching file"
+                        triggerIcon={<FileSearch aria-hidden />}
+                        onChange={(path) => {
+                          const entry = visibleReviewEntriesRef.current.get(path)
+                          if (entry) openReviewEntry(entry)
+                        }}
                       />
                     </div>
-                  ) : null}
-                </div>
+                  </HoverTip>
+                ) : null}
+                <DropdownMenu open={reviewMenuOpen} onOpenChange={setReviewMenuOpen}>
+                  <DropdownMenuTrigger asChild>
+                    <IconButton
+                      label="Review options"
+                      className={reviewMenuOpen ? 'active' : undefined}
+                    >
+                      <MoreHorizontal aria-hidden />
+                    </IconButton>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="shui-review-menu-content">
+                    <ReviewMenuAction
+                      label="Refresh"
+                      icon={<RefreshCw />}
+                      onSelect={reloadReview}
+                    />
+                    <ReviewOption
+                      label="Enable word wrap"
+                      icon={<WrapText />}
+                      checked={reviewOptions.wordWrap}
+                      onChange={(wordWrap) =>
+                        setReviewOptions((value) => ({ ...value, wordWrap }))
+                      }
+                    />
+                    <DropdownMenuSeparator />
+                    <ReviewOption
+                      label="Load full files"
+                      icon={<FileStack />}
+                      checked={reviewOptions.expandUnchanged}
+                      onChange={(expandUnchanged) =>
+                        setReviewOptions((value) => ({
+                          ...value,
+                          expandUnchanged,
+                        }))
+                      }
+                    />
+                    <ReviewOption
+                      label="Enable rich preview"
+                      icon={<Image />}
+                      checked={reviewOptions.richPreview}
+                      onChange={(richPreview) =>
+                        setReviewOptions((value) => ({
+                          ...value,
+                          richPreview,
+                        }))
+                      }
+                    />
+                    <ReviewOption
+                      label="Enable word diffs"
+                      icon={<WholeWord />}
+                      checked={reviewOptions.wordDiffs}
+                      onChange={(wordDiffs) =>
+                        setReviewOptions((value) => ({ ...value, wordDiffs }))
+                      }
+                    />
+                    <ReviewOption
+                      label="Hide whitespace"
+                      icon={<Space />}
+                      checked={reviewOptions.hideWhitespace}
+                      onChange={(hideWhitespace) =>
+                        setReviewOptions((value) => ({
+                          ...value,
+                          hideWhitespace,
+                        }))
+                      }
+                    />
+                    <DropdownMenuSeparator />
+                    <ReviewMenuAction
+                      label={
+                        reviewScope.kind === 'last-turn'
+                          ? 'Copy git apply command (git scopes only)'
+                          : 'Copy git apply command'
+                      }
+                      icon={<ClipboardCopy />}
+                      disabled={reviewScope.kind === 'last-turn' || copyingPatch}
+                      onSelect={() => void copyApplyCommand()}
+                    />
+                  </DropdownMenuContent>
+                </DropdownMenu>
+                <IconButton label="Expand all diffs" onClick={() => setReviewExpandEpoch((value) => value + 1)}>
+                  <ChevronsUpDown aria-hidden />
+                </IconButton>
+                <IconButton label="Collapse all diffs" onClick={() => setReviewCollapseEpoch((value) => value + 1)}>
+                  <ChevronsDownUp aria-hidden />
+                </IconButton>
+                <IconButton
+                  label={
+                    reviewOptions.diffStyle === 'unified'
+                      ? 'Switch to split diff'
+                      : 'Switch to unified diff'
+                  }
+                  onClick={() =>
+                    setReviewOptions((previous) => ({
+                      ...previous,
+                      diffStyle:
+                        previous.diffStyle === 'unified' ? 'split' : 'unified',
+                    }))
+                  }
+                >
+                  {reviewOptions.diffStyle === 'unified' ? (
+                    <Columns2 aria-hidden />
+                  ) : (
+                    <Rows3 aria-hidden />
+                  )}
+                </IconButton>
+                <IconButton
+                  label={collapsed ? 'Show files' : 'Hide files'}
+                  aria-pressed={collapsed}
+                  onClick={() => setCollapsed((value) => !value)}
+                >
+                  {collapsed ? (
+                    <PanelRightOpen aria-hidden />
+                  ) : (
+                    <PanelRightClose aria-hidden />
+                  )}
+                </IconButton>
               </div>
             ) : null}
             {(diff === null && tabs.tabs.length > 0) ||

--- a/shell/ui/src/page/index.tsx
+++ b/shell/ui/src/page/index.tsx
@@ -32,7 +32,6 @@ import {
   ChevronsDownUp,
   ChevronsUpDown,
   ClipboardCopy,
-  Columns2,
   Eye,
   EyeOff,
   FileSearch,
@@ -42,10 +41,7 @@ import {
   MoreHorizontal,
   PanelLeft,
   PanelRight,
-  PanelRightClose,
-  PanelRightOpen,
   RefreshCw,
-  Rows3,
   Search,
   Space,
   SquareTerminal,
@@ -234,6 +230,26 @@ function ReviewOption({
         {checked ? <Check /> : null}
       </span>
     </DropdownMenuItem>
+  )
+}
+
+function SplitDiffIcon() {
+  return (
+    <svg className="shui-diff-style-icon" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+      <rect x="1.5" y="2.5" width="13" height="11" rx="2.5" className="frame" />
+      <rect x="3" y="4" width="4.5" height="8" rx="1.2" className="del" />
+      <rect x="8.5" y="4" width="4.5" height="8" rx="1.2" className="add" />
+    </svg>
+  )
+}
+
+function UnifiedDiffIcon() {
+  return (
+    <svg className="shui-diff-style-icon" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+      <rect x="1.5" y="2.5" width="13" height="11" rx="2.5" className="frame" />
+      <rect x="3" y="4" width="10" height="3.5" rx="1.2" className="del" />
+      <rect x="3" y="8.5" width="10" height="3.5" rx="1.2" className="add" />
+    </svg>
   )
 }
 
@@ -434,6 +450,12 @@ export function ShellExplorerPage({
   const [reviewRefreshEpoch, setReviewRefreshEpoch] = useState(0)
   const [reviewCollapseEpoch, setReviewCollapseEpoch] = useState(0)
   const [reviewExpandEpoch, setReviewExpandEpoch] = useState(0)
+  const [reviewAllCollapsed, setReviewAllCollapsed] = useState(false)
+  const toggleAllDiffs = () => {
+    if (reviewAllCollapsed) setReviewExpandEpoch((value) => value + 1)
+    else setReviewCollapseEpoch((value) => value + 1)
+    setReviewAllCollapsed((value) => !value)
+  }
   const [reviewMenuOpen, setReviewMenuOpen] = useState(false)
   const [copyingPatch, setCopyingPatch] = useState(false)
   const reloadReview = () => {
@@ -2588,30 +2610,6 @@ export function ShellExplorerPage({
                   </span>
                 ) : null}
                 <span className="spacer" />
-                {orderedReviewEntries.length > 1 ? (
-                  <HoverTip label="Jump to file">
-                    <div className="shui-review-jump-wrap">
-                      <Selector
-                        aria-label="Jump to file"
-                        className="shui-review-jump"
-                        contentClassName="shui-review-jump-list"
-                        value={undefined}
-                        options={orderedReviewEntries.map((entry) => ({
-                          value: entry.path,
-                          label: entry.path,
-                        }))}
-                        placeholder=""
-                        searchPlaceholder="Jump to file…"
-                        emptyMessage="no matching file"
-                        triggerIcon={<FileSearch aria-hidden />}
-                        onChange={(path) => {
-                          const entry = visibleReviewEntriesRef.current.get(path)
-                          if (entry) openReviewEntry(entry)
-                        }}
-                      />
-                    </div>
-                  </HoverTip>
-                ) : null}
                 <DropdownMenu open={reviewMenuOpen} onOpenChange={setReviewMenuOpen}>
                   <DropdownMenuTrigger asChild>
                     <IconButton
@@ -2690,11 +2688,39 @@ export function ShellExplorerPage({
                     />
                   </DropdownMenuContent>
                 </DropdownMenu>
-                <IconButton label="Expand all diffs" onClick={() => setReviewExpandEpoch((value) => value + 1)}>
-                  <ChevronsUpDown aria-hidden />
-                </IconButton>
-                <IconButton label="Collapse all diffs" onClick={() => setReviewCollapseEpoch((value) => value + 1)}>
-                  <ChevronsDownUp aria-hidden />
+                {orderedReviewEntries.length > 1 ? (
+                  <HoverTip label="Jump to file">
+                    <div className="shui-review-jump-wrap">
+                      <Selector
+                        aria-label="Jump to file"
+                        className="shui-review-jump"
+                        contentClassName="shui-review-jump-list"
+                        value={undefined}
+                        options={orderedReviewEntries.map((entry) => ({
+                          value: entry.path,
+                          label: entry.path,
+                        }))}
+                        placeholder=""
+                        searchPlaceholder="Jump to file…"
+                        emptyMessage="no matching file"
+                        triggerIcon={<FileSearch aria-hidden />}
+                        onChange={(path) => {
+                          const entry = visibleReviewEntriesRef.current.get(path)
+                          if (entry) openReviewEntry(entry)
+                        }}
+                      />
+                    </div>
+                  </HoverTip>
+                ) : null}
+                <IconButton
+                  label={reviewAllCollapsed ? 'Expand all diffs' : 'Collapse all diffs'}
+                  onClick={toggleAllDiffs}
+                >
+                  {reviewAllCollapsed ? (
+                    <ChevronsUpDown aria-hidden />
+                  ) : (
+                    <ChevronsDownUp aria-hidden />
+                  )}
                 </IconButton>
                 <IconButton
                   label={
@@ -2711,20 +2737,9 @@ export function ShellExplorerPage({
                   }
                 >
                   {reviewOptions.diffStyle === 'unified' ? (
-                    <Columns2 aria-hidden />
+                    <SplitDiffIcon />
                   ) : (
-                    <Rows3 aria-hidden />
-                  )}
-                </IconButton>
-                <IconButton
-                  label={collapsed ? 'Show files' : 'Hide files'}
-                  aria-pressed={collapsed}
-                  onClick={() => setCollapsed((value) => !value)}
-                >
-                  {collapsed ? (
-                    <PanelRightOpen aria-hidden />
-                  ) : (
-                    <PanelRightClose aria-hidden />
+                    <UnifiedDiffIcon />
                   )}
                 </IconButton>
               </div>

--- a/shell/ui/src/page/rich-preview.tsx
+++ b/shell/ui/src/page/rich-preview.tsx
@@ -1,0 +1,32 @@
+import { Markdown } from '@iii-dev/console-ui'
+import type React from 'react'
+
+export function isRichPreviewPath(path: string): boolean {
+  const lower = path.toLowerCase()
+  return (
+    lower.endsWith('.html') ||
+    lower.endsWith('.htm') ||
+    lower.endsWith('.svg') ||
+    lower.endsWith('.md') ||
+    lower.endsWith('.markdown')
+  )
+}
+
+export function richPreviewNode(path: string, contents: string): React.ReactNode | null {
+  const lower = path.toLowerCase()
+  if (lower.endsWith('.html') || lower.endsWith('.htm')) {
+    return <iframe className="shui-rich-preview" title={`preview ${path}`} sandbox="" srcDoc={contents} />
+  }
+  if (lower.endsWith('.svg')) {
+    const src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(contents)}`
+    return <img className="shui-rich-preview-image" src={src} alt={`preview ${path}`} />
+  }
+  if (lower.endsWith('.md') || lower.endsWith('.markdown')) {
+    return (
+      <article className="shui-markdown-preview">
+        <Markdown>{contents}</Markdown>
+      </article>
+    )
+  }
+  return null
+}

--- a/shell/ui/styles.css
+++ b/shell/ui/styles.css
@@ -1257,7 +1257,7 @@
 }
 [data-iii-ui="shell"] .shui-diff-style-icon .frame {
   fill: none;
-  stroke: currentColor;
+  stroke: currentcolor;
   stroke-width: 1.2;
   opacity: 0.75;
 }

--- a/shell/ui/styles.css
+++ b/shell/ui/styles.css
@@ -1497,6 +1497,14 @@
 [data-iii-ui="shell"] .shui-file-type-icon[data-token="text"] {
   color: var(--shui-icon-gray);
 }
+[data-iii-ui="shell"] .shui-editor-preview {
+  height: 100%;
+  overflow: auto;
+  background: var(--color-panel);
+}
+[data-iii-ui="shell"] .shui-editor-preview .shui-rich-preview {
+  min-height: 100%;
+}
 [data-iii-ui="shell"] .shui-file-type-icon {
   width: 16px;
   height: 16px;

--- a/shell/ui/styles.css
+++ b/shell/ui/styles.css
@@ -1103,7 +1103,7 @@
 [data-iii-ui="shell"] .shui-review-scope-button {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
   min-height: 30px;
   padding: 0 7px;
   border: 0;
@@ -1117,6 +1117,12 @@
     "Segoe UI",
     sans-serif;
   cursor: pointer;
+  transition:
+    background-color var(--motion-duration-control) var(--motion-ease-standard),
+    color var(--motion-duration-control) var(--motion-ease-standard);
+}
+[data-iii-ui="shell"] .shui-review-scope-button .menu-icon {
+  color: var(--color-ink-faint);
 }
 [data-iii-ui="shell"] .shui-review-scope-button:hover,
 [data-iii-ui="shell"] .shui-review-scope-button[aria-expanded="true"] {
@@ -1165,9 +1171,12 @@
 [data-iii-ui="shell"] .shui-review-scope-menu button:hover {
   background: var(--color-surface-hover);
 }
-[data-iii-ui="shell"] .shui-review-scope-menu button > :first-child:not(svg) {
+[data-iii-ui="shell"] .shui-review-scope-menu button > span:not(.menu-icon-gap) {
   min-width: 0;
   flex: 1;
+}
+[data-iii-ui="shell"] .shui-review-scope-menu button > .menu-icon {
+  color: var(--color-ink-faint);
 }
 [data-iii-ui="shell"] .shui-review-scope-menu button > svg,
 [data-iii-ui="shell"] .shui-review-scope-menu .menu-icon-gap {
@@ -1238,66 +1247,57 @@
 [data-iii-ui="shell"] .shui-review-total.del {
   color: var(--color-git-deleted, #fa423e);
 }
-[data-iii-ui="shell"] .shui-review-action {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 30px;
-  height: 30px;
-  flex: none;
-  padding: 0;
-  border: 1px solid transparent;
-  border-radius: 8px;
-  background: transparent;
-  color: var(--color-ink-faint);
-  cursor: pointer;
-}
-[data-iii-ui="shell"] .shui-review-action:hover,
-[data-iii-ui="shell"] .shui-review-action.active {
+[data-iii-ui="shell"] .shui-review-toolbar .active {
   color: var(--color-ink);
   background: var(--color-surface-hover);
 }
-[data-iii-ui="shell"] .shui-review-action:focus-visible {
-  outline: 1px solid var(--color-rule-focus);
-  outline-offset: -2px;
+[data-iii-ui="shell"] .shui-review-menu-content {
+  min-width: 248px;
 }
-[data-iii-ui="shell"] .shui-review-action svg {
+[data-iii-ui="shell"] .shui-review-jump > button {
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  justify-content: center;
+  gap: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--color-ink-faint);
+}
+[data-iii-ui="shell"] .shui-review-jump > button:hover {
+  color: var(--color-ink);
+  background: var(--color-surface-hover);
+}
+[data-iii-ui="shell"] .shui-review-jump > button > span:not(:first-child),
+[data-iii-ui="shell"] .shui-review-jump > button > svg:last-child {
+  display: none;
+}
+[data-iii-ui="shell"] .shui-review-jump > button > span:first-child {
+  color: inherit;
+}
+[data-iii-ui="shell"] .shui-review-jump > button > span:first-child svg {
   width: 16px;
   height: 16px;
 }
-[data-iii-ui="shell"] .shui-review-menu-wrap {
-  position: relative;
-}
-[data-iii-ui="shell"] .shui-review-menu {
-  position: absolute;
-  top: calc(100% + 5px);
-  right: 0;
-  display: flex;
-  flex-direction: column;
-  width: 224px;
-  padding: 5px;
-  border: 1px solid var(--color-edge);
-  border-radius: 12px;
-  background: var(--color-panel-raised);
-  box-shadow: 0 12px 36px rgb(0 0 0 / 32%);
+[data-iii-ui="shell"] .shui-review-jump-list {
+  width: min(420px, 80vw);
 }
 [data-iii-ui="shell"] .shui-review-option {
   display: flex;
   align-items: center;
-  gap: 12px;
-  width: 100%;
-  min-height: 34px;
-  padding: 0 9px;
-  border: 0;
-  border-radius: 7px;
-  background: transparent;
-  color: var(--color-ink);
-  font: inherit;
-  text-align: left;
-  cursor: pointer;
+  gap: 10px;
+  min-height: 32px;
 }
-[data-iii-ui="shell"] .shui-review-option:hover {
-  background: var(--color-surface-hover);
+[data-iii-ui="shell"] .shui-review-option .menu-icon {
+  display: inline-flex;
+  width: 16px;
+  height: 16px;
+  flex: none;
+  color: var(--color-ink-faint);
+}
+[data-iii-ui="shell"] .shui-review-option .menu-icon svg {
+  width: 16px;
+  height: 16px;
 }
 [data-iii-ui="shell"] .shui-review-option .check {
   display: inline-flex;
@@ -1346,10 +1346,34 @@
     sans-serif;
   text-align: left;
 }
+[data-iii-ui="shell"] .shui-review-file-head {
+  transition:
+    background-color var(--motion-duration-control) var(--motion-ease-standard),
+    color var(--motion-duration-control) var(--motion-ease-standard);
+}
 [data-iii-ui="shell"] .shui-review-file.active > .shui-review-file-head,
 [data-iii-ui="shell"] .shui-review-file-head:hover {
   color: var(--color-ink);
   background: var(--color-surface-hover);
+}
+[data-iii-ui="shell"] .shui-review-file-toggle .chevron {
+  transition: transform var(--motion-duration-control) var(--motion-ease-standard);
+}
+[data-iii-ui="shell"] .shui-review-file-toggle .chevron.open {
+  transform: rotate(90deg);
+}
+[data-iii-ui="shell"] .shui-review-file > :not(.shui-review-file-head) {
+  animation: shui-review-reveal var(--motion-duration-panel) var(--motion-ease-enter) both;
+}
+@keyframes shui-review-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(-3px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
 }
 [data-iii-ui="shell"] .shui-review-file-toggle {
   display: flex;
@@ -1371,8 +1395,97 @@
   height: 16px;
   flex: none;
 }
-[data-iii-ui="shell"] .shui-review-file-head .file-icon {
-  color: var(--color-accent);
+[data-iii-ui="shell"] {
+  --shui-icon-blue: light-dark(#1a85d4, #69b1ff);
+  --shui-icon-cyan: light-dark(#1ca1c7, #68cdf2);
+  --shui-icon-gray: light-dark(#84848a, #adadb1);
+  --shui-icon-green: light-dark(#199f43, #5ecc71);
+  --shui-icon-indigo: light-dark(#693acf, #9d6afb);
+  --shui-icon-mauve: light-dark(#594c5b, #79697b);
+  --shui-icon-orange: light-dark(#d47628, #ffa359);
+  --shui-icon-pink: light-dark(#d32a61, #ff678d);
+  --shui-icon-purple: light-dark(#a631be, #d568ea);
+  --shui-icon-red: light-dark(#d52c36, #ff6762);
+  --shui-icon-teal: light-dark(#17a5af, #64d1db);
+  --shui-icon-vermilion: light-dark(#ff8c5b, #d5512f);
+  --shui-icon-yellow: light-dark(#d5a910, #ffd452);
+}
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="astro"],
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="database"],
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="vite"] {
+  color: var(--shui-icon-purple);
+}
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="babel"],
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="browserslist"],
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="javascript"] {
+  color: var(--shui-icon-yellow);
+}
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="bash"],
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="markdown"],
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="svgo"],
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="vue"] {
+  color: var(--shui-icon-green);
+}
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="biome"],
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="c"],
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="cpp"],
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="docker"],
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="python"],
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="typescript"],
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="vscode"],
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="webpack"] {
+  color: var(--shui-icon-blue);
+}
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="bootstrap"],
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="css"],
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="eslint"],
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="terraform"],
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="wasm"] {
+  color: var(--shui-icon-indigo);
+}
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="bun"] {
+  color: var(--shui-icon-mauve);
+}
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="claude"],
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="html"],
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="json"],
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="rust"],
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="svg"],
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="swift"],
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="zig"],
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="zip"] {
+  color: var(--shui-icon-orange);
+}
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="go"],
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="react"],
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="tailwind"] {
+  color: var(--shui-icon-cyan);
+}
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="graphql"],
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="image"],
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="sass"] {
+  color: var(--shui-icon-pink);
+}
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="mcp"],
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="prettier"],
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="table"] {
+  color: var(--shui-icon-teal);
+}
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="npm"],
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="postcss"],
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="ruby"],
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="svelte"],
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="yml"] {
+  color: var(--shui-icon-red);
+}
+[data-iii-ui="shell"] .shui-file-type-icon[data-token="text"] {
+  color: var(--shui-icon-gray);
+}
+[data-iii-ui="shell"] .shui-file-type-icon {
+  width: 16px;
+  height: 16px;
+  flex: none;
+  color: var(--shui-icon-gray);
 }
 [data-iii-ui="shell"] .shui-review-file-toggle .path {
   min-width: 0;
@@ -1396,6 +1509,11 @@
   background: transparent;
   color: var(--color-ink-faint);
   cursor: pointer;
+}
+[data-iii-ui="shell"] .shui-review-file-action {
+  transition:
+    background-color var(--motion-duration-control) var(--motion-ease-standard),
+    color var(--motion-duration-control) var(--motion-ease-standard);
 }
 [data-iii-ui="shell"] .shui-review-file-action:hover {
   color: var(--color-ink);

--- a/shell/ui/styles.css
+++ b/shell/ui/styles.css
@@ -1251,6 +1251,22 @@
   color: var(--color-ink);
   background: var(--color-surface-hover);
 }
+[data-iii-ui="shell"] .shui-diff-style-icon {
+  width: 16px;
+  height: 16px;
+}
+[data-iii-ui="shell"] .shui-diff-style-icon .frame {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.2;
+  opacity: 0.75;
+}
+[data-iii-ui="shell"] .shui-diff-style-icon .del {
+  fill: var(--color-git-deleted, #c05353);
+}
+[data-iii-ui="shell"] .shui-diff-style-icon .add {
+  fill: var(--color-git-added, #4d9a57);
+}
 [data-iii-ui="shell"] .shui-review-menu-content {
   min-width: 248px;
 }


### PR DESCRIPTION
## Why

The review pane's `Enable rich preview` option covered `.html`, `.svg`, and `.md` only, and the markdown path was a four-rule renderer (headings, bullets, blank lines, paragraphs). Bold, links, inline code, fenced code, numbered lists, tables, and images came out as plain text, so the toggle looked broken. Raster images fell through to the text diff and rendered as replacement-character noise, while the Files tab already previews them through `coder::read-file` with `encoding: base64`.

The same pane also predates the shared UI pass (#837): raw toolbar buttons with a local tooltip wrapper, a hand-rolled absolutely positioned options menu, one fixed `FileCode2` glyph for every file, no file-type icons in the tree, and no motion at all in the review block.

## What

### Rich preview (`ReviewPane.tsx`)

- Markdown renders through the shared `Markdown` component from `@iii-dev/console-ui`, the same renderer chat uses. The hand-rolled `MarkdownPreview` is gone.
- Raster image rows (`png`, `jpg`, `jpeg`, `gif`, `webp`, `bmp`, `ico`, `avif`, via the existing `imageMimeFromPath`) load the working copy with `coderReadFileBase64` and carry it on `ReviewContents.image`; the text sides stay empty because the bytes are not diffable. With rich preview on, the row shows the image. With it off, the row says `binary image; enable rich preview to view it` instead of a garbage diff. A deleted image says `image deleted`. Inline edit is disabled for image rows.
- HTML (sandboxed iframe) and SVG are unchanged. The renderer lives in `rich-preview.tsx` and is shared with the editor.
- Editor tabs (files opened from the sidebar) honor the same option: a `.md`, `.html`, or `.svg` file opens rendered when rich preview is on, and an eye/code `IconButton` in the tab header flips Source and Preview per file. Preview follows the live draft.

### Review toolbar on shared atoms (`index.tsx`, `styles.css`)

- Every icon action is an `IconButton` (accessible label plus the shared tooltip), in this order: Review options, Jump to file, one Collapse all / Expand all toggle, Switch to split/unified diff. The split/unified glyph is drawn with the git added/deleted colors so the two layouts read at a glance. The sidebar keeps its own collapse control from `PageSidebar`.
- The options menu is the shared `DropdownMenu`. Each item carries a leading icon: Refresh, Enable word wrap, Load full files, Enable rich preview, Enable word diffs, Hide whitespace, and a new **Copy git apply command** that copies `git apply <<'PATCH' ... PATCH` for git-backed scopes (`git diff HEAD`, `git diff`, `git diff --cached`, `git show --format= <sha>`, `git diff <ref>...HEAD`); it stays disabled on Last Turn, which is not a git range. Checkbox items keep the menu open so several can be toggled in one visit.
- New **Jump to file**: the shared searchable `Selector`, compact icon trigger, one row per changed file, selecting scrolls the review to it.
- The scope picker keeps its sanctioned local submenu (`docs/sops/console-ui-conformance.md`) and gains icons on Last Turn, Uncommitted, Unstaged, Staged, Committed, Branch, plus the active scope's icon on the trigger.

### File-type icons (`file-type-icon.tsx`, `FilesTab.tsx`)

- The file tree turns on `@pierre/trees`' built-in colored icon set (`icons: { set: 'complete', colored: true }`), so `.rs`, `.ts`, `.py`, `.md`, images, configs and the rest get their language logo.
- The diff header uses the same sprite through `createFileTreeIconResolver` and `getBuiltInSpriteSheet`: one hidden sprite host in the document, `<use href>` per row, colors mirrored from the library's palette as `--shui-icon-*` tokens keyed by `data-token`.

### Motion

Review file headers, scope button, file actions and option rows transition on `--motion-duration-control` / `--motion-ease-standard`; the collapse chevron rotates instead of swapping glyphs; a revealed diff body plays `shui-review-reveal` on `--motion-duration-panel` / `--motion-ease-enter`. Tokens collapse to 0ms under reduced motion through the console's global override.

No console or shared-package changes.

The diff remounts when the split/unified style flips, so the layout change is immediate.

## Verification

- `shell/ui`: `tsc --noEmit`, vitest 292 passing including two new `loadReviewContents` cases (image row reads base64 once with the right path; deleted image reads nothing), esbuild bundle.
- `shell` crate: `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, `cargo test` (669).
- Rig: built binary installed, `GET /ui/shell/page.js` and `/ui/shell/styles.css` serve the new code; a harness turn wrote `rich-preview-check.md` and `rich-preview-check.png` into the workspace so the Last Turn review shows both rows.

Linear: MOT-4509


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added rich previews for HTML, SVG, Markdown, and supported image files.
  - Added review toolbar controls for refreshing, word wrapping, whitespace, diff styles, previews, copying commands, and navigating files.
  - Added global collapse and expand controls for review sections.
  - Added colored file-type icons and icons for review scopes.
  - Added Git comparison options for uncommitted, staged, committed, and branch changes.

- **Bug Fixes**
  - Improved handling and display of deleted or binary image files in reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->