### PR TITLE
(MOT-4512) feat(console-ui): CodeEditorHandle.revealLine

### DIFF
--- a/console/web/src/components/ui/CodeEditor.stories.tsx
+++ b/console/web/src/components/ui/CodeEditor.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { useEffect, useRef, useState } from 'react'
+import { CodeEditor, type CodeEditorHandle } from './CodeEditor'
+
+const LONG_FILE = Array.from(
+  { length: 200 },
+  (_, index) => `fn step_${index + 1}() {\n    // line ${index + 1}\n}\n`,
+).join('\n')
+
+function RevealOnMount({ line }: { line: number }) {
+  const handle = useRef<CodeEditorHandle>(null)
+  const [value, setValue] = useState(LONG_FILE)
+  useEffect(() => {
+    handle.current?.revealLine(line)
+  }, [line])
+  return (
+    <div className="h-[480px] w-[720px] overflow-auto border border-edge">
+      <CodeEditor
+        ref={handle}
+        value={value}
+        onChange={setValue}
+        language="rust"
+        aria-label="reveal demo"
+      />
+    </div>
+  )
+}
+
+const meta = {
+  title: 'UI/CodeEditor',
+  component: RevealOnMount,
+  parameters: { layout: 'padded' },
+} satisfies Meta<typeof RevealOnMount>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const RevealLineOnMount: Story = {
+  name: 'reveal line 300 on mount',
+  args: { line: 300 },
+}

--- a/console/web/src/components/ui/CodeEditor.tsx
+++ b/console/web/src/components/ui/CodeEditor.tsx
@@ -1,9 +1,14 @@
 import type * as monacoNs from 'monaco-editor'
 import * as React from 'react'
+import { centeredScrollTop, clampLine, scrollParentOf } from '@/lib/reveal-line'
 import { cn } from '@/lib/utils'
 
 export interface CodeEditorHandle {
   focus(): void
+  /** Put the cursor on `line` (1-based, clamped), scroll the pane that
+      holds the editor so the line sits centered, and focus. Before Monaco
+      mounts the request is kept and replayed once it does. */
+  revealLine(line: number, column?: number): void
 }
 
 export interface CodeEditorProps {
@@ -108,7 +113,48 @@ export const CodeEditor = React.forwardRef<CodeEditorHandle, CodeEditorProps>(
     const fallbackRef = React.useRef<HTMLTextAreaElement>(null)
     const editorRef = React.useRef<monacoNs.editor.IStandaloneCodeEditor>(null)
     const applyingRef = React.useRef(false)
+    const pendingRevealRef = React.useRef<{
+      line: number
+      column: number
+    } | null>(null)
     const [ready, setReady] = React.useState(false)
+
+    const revealLine = React.useCallback((line: number, column = 1) => {
+      const editor = editorRef.current
+      if (!editor) {
+        pendingRevealRef.current = { line, column }
+        return
+      }
+      const lineNumber = clampLine(line, editor.getModel()?.getLineCount() ?? 1)
+      editor.setPosition({ lineNumber, column: Math.max(1, column) })
+      editor.revealLineInCenter(lineNumber)
+      const host = hostRef.current
+      const scroller = scrollParentOf(host)
+      if (host && scroller) {
+        const hostTop =
+          host.getBoundingClientRect().top -
+          scroller.getBoundingClientRect().top +
+          scroller.scrollTop
+        const lineTop = editor.getTopForLineNumber(lineNumber)
+        const lineHeight = Math.max(
+          0,
+          editor.getTopForLineNumber(lineNumber + 1) - lineTop,
+        )
+        scroller.scrollTo({
+          top: centeredScrollTop(
+            hostTop,
+            lineTop,
+            scroller.clientHeight,
+            lineHeight,
+          ),
+          behavior: window.matchMedia('(prefers-reduced-motion: reduce)')
+            .matches
+            ? 'auto'
+            : 'smooth',
+        })
+      }
+      editor.focus()
+    }, [])
 
     // The mount effect runs once; it reads mount-time props through here.
     const latest = React.useRef({ value, language, autoFocus })
@@ -121,6 +167,7 @@ export const CodeEditor = React.forwardRef<CodeEditorHandle, CodeEditorProps>(
         if (editorRef.current) editorRef.current.focus()
         else fallbackRef.current?.focus()
       },
+      revealLine,
     }))
 
     React.useEffect(() => {
@@ -152,6 +199,11 @@ export const CodeEditor = React.forwardRef<CodeEditorHandle, CodeEditorProps>(
           fitHeight()
           if (latest.current.autoFocus) editor.focus()
           setReady(true)
+          const pending = pendingRevealRef.current
+          if (pending) {
+            pendingRevealRef.current = null
+            revealLine(pending.line, pending.column)
+          }
         })
         .catch((err) => {
           console.warn(
@@ -164,7 +216,7 @@ export const CodeEditor = React.forwardRef<CodeEditorHandle, CodeEditorProps>(
         editorRef.current?.dispose()
         editorRef.current = null
       }
-    }, [])
+    }, [revealLine])
 
     // Prop → editor sync (external value swaps, language, options).
     React.useEffect(() => {

--- a/console/web/src/lib/reveal-line.test.ts
+++ b/console/web/src/lib/reveal-line.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { centeredScrollTop, clampLine } from './reveal-line'
+
+describe('clampLine', () => {
+  it('keeps lines inside the model and floors fractions', () => {
+    expect(clampLine(0, 10)).toBe(1)
+    expect(clampLine(7.8, 10)).toBe(7)
+    expect(clampLine(99, 10)).toBe(10)
+    expect(clampLine(Number.NaN, 10)).toBe(1)
+    expect(clampLine(3, 0)).toBe(1)
+  })
+})
+
+describe('centeredScrollTop', () => {
+  it('centers the line in the scroller and never goes negative', () => {
+    expect(centeredScrollTop(100, 400, 600, 20)).toBe(210)
+    expect(centeredScrollTop(0, 10, 600, 20)).toBe(0)
+  })
+})

--- a/console/web/src/lib/reveal-line.ts
+++ b/console/web/src/lib/reveal-line.ts
@@ -1,0 +1,33 @@
+/** The nearest ancestor that scrolls vertically, or null when the document does. */
+export function scrollParentOf(
+  element: HTMLElement | null,
+): HTMLElement | null {
+  let node = element?.parentElement ?? null
+  while (node) {
+    const overflowY = getComputedStyle(node).overflowY
+    if (
+      (overflowY === 'auto' || overflowY === 'scroll') &&
+      node.scrollHeight > node.clientHeight
+    ) {
+      return node
+    }
+    node = node.parentElement
+  }
+  return null
+}
+
+/** Scroll offset that centers a line, given the editor host's offset inside
+    the scroller and the line's offset inside the host. */
+export function centeredScrollTop(
+  hostTop: number,
+  lineTop: number,
+  clientHeight: number,
+  lineHeight: number,
+): number {
+  return Math.max(0, hostTop + lineTop - clientHeight / 2 + lineHeight / 2)
+}
+
+export function clampLine(line: number, lineCount: number): number {
+  if (!Number.isFinite(line)) return 1
+  return Math.min(Math.max(1, Math.floor(line)), Math.max(1, lineCount))
+}

--- a/packages/console-ui/index.d.ts
+++ b/packages/console-ui/index.d.ts
@@ -954,6 +954,10 @@ export declare const TooltipContent: React.ComponentType<TooltipContentProps>
 
 export interface CodeEditorHandle {
   focus(): void
+  /** Put the cursor on `line` (1-based, clamped), scroll the pane that holds
+      the editor so the line sits centered, and focus. Before the editor
+      mounts the request is kept and replayed once it does. */
+  revealLine(line: number, column?: number): void
 }
 export interface CodeEditorProps {
   value: string


### PR DESCRIPTION
## Why

The shared `CodeEditor` exposes an imperative handle with only `focus()`. Any surface that opens a file from a diff line, a search hit, a stack trace, or a deep link has no way to land the cursor on that line without bundling its own editor, which the injectable-UI SOP forbids. First consumer: the shell review pane (open a diff line in the editor, separate PR); the editor worker's `open` at `line:col` is next.

## What

`CodeEditorHandle.revealLine(line: number, column?: number)` in `components/ui/CodeEditor.tsx`, typed in `packages/console-ui/index.d.ts`.

- Clamps `line` to the model, sets the cursor, calls Monaco's `revealLineInCenter`, and focuses.
- The shared editor grows to its content and the surrounding pane scrolls, so Monaco's own reveal cannot move the viewport. The handle finds the nearest scrolling ancestor of the editor host and scrolls it so the line sits centered, using `getTopForLineNumber` for the offset; `prefers-reduced-motion` makes the scroll instant.
- Called before Monaco mounts, the request is kept and replayed once the editor exists, so a consumer can open a file and reveal in the same tick.

Pure helpers in `lib/reveal-line.ts` (`scrollParentOf`, `centeredScrollTop`, `clampLine`) with unit tests. Storybook `UI/CodeEditor` reveals a deep line on mount in a 480px pane.

## Verification

- `tsc -b`, biome on the changed files, vitest 1458 passing (2 new).

Linear: MOT-4512
