### PR TITLE
fix(providers): refresh llm-router lockfiles

### DIFF
--- a/crates/provider-integration-testkit/Cargo.lock
+++ b/crates/provider-integration-testkit/Cargo.lock
@@ -1048,7 +1048,7 @@ checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "llm-router"
-version = "1.4.10"
+version = "1.4.11"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-anthropic/Cargo.lock
+++ b/provider-anthropic/Cargo.lock
@@ -996,7 +996,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.10"
+version = "1.4.11"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-claude-code/Cargo.lock
+++ b/provider-claude-code/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.10"
+version = "1.4.11"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-deepseek/Cargo.lock
+++ b/provider-deepseek/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.10"
+version = "1.4.11"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-github-copilot/Cargo.lock
+++ b/provider-github-copilot/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.10"
+version = "1.4.11"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-kimi/Cargo.lock
+++ b/provider-kimi/Cargo.lock
@@ -943,7 +943,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.10"
+version = "1.4.11"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-llamacpp/Cargo.lock
+++ b/provider-llamacpp/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.10"
+version = "1.4.11"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-openai-codex/Cargo.lock
+++ b/provider-openai-codex/Cargo.lock
@@ -1008,7 +1008,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.10"
+version = "1.4.11"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-openai/Cargo.lock
+++ b/provider-openai/Cargo.lock
@@ -996,7 +996,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.10"
+version = "1.4.11"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-opencode-go/Cargo.lock
+++ b/provider-opencode-go/Cargo.lock
@@ -976,7 +976,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.10"
+version = "1.4.11"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-openrouter/Cargo.lock
+++ b/provider-openrouter/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.10"
+version = "1.4.11"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-xai/Cargo.lock
+++ b/provider-xai/Cargo.lock
@@ -996,7 +996,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.10"
+version = "1.4.11"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-zai/Cargo.lock
+++ b/provider-zai/Cargo.lock
@@ -996,7 +996,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.10"
+version = "1.4.11"
 dependencies = [
  "async-trait",
  "clap",


### PR DESCRIPTION
`chore(llm-router): bump to v1.4.11` (d0bff54e0) landed without refreshing the provider lockfiles, so `test_provider_related_lockfiles_track_llm_router_version` fails on `main` and on **every open PR**, not just this one's neighbours.

Same refresh as #845, and #848 carried a partial one for the testkit. Produced by running `cargo metadata` in each crate rather than editing by hand; the only change is the `llm-router` path-dependency version, `1.4.10` → `1.4.11`, across the 12 providers and the provider-contract testkit.

The entire diff is 13 lines:

```
13 -version = "1.4.10"
13 +version = "1.4.11"
```

Verified every `llm-router` lock entry now matches `llm-router/Cargo.toml`'s `1.4.11`, which is what the assertion checks.

This recurs on every llm-router release. Worth considering whether the release bot should refresh dependent lockfiles as part of the version-bump commit, so the tree isn't briefly red after each one — happy to file that separately if it's wanted.

No ticket: lockfile-only chore, matching #845's precedent.