### PR TITLE
(MOT-4510) feat(console): turn rail, a chat minimap with previews and jump

### DIFF
--- a/console/web/src/App.tsx
+++ b/console/web/src/App.tsx
@@ -43,6 +43,7 @@ import {
   type UseWorkspaceTabsReturn,
   useWorkspaceTabs,
 } from '@/hooks/use-workspace-tabs'
+import { stepChatTurn } from '@/lib/chat-turn-nav'
 import {
   ConversationsProvider,
   useConversationsCtx,
@@ -191,6 +192,8 @@ export function App() {
     'shortcuts.open': () => setShortcutsOpen(true),
     'app.settings': toggleSettings,
     'workspace.create': () => workspaceRef.current.createTab({ columns: 1 }),
+    'chat.previousTurn': () => stepChatTurn(-1),
+    'chat.nextTurn': () => stepChatTurn(1),
     'panel.split': () =>
       workspaceRef.current.addColumn(
         workspaceRef.current.activeTab.id,

--- a/console/web/src/components/chat/Message.tsx
+++ b/console/web/src/components/chat/Message.tsx
@@ -852,6 +852,7 @@ function UserMessage({ message }: { message: UserMessageType }) {
     <article
       className="group flex flex-col items-end gap-2"
       data-message-role="user"
+      data-message-id={message.id}
     >
       <header className="flex items-center gap-2 font-sans text-base font-medium text-ink-faint sm:text-sm">
         {message.content ? (
@@ -911,6 +912,7 @@ function AssistantMessage({
     <article
       className="group flex flex-col gap-2"
       data-message-role="assistant"
+      data-message-id={message.id}
     >
       <header className="flex flex-wrap items-center gap-2 font-sans text-base text-ink-ghost sm:text-sm">
         <span className="font-medium text-ink-faint">Agent</span>

--- a/console/web/src/components/chat/MessageList.stories.tsx
+++ b/console/web/src/components/chat/MessageList.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { Message } from '@/types/chat'
+import { MessageList } from './MessageList'
+
+const TOPICS = [
+  'Why does the router drop the first model after a reconnect?',
+  'Add a retry budget to the queue worker and show it in the console.',
+  'Summarize the failing harness e2e and propose a fix.',
+  'Which workers register functions with an empty request schema?',
+  'Draft the release notes for shell 0.12.',
+  'Port the database introspection to the editor worker.',
+  'Explain the ask-mode policy cap in two paragraphs.',
+  'Find every call site of configuration::set in the console.',
+]
+
+function longSession(turns: number): Message[] {
+  const messages: Message[] = []
+  let clock = 1
+  for (let index = 0; index < turns; index += 1) {
+    const topic = TOPICS[index % TOPICS.length]
+    messages.push({
+      id: `u-${index}`,
+      createdAt: clock++,
+      role: 'user',
+      content: `${topic} (turn ${index + 1})`,
+    })
+    const calls = index % 3
+    for (let call = 0; call < calls; call += 1) {
+      messages.push({
+        id: `f-${index}-${call}`,
+        createdAt: clock++,
+        role: 'function-trigger',
+        functionId: call === 0 ? 'shell::exec' : 'coder::read-file',
+        input: { path: `src/module-${index}.rs` },
+        output: { ok: true },
+        durationMs: 120 + call * 40,
+      })
+    }
+    const failed = index % 11 === 7
+    messages.push({
+      id: `a-${index}`,
+      createdAt: clock++,
+      role: 'assistant',
+      model: 'anthropic::claude-sonnet-4-6',
+      mode: 'agent',
+      content: failed
+        ? 'The provider rejected the request before any tokens streamed.'
+        : `Here is what I found for "${topic.toLowerCase()}". ${'The relevant code path runs through the router registry, then the provider adapter, then the stream writer. '.repeat(2 + (index % 4))}`,
+      stopReason: failed ? 'error' : 'end',
+      streaming: index === turns - 1,
+    })
+  }
+  return messages
+}
+
+const meta = {
+  title: 'Chat/MessageList',
+  component: MessageList,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <div className="flex h-screen w-full bg-bg">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof MessageList>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const LongSessionWithTurnRail: Story = {
+  name: 'long session, turn rail',
+  args: { messages: longSession(40) },
+}
+
+export const ShortSessionNoRail: Story = {
+  name: 'short session, no rail',
+  args: { messages: longSession(3) },
+}

--- a/console/web/src/components/chat/MessageList.stories.tsx
+++ b/console/web/src/components/chat/MessageList.stories.tsx
@@ -74,6 +74,46 @@ export const LongSessionWithTurnRail: Story = {
   args: { messages: longSession(40) },
 }
 
+function agentLoop(steps: number): Message[] {
+  const messages: Message[] = [
+    {
+      id: 'u-0',
+      createdAt: 1,
+      role: 'user',
+      content:
+        'Port the python client to rust, keep the public API, and prove it with the existing fixtures.',
+    },
+  ]
+  let clock = 2
+  for (let index = 0; index < steps; index += 1) {
+    messages.push({
+      id: `f-${index}`,
+      createdAt: clock++,
+      role: 'function-trigger',
+      functionId: index % 2 === 0 ? 'coder::read-file' : 'shell::exec',
+      input: { path: `src/step-${index}.rs` },
+      output: { ok: true },
+      durationMs: 80 + index,
+    })
+    messages.push({
+      id: `a-${index}`,
+      createdAt: clock++,
+      role: 'assistant',
+      model: 'anthropic::claude-haiku-4-5-20251001',
+      mode: 'agent',
+      content: `Step ${index + 1}: ${index % 5 === 4 ? 'tests pass for this module, moving on.' : 'reading the module and sketching the rust signature before writing it.'}`,
+      stopReason: 'end',
+      streaming: index === steps - 1,
+    })
+  }
+  return messages
+}
+
+export const AgentLoopWithTurnRail: Story = {
+  name: 'single prompt, long agent loop',
+  args: { messages: agentLoop(30) },
+}
+
 export const ShortSessionNoRail: Story = {
   name: 'short session, no rail',
   args: { messages: longSession(3) },

--- a/console/web/src/components/chat/MessageList.test.tsx
+++ b/console/web/src/components/chat/MessageList.test.tsx
@@ -87,4 +87,20 @@ describe('MessageList function-trigger groups', () => {
     expect(html).toContain('tabindex="-1"')
     expect(html).toContain('data-approval-actions=""')
   })
+
+  it('anchors user and assistant messages by id for the turn rail', () => {
+    const html = renderToStaticMarkup(
+      <MessageList
+        messages={[
+          { id: 'u-1', createdAt: 1, role: 'user', content: 'hello' },
+          { id: 'a-1', createdAt: 2, role: 'assistant', content: 'hi' },
+        ]}
+      />,
+    )
+
+    expect(html).toContain('data-message-role="user" data-message-id="u-1"')
+    expect(html).toContain(
+      'data-message-role="assistant" data-message-id="a-1"',
+    )
+  })
 })

--- a/console/web/src/components/chat/MessageList.tsx
+++ b/console/web/src/components/chat/MessageList.tsx
@@ -40,6 +40,7 @@ import {
   DEFAULT_SYSTEM_PROMPT_STATE,
   type SystemPromptState,
 } from './system-prompt-selection'
+import { TurnRail } from './TurnRail'
 import {
   nextTailScrollTop,
   TAIL_GLIDE_SETTLE_DISTANCE_PX,
@@ -519,6 +520,11 @@ export function MessageList({
 
   return (
     <div className="relative flex min-h-0 min-w-0 flex-1">
+      <TurnRail
+        messages={messages}
+        container={containerRef}
+        content={contentRef}
+      />
       <section
         ref={containerRef}
         data-tail-scroll={tailState}

--- a/console/web/src/components/chat/TurnRail.tsx
+++ b/console/web/src/components/chat/TurnRail.tsx
@@ -1,0 +1,291 @@
+import {
+  type RefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import { subscribeChatTurnStep } from '@/lib/chat-turn-nav'
+import {
+  currentTickIndex,
+  nearestTickIndex,
+  steppedTickIndex,
+  TURN_RAIL_MIN_TURNS,
+  TURN_RAIL_MIN_WIDTH_PX,
+  type TurnSummary,
+  type TurnTone,
+  turnsFromMessages,
+  type ViewportSegment,
+  viewportSegment,
+} from '@/lib/turn-rail'
+import { cn } from '@/lib/utils'
+import type { Message } from '@/types/chat'
+
+interface TurnRailProps {
+  messages: readonly Message[]
+  container: RefObject<HTMLElement | null>
+  content: RefObject<HTMLElement | null>
+}
+
+interface Tick extends TurnSummary {
+  /** Scroll offset of the user message, in container scroll space. */
+  offset: number
+  /** The same as a fraction of the scroll height. */
+  fraction: number
+}
+
+const TICK_TONE: Record<TurnTone, string> = {
+  ink: 'bg-ink-ghost group-hover/tick:bg-ink',
+  accent: 'bg-accent',
+  alert: 'bg-alert',
+}
+
+const JUMP_MARGIN_PX = 16
+
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  )
+}
+
+/**
+ * A minimap of the conversation along the left edge: one tick per user turn
+ * placed where that turn sits in the scroll range, a bar for the visible
+ * window, a hover preview of the exchange, click to jump, drag to scrub.
+ */
+export function TurnRail({ messages, container, content }: TurnRailProps) {
+  const turns = useMemo(() => turnsFromMessages(messages), [messages])
+  const [ticks, setTicks] = useState<Tick[]>([])
+  const [viewport, setViewport] = useState<ViewportSegment>({
+    top: 0,
+    height: 1,
+  })
+  const [wide, setWide] = useState(true)
+  const [hover, setHover] = useState<number | null>(null)
+  const [scrubbing, setScrubbing] = useState(false)
+  const railRef = useRef<HTMLDivElement>(null)
+  const ticksRef = useRef<Tick[]>([])
+  ticksRef.current = ticks
+  const frameRef = useRef<number | null>(null)
+
+  const measure = useCallback(() => {
+    const scroller = container.current
+    const column = content.current
+    if (!scroller || !column) return
+    const scrollHeight = scroller.scrollHeight
+    const base = scroller.getBoundingClientRect().top - scroller.scrollTop
+    const next: Tick[] = []
+    for (const turn of turns) {
+      const element = column.querySelector<HTMLElement>(
+        `[data-message-id="${CSS.escape(turn.id)}"]`,
+      )
+      if (!element) continue
+      const offset = Math.max(0, element.getBoundingClientRect().top - base)
+      next.push({
+        ...turn,
+        offset,
+        fraction: scrollHeight > 0 ? offset / scrollHeight : 0,
+      })
+    }
+    setTicks(next)
+    setViewport(
+      viewportSegment(scroller.scrollTop, scroller.clientHeight, scrollHeight),
+    )
+    setWide(scroller.clientWidth >= TURN_RAIL_MIN_WIDTH_PX)
+  }, [container, content, turns])
+
+  useEffect(() => {
+    measure()
+    const column = content.current
+    const scroller = container.current
+    if (!column || !scroller) return
+    const observer = new ResizeObserver(() => measure())
+    observer.observe(column)
+    observer.observe(scroller)
+    return () => observer.disconnect()
+  }, [measure, container, content])
+
+  useEffect(() => {
+    const scroller = container.current
+    if (!scroller) return
+    const onScroll = () => {
+      if (frameRef.current !== null) return
+      frameRef.current = requestAnimationFrame(() => {
+        frameRef.current = null
+        setViewport(
+          viewportSegment(
+            scroller.scrollTop,
+            scroller.clientHeight,
+            scroller.scrollHeight,
+          ),
+        )
+      })
+    }
+    scroller.addEventListener('scroll', onScroll, { passive: true })
+    return () => {
+      scroller.removeEventListener('scroll', onScroll)
+      if (frameRef.current !== null) cancelAnimationFrame(frameRef.current)
+      frameRef.current = null
+    }
+  }, [container])
+
+  const jumpTo = useCallback(
+    (index: number) => {
+      const scroller = container.current
+      const tick = ticksRef.current[index]
+      if (!scroller || !tick) return
+      scroller.scrollTo({
+        top: Math.max(0, tick.offset - JUMP_MARGIN_PX),
+        behavior: prefersReducedMotion() ? 'auto' : 'smooth',
+      })
+    },
+    [container],
+  )
+
+  useEffect(
+    () =>
+      subscribeChatTurnStep((delta) => {
+        const scroller = container.current
+        if (!scroller) return
+        const offsets = ticksRef.current.map(
+          (tick) => tick.offset - JUMP_MARGIN_PX,
+        )
+        const current = currentTickIndex(scroller.scrollTop, offsets)
+        const next = steppedTickIndex(current, delta, offsets.length)
+        if (next >= 0) jumpTo(next)
+      }),
+    [container, jumpTo],
+  )
+
+  const fractionAt = useCallback((clientY: number): number => {
+    const rail = railRef.current
+    if (!rail) return 0
+    const rect = rail.getBoundingClientRect()
+    if (rect.height <= 0) return 0
+    return Math.min(1, Math.max(0, (clientY - rect.top) / rect.height))
+  }, [])
+
+  const scrubTo = useCallback(
+    (clientY: number) => {
+      const scroller = container.current
+      if (!scroller) return
+      const fraction = fractionAt(clientY)
+      scroller.scrollTop =
+        fraction * (scroller.scrollHeight - scroller.clientHeight)
+      const near = nearestTickIndex(
+        fraction,
+        ticksRef.current.map((tick) => tick.fraction),
+      )
+      setHover(near >= 0 ? near : null)
+    },
+    [container, fractionAt],
+  )
+
+  if (turns.length < TURN_RAIL_MIN_TURNS || !wide) return null
+
+  const active = hover
+  const preview = active !== null ? ticks[active] : undefined
+
+  return (
+    <div
+      className="group/rail pointer-events-none absolute inset-y-3 left-0 z-10 w-9 pointer-fine:block hidden"
+      data-turn-rail
+    >
+      <div
+        ref={railRef}
+        className={cn(
+          'pointer-events-auto absolute inset-y-0 left-2 w-5 cursor-pointer touch-none select-none',
+          'iii-ui-motion-control',
+        )}
+        onPointerDown={(event) => {
+          if (event.button !== 0) return
+          event.currentTarget.setPointerCapture(event.pointerId)
+          setScrubbing(true)
+          scrubTo(event.clientY)
+        }}
+        onPointerMove={(event) => {
+          if (scrubbing) {
+            scrubTo(event.clientY)
+            return
+          }
+          const near = nearestTickIndex(
+            fractionAt(event.clientY),
+            ticks.map((tick) => tick.fraction),
+          )
+          setHover(near >= 0 ? near : null)
+        }}
+        onPointerUp={(event) => {
+          if (!scrubbing) return
+          event.currentTarget.releasePointerCapture(event.pointerId)
+          setScrubbing(false)
+        }}
+        onPointerLeave={() => {
+          if (!scrubbing) setHover(null)
+        }}
+      >
+        <span
+          aria-hidden="true"
+          className="absolute inset-y-0 left-[9px] w-px bg-edge opacity-0 transition-opacity duration-[var(--motion-duration-control)] ease-[var(--motion-ease-standard)] group-hover/rail:opacity-100"
+        />
+        <span
+          aria-hidden="true"
+          className="absolute left-[7px] w-[5px] rounded-full bg-ink/15 transition-[top,height] duration-[var(--motion-duration-fast)] ease-[var(--motion-ease-standard)] group-hover/rail:bg-ink/25"
+          style={{
+            top: `${viewport.top * 100}%`,
+            height: `max(12px, ${viewport.height * 100}%)`,
+          }}
+        />
+        {ticks.map((tick, index) => (
+          <button
+            key={tick.id}
+            type="button"
+            tabIndex={-1}
+            aria-label={`turn ${index + 1}: ${tick.prompt}`}
+            className="group/tick absolute left-0 flex h-3 w-5 -translate-y-1/2 items-center"
+            style={{ top: `${tick.fraction * 100}%` }}
+            onPointerEnter={() => setHover(index)}
+            onClick={() => jumpTo(index)}
+          >
+            <span
+              aria-hidden="true"
+              className={cn(
+                'block h-px rounded-full transition-[width,background-color] duration-[var(--motion-duration-control)] ease-[var(--motion-ease-standard)]',
+                TICK_TONE[tick.tone],
+                active === index ? 'w-5' : 'w-3',
+                tick.tone === 'accent' && 'animate-pulse',
+              )}
+            />
+            {tick.calls > 0 ? (
+              <span
+                aria-hidden="true"
+                className="ml-0.5 size-1 rounded-full bg-ink-ghost"
+              />
+            ) : null}
+          </button>
+        ))}
+      </div>
+      {preview ? (
+        <div
+          role="tooltip"
+          className="pointer-events-none absolute left-10 w-[min(360px,60vw)] -translate-y-1/2 rounded-md border border-edge bg-panel-raised px-3 py-2 font-sans text-[13px] shadow-lg"
+          style={{
+            top: `min(calc(100% - 48px), max(24px, ${preview.fraction * 100}%))`,
+          }}
+        >
+          <p className="line-clamp-1 font-medium text-ink">{preview.prompt}</p>
+          {preview.reply ? (
+            <p className="mt-1 line-clamp-3 text-ink-faint">{preview.reply}</p>
+          ) : null}
+          {preview.calls > 0 ? (
+            <p className="mt-1 text-ink-ghost">
+              {preview.calls}{' '}
+              {preview.calls === 1 ? 'function call' : 'function calls'}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/console/web/src/components/chat/TurnRail.tsx
+++ b/console/web/src/components/chat/TurnRail.tsx
@@ -13,6 +13,7 @@ import {
   steppedTickIndex,
   TURN_RAIL_MIN_TURNS,
   TURN_RAIL_MIN_WIDTH_PX,
+  type TurnKind,
   type TurnSummary,
   type TurnTone,
   turnsFromMessages,
@@ -39,6 +40,11 @@ const TICK_TONE: Record<TurnTone, string> = {
   ink: 'bg-ink-ghost group-hover/tick:bg-ink',
   accent: 'bg-accent',
   alert: 'bg-alert',
+}
+
+function tickWidth(kind: TurnKind, active: boolean): string {
+  if (kind === 'user') return active ? 'w-5' : 'w-3'
+  return active ? 'w-4' : 'w-2'
 }
 
 const JUMP_MARGIN_PX = 16
@@ -242,7 +248,11 @@ export function TurnRail({ messages, container, content }: TurnRailProps) {
             key={tick.id}
             type="button"
             tabIndex={-1}
-            aria-label={`turn ${index + 1}: ${tick.prompt}`}
+            aria-label={
+              tick.kind === 'user'
+                ? `turn ${index + 1}: ${tick.prompt}`
+                : `agent step ${index + 1}: ${tick.reply}`
+            }
             className="group/tick absolute left-0 flex h-3 w-5 -translate-y-1/2 items-center"
             style={{ top: `${tick.fraction * 100}%` }}
             onPointerEnter={() => setHover(index)}
@@ -253,7 +263,8 @@ export function TurnRail({ messages, container, content }: TurnRailProps) {
               className={cn(
                 'block h-px rounded-full transition-[width,background-color] duration-[var(--motion-duration-control)] ease-[var(--motion-ease-standard)]',
                 TICK_TONE[tick.tone],
-                active === index ? 'w-5' : 'w-3',
+                tickWidth(tick.kind, active === index),
+                tick.kind === 'agent' && tick.tone === 'ink' && 'opacity-60',
                 tick.tone === 'accent' && 'animate-pulse',
               )}
             />
@@ -274,9 +285,22 @@ export function TurnRail({ messages, container, content }: TurnRailProps) {
             top: `min(calc(100% - 48px), max(24px, ${preview.fraction * 100}%))`,
           }}
         >
-          <p className="line-clamp-1 font-medium text-ink">{preview.prompt}</p>
+          {preview.kind === 'user' ? (
+            <p className="line-clamp-1 font-medium text-ink">
+              {preview.prompt}
+            </p>
+          ) : (
+            <p className="text-ink-ghost">Agent</p>
+          )}
           {preview.reply ? (
-            <p className="mt-1 line-clamp-3 text-ink-faint">{preview.reply}</p>
+            <p
+              className={cn(
+                'mt-1 line-clamp-3',
+                preview.kind === 'user' ? 'text-ink-faint' : 'text-ink',
+              )}
+            >
+              {preview.reply}
+            </p>
           ) : null}
           {preview.calls > 0 ? (
             <p className="mt-1 text-ink-ghost">

--- a/console/web/src/lib/chat-turn-nav.ts
+++ b/console/web/src/lib/chat-turn-nav.ts
@@ -1,0 +1,13 @@
+type StepListener = (delta: number) => void
+
+const listeners = new Set<StepListener>()
+
+/** Move the active chat by whole turns; the mounted message list answers. */
+export function stepChatTurn(delta: number): void {
+  for (const listener of [...listeners]) listener(delta)
+}
+
+export function subscribeChatTurnStep(listener: StepListener): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}

--- a/console/web/src/lib/keybindings/registry.ts
+++ b/console/web/src/lib/keybindings/registry.ts
@@ -38,6 +38,8 @@ export type KeybindingActionId =
   | 'palette.cycleFilter'
   | 'palette.choose'
   | 'palette.close'
+  | 'chat.previousTurn'
+  | 'chat.nextTurn'
 
 /**
  * One list when the chord is the same everywhere, or a chord per platform
@@ -92,6 +94,22 @@ export const KEYBINDINGS: readonly KeybindingDefinition[] = [
     scope: 'global',
     bindings: ['?'],
     keywords: ['keys', 'help', 'shortcut'],
+  },
+  {
+    id: 'chat.previousTurn',
+    title: 'Previous turn in the chat',
+    group: 'Chat',
+    scope: 'global',
+    bindings: ['['],
+    keywords: ['turn', 'back', 'scroll', 'rail'],
+  },
+  {
+    id: 'chat.nextTurn',
+    title: 'Next turn in the chat',
+    group: 'Chat',
+    scope: 'global',
+    bindings: [']'],
+    keywords: ['turn', 'forward', 'scroll', 'rail'],
   },
   // The emacs pair is Mac-only on purpose: ctrl+N opens a browser window on
   // Windows and Linux, where the same menu item is ⌘N on a Mac and ctrl is

--- a/console/web/src/lib/turn-rail.test.ts
+++ b/console/web/src/lib/turn-rail.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest'
+import type { Message } from '@/types/chat'
+import {
+  currentTickIndex,
+  nearestTickIndex,
+  steppedTickIndex,
+  turnsFromMessages,
+  viewportSegment,
+} from './turn-rail'
+
+let seq = 0
+const user = (content: string, extra: Partial<Message> = {}): Message =>
+  ({
+    id: `u${++seq}`,
+    createdAt: seq,
+    role: 'user',
+    content,
+    ...extra,
+  }) as Message
+const assistant = (content: string, extra: Partial<Message> = {}): Message =>
+  ({
+    id: `a${++seq}`,
+    createdAt: seq,
+    role: 'assistant',
+    content,
+    ...extra,
+  }) as Message
+const call = (): Message =>
+  ({
+    id: `f${++seq}`,
+    createdAt: seq,
+    role: 'function-trigger',
+    functionId: 'shell::exec',
+    input: {},
+  }) as Message
+
+describe('turnsFromMessages', () => {
+  it('opens a turn per real user message and previews the first reply', () => {
+    const turns = turnsFromMessages([
+      user('  first\nquestion  '),
+      call(),
+      call(),
+      assistant(''),
+      assistant('the answer\nwith detail'),
+      user('ping', { notification: true } as Partial<Message>),
+      user('second'),
+      assistant('ok', { streaming: true } as Partial<Message>),
+    ])
+    expect(turns.map((t) => t.prompt)).toEqual(['first question', 'second'])
+    expect(turns[0]).toMatchObject({
+      reply: 'the answer with detail',
+      calls: 2,
+      tone: 'ink',
+    })
+    expect(turns[1]).toMatchObject({ reply: 'ok', calls: 0, tone: 'accent' })
+  })
+
+  it('marks failed turns and keeps alert over accent', () => {
+    const turns = turnsFromMessages([
+      user('one'),
+      assistant('boom', { stopReason: 'error' } as Partial<Message>),
+      user('two'),
+      {
+        id: 's1',
+        createdAt: 99,
+        role: 'system',
+        content: 'x',
+        tone: 'error',
+      } as Message,
+      assistant('retrying', { streaming: true } as Partial<Message>),
+    ])
+    expect(turns.map((t) => t.tone)).toEqual(['alert', 'alert'])
+  })
+
+  it('truncates long prompts and replies', () => {
+    const turns = turnsFromMessages([
+      user('p'.repeat(400)),
+      assistant('r'.repeat(400)),
+    ])
+    expect(turns[0].prompt.length).toBe(140)
+    expect(turns[0].prompt.endsWith('…')).toBe(true)
+    expect(turns[0].reply.length).toBe(240)
+  })
+
+  it('ignores leading replies with no turn and empty input', () => {
+    expect(turnsFromMessages([assistant('stray')])).toEqual([])
+    expect(turnsFromMessages([])).toEqual([])
+  })
+})
+
+describe('viewportSegment', () => {
+  it('maps the visible window to fractions and clamps to the range', () => {
+    expect(viewportSegment(0, 500, 2000)).toEqual({ top: 0, height: 0.25 })
+    expect(viewportSegment(1500, 500, 2000)).toEqual({
+      top: 0.75,
+      height: 0.25,
+    })
+    expect(viewportSegment(1900, 500, 2000)).toEqual({
+      top: 0.75,
+      height: 0.25,
+    })
+    expect(viewportSegment(0, 500, 300)).toEqual({ top: 0, height: 1 })
+    expect(viewportSegment(10, 500, 0)).toEqual({ top: 0, height: 1 })
+  })
+})
+
+describe('tick lookups', () => {
+  const ticks = [0, 0.3, 0.6, 0.9]
+
+  it('finds the nearest tick to a fraction', () => {
+    expect(nearestTickIndex(0.1, ticks)).toBe(0)
+    expect(nearestTickIndex(0.46, ticks)).toBe(2)
+    expect(nearestTickIndex(1, ticks)).toBe(3)
+    expect(nearestTickIndex(0.5, [])).toBe(-1)
+  })
+
+  it('reports the turn containing the viewport top and steps within bounds', () => {
+    const offsets = [0, 300, 600, 900]
+    expect(currentTickIndex(0, offsets)).toBe(0)
+    expect(currentTickIndex(450, offsets)).toBe(1)
+    expect(currentTickIndex(601, offsets)).toBe(2)
+    expect(currentTickIndex(-5, offsets)).toBe(-1)
+    expect(steppedTickIndex(1, 1, 4)).toBe(2)
+    expect(steppedTickIndex(0, -1, 4)).toBe(0)
+    expect(steppedTickIndex(3, 1, 4)).toBe(3)
+    expect(steppedTickIndex(-1, 1, 4)).toBe(0)
+    expect(steppedTickIndex(-1, -1, 4)).toBe(0)
+    expect(steppedTickIndex(0, 1, 0)).toBe(-1)
+  })
+})

--- a/console/web/src/lib/turn-rail.test.ts
+++ b/console/web/src/lib/turn-rail.test.ts
@@ -35,27 +35,36 @@ const call = (): Message =>
   }) as Message
 
 describe('turnsFromMessages', () => {
-  it('opens a turn per real user message and previews the first reply', () => {
+  it('ticks user prompts and agent prose, attributing calls to the tick before them', () => {
     const turns = turnsFromMessages([
       user('  first\nquestion  '),
       call(),
       call(),
       assistant(''),
       assistant('the answer\nwith detail'),
+      call(),
       user('ping', { notification: true } as Partial<Message>),
       user('second'),
       assistant('ok', { streaming: true } as Partial<Message>),
     ])
-    expect(turns.map((t) => t.prompt)).toEqual(['first question', 'second'])
+    expect(turns.map((t) => [t.kind, t.calls, t.tone])).toEqual([
+      ['user', 2, 'ink'],
+      ['agent', 1, 'ink'],
+      ['user', 0, 'ink'],
+      ['agent', 0, 'accent'],
+    ])
     expect(turns[0]).toMatchObject({
+      prompt: 'first question',
       reply: 'the answer with detail',
-      calls: 2,
-      tone: 'ink',
     })
-    expect(turns[1]).toMatchObject({ reply: 'ok', calls: 0, tone: 'accent' })
+    expect(turns[1]).toMatchObject({
+      prompt: '',
+      reply: 'the answer with detail',
+    })
+    expect(turns[3].reply).toBe('ok')
   })
 
-  it('marks failed turns and keeps alert over accent', () => {
+  it('marks failed replies and system errors alert', () => {
     const turns = turnsFromMessages([
       user('one'),
       assistant('boom', { stopReason: 'error' } as Partial<Message>),
@@ -67,9 +76,13 @@ describe('turnsFromMessages', () => {
         content: 'x',
         tone: 'error',
       } as Message,
-      assistant('retrying', { streaming: true } as Partial<Message>),
+      assistant('', { streaming: true } as Partial<Message>),
     ])
-    expect(turns.map((t) => t.tone)).toEqual(['alert', 'alert'])
+    expect(turns.map((t) => [t.kind, t.tone])).toEqual([
+      ['user', 'ink'],
+      ['agent', 'alert'],
+      ['user', 'alert'],
+    ])
   })
 
   it('truncates long prompts and replies', () => {
@@ -80,6 +93,7 @@ describe('turnsFromMessages', () => {
     expect(turns[0].prompt.length).toBe(140)
     expect(turns[0].prompt.endsWith('…')).toBe(true)
     expect(turns[0].reply.length).toBe(240)
+    expect(turns[1].reply.length).toBe(240)
   })
 
   it('ignores leading replies with no turn and empty input', () => {

--- a/console/web/src/lib/turn-rail.ts
+++ b/console/web/src/lib/turn-rail.ts
@@ -1,17 +1,22 @@
 import type { Message } from '@/types/chat'
 
 export type TurnTone = 'ink' | 'accent' | 'alert'
+export type TurnKind = 'user' | 'agent'
 
 export interface TurnSummary {
-  /** Id of the user message that opens the turn. */
+  /** Id of the message the tick anchors to. */
   id: string
+  kind: TurnKind
+  /** User prompt for a user tick; empty for an agent tick. */
   prompt: string
+  /** First reply after a user tick; the agent text for an agent tick. */
   reply: string
+  /** Function calls between this tick and the next. */
   calls: number
   tone: TurnTone
 }
 
-/** The rail hides below this many turns; fewer is faster to scroll. */
+/** The rail hides below this many ticks; fewer is faster to scroll. */
 export const TURN_RAIL_MIN_TURNS = 5
 /** And below this container width, where the gutter would crowd the text. */
 export const TURN_RAIL_MIN_WIDTH_PX = 480
@@ -33,41 +38,59 @@ function opensTurn(message: Message): boolean {
   )
 }
 
-/** One entry per user turn: prompt, first reply, call count, and a tone
-    (alert for a failed turn, accent while the reply streams). */
+/** A tick per user prompt and per agent prose message, in order. Agent
+    loops are mostly one prompt followed by many steps, so the agent's own
+    messages are the landmarks. Calls land on the tick before them; a failed
+    reply turns its tick alert, a streaming one accent. */
 export function turnsFromMessages(messages: readonly Message[]): TurnSummary[] {
   const turns: TurnSummary[] = []
   let current: TurnSummary | null = null
-  let replyFound = false
+  let lastUser: TurnSummary | null = null
   for (const message of messages) {
     if (opensTurn(message) && message.role === 'user') {
       current = {
         id: message.id,
+        kind: 'user',
         prompt: firstLines(message.content, PROMPT_PREVIEW_CHARS),
         reply: '',
         calls: 0,
         tone: 'ink',
       }
-      replyFound = false
+      lastUser = current
       turns.push(current)
       continue
     }
     if (current === null) continue
     if (message.role === 'function-trigger') {
       current.calls += 1
-    } else if (message.role === 'assistant') {
-      if (!replyFound && message.content.trim() !== '') {
-        current.reply = firstLines(message.content, REPLY_PREVIEW_CHARS)
-        replyFound = true
-      }
-      if (message.stopReason === 'error' || message.stopReason === 'aborted') {
-        current.tone = 'alert'
-      } else if (message.streaming && current.tone !== 'alert') {
-        current.tone = 'accent'
-      }
-    } else if (message.role === 'system' && message.tone === 'error') {
-      current.tone = 'alert'
+      continue
     }
+    if (message.role === 'system' && message.tone === 'error') {
+      current.tone = 'alert'
+      continue
+    }
+    if (message.role !== 'assistant') continue
+    const text = firstLines(message.content, REPLY_PREVIEW_CHARS)
+    const failed =
+      message.stopReason === 'error' || message.stopReason === 'aborted'
+    if (lastUser !== null && lastUser.reply === '' && text !== '') {
+      lastUser.reply = text
+    }
+    if (text === '') {
+      if (failed) current.tone = 'alert'
+      else if (message.streaming && current.tone !== 'alert')
+        current.tone = 'accent'
+      continue
+    }
+    current = {
+      id: message.id,
+      kind: 'agent',
+      prompt: '',
+      reply: text,
+      calls: 0,
+      tone: failed ? 'alert' : message.streaming ? 'accent' : 'ink',
+    }
+    turns.push(current)
   }
   return turns
 }

--- a/console/web/src/lib/turn-rail.ts
+++ b/console/web/src/lib/turn-rail.ts
@@ -14,7 +14,7 @@ export interface TurnSummary {
 /** The rail hides below this many turns; fewer is faster to scroll. */
 export const TURN_RAIL_MIN_TURNS = 5
 /** And below this container width, where the gutter would crowd the text. */
-export const TURN_RAIL_MIN_WIDTH_PX = 640
+export const TURN_RAIL_MIN_WIDTH_PX = 480
 
 const REPLY_PREVIEW_CHARS = 240
 const PROMPT_PREVIEW_CHARS = 140

--- a/console/web/src/lib/turn-rail.ts
+++ b/console/web/src/lib/turn-rail.ts
@@ -1,0 +1,129 @@
+import type { Message } from '@/types/chat'
+
+export type TurnTone = 'ink' | 'accent' | 'alert'
+
+export interface TurnSummary {
+  /** Id of the user message that opens the turn. */
+  id: string
+  prompt: string
+  reply: string
+  calls: number
+  tone: TurnTone
+}
+
+/** The rail hides below this many turns; fewer is faster to scroll. */
+export const TURN_RAIL_MIN_TURNS = 5
+/** And below this container width, where the gutter would crowd the text. */
+export const TURN_RAIL_MIN_WIDTH_PX = 640
+
+const REPLY_PREVIEW_CHARS = 240
+const PROMPT_PREVIEW_CHARS = 140
+
+function firstLines(text: string, max: number): string {
+  const flat = text.replace(/\s+/g, ' ').trim()
+  return flat.length > max ? `${flat.slice(0, max - 1)}…` : flat
+}
+
+function opensTurn(message: Message): boolean {
+  return (
+    message.role === 'user' &&
+    !message.notification &&
+    !message.reaction &&
+    !message.validation
+  )
+}
+
+/** One entry per user turn: prompt, first reply, call count, and a tone
+    (alert for a failed turn, accent while the reply streams). */
+export function turnsFromMessages(messages: readonly Message[]): TurnSummary[] {
+  const turns: TurnSummary[] = []
+  let current: TurnSummary | null = null
+  let replyFound = false
+  for (const message of messages) {
+    if (opensTurn(message) && message.role === 'user') {
+      current = {
+        id: message.id,
+        prompt: firstLines(message.content, PROMPT_PREVIEW_CHARS),
+        reply: '',
+        calls: 0,
+        tone: 'ink',
+      }
+      replyFound = false
+      turns.push(current)
+      continue
+    }
+    if (current === null) continue
+    if (message.role === 'function-trigger') {
+      current.calls += 1
+    } else if (message.role === 'assistant') {
+      if (!replyFound && message.content.trim() !== '') {
+        current.reply = firstLines(message.content, REPLY_PREVIEW_CHARS)
+        replyFound = true
+      }
+      if (message.stopReason === 'error' || message.stopReason === 'aborted') {
+        current.tone = 'alert'
+      } else if (message.streaming && current.tone !== 'alert') {
+        current.tone = 'accent'
+      }
+    } else if (message.role === 'system' && message.tone === 'error') {
+      current.tone = 'alert'
+    }
+  }
+  return turns
+}
+
+export interface ViewportSegment {
+  top: number
+  height: number
+}
+
+/** Where the visible window sits in the scroll range, both as fractions. */
+export function viewportSegment(
+  scrollTop: number,
+  clientHeight: number,
+  scrollHeight: number,
+): ViewportSegment {
+  if (scrollHeight <= 0) return { top: 0, height: 1 }
+  const height = Math.min(1, clientHeight / scrollHeight)
+  const top = Math.min(1 - height, Math.max(0, scrollTop / scrollHeight))
+  return { top, height }
+}
+
+/** The tick closest to a fraction of the rail, or -1 with no ticks. */
+export function nearestTickIndex(
+  fraction: number,
+  ticks: readonly number[],
+): number {
+  let best = -1
+  let bestDistance = Number.POSITIVE_INFINITY
+  ticks.forEach((tick, index) => {
+    const distance = Math.abs(tick - fraction)
+    if (distance < bestDistance) {
+      bestDistance = distance
+      best = index
+    }
+  })
+  return best
+}
+
+/** The turn the top of the viewport is in: the last tick at or above it. */
+export function currentTickIndex(
+  scrollTop: number,
+  offsets: readonly number[],
+): number {
+  let current = -1
+  offsets.forEach((offset, index) => {
+    if (offset <= scrollTop + 1) current = index
+  })
+  return current
+}
+
+/** Scroll target for a step from `current`, clamped to the tick range. */
+export function steppedTickIndex(
+  current: number,
+  delta: number,
+  count: number,
+): number {
+  if (count === 0) return -1
+  return Math.min(count - 1, Math.max(0, current + delta))
+}


### PR DESCRIPTION
## Why

Harness sessions run for hours and dozens of turns (the rig has sessions with 264 messages). Finding the turn where the agent decided something means scrolling the whole transcript. A rail at the chat's edge with one tick per user turn, a hover preview of the exchange, click to jump, and drag to scrub makes long sessions navigable.

## What

### `TurnRail` (`components/chat/TurnRail.tsx`)

Mounted inside `MessageList`'s existing relative wrapper, over the left gutter of the scroll container.

- One tick per user prompt and one per agent prose message, positioned by that message's offset in the scroll range, so the rail is a true minimap rather than an evenly spaced list. Harness sessions are mostly one prompt followed by a long agent loop, so the agent's own messages are the landmarks; user ticks are longer and darker, agent ticks shorter and fainter. A thin bar shows the visible window.
- Tick tones from data the console already has: `alert` for a reply that stopped with `error` or `aborted` (or a `system` message with `tone: 'error'`), `accent` with a pulse for the streaming reply, a small dot after a tick whose segment made function calls.
- Hover a tick: a preview with the prompt (one line) and the first reply for a user tick, or the agent text for an agent tick, plus the call count. Click jumps to the message; press and drag scrubs the transcript with the preview following. `prefers-reduced-motion` switches the jump to instant.
- Measurement runs on mount, on `ResizeObserver` of the column and the scroller, and when the message array changes; the viewport bar updates from a `requestAnimationFrame`-throttled passive scroll listener. No layout reads per scroll beyond `scrollTop`.
- Hidden under 5 ticks, under 480px of column width, and on coarse pointers.

### Anchors

`Message.tsx` now stamps `data-message-id` on user and assistant articles, alongside the existing `data-message-role`. Function-call cards already had it.

### Keyboard

`[` and `]` step to the previous and next tick through the shortcut registry (`chat.previousTurn`, `chat.nextTurn`, group Chat), dispatched from the single global `useKeybindings` in `App.tsx` via a small pub/sub (`lib/chat-turn-nav.ts`) that the mounted message list subscribes to. They appear in the shortcuts overlay automatically.

### Pure logic (`lib/turn-rail.ts`)

`turnsFromMessages`, `viewportSegment`, `nearestTickIndex`, `currentTickIndex`, `steppedTickIndex`, each unit tested.

## Verification

- `tsc -b`, biome on the changed files, vitest 1464 passing (14 new: turn summaries, tones, truncation, viewport math, tick lookups, and the `data-message-id` anchors in `MessageList`).
- Storybook: `Chat/MessageList` with a generated 40-turn session (failed turns, streaming tail, call counts), a single-prompt 30-step agent loop, and a 3-turn session where the rail stays hidden.
- Rig: console binary built from this branch and installed; the rail renders on sessions with five or more turns at column widths of 480px and up.

Linear: MOT-4510
