### PR TITLE
(MOT-4516) fix(opengantry): type response schemas so the release can publish

### DIFF
--- a/opengantry/src/formats.js
+++ b/opengantry/src/formats.js
@@ -39,7 +39,13 @@ export const MiddlewareRequestSchema = z
   })
   .strict();
 
-export const MiddlewareResponseSchema = z.unknown();
+// The gate is a pass-through: on allow, the response is whatever the forwarded
+// call returned. Typed as an open object rather than z.unknown() because
+// z.toJSONSchema(z.unknown()) is `{}`, which the registry renders as "unknown"
+// and `collect_worker_interface.py --assert-typed-schemas` rejects at publish.
+// Same shape openwiki uses for open payloads. Widen to anyOf if a governed
+// function ever returns a bare scalar or array.
+export const MiddlewareResponseSchema = z.record(z.string(), z.unknown());
 
 export const VerifyRequestSchema = z
   .object({
@@ -87,7 +93,10 @@ export const OnTriggerTypeRegistrationRequestSchema = z
   })
   .strict();
 
-export const OnTriggerTypeRegistrationResponseSchema = z.unknown();
+// onTriggerTypeRegistration is an unconditional deny — it always throws
+// GantryDenied and has no success shape. Declared as the empty strict object so
+// the schema stays typed (see the note on MiddlewareResponseSchema).
+export const OnTriggerTypeRegistrationResponseSchema = z.object({}).strict();
 
 export const FUNCTION_FORMATS = {
   'gantry::middleware': {

--- a/opengantry/tests/formats.test.mjs
+++ b/opengantry/tests/formats.test.mjs
@@ -1,0 +1,47 @@
+/**
+ * Publish gate, enforced locally. `_publish-registry.yml` boots the released
+ * bundle and runs `collect_worker_interface.py --assert-typed-schemas`, which
+ * fails the release if any registered function's request or response schema
+ * lacks a schema-defining keyword — `z.unknown()` compiles to `{}` and trips it.
+ * That check only runs *after* the tag, the GitHub Release, and the tarball
+ * upload, so catch it here instead.
+ */
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { formatFor, FUNCTION_FORMATS } from '../src/formats.js';
+
+// Keep in sync with SCHEMA_DEFINING_KEYS in
+// .github/scripts/collect_worker_interface.py.
+const SCHEMA_DEFINING_KEYS = [
+  'type',
+  'properties',
+  '$ref',
+  'allOf',
+  'anyOf',
+  'oneOf',
+  'enum',
+  'items',
+  'const',
+];
+
+test('every registered function publishes typed request and response schemas', () => {
+  const violations = [];
+  for (const [functionId, formats] of Object.entries(FUNCTION_FORMATS)) {
+    for (const field of ['request', 'response']) {
+      const schema = formatFor(formats[field]);
+      const typed =
+        schema !== null &&
+        typeof schema === 'object' &&
+        SCHEMA_DEFINING_KEYS.some((key) => key in schema);
+      if (!typed) {
+        violations.push(`${functionId}.${field}_schema`);
+      }
+    }
+  }
+  assert.deepEqual(
+    violations,
+    [],
+    `untyped schemas would fail --assert-typed-schemas at publish: ${violations.join(', ')}`,
+  );
+});


### PR DESCRIPTION
`opengantry` landed in #814 but has never been released — it is the only bundle worker with no `opengantry/v*` tag. This makes its first release possible.

There is no release pipeline to add. Release here is one generic, manifest-driven machine: `release.yml` parses the `<worker>/vX.Y.Z` tag, reads `iii.worker.yaml`, and fans out on `deploy:`. `ci.yml`'s `discover` job enumerates workers off the filesystem and buckets them on `language:`. No workflow names a worker, and `grep -rn opengantry .github/` returns nothing — correctly so. opengantry already declares `language: javascript` + `deploy: bundle` and has the `build:bundle` script `_bundle.yml` needs, so it is routed fine.

It just isn't publishable.

## The blocker

`_publish-registry.yml` downloads the built tarball, boots the worker against a real engine, and runs `collect_worker_interface.py --assert-non-empty --assert-typed-schemas`. That rejects any request/response schema lacking a schema-defining keyword (`SCHEMA_DEFINING_KEYS` in `.github/scripts/collect_worker_interface.py:22`).

Two responses were `z.unknown()`, which `z.toJSONSchema` compiles to `{}`:

| Function | Was | Now |
|---|---|---|
| `gantry::middleware` | `z.unknown()` | `z.record(z.string(), z.unknown())` |
| `gantry::on-trigger-type-registration` | `z.unknown()` | `z.object({}).strict()` |

`middleware` is a pass-through gate — on allow the response is whatever the forwarded call returned (`middleware.js:86`), so it is typed as an open object, the shape `openwiki/src/lib/configuration.mjs:89` already uses for open payloads. Widen to `anyOf` if a governed function ever returns a bare scalar or array; it is registry documentation, not a runtime validator. `onTriggerTypeRegistration` throws `GantryDenied` unconditionally (`registration-hooks.js:36`) and has no success shape at all.

That assertion only runs **after** the tag, the GitHub Release, and the tarball upload — so this would have failed mid-operation and needed a Release Control recovery.

## The guard

`tests/formats.test.mjs` asserts every `FUNCTION_FORMATS` entry compiles to a typed schema, mirroring the CI keyword set with a comment pointing back at the script. No workflow changes needed: `ci.yml`'s `node` job already runs `npm test` for changed workers in the `node` bucket.

Verified it discriminates — reverting `MiddlewareResponseSchema` to `z.unknown()` fails with `gantry::middleware.response_schema`.

## Verification

From `opengantry/`, using the release path's own commands:

- `pnpm install --frozen-lockfile --ignore-workspace`
- `pnpm test` — 42/42 pass
- `pnpm lint` — biome 2.4.10 clean
- `pnpm run build:bundle` — 1.2mb
- `pnpm run verify:sandbox` — boots and registers

All ten schemas now carry `type`.

## Not in scope

- **`gantry::verdict`** publishes with no invocation schema and renders as "unknown" in the registry. Warning, not a blocker (`_untyped_trigger_names` warns; `_typed_schema_violations` fails), and not fixable here: `RegisterTriggerTypeInput` in iii-sdk 0.22.1 is `{id, description}` only, with no JS equivalent of Rust's `.trigger_request_format::<T>()`.
- **`ci.yml`'s `node` job** installs with `npm install` (opengantry ships only a `pnpm-lock.yaml`) while `_bundle.yml` and `release_train.py` use `pnpm install --frozen-lockfile --ignore-workspace`, so PR CI resolves deps unpinned. Pre-existing, affects all five JS workers, deliberately left alone.
- **No version bump** — `create-tag.yml` owns that.

## After merge

Cutting `opengantry/v0.1.0` is a Release Control dispatch (`create-tag.yml`, then `release.yml`). It requires `opengantry` in the Release Control typed release policy first (`docs/sops/new-worker.md` §6) — that is outside this repo and cannot be done from here.

Fixes MOT-4516