### PR TITLE
(MOT-4463) fix(workers): require namespace-aware dependencies

### DIFF
--- a/.github/scripts/tests/test_worker_dependency_compatibility.py
+++ b/.github/scripts/tests/test_worker_dependency_compatibility.py
@@ -11,6 +11,7 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 SHARED_DEPENDENCY_RANGES = {
     "configuration": "0.x",
     "llm-router": "^1.0.0",
+    "queue": "^0.21.4",
     "state": "^0.22.1",
 }
 

--- a/.github/scripts/tests/test_worker_dependency_compatibility.py
+++ b/.github/scripts/tests/test_worker_dependency_compatibility.py
@@ -11,7 +11,7 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 SHARED_DEPENDENCY_RANGES = {
     "configuration": "0.x",
     "llm-router": "^1.0.0",
-    "state": "0.x",
+    "state": "^0.22.1",
 }
 
 
@@ -35,7 +35,7 @@ def test_shared_dependencies_use_compatible_ranges() -> None:
                 assert dependency_range == expected_range, (
                     f"{manifest.relative_to(REPO_ROOT)} pins shared dependency "
                     f"{dependency} to {dependency_range!r}; use {expected_range!r} so "
-                    "compatible releases remain allowed without crossing majors"
+                    "all consumers resolve the same compatible worker version"
                 )
 
     for dependency, workers in consumers.items():

--- a/approval-gate/iii.worker.yaml
+++ b/approval-gate/iii.worker.yaml
@@ -9,7 +9,7 @@ tags: [approval, human-in-the-loop, permissions, policy, security]
 description: Policy and decision surface for human-held function calls — pre_trigger gate, pending inbox, per-session permission settings, and two notification trigger types.
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.1"
   configuration: "0.x"
   iii-directory: "^1.0.0"
   session-manager: "^1.0.0"

--- a/canvas/iii.worker.yaml
+++ b/canvas/iii.worker.yaml
@@ -8,5 +8,5 @@ bin: canvas
 tags: [diagram, mermaid, flowchart, whiteboard, drawing, svg]
 description: Create, edit and render diagrams in the console — stored as editable source, drawn live in chat and on a canvas page.
 dependencies:
-  state: "0.x"
+  state: "^0.22.1"
   configuration: "0.x"

--- a/claude-code/iii.worker.yaml
+++ b/claude-code/iii.worker.yaml
@@ -14,5 +14,5 @@ scripts:
   start: node ./index.mjs
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.1"
   iii-stream: "^0.21.6"

--- a/crates/provider-integration-testkit/Cargo.lock
+++ b/crates/provider-integration-testkit/Cargo.lock
@@ -1326,7 +1326,7 @@ dependencies = [
 
 [[package]]
 name = "provider-anthropic"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "clap",
  "futures",
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "provider-openai"
-version = "1.2.5"
+version = "1.2.6"
 dependencies = [
  "clap",
  "futures",

--- a/docs/architecture/iii-worker-yaml.md
+++ b/docs/architecture/iii-worker-yaml.md
@@ -57,10 +57,11 @@ Example: [`harness/iii.worker.yaml`](../../harness/iii.worker.yaml).
 
 Shared dependencies that are still pre-1.0 use ranges matched to their runtime
 compatibility contract. Workers declare `^0.22.1` for `state`, the first
-namespace-aware release, and `0.x` for `configuration`. Consumers of
-`llm-router` retain `^1.0.0`: once a dependency is on a stable major, the caret
-accepts compatible `1.x` releases and excludes `2.0.0` and above. These forms
-are understood directly by iii and the Registry.
+namespace-aware release, `^0.21.4` for the namespace-aware `queue` release, and
+`0.x` for `configuration`. Consumers of `llm-router` retain `^1.0.0`: once a
+dependency is on a stable major, the caret accepts compatible `1.x` releases
+and excludes `2.0.0` and above. These forms are understood directly by iii and
+the Registry.
 
 ## Example (minimal Rust binary)
 

--- a/docs/architecture/iii-worker-yaml.md
+++ b/docs/architecture/iii-worker-yaml.md
@@ -55,12 +55,12 @@ tags:
 
 Example: [`harness/iii.worker.yaml`](../../harness/iii.worker.yaml).
 
-Shared dependencies that are still pre-1.0 use npm-style major wildcards.
-Workers declare `0.x` for `state` and `configuration`, accepting every stable
-`0.x` release while still excluding `1.0.0` and above. Consumers of
+Shared dependencies that are still pre-1.0 use ranges matched to their runtime
+compatibility contract. Workers declare `^0.22.1` for `state`, the first
+namespace-aware release, and `0.x` for `configuration`. Consumers of
 `llm-router` retain `^1.0.0`: once a dependency is on a stable major, the caret
-already accepts compatible `1.x` releases and excludes `2.0.0` and above. Both
-forms are understood directly by iii and the Registry.
+accepts compatible `1.x` releases and excludes `2.0.0` and above. These forms
+are understood directly by iii and the Registry.
 
 ## Example (minimal Rust binary)
 

--- a/editor/iii.worker.yaml
+++ b/editor/iii.worker.yaml
@@ -10,5 +10,5 @@ description: A shared code workspace — open buffers, a file tree, unified diff
 
 dependencies:
   shell: "^0.10.3"
-  state: "0.x"
+  state: "^0.22.1"
   configuration: "0.x"

--- a/eval/iii.worker.yaml
+++ b/eval/iii.worker.yaml
@@ -9,7 +9,7 @@ tags: [evaluation, benchmark, sessions, metrics, prompt, system-prompt]
 description: Compare live objective metrics for 2-5 root sessions; retain durable prompt experiments as an advanced surface.
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.1"
   queue: "^0.2.0"
   cron: "^0.21.0"
   iii-observability: "^0.21.6"

--- a/eval/iii.worker.yaml
+++ b/eval/iii.worker.yaml
@@ -10,6 +10,6 @@ description: Compare live objective metrics for 2-5 root sessions; retain durabl
 
 dependencies:
   state: "^0.22.1"
-  queue: "^0.2.0"
+  queue: "^0.21.4"
   cron: "^0.21.0"
   iii-observability: "^0.21.6"

--- a/harness/iii.worker.yaml
+++ b/harness/iii.worker.yaml
@@ -9,7 +9,7 @@ tags: [agent, harness, loop, autonomous]
 description: Thin durable turn loop that wires session-manager, context-manager, and llm-router into an agent loop; spawns sub-agents as child sessions.
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.1"
   queue: "^0.21.2"
   cron: "^0.21.0"
   configuration: "0.x"

--- a/harness/iii.worker.yaml
+++ b/harness/iii.worker.yaml
@@ -10,7 +10,7 @@ description: Thin durable turn loop that wires session-manager, context-manager,
 
 dependencies:
   state: "^0.22.1"
-  queue: "^0.21.2"
+  queue: "^0.21.4"
   cron: "^0.21.0"
   configuration: "0.x"
   iii-observability: "^0.21.6"

--- a/harness/tests/manifest.rs
+++ b/harness/tests/manifest.rs
@@ -54,7 +54,7 @@ fn worker_manifest_uses_the_standalone_queue_worker() {
 
     assert_eq!(
         dependencies.get(serde_yaml::Value::String("queue".into())),
-        Some(&serde_yaml::Value::String("^0.21.2".into()))
+        Some(&serde_yaml::Value::String("^0.21.4".into()))
     );
     assert!(!dependencies.contains_key(serde_yaml::Value::String("iii-queue".into())));
 }

--- a/harness/tests/manifest.rs
+++ b/harness/tests/manifest.rs
@@ -70,7 +70,7 @@ fn worker_manifest_uses_the_standalone_state_worker() {
 
     assert_eq!(
         dependencies.get(serde_yaml::Value::String("state".into())),
-        Some(&serde_yaml::Value::String("0.x".into()))
+        Some(&serde_yaml::Value::String("^0.22.1".into()))
     );
     assert!(!dependencies.contains_key(serde_yaml::Value::String("iii-state".into())));
 }

--- a/llm-router/iii.worker.yaml
+++ b/llm-router/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, router, models, providers]
 description: One front door + provider protocol in front of every LLM provider.
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.1"
   configuration: "0.x"

--- a/memory-consolidate/iii.worker.yaml
+++ b/memory-consolidate/iii.worker.yaml
@@ -11,4 +11,4 @@ description: Scheduled hygiene for the memory worker — deterministic dedup of 
 dependencies:
   memory: "^0.1.0"
   configuration: "0.x"
-  state: "0.x"
+  state: "^0.22.1"

--- a/memory/iii.worker.yaml
+++ b/memory/iii.worker.yaml
@@ -13,4 +13,4 @@ dependencies:
   session-manager: "^1.0.0"
   llm-router: "^1.0.0"
   state: "^0.22.1"
-  queue: "^0.2.0"
+  queue: "^0.21.4"

--- a/memory/iii.worker.yaml
+++ b/memory/iii.worker.yaml
@@ -12,5 +12,5 @@ dependencies:
   configuration: "0.x"
   session-manager: "^1.0.0"
   llm-router: "^1.0.0"
-  state: "0.x"
+  state: "^0.22.1"
   queue: "^0.2.0"

--- a/opencode/iii.worker.yaml
+++ b/opencode/iii.worker.yaml
@@ -14,5 +14,5 @@ scripts:
   start: node ./index.mjs
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.1"
   iii-stream: "^0.21.6"

--- a/openwiki/iii.worker.yaml
+++ b/openwiki/iii.worker.yaml
@@ -14,6 +14,6 @@ scripts:
   start: node ./index.mjs
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.1"
   cron: "^0.21.0"
   llm-router: "^1.0.0"

--- a/pi/iii.worker.yaml
+++ b/pi/iii.worker.yaml
@@ -14,5 +14,5 @@ scripts:
   start: node ./index.mjs
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.1"
   iii-stream: "^0.21.6"

--- a/provider-anthropic/iii.worker.yaml
+++ b/provider-anthropic/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, anthropic, claude, messages, provider]
 description: Anthropic Messages API provider worker; implements provider::anthropic::stream and provider::anthropic::refresh_models behind llm-router.
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.1"
   llm-router: "^1.0.0"

--- a/provider-claude-code/iii.worker.yaml
+++ b/provider-claude-code/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, anthropic, claude, claude-code, subscription, provider]
 description: Claude Code (Pro/Max subscription) Messages API provider worker; implements provider::claude-code::stream and provider::claude-code::refresh_models behind llm-router, using OAuth credentials from the auth-credentials vault or ~/.claude/.credentials.json.
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.1"
   llm-router: "^1.0.0"

--- a/provider-deepseek/iii.worker.yaml
+++ b/provider-deepseek/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, deepseek, chat-completions, provider]
 description: DeepSeek Chat Completions provider worker; implements provider::deepseek::stream and provider::deepseek::refresh_models behind llm-router.
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.1"
   llm-router: "^1.0.0"

--- a/provider-github-copilot/iii.worker.yaml
+++ b/provider-github-copilot/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, github, copilot, subscription, chat-completions, provider]
 description: GitHub Copilot subscription provider worker; sign in with GitHub once and the models the plan grants appear in the picker. Implements provider::github-copilot::stream, refresh_models, and a device-flow login surface behind llm-router.
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.1"
   llm-router: "^1.0.0"

--- a/provider-kimi/iii.worker.yaml
+++ b/provider-kimi/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, kimi, moonshot, chat-completions, provider]
 description: Moonshot (Kimi) Chat Completions provider worker; implements provider::kimi::stream and provider::kimi::refresh_models behind llm-router.
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.1"
   llm-router: "^1.0.0"

--- a/provider-llamacpp/iii.worker.yaml
+++ b/provider-llamacpp/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, llama.cpp, local, open-source, provider]
 description: llama.cpp server (llama-server) Chat Completions provider worker; implements provider::llamacpp::stream and provider::llamacpp::refresh_models behind llm-router.
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.1"
   llm-router: "^1.0.0"

--- a/provider-openai-codex/iii.worker.yaml
+++ b/provider-openai-codex/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, openai, codex, chatgpt, subscription, provider]
 description: OpenAI Codex (ChatGPT subscription) provider; implements provider::openai-codex::stream and provider::openai-codex::refresh_models behind llm-router, sourcing credentials from the auth-credentials vault.
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.1"
   llm-router: "^1.0.0"

--- a/provider-openai/iii.worker.yaml
+++ b/provider-openai/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, openai, responses, chat-completions, provider]
 description: OpenAI Responses provider worker with Chat Completions compatibility; implements provider::openai::stream and provider::openai::refresh_models behind llm-router.
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.1"
   llm-router: "^1.0.0"

--- a/provider-opencode-go/iii.worker.yaml
+++ b/provider-opencode-go/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, opencode, go, chat-completions, subscription, provider]
 description: OpenCode Go Chat Completions provider worker; implements provider::opencode_go::stream and provider::opencode_go::refresh_models behind llm-router.
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.1"
   llm-router: "^1.0.0"

--- a/provider-openrouter/iii.worker.yaml
+++ b/provider-openrouter/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, openrouter, aggregator, chat-completions, provider]
 description: OpenRouter Chat Completions provider worker; one API key in front of every major vendor. Implements provider::openrouter::stream and provider::openrouter::refresh_models behind llm-router.
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.1"
   llm-router: "^1.0.0"

--- a/provider-xai/iii.worker.yaml
+++ b/provider-xai/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, xai, grok, chat-completions, provider]
 description: xAI Chat Completions provider worker; implements provider::xai::stream and provider::xai::refresh_models behind llm-router.
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.1"
   llm-router: "^1.0.0"

--- a/provider-zai/iii.worker.yaml
+++ b/provider-zai/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, zai, glm, chat-completions, provider]
 description: Z.AI Chat Completions provider worker; implements provider::zai::stream and provider::zai::refresh_models behind llm-router.
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.1"
   llm-router: "^1.0.0"

--- a/slack/iii.worker.yaml
+++ b/slack/iii.worker.yaml
@@ -10,6 +10,6 @@ description: Slack as an iii worker — exposes the Slack Web API as slack::* fu
 
 dependencies:
   configuration: "0.x"
-  state: "0.x"
+  state: "^0.22.1"
   harness: "^1.0.0"
   session-manager: "^1.0.0"

--- a/telegram-bot/iii.worker.yaml
+++ b/telegram-bot/iii.worker.yaml
@@ -10,7 +10,7 @@ description: Telegram bridge to the harness stack — polling or webhook ingress
 
 dependencies:
   state: "^0.22.1"
-  queue: "^0.2.0"
+  queue: "^0.21.4"
   configuration: "0.x"
   session-manager: "^1.0.0"
   harness: "^1.0.0"

--- a/telegram-bot/iii.worker.yaml
+++ b/telegram-bot/iii.worker.yaml
@@ -9,7 +9,7 @@ tags: [telegram, bot, messaging, chat, webhook]
 description: Telegram bridge to the harness stack — polling or webhook ingress, live message edits, approvals, and configurable verbosity.
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.1"
   queue: "^0.2.0"
   configuration: "0.x"
   session-manager: "^1.0.0"

--- a/worktree/iii.worker.yaml
+++ b/worktree/iii.worker.yaml
@@ -10,5 +10,5 @@ description: Git worktree lifecycle for parallel agents — mint, claim, and tra
 
 dependencies:
   configuration: "0.x"
-  state: "0.x"
+  state: "^0.22.1"
   shell: "^0.7.0"


### PR DESCRIPTION
## Summary

- require state ^0.22.1 for every worker that depends on state
- require queue ^0.21.4 for eval, harness, memory, and telegram-bot
- keep shared dependency ranges aligned across runtime consumers
- update dependency compatibility tests and manifest documentation

## Why

The Registry does not propagate a root worker next channel to its dependencies. Broad or outdated ranges can therefore resolve workers that predate project namespace support.

State 0.22.1 and queue 0.21.4 are the namespace-aware releases used by the updated workers. Setting these versions as the minimum prevents Compose dependency resolution from downgrading a namespaced project to incompatible state or queue workers.

## Validation

- dependency compatibility tests: 4 passed
- harness manifest tests: 4 passed
- cargo fmt --check --manifest-path harness/Cargo.toml
- git diff --check

Refs MOT-4463

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Standardized worker compatibility requirements across the platform.
  - Updated state components to use the 0.22.x release line.
  - Updated queue components to use the 0.21.4 release line where applicable.
  - Improved compatibility checks to ensure workers resolve consistent, compatible versions.

- **Documentation**
  - Updated architecture guidance to clarify supported version ranges and how they are interpreted by the platform and Registry.

- **Tests**
  - Revised manifest validation checks to reflect the updated compatibility requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->