### PR TITLE
(MOT-4513) feat(shell): open a diff line in the editor from the review pane

### DIFF
--- a/shell/ui/src/page/EditorPane.tsx
+++ b/shell/ui/src/page/EditorPane.tsx
@@ -7,7 +7,12 @@
    remounted per file (key=path) and rehydrates from the cache instead
    of re-reading. */
 
-import { CodeEditor, type Host, IconButton } from '@iii-dev/console-ui'
+import {
+  CodeEditor,
+  type CodeEditorHandle,
+  type Host,
+  IconButton,
+} from '@iii-dev/console-ui'
 import { Code, Eye } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { errorMessage, formatBytes } from '../lib/format'
@@ -135,6 +140,9 @@ interface EditorPaneProps {
   onDirtyChange: (relPath: string, dirty: boolean) => void
   /** Global review-pane preference; the header toggle overrides it per file. */
   richPreview?: boolean
+  /** Land the cursor on a line once the file is loaded; `seq` distinguishes
+      repeated requests for the same line. */
+  reveal?: { line: number; seq: number } | null
 }
 
 export function EditorPane({
@@ -143,10 +151,12 @@ export function EditorPane({
   relPath,
   cache,
   richPreview = false,
+  reveal = null,
   onSaved,
   onDirtyChange,
 }: EditorPaneProps) {
   const absPath = joinPath(root, relPath)
+  const editorRef = useRef<CodeEditorHandle>(null)
   const previewable = isRichPreviewPath(relPath)
   const [previewChoice, setPreviewChoice] = useState<boolean | null>(null)
   useEffect(() => {
@@ -231,6 +241,14 @@ export function EditorPane({
 
   const dirty = pane.phase === 'ready' && draft !== savedContent
   const readOnly = entry?.readOnly ?? null
+  const ready = pane.phase === 'ready'
+  useEffect(() => {
+    if (!reveal || !ready) return
+    const handle = editorRef.current as
+      | (CodeEditorHandle & { revealLine?: (line: number) => void })
+      | null
+    handle?.revealLine?.(reveal.line)
+  }, [reveal, ready])
   const canSave = pane.phase === 'ready' && readOnly === null && dirty && !saving
 
   const setDraft = useCallback(
@@ -340,6 +358,7 @@ export function EditorPane({
           <div className="shui-editor-preview">{richPreviewNode(relPath, draft)}</div>
         ) : (
           <CodeEditor
+            ref={editorRef}
             value={draft}
             onChange={setDraft}
             language={monacoLangFromPath(relPath)}

--- a/shell/ui/src/page/ReviewPane.tsx
+++ b/shell/ui/src/page/ReviewPane.tsx
@@ -5,6 +5,7 @@ import {
 } from '@iii-dev/console-ui'
 import {
   ChevronRight,
+  FileSymlink,
   Pencil,
   Save,
   X,
@@ -20,6 +21,11 @@ import {
 } from './coder'
 import { imageMimeFromPath } from './EditorPane'
 import { FileTypeIcon } from './file-type-icon'
+import {
+  firstChangedLine,
+  gutterLineFromPath,
+  resolveEditorLine,
+} from './open-line'
 import { richPreviewNode } from './rich-preview'
 import { diffLines, diffTotals } from './diff'
 import { gitHeadBaseline, gitReadSource, gitShowHead } from './git'
@@ -68,6 +74,8 @@ interface ReviewPaneProps {
   onEditSavingChange: (path: string, saving: boolean) => void
   onFileSaved: (path: string, contents: string, revision?: string) => void
   onSummaryChange: (files: readonly ReviewFileSummary[]) => void
+  /** Open the working file in an editor tab with the cursor on `line`. */
+  onOpenLine?: (path: string, line: number) => void
 }
 
 type FileState =
@@ -494,6 +502,7 @@ export function ReviewPane({
   onEditSavingChange,
   onFileSaved,
   onSummaryChange,
+  onOpenLine,
 }: ReviewPaneProps) {
   const [collapsed, setCollapsed] = useState<ReadonlySet<string>>(() =>
     defaultCollapsedReviewPaths(entries),
@@ -816,6 +825,7 @@ export function ReviewPane({
             onEditDirtyChange={onEditDirtyChange}
             onEditSavingChange={onEditSavingChange}
             onSave={saveFile}
+            onOpenLine={onOpenLine}
             onActivate={() => onActivate(entry.path)}
             onToggle={() => {
               const isCollapsed = collapsed.has(entry.path)
@@ -854,6 +864,7 @@ function ReviewFile({
   onEditDirtyChange,
   onEditSavingChange,
   onSave,
+  onOpenLine,
   onActivate,
   onToggle,
   onStats,
@@ -877,6 +888,7 @@ function ReviewFile({
     contents: string,
     expectedRevision: string | undefined,
   ) => Promise<void>
+  onOpenLine?: (path: string, line: number) => void
   onActivate: () => void
   onToggle: () => void
   onStats: (summary: ReviewFileSummary | null, path: string) => void
@@ -947,6 +959,27 @@ function ReviewFile({
         : null,
     [state, options.hideWhitespace],
   )
+  const openable =
+    onOpenLine !== undefined &&
+    reviewEntryWorktreePath(entry) !== null &&
+    state.phase === 'ready' &&
+    state.image === undefined &&
+    !state.imageUnavailable
+  const lineOps = useMemo(
+    () => (openable && state.phase === 'ready' ? diffLines(state.oldContents, state.newContents) : []),
+    [openable, state],
+  )
+  const openAtLine = (line: number) => {
+    const path = reviewEntryWorktreePath(entry)
+    if (path !== null && onOpenLine) onOpenLine(path, line)
+  }
+  const openFromGutter = (event: React.MouseEvent<HTMLElement>) => {
+    if (!openable || editing) return
+    const target = gutterLineFromPath(event.nativeEvent.composedPath())
+    if (target === null) return
+    event.preventDefault()
+    openAtLine(resolveEditorLine(lineOps, target))
+  }
   useEffect(() => {
     onStats(
       totals === null || state.phase !== 'ready'
@@ -1097,6 +1130,7 @@ function ReviewFile({
       className={`shui-review-file${active ? ' active' : ''}`}
       data-review-path={entry.path}
       aria-busy={saving}
+      onClick={openFromGutter}
       onKeyDownCapture={(event) => {
         if (
           editing &&
@@ -1128,6 +1162,17 @@ function ReviewFile({
           </span>
         ) : null}
         {dirty ? <span className="shui-dirty" title="unsaved diff edit" /> : null}
+        {openable && !editing ? (
+          <button
+            type="button"
+            className="shui-review-file-action"
+            onClick={() => openAtLine(firstChangedLine(lineOps))}
+            aria-label={`open ${entry.path} in the editor`}
+            title="open in editor at the first change (or click a line number)"
+          >
+            <FileSymlink aria-hidden />
+          </button>
+        ) : null}
         {editable && state.phase === 'ready' ? (
           editing ? (
             <>

--- a/shell/ui/src/page/__tests__/open-line.test.ts
+++ b/shell/ui/src/page/__tests__/open-line.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { diffLines } from '../diff'
+import {
+  firstChangedLine,
+  gutterLineFromPath,
+  newLineForOld,
+  resolveEditorLine,
+} from '../open-line'
+
+const cellOf = (dataset: Record<string, string>) => ({ dataset }) as unknown as EventTarget
+
+describe('gutterLineFromPath', () => {
+  it('reads the first gutter cell on the composed path and its side', () => {
+    const cell = cellOf({ columnNumber: '42', lineType: 'addition' })
+    const deleted = cellOf({ columnNumber: '7', lineType: 'deletion' })
+    const text = cellOf({ lineNumberContent: '' })
+    expect(gutterLineFromPath([text, cell])).toEqual({ line: 42, side: 'new' })
+    expect(gutterLineFromPath([deleted])).toEqual({ line: 7, side: 'old' })
+    expect(gutterLineFromPath([text])).toBeNull()
+    expect(gutterLineFromPath([])).toBeNull()
+  })
+
+  it('rejects cells without a usable number', () => {
+    const blank = cellOf({ columnNumber: '', lineType: 'context' })
+    expect(gutterLineFromPath([blank])).toBeNull()
+  })
+})
+
+describe('line resolution against the diff', () => {
+  const ops = diffLines('a\nb\nc\nd\ne\n', 'a\nX\nc\ne\nY\n')
+
+  it('maps old lines to the working file', () => {
+    expect(newLineForOld(ops, 1)).toBe(1)
+    expect(newLineForOld(ops, 2)).toBe(2)
+    expect(newLineForOld(ops, 3)).toBe(3)
+    expect(newLineForOld(ops, 4)).toBe(4)
+    expect(newLineForOld(ops, 5)).toBe(4)
+    expect(newLineForOld(ops, 99)).toBe(6)
+  })
+
+  it('finds the first change and resolves gutter targets by side', () => {
+    expect(firstChangedLine(ops)).toBe(2)
+    expect(firstChangedLine(diffLines('same\n', 'same\n'))).toBe(1)
+    expect(resolveEditorLine(ops, { line: 5, side: 'new' })).toBe(5)
+    expect(resolveEditorLine(ops, { line: 4, side: 'old' })).toBe(4)
+  })
+})

--- a/shell/ui/src/page/index.tsx
+++ b/shell/ui/src/page/index.tsx
@@ -1716,6 +1716,28 @@ export function ShellExplorerPage({
     [openReviewEntry, previewFile],
   )
 
+  const [revealLineRequest, setRevealLineRequest] = useState<{
+    path: string
+    line: number
+    seq: number
+  } | null>(null)
+  const openFileAtLine = useCallback(
+    (relPath: string, line: number) => {
+      if (!confirmDiscardReviewEdits()) return
+      setTerminalActive(false)
+      diffRequestRef.current += 1
+      setContextDiff(null)
+      setDiff(null)
+      setTabs((s) => openPinned(s, relPath))
+      setRevealLineRequest((previous) => ({
+        path: relPath,
+        line,
+        seq: (previous?.seq ?? 0) + 1,
+      }))
+    },
+    [confirmDiscardReviewEdits],
+  )
+
   const pinFile = useCallback(
     (relPath: string) => {
       const entry = visibleReviewEntriesRef.current.get(relPath)
@@ -2871,6 +2893,7 @@ export function ShellExplorerPage({
                 onEditDirtyChange={onReviewEditDirtyChange}
                 onEditSavingChange={onReviewEditSavingChange}
                 onFileSaved={onReviewFileSaved}
+                onOpenLine={openFileAtLine}
                 onActivate={(path) => {
                   const entry = visibleReviewEntriesRef.current.get(path)
                   if (entry) openReviewEntry(entry)
@@ -2898,6 +2921,11 @@ export function ShellExplorerPage({
             ) : tabs.active !== null ? (
               <EditorPane
                 richPreview={reviewOptions.richPreview}
+                reveal={
+                  revealLineRequest?.path === tabs.active
+                    ? revealLineRequest
+                    : null
+                }
                 // fileBump remounts after an agent-side write to the active
                 // file: the pane rehydrates from the refreshed cache entry.
                 key={`${tabs.active}:${fileBump}`}

--- a/shell/ui/src/page/open-line.ts
+++ b/shell/ui/src/page/open-line.ts
@@ -1,0 +1,52 @@
+import type { DiffOp } from './diff'
+
+export interface GutterLine {
+  line: number
+  side: 'old' | 'new'
+}
+
+/** Pierre renders each gutter cell as `[data-line-type][data-column-number]`
+    inside the diff's shadow root; the click reaches the host with the inner
+    nodes on `composedPath()`. Deleted rows number the old file. */
+export function gutterLineFromPath(path: readonly EventTarget[]): GutterLine | null {
+  for (const target of path) {
+    const dataset = (target as { dataset?: DOMStringMap }).dataset
+    const raw = dataset?.columnNumber
+    if (raw === undefined) continue
+    const line = Number.parseInt(raw, 10)
+    if (!Number.isFinite(line) || line < 1) return null
+    return { line, side: dataset?.lineType === 'deletion' ? 'old' : 'new' }
+  }
+  return null
+}
+
+/** The working-file line that stands where an old-file line used to be:
+    the line itself when it survived, else the first line after the last
+    kept line before it. */
+export function newLineForOld(ops: readonly DiffOp[], oldLine: number): number {
+  let lastNew = 0
+  for (const op of ops) {
+    if (op.type === 'same') {
+      if (op.oldLine >= oldLine) return op.newLine
+      lastNew = op.newLine
+    } else if (op.type === 'add') {
+      lastNew = op.newLine
+    } else if (op.oldLine >= oldLine) {
+      return Math.max(1, lastNew + 1)
+    }
+  }
+  return Math.max(1, lastNew + 1)
+}
+
+/** First changed line in the working file, or 1 for an unchanged body. */
+export function firstChangedLine(ops: readonly DiffOp[]): number {
+  for (const op of ops) {
+    if (op.type === 'add') return op.newLine
+    if (op.type === 'del') return newLineForOld(ops, op.oldLine)
+  }
+  return 1
+}
+
+export function resolveEditorLine(ops: readonly DiffOp[], target: GutterLine): number {
+  return target.side === 'new' ? target.line : newLineForOld(ops, target.line)
+}


### PR DESCRIPTION
## Why

Reading a hunk often ends in wanting the whole file at that spot. The review pane offered inline edit of the diff or nothing, and an editor tab opened at the top of the file. Hunk's `hunk-diff-context` extension is the reference for the motion: diff line to the full file in one action.

## What

- **Click a line number** in a review diff and the file opens in an editor tab with the cursor on that line. Pierre renders the gutter inside an open shadow root, so the section's click handler reads `composedPath()` for the `[data-line-type][data-column-number]` cell (`open-line.ts`). Addition and context rows use the working-file number; a deleted row numbers the old file and resolves to the first surviving line after the last kept line before it, computed from the shell's own `diffLines` (`newLineForOld`).
- **Open in editor** action in the review file header (`FileSymlink`), landing on the first changed line (`firstChangedLine`). Hidden for image rows, deleted files, revision-only rows, and while inline edit is active.
- `EditorPane` takes a `reveal` request (`line`, `seq`) and calls `CodeEditorHandle.revealLine` once the file is loaded. The call is feature-detected: on a console without #849 the file still opens, at the top. `index.tsx` routes both entry points through `openFileAtLine`, which pins the tab and records the request for that path.

No console or shared-package changes. Cursor placement needs #849 (`CodeEditorHandle.revealLine`) on the console side.

## Verification

- `shell/ui`: `tsc --noEmit`, vitest 297 passing (4 new: gutter cell parsing and side, rejection of blank cells, old-to-new line mapping across replaced and deleted lines, first-change and side resolution), esbuild bundle.
- `shell` crate: `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, `cargo test` (669).
- Rig: binary built and installed; the console there runs a build with #849 merged.

Linear: MOT-4513
