### PR TITLE
fix(providers): refresh llm-router lockfiles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,13 @@ jobs:
           [[ "$(git tag -l --format='%(contents)' "$RAW_TAG" | sed -n 's/^operation-id: //p')" == '${{ inputs.operation_id }}' ]]
           [[ "$(git tag -l --format='%(contents)' "$RAW_TAG" | sed -n 's/^step-id: //p')" == '${{ inputs.source_tag_step_id }}' ]]
 
+      - name: Validate Rust lockfile
+        if: ${{ steps.meta.outputs.language == 'rust' }}
+        env:
+          WORKER: ${{ steps.meta.outputs.worker }}
+          MANIFEST: ${{ steps.meta.outputs.manifest }}
+        run: cargo metadata --locked --format-version 1 --manifest-path "$WORKER/$MANIFEST" >/dev/null
+
       - name: Detect web bundle
         id: web
         env:
@@ -100,7 +107,7 @@ jobs:
           fi
 
   github-release:
-    name: Create GitHub Release shell
+    name: Create GitHub Release
     needs: setup
     runs-on: ubuntu-latest
     permissions:

--- a/crates/provider-integration-testkit/Cargo.lock
+++ b/crates/provider-integration-testkit/Cargo.lock
@@ -1048,7 +1048,7 @@ checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "llm-router"
-version = "1.4.9"
+version = "1.4.10"
 dependencies = [
  "async-trait",
  "clap",
@@ -1326,7 +1326,7 @@ dependencies = [
 
 [[package]]
 name = "provider-anthropic"
-version = "1.2.5"
+version = "1.2.6"
 dependencies = [
  "clap",
  "futures",
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "provider-openai"
-version = "1.2.4"
+version = "1.2.5"
 dependencies = [
  "clap",
  "futures",

--- a/provider-anthropic/Cargo.lock
+++ b/provider-anthropic/Cargo.lock
@@ -996,7 +996,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.9"
+version = "1.4.10"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-claude-code/Cargo.lock
+++ b/provider-claude-code/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.9"
+version = "1.4.10"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-deepseek/Cargo.lock
+++ b/provider-deepseek/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.9"
+version = "1.4.10"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-github-copilot/Cargo.lock
+++ b/provider-github-copilot/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.9"
+version = "1.4.10"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-kimi/Cargo.lock
+++ b/provider-kimi/Cargo.lock
@@ -943,7 +943,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.9"
+version = "1.4.10"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-llamacpp/Cargo.lock
+++ b/provider-llamacpp/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.9"
+version = "1.4.10"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-openai-codex/Cargo.lock
+++ b/provider-openai-codex/Cargo.lock
@@ -1008,7 +1008,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.9"
+version = "1.4.10"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-openai/Cargo.lock
+++ b/provider-openai/Cargo.lock
@@ -996,7 +996,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.9"
+version = "1.4.10"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-opencode-go/Cargo.lock
+++ b/provider-opencode-go/Cargo.lock
@@ -976,7 +976,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.9"
+version = "1.4.10"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-openrouter/Cargo.lock
+++ b/provider-openrouter/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.9"
+version = "1.4.10"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-xai/Cargo.lock
+++ b/provider-xai/Cargo.lock
@@ -996,7 +996,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.9"
+version = "1.4.10"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-zai/Cargo.lock
+++ b/provider-zai/Cargo.lock
@@ -996,7 +996,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.9"
+version = "1.4.10"
 dependencies = [
  "async-trait",
  "clap",


### PR DESCRIPTION
## Summary

- refresh all Rust provider lockfiles from llm-router 1.4.9 to 1.4.10
- validate Rust lockfiles before creating a GitHub Release
- remove the misleading shell-specific GitHub Release job name

## Why

The provider-anthropic/v1.2.6 release failed on native targets because its lockfile still referenced llm-router 1.4.9 while the path dependency was already at 1.4.10. The release was created before Cargo validated the lockfile, which left a partial release.

All Rust providers depend on the local llm-router package and had the same stale lockfile entry.

## Validation

- cargo metadata --locked passed for all 12 provider manifests
- pytest -q .github/scripts/tests/test_release_workflows.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release validation for Rust-based releases by verifying dependencies against the lockfile.
* **Chores**
  * Updated the GitHub release job name for clearer workflow visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->