### PR TITLE
(MOT-4503) feat(cron): schedules page as injectable console UI

### DIFF
--- a/cron/Cargo.lock
+++ b/cron/Cargo.lock
@@ -4,18 +4,18 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -72,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arc-swap"
@@ -87,13 +87,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -125,9 +125,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -146,15 +146,15 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -168,9 +168,20 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -185,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -195,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -207,14 +218,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -269,6 +280,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cron"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "digest"
@@ -307,13 +327,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -324,9 +344,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "equivalent"
@@ -346,15 +366,15 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "form_urlencoded"
@@ -367,9 +387,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -382,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -392,15 +412,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -409,38 +429,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -483,11 +503,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -497,8 +515,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -526,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -536,9 +557,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -546,9 +567,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -565,9 +586,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -616,7 +637,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.6.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -648,9 +669,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -662,9 +683,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -675,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -689,16 +710,17 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -709,15 +731,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -750,14 +772,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "iii-console-ui"
+version = "0.1.0"
+dependencies = [
+ "iii-sdk",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "iii-cron"
-version = "0.21.5"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
  "clap",
  "cron",
+ "iii-console-ui",
  "iii-sdk",
  "redis",
  "schemars",
@@ -825,9 +860,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -852,9 +887,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -869,15 +904,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "lock_api"
@@ -911,9 +946,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "minimal-lexical"
@@ -923,9 +958,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -962,9 +997,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c863e9ab5e7bf9c99ba75e1050f1e4d624ae87ed3532d6238ffbdc7b585dbbe6"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -972,9 +1007,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -1063,7 +1098,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand",
+ "rand 0.9.5",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -1106,9 +1141,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -1124,9 +1159,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1144,7 +1179,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.6.5",
  "thiserror",
  "tokio",
  "tracing",
@@ -1153,14 +1188,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.15"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1174,23 +1210,23 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.6.5",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -1209,12 +1245,23 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1224,7 +1271,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1234,6 +1281,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1273,9 +1335,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1348,9 +1410,9 @@ checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustls"
-version = "0.23.41"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "once_cell",
  "ring",
@@ -1374,9 +1436,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -1384,9 +1446,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1395,9 +1457,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -1435,7 +1497,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1469,9 +1531,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1479,22 +1541,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1505,14 +1567,14 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -1568,17 +1630,17 @@ checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -1637,9 +1699,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -1665,9 +1727,20 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1691,7 +1764,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1710,38 +1783,38 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -1749,9 +1822,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1764,29 +1837,29 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.4",
+ "socket2 0.6.5",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1801,9 +1874,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -1828,13 +1901,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -1903,7 +1977,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1962,7 +2036,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.9.5",
  "rustls",
  "rustls-pki-types",
  "sha1",
@@ -2026,9 +2100,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -2074,9 +2148,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2087,9 +2161,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2097,9 +2171,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2107,31 +2181,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2149,9 +2223,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2231,7 +2305,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2242,7 +2316,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2285,16 +2359,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2312,31 +2377,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -2355,22 +2403,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2379,22 +2415,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2403,22 +2427,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2427,22 +2439,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
@@ -2452,9 +2452,9 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "yoke"
@@ -2475,28 +2475,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2516,7 +2516,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -2528,9 +2528,9 @@ checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -2539,9 +2539,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -2550,17 +2550,17 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/cron/Cargo.lock
+++ b/cron/Cargo.lock
@@ -785,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "iii-cron"
-version = "0.22.0"
+version = "0.21.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/cron/Cargo.toml
+++ b/cron/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "iii-cron"
-version = "0.21.5"
+version = "0.22.0"
 edition = "2021"
 description = "Cron scheduler worker for iii - schedules functions with cron expressions (cron trigger type)"
 license = "Apache-2.0"
@@ -19,6 +19,7 @@ path = "src/main.rs"
 
 [dependencies]
 iii-sdk = "=0.23.0-rc.2"
+iii-console-ui = { path = "../crates/console-ui" }
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time"] }
 serde = { version = "1", features = ["derive"] }

--- a/cron/Cargo.toml
+++ b/cron/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "iii-cron"
-version = "0.22.0"
+version = "0.21.6"
 edition = "2021"
 description = "Cron scheduler worker for iii - schedules functions with cron expressions (cron trigger type)"
 license = "Apache-2.0"

--- a/cron/README.md
+++ b/cron/README.md
@@ -72,6 +72,15 @@ console (**Configuration -> Workers -> cron**) or seed it once via
 scheduler under a serialized apply lock: existing jobs are stopped, re-created
 with the new backend, and never run in two scheduler instances at once.
 
+## Console page
+
+While the worker is connected it injects a **cron** page into the console
+(`#/ext/cron`): every agent-owned schedule with its cadence, next UTC run and
+fire count, the cron bindings other workers registered for themselves, and a
+composer that turns "every weekday at 09:00, summarise open PRs" into a
+registered schedule. Schedules created there live in a session of their own,
+so each routine keeps its own transcript.
+
 ## Trigger type
 
 This worker always registers the `cron` trigger type. Bind a function to it
@@ -84,6 +93,9 @@ with:
 
 All schedules use UTC. Missed fires while the worker is stopped are skipped;
 there is no catch-up replay.
+
+Write the day of week as a name (`Mon` ... `Sun`). Numerically the crate counts
+Sunday as 1, so `0 0 9 * * 1` fires on Sunday, not Monday.
 
 ### Requires removing the legacy built-in cron worker
 

--- a/cron/build.rs
+++ b/cron/build.rs
@@ -1,0 +1,138 @@
+//! Build script for the cron worker's injectable console UI.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::SystemTime;
+
+fn main() {
+    println!(
+        "cargo:rustc-env=TARGET={}",
+        std::env::var("TARGET").unwrap()
+    );
+
+    println!("cargo:rerun-if-changed=ui/page.tsx");
+    println!("cargo:rerun-if-changed=ui/styles.css");
+    println!("cargo:rerun-if-changed=ui/src");
+    println!("cargo:rerun-if-changed=ui/build.mjs");
+    println!("cargo:rerun-if-changed=ui/package.json");
+    println!("cargo:rerun-if-changed=../pnpm-lock.yaml");
+    println!("cargo:rerun-if-changed=ui/tsconfig.json");
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let ui_dir = manifest_dir.join("ui");
+    let dist_assets = [
+        ui_dir.join("dist").join("page.js"),
+        ui_dir.join("dist").join("styles.css"),
+    ];
+
+    if dist_assets
+        .iter()
+        .all(|asset| asset.exists() && dist_is_fresh(asset, &ui_dir))
+    {
+        return;
+    }
+
+    if std::env::var_os("SKIP_UI_BUILD").is_some() {
+        for asset in &dist_assets {
+            if !asset.exists() {
+                panic!(
+                    "SKIP_UI_BUILD set but {} is missing; build the UI first",
+                    asset.display()
+                );
+            }
+        }
+        return;
+    }
+
+    let pnpm = locate_pnpm();
+    run(&pnpm, &["install"], &ui_dir);
+    run(&pnpm, &["build"], &ui_dir);
+
+    for asset in &dist_assets {
+        if !asset.exists() {
+            panic!("UI build completed but {} is missing", asset.display());
+        }
+    }
+}
+
+fn run(command: &Path, args: &[&str], cwd: &Path) {
+    let status = Command::new(command)
+        .args(args)
+        .current_dir(cwd)
+        .status()
+        .unwrap_or_else(|error| panic!("failed to run {}: {error}", command.display()));
+    if !status.success() {
+        panic!("{} exited with {status}", command.display());
+    }
+}
+
+fn dist_is_fresh(dist_asset: &Path, ui_dir: &Path) -> bool {
+    let Ok(dist_mtime) = dist_asset.metadata().and_then(|meta| meta.modified()) else {
+        return false;
+    };
+    let watched_files = [
+        ui_dir.join("page.tsx"),
+        ui_dir.join("styles.css"),
+        ui_dir.join("build.mjs"),
+        ui_dir.join("package.json"),
+        ui_dir.join("../../pnpm-lock.yaml"),
+        ui_dir.join("tsconfig.json"),
+    ];
+    for file in watched_files {
+        if !file.exists() {
+            continue;
+        }
+        let Ok(modified) = file.metadata().and_then(|meta| meta.modified()) else {
+            return false;
+        };
+        if modified > dist_mtime {
+            return false;
+        }
+    }
+    subtree_older_than(&ui_dir.join("src"), dist_mtime)
+}
+
+fn subtree_older_than(root: &Path, ceiling: SystemTime) -> bool {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(meta) = entry.metadata() else {
+            return false;
+        };
+        if meta.is_dir() {
+            if !subtree_older_than(&path, ceiling) {
+                return false;
+            }
+        } else {
+            let Ok(modified) = meta.modified() else {
+                return false;
+            };
+            if modified > ceiling {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+fn locate_pnpm() -> PathBuf {
+    if let Ok(explicit) = std::env::var("PNPM") {
+        return PathBuf::from(explicit);
+    }
+    let names = if cfg!(windows) {
+        ["pnpm.cmd", "pnpm.exe", "pnpm"].as_slice()
+    } else {
+        ["pnpm"].as_slice()
+    };
+    for directory in std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default()) {
+        for name in names {
+            let candidate = directory.join(name);
+            if candidate.is_file() {
+                return candidate;
+            }
+        }
+    }
+    panic!("pnpm not found on PATH");
+}

--- a/cron/iii.worker.yaml
+++ b/cron/iii.worker.yaml
@@ -11,4 +11,4 @@ config:
   adapter:
     name: local
 dependencies:
-  configuration: "0.x"
+  configuration: "^0.21.6"

--- a/cron/iii.worker.yaml
+++ b/cron/iii.worker.yaml
@@ -11,4 +11,4 @@ config:
   adapter:
     name: local
 dependencies:
-  configuration: "^0.21.6"
+  configuration: "0.x"

--- a/cron/skills/SKILL.md
+++ b/cron/skills/SKILL.md
@@ -29,6 +29,11 @@ The schedule grammar is the Rust `cron` crate dialect: six or seven fields,
 optional. The leading field is always seconds, so `0 */5 * * * *` fires every
 5 minutes at second 0, while `*/5 * * * * *` fires every 5 seconds.
 
+Write the day of week as a name: `Mon`, `Tue`, `Wed`, `Thu`, `Fri`, `Sat`,
+`Sun`. Numerically this dialect counts Sunday as 1, one ahead of the Unix
+convention, so `0 0 9 * * 1` fires on Sunday and a `1` written for Monday
+fires a day early. Names avoid the whole question.
+
 Two lock backends govern duplicate firing. `local` is the default and is only
 process-local; every worker instance can fire the same job in a multi-instance
 deployment. `redis` uses Redis locking and is required for once-only firing

--- a/cron/src/boot.rs
+++ b/cron/src/boot.rs
@@ -95,6 +95,8 @@ pub async fn start(iii: Arc<IIIClient>, config: CronConfig) -> anyhow::Result<Bo
             .trigger_request_format::<CronTriggerSpec>(),
     );
 
+    crate::ui::register(&iii);
+
     Ok(BootHandle {
         scheduler: scheduler_cell,
         config: Arc::new(tokio::sync::RwLock::new(config.normalized())),

--- a/cron/src/configuration.rs
+++ b/cron/src/configuration.rs
@@ -13,25 +13,7 @@ use crate::config::CronConfig;
 use crate::locks;
 use crate::scheduler::Scheduler;
 
-pub const DEFAULT_CONFIG_ID: &str = "cron";
-
-/// The configuration entry this worker owns.
-///
-/// `III_CONFIG_NAME` when a supervisor set it, else the built-in name. A worker
-/// that hardcodes its id turns that id into a global scarce name: two instances
-/// share one entry and take turns overwriting it, and each write wakes both.
-/// Being told which entry is its own is what lets them differ.
-pub fn config_id() -> &'static str {
-    static ID: std::sync::OnceLock<String> = std::sync::OnceLock::new();
-    ID.get_or_init(|| {
-        std::env::var("III_CONFIG_NAME")
-            .ok()
-            .map(|value| value.trim().to_string())
-            .filter(|value| !value.is_empty())
-            .unwrap_or_else(|| DEFAULT_CONFIG_ID.to_string())
-    })
-    .as_str()
-}
+pub const CONFIG_ID: &str = "cron";
 const CONFIG_FN_ID: &str = "cron::on-config-change";
 const CONFIG_RETRIES: u32 = 3;
 const CONFIG_RETRY_BACKOFF_MS: u64 = 250;
@@ -39,7 +21,7 @@ const CONFIG_BUS_TIMEOUT_MS: u64 = 10_000;
 
 pub async fn register_config(iii: &IIIClient, seed: Option<&CronConfig>) -> Result<(), String> {
     let mut payload = json!({
-        "id": config_id(),
+        "id": CONFIG_ID,
         "name": "Cron",
         "description": "Cron scheduler settings - lock backend for multi-instance mutual exclusion (local or redis).",
         "schema": CronConfig::json_schema(),
@@ -48,7 +30,7 @@ pub async fn register_config(iii: &IIIClient, seed: Option<&CronConfig>) -> Resu
         let seed = seed.cloned().unwrap_or_default().normalized();
         payload["initial_value"] = seed.to_json();
     }
-    trigger_configuration_with_retry(
+    trigger_with_retry(
         iii,
         "configuration::register",
         payload,
@@ -62,10 +44,7 @@ pub async fn fetch_config(iii: &IIIClient) -> Result<CronConfig, String> {
     match try_get_config_value(iii).await? {
         Some(value) if !value.is_null() => CronConfig::from_json(&value),
         _ => {
-            tracing::info!(
-                "no `{config_entry}` configuration value stored; using built-in default",
-                config_entry = config_id()
-            );
+            tracing::info!("no `{CONFIG_ID}` configuration value stored; using built-in default");
             Ok(CronConfig::default())
         }
     }
@@ -79,10 +58,10 @@ async fn should_seed_initial_value(iii: &IIIClient) -> Result<bool, String> {
 }
 
 async fn try_get_config_value(iii: &IIIClient) -> Result<Option<Value>, String> {
-    match trigger_configuration_with_retry(
+    match trigger_with_retry(
         iii,
         "configuration::get",
-        json!({ "id": config_id() }),
+        json!({ "id": CONFIG_ID }),
         CONFIG_BUS_TIMEOUT_MS,
     )
     .await
@@ -113,7 +92,7 @@ pub fn register_config_trigger(iii: &Arc<IIIClient>, parts: BootParts) -> Result
         "configuration".to_string(),
         CONFIG_FN_ID.to_string(),
         json!({
-            "configuration_id": config_id(),
+            "configuration_id": CONFIG_ID,
             "event_types": ["configuration:updated"],
         }),
     ))?;
@@ -177,7 +156,7 @@ fn swap_needed(current: &CronConfig, next: &CronConfig) -> bool {
             != next.adapter.as_ref().and_then(|a| a.config.clone())
 }
 
-async fn trigger_configuration_with_retry(
+async fn trigger_with_retry(
     iii: &IIIClient,
     function_id: &str,
     payload: Value,
@@ -186,15 +165,12 @@ async fn trigger_configuration_with_retry(
     let mut last_err = String::new();
     for attempt in 1..=CONFIG_RETRIES {
         match iii
-            .trigger(
-                TriggerRequest {
-                    function_id: function_id.to_string(),
-                    payload: payload.clone(),
-                    action: None,
-                    timeout_ms: Some(timeout_ms),
-                }
-                .namespace("default"),
-            )
+            .trigger(TriggerRequest {
+                function_id: function_id.to_string(),
+                payload: payload.clone(),
+                action: None,
+                timeout_ms: Some(timeout_ms),
+            })
             .await
         {
             Ok(v) => return Ok(v),

--- a/cron/src/lib.rs
+++ b/cron/src/lib.rs
@@ -10,3 +10,4 @@ pub mod locks;
 pub mod manifest;
 pub mod scheduler;
 pub mod trigger;
+pub mod ui;

--- a/cron/src/ui.rs
+++ b/cron/src/ui.rs
@@ -1,0 +1,46 @@
+//! Injectable console UI for the cron worker.
+
+use std::sync::Arc;
+
+use iii_console_ui::ConsoleUi;
+use iii_sdk::IIIClient;
+
+pub const PAGE_PATH: &str = "cron/page.js";
+pub const STYLES_PATH: &str = "cron/styles.css";
+
+const PAGE_JS: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/ui/dist/page.js"));
+const STYLES_CSS: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/ui/dist/styles.css"));
+
+fn console_ui() -> ConsoleUi {
+    ConsoleUi::new("cron")
+        .script(PAGE_PATH, PAGE_JS)
+        .style(STYLES_PATH, STYLES_CSS)
+}
+
+pub fn register(iii: &Arc<IIIClient>) {
+    console_ui().register(iii);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ui_builder_accepts_the_assets() {
+        let _ = console_ui();
+    }
+
+    #[test]
+    fn embedded_page_is_nonempty_esm() {
+        assert!(PAGE_JS.contains("export"), "built page.js looks wrong");
+    }
+
+    #[test]
+    fn embedded_styles_are_scoped() {
+        assert!(
+            STYLES_CSS.contains(r#"[data-iii-ui="cron"]"#)
+                || STYLES_CSS.contains("[data-iii-ui=cron]"),
+            "built styles.css must be scoped under the cron worker"
+        );
+    }
+}

--- a/cron/ui/build.mjs
+++ b/cron/ui/build.mjs
@@ -1,0 +1,24 @@
+import esbuild from 'esbuild'
+
+const options = {
+  entryPoints: ['page.tsx', 'styles.css'],
+  bundle: true,
+  format: 'esm',
+  jsx: 'automatic',
+  outdir: 'dist',
+  external: [
+    'react',
+    'react-dom',
+    'react-dom/client',
+    'react/jsx-runtime',
+    '@iii-dev/console-ui',
+  ],
+  logLevel: 'info',
+}
+
+if (process.argv.includes('--watch')) {
+  const context = await esbuild.context(options)
+  await context.watch()
+} else {
+  await esbuild.build(options)
+}

--- a/cron/ui/package.json
+++ b/cron/ui/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@iii-workers/cron-ui",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "build": "tsc --noEmit && node build.mjs",
+    "watch": "node build.mjs --watch"
+  },
+  "dependencies": {
+    "@iii-dev/console-ui": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.14",
+    "esbuild": "^0.25.0",
+    "typescript": "^5.9.2"
+  }
+}

--- a/cron/ui/page.tsx
+++ b/cron/ui/page.tsx
@@ -1,0 +1,12 @@
+import type { Host } from '@iii-dev/console-ui'
+import { CronConfigForm } from './src/configuration'
+import { CronSchedulesPage } from './src/page'
+
+export default function setup(host: Host) {
+  host.pages.register({
+    id: 'cron',
+    title: 'cron',
+    render: (props) => <CronSchedulesPage host={host} {...props} />,
+  })
+  host.configForms.register('cron', CronConfigForm)
+}

--- a/cron/ui/src/components.tsx
+++ b/cron/ui/src/components.tsx
@@ -1,0 +1,55 @@
+import { uiClasses } from '@iii-dev/console-ui'
+import type { ReactNode } from 'react'
+
+/** The console's field recipe: label above the control, hint or error below.
+    Using it rather than local metrics is what keeps this page reading like
+    the rest of the console. */
+export function Field({
+  label,
+  hint,
+  htmlFor,
+  className,
+  children,
+}: {
+  label: string
+  hint?: ReactNode
+  htmlFor?: string
+  className?: string
+  children: ReactNode
+}) {
+  const classes = className ? `${uiClasses.field} ${className}` : uiClasses.field
+  return (
+    <div className={classes}>
+      <label className={uiClasses.fieldLabel} htmlFor={htmlFor}>
+        {label}
+      </label>
+      {children}
+      {hint ? <span className={uiClasses.fieldDescription}>{hint}</span> : null}
+    </div>
+  )
+}
+
+/** The library has no multi-line input, so this is the local one, painted to
+    match the shared Input. */
+export function TextArea({
+  id,
+  value,
+  onChange,
+  placeholder,
+}: {
+  id?: string
+  value: string
+  onChange: (next: string) => void
+  placeholder?: string
+}) {
+  return (
+    <textarea
+      id={id}
+      className="cron-ui-textarea"
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      placeholder={placeholder}
+      rows={3}
+    />
+  )
+}

--- a/cron/ui/src/configuration/index.tsx
+++ b/cron/ui/src/configuration/index.tsx
@@ -1,0 +1,86 @@
+import type { ConfigFormProps, JsonValue } from '@iii-dev/console-ui'
+import { Input, Select, StatusPanel } from '@iii-dev/console-ui'
+import { useEffect, useRef } from 'react'
+import { Field } from '../components'
+
+type JsonObject = { [key: string]: JsonValue }
+
+function asObject(value: JsonValue | undefined): JsonObject {
+  return value && typeof value === 'object' && !Array.isArray(value) ? { ...value } : {}
+}
+
+function asString(value: JsonValue | undefined): string {
+  return typeof value === 'string' ? value : ''
+}
+
+export function CronConfigForm(props: ConfigFormProps) {
+  const value = asObject(props.value)
+  const adapter = asObject(value.adapter)
+  const adapterName = asString(adapter.name) || 'local'
+  const adapterConfig = asObject(adapter.config)
+
+  const setAdapterName = (name: string) => {
+    props.onChange({ ...value, adapter: { name } })
+  }
+
+  const setRedisUrl = (redisUrl: string) => {
+    const config = { ...adapterConfig }
+    if (redisUrl === '') delete config.redis_url
+    else config.redis_url = redisUrl
+
+    const nextAdapter: JsonObject = { ...adapter, name: adapterName }
+    if (Object.keys(config).length > 0) nextAdapter.config = config
+    else delete nextAdapter.config
+    props.onChange({ ...value, adapter: nextAdapter })
+  }
+
+  const rootRef = useRef<HTMLDivElement | null>(null)
+  useEffect(() => {
+    const field = props.focusField?.at(-1)
+    if (!field || !rootRef.current) return
+    const target = rootRef.current.querySelector<HTMLElement>(`[data-field="${field}"]`)
+    target?.focus()
+    target?.scrollIntoView({ block: 'center' })
+  }, [props.focusField])
+
+  return (
+    <div className="cron-ui-form" ref={rootRef}>
+      <span className="cron-ui-form-caption">custom form · shipped by the cron worker</span>
+
+      <Field label="Lock adapter" hint="Use redis when more than one cron worker can schedule the same jobs.">
+        <Select
+          value={adapterName}
+          data-field="adapter"
+          options={[
+            { value: 'local', label: 'local · process-local locks' },
+            { value: 'redis', label: 'redis · shared distributed locks' },
+          ]}
+          onChange={setAdapterName}
+          aria-label="Lock adapter"
+        />
+      </Field>
+
+      {adapterName === 'redis' ? (
+        <Field label="Redis URL" htmlFor="cron-cfg-redis-url">
+          <Input
+            id="cron-cfg-redis-url"
+            data-field="redis_url"
+            value={asString(adapterConfig.redis_url)}
+            placeholder="redis://localhost:6379"
+            onChange={setRedisUrl}
+          />
+        </Field>
+      ) : null}
+
+      {props.errors && props.errors.size > 0 ? (
+        <StatusPanel
+          variant="alert"
+          headline="This configuration cannot be saved yet"
+          detail={[...props.errors.entries()]
+            .map(([pointer, message]) => (pointer ? `${pointer}: ${message}` : message))
+            .join('\n')}
+        />
+      ) : null}
+    </div>
+  )
+}

--- a/cron/ui/src/lib/api.ts
+++ b/cron/ui/src/lib/api.ts
@@ -1,0 +1,345 @@
+import type { Host } from '@iii-dev/console-ui'
+
+export interface SessionCronTask {
+  /** The session a fire wakes. Every schedule the page creates gets its own,
+      so a routine never lands in whatever chat happened to be open. */
+  sessionId: string
+  sessionTitle?: string
+  subscriptionId: string
+  triggerId?: string
+  expression: string
+  target?: string
+  label?: string
+  conditions: unknown[]
+  once: boolean
+  maxFires?: number
+  expiresAt?: number
+  fires: number
+  createdAt: number
+}
+
+export interface SystemCronBinding {
+  id: string
+  functionId: string
+  workerName: string
+  expression: string
+  conditionFunctionId?: string
+  configSummary?: string
+}
+
+export interface FunctionSummary {
+  functionId: string
+  workerName: string
+  description?: string
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function rows(value: unknown, key: string): unknown[] {
+  return isRecord(value) && Array.isArray(value[key]) ? value[key] : []
+}
+
+function jsonRecord(value: string | undefined): Record<string, unknown> {
+  if (!value) return {}
+  try {
+    const parsed: unknown = JSON.parse(value)
+    return isRecord(parsed) ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+export function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  if (isRecord(error)) {
+    for (const key of ['message', 'error', 'reason', 'detail']) {
+      const candidate = error[key]
+      if (typeof candidate === 'string' && candidate.trim()) return candidate
+    }
+  }
+  try {
+    return JSON.stringify(error) ?? String(error)
+  } catch {
+    return String(error)
+  }
+}
+
+async function listSessionCronTasks(host: Host, sessionId: string): Promise<SessionCronTask[]> {
+  const response = await host.iii.trigger('harness::triggers::list', {
+    session_id: sessionId,
+  })
+  return rows(response, 'subscriptions')
+    .map((row): SessionCronTask | null => {
+      if (!isRecord(row) || row.trigger_type !== 'cron') return null
+      const subscriptionId = stringValue(row.subscription_id)
+      const config = isRecord(row.config) ? row.config : {}
+      const expression = stringValue(config.expression)
+      if (!subscriptionId || !expression) return null
+      return {
+        sessionId,
+        subscriptionId,
+        triggerId: stringValue(row.trigger_id),
+        expression,
+        target: stringValue(row.target),
+        label: stringValue(row.label),
+        conditions: Array.isArray(row.conditions) ? row.conditions : [],
+        once: row.once === true,
+        maxFires: numberValue(row.max_fires),
+        expiresAt: numberValue(row.expires_at),
+        fires: numberValue(row.fires) ?? 0,
+        createdAt: numberValue(row.created_at) ?? 0,
+      }
+    })
+    .filter((task): task is SessionCronTask => task !== null)
+    .sort((left, right) => right.createdAt - left.createdAt)
+}
+
+export async function removeSessionCronTask(host: Host, sessionId: string, subscriptionId: string): Promise<boolean> {
+  const response = await host.iii.trigger('harness::triggers::unregister', {
+    session_id: sessionId,
+    subscription_id: subscriptionId,
+  })
+  return isRecord(response) && response.removed === true
+}
+
+const LAST_MODEL_KEY = 'iii-chat-last-model'
+
+/** A session that has never taken a turn has no model to inherit, so the send
+    has to name one, and the console's own last pick is the only defensible
+    source. Picking off the catalogue instead looks helpful and is not: the
+    first entry is arbitrary, and a model that cannot emit function calls
+    burns the whole turn failing to register anything. Undefined here means
+    the caller asks the operator to choose. */
+export function resolveModel(host: Host, conversationId?: string | null): string | undefined {
+  // The console knows what the operator picked, including a draft they have
+  // not sent yet. Storage is the fallback for a console that predates the
+  // chat host API.
+  const live = host.chat?.composerModel?.(conversationId ?? undefined)
+  if (live) return live
+  try {
+    return window.localStorage?.getItem(LAST_MODEL_KEY) ?? undefined
+  } catch {
+    return undefined
+  }
+}
+
+export async function sendToSession(host: Host, sessionId: string, message: string, model?: string): Promise<void> {
+  await host.iii.trigger('harness::send', {
+    session_id: sessionId,
+    message,
+    ...(model ? { model } : {}),
+  })
+}
+
+/** Marks a session as one this page created to own a schedule, so the list
+    can find every routine again without depending on the open conversation. */
+export const SCHEDULE_SESSION_METADATA = { cron_ui: true, kind: 'schedule' }
+
+interface ScheduleSession {
+  sessionId: string
+  title?: string
+}
+
+const SESSION_PAGE = 200
+
+/** Reading every session at once would open one socket per schedule. */
+const READ_CONCURRENCY = 8
+
+/** Every session this page created, followed across pages. The metadata
+    filter is applied by session-manager, so an operator with hundreds of
+    chats does not lose schedules behind a page of unrelated conversations. */
+async function listScheduleSessions(host: Host): Promise<ScheduleSession[]> {
+  const found: ScheduleSession[] = []
+  const seenCursors = new Set<string>()
+  let cursor: string | undefined
+  for (;;) {
+    const response = await host.iii.trigger('session::list', {
+      metadata: { cron_ui: true },
+      limit: SESSION_PAGE,
+      ...(cursor ? { cursor } : {}),
+    })
+    for (const row of rows(response, 'sessions')) {
+      if (!isRecord(row)) continue
+      const sessionId = stringValue(row.session_id)
+      if (sessionId) found.push({ sessionId, title: stringValue(row.title) })
+    }
+    const next = isRecord(response) ? stringValue(response.next_cursor) : undefined
+    // A repeated cursor means the store is paging in circles; stop rather
+    // than fetch forever.
+    if (!next || seenCursors.has(next)) return found
+    seenCursors.add(next)
+    cursor = next
+  }
+}
+
+/** Every schedule this page owns, plus the open conversation's own, so a
+    routine created from chat is not hidden here. */
+export async function listAllSchedules(host: Host, conversationId?: string): Promise<SessionCronTask[]> {
+  const sessions = await listScheduleSessions(host)
+  const ids = new Map<string, string | undefined>()
+  for (const session of sessions) ids.set(session.sessionId, session.title)
+  if (conversationId && !ids.has(conversationId)) {
+    ids.set(conversationId, undefined)
+  }
+
+  const pending = [...ids]
+  const collected: SessionCronTask[] = []
+  const readers = Array.from({ length: Math.min(READ_CONCURRENCY, pending.length) }, async () => {
+    for (;;) {
+      const entry = pending.pop()
+      if (!entry) return
+      const [sessionId, title] = entry
+      try {
+        for (const task of await listSessionCronTasks(host, sessionId)) {
+          collected.push({ ...task, sessionTitle: title })
+        }
+      } catch {
+        // One unreadable session must not blank the whole list.
+      }
+    }
+  })
+  await Promise.all(readers)
+  return collected
+}
+
+/** Create a schedule in a session of its own. The policy is exactly the two
+    calls a registration needs, and the gate is set to accept them, because the
+    operator asked for this by pressing the button. */
+export async function createSchedule(
+  host: Host,
+  input: { title: string; instruction: string; model: string },
+): Promise<string> {
+  const response = await host.iii.trigger('harness::send', {
+    message: input.instruction,
+    model: input.model,
+    session: {
+      title: input.title,
+      metadata: SCHEDULE_SESSION_METADATA,
+    },
+    options: {
+      mode: 'agent',
+      max_turns: 6,
+      functions: {
+        allow: ['engine::register_trigger', 'engine::unregister_trigger'],
+        expose: 'native',
+      },
+    },
+  })
+  const sessionId = isRecord(response) ? stringValue(response.session_id) : undefined
+  if (!sessionId) {
+    throw new Error('Harness accepted the request without naming a session')
+  }
+  return sessionId
+}
+
+const SCHEDULE_CALLS = ['engine::register_trigger', 'engine::unregister_trigger']
+
+/** Grant exactly the two calls a registration makes, rather than putting the
+    session in full-permission mode: the schedule session stays a real chat the
+    operator can type into, and a blanket grant would outlive this turn.
+
+    Sequential, not concurrent: both grants edit one settings record, and
+    issued together the second read starts before the first write lands, so one
+    grant disappears.
+
+    A turn that reached the gate before the grants did leaves a held call, so
+    anything already waiting for these two functions is released here — the
+    operator asked for this schedule by pressing the button.
+
+    Best effort throughout: with no approval gate deployed there is nothing to
+    grant, and the registration simply waits for a human instead. */
+export async function allowScheduleCalls(host: Host, sessionId: string): Promise<void> {
+  for (const functionId of SCHEDULE_CALLS) {
+    try {
+      await host.iii.trigger('approval::approve-always', {
+        session_id: sessionId,
+        function_id: functionId,
+      })
+    } catch {
+      return
+    }
+  }
+  await releaseHeldScheduleCalls(host, sessionId)
+}
+
+async function releaseHeldScheduleCalls(host: Host, sessionId: string): Promise<void> {
+  try {
+    const response = await host.iii.trigger('approval::list-pending', {
+      session_id: sessionId,
+    })
+    for (const row of rows(response, 'pending')) {
+      if (!isRecord(row)) continue
+      const functionId = stringValue(row.function_id)
+      const callId = stringValue(row.function_call_id)
+      if (!callId || !functionId || !SCHEDULE_CALLS.includes(functionId)) continue
+      await host.iii.trigger('approval::resolve', {
+        session_id: sessionId,
+        function_call_id: callId,
+        decision: 'allow',
+      })
+    }
+  } catch {
+    // No gate, or nothing held: the turn proceeds either way.
+  }
+}
+
+export async function listSystemCronBindings(host: Host): Promise<SystemCronBinding[]> {
+  const response = await host.iii.trigger('engine::registered-triggers::list', {
+    include_internal: false,
+    trigger_type: 'cron',
+  })
+  return rows(response, 'registered_triggers')
+    .map((row): SystemCronBinding | null => {
+      if (!isRecord(row) || row.trigger_type !== 'cron') return null
+      const id = stringValue(row.id)
+      const functionId = stringValue(row.function_id)
+      if (!id || !functionId || functionId === 'harness::trigger::deliver') {
+        return null
+      }
+      const configSummary = stringValue(row.config_summary)
+      const summaryConfig = jsonRecord(configSummary)
+      const config = isRecord(row.config) ? row.config : {}
+      const expression = stringValue(config.expression) ?? stringValue(summaryConfig.expression)
+      if (!expression) return null
+      return {
+        id,
+        functionId,
+        workerName: stringValue(row.worker_name) ?? 'unknown',
+        expression,
+        conditionFunctionId:
+          stringValue(config.condition_function_id) ?? stringValue(summaryConfig.condition_function_id),
+        configSummary,
+      }
+    })
+    .filter((binding): binding is SystemCronBinding => binding !== null)
+    .sort((left, right) => left.functionId.localeCompare(right.functionId))
+}
+
+export async function listFunctions(host: Host): Promise<FunctionSummary[]> {
+  const response = await host.iii.trigger('engine::functions::list', {
+    include_internal: false,
+  })
+  return rows(response, 'functions')
+    .map((row): FunctionSummary | null => {
+      if (!isRecord(row)) return null
+      const functionId = stringValue(row.function_id)
+      if (!functionId || functionId.startsWith('harness::')) return null
+      return {
+        functionId,
+        workerName: stringValue(row.worker_name) ?? 'unknown',
+        description: stringValue(row.description),
+      }
+    })
+    .filter((fn): fn is FunctionSummary => fn !== null)
+    .sort((left, right) => left.functionId.localeCompare(right.functionId))
+}

--- a/cron/ui/src/lib/cron.ts
+++ b/cron/ui/src/lib/cron.ts
@@ -1,0 +1,255 @@
+const pad = (value: number) => String(value).padStart(2, '0')
+
+interface CronFields {
+  sec: string
+  min: string
+  hour: string
+  dom: string
+  month: string
+  weekday: string
+  year: string
+}
+
+function fields(expression: string): CronFields | null {
+  const values = expression.trim().split(/\s+/)
+  if (values.length !== 6 && values.length !== 7) return null
+  return {
+    sec: values[0],
+    min: values[1],
+    hour: values[2],
+    dom: values[3],
+    month: values[4],
+    weekday: values[5],
+    year: values[6] ?? '*',
+  }
+}
+
+function numberIn(value: string, minimum: number, maximum: number): number | null {
+  if (!/^\d+$/.test(value)) return null
+  const parsed = Number(value)
+  return parsed >= minimum && parsed <= maximum ? parsed : null
+}
+
+function step(value: string, maximum: number): number | null {
+  const match = /^\*\/(\d+)$/.exec(value)
+  const parsed = match ? Number(match[1]) : 0
+  return parsed > 0 && parsed <= maximum ? parsed : null
+}
+
+interface FieldRules {
+  label: string
+  minimum: number
+  maximum: number
+  allowAny?: boolean
+  names?: Record<string, number>
+}
+
+const MONTH_NAMES: Record<string, number> = {
+  jan: 1,
+  january: 1,
+  feb: 2,
+  february: 2,
+  mar: 3,
+  march: 3,
+  apr: 4,
+  april: 4,
+  may: 5,
+  jun: 6,
+  june: 6,
+  jul: 7,
+  july: 7,
+  aug: 8,
+  august: 8,
+  sep: 9,
+  september: 9,
+  oct: 10,
+  october: 10,
+  nov: 11,
+  november: 11,
+  dec: 12,
+  december: 12,
+}
+
+const WEEKDAY_NAMES: Record<string, number> = {
+  sun: 1,
+  sunday: 1,
+  mon: 2,
+  monday: 2,
+  tue: 3,
+  tues: 3,
+  tuesday: 3,
+  wed: 4,
+  wednesday: 4,
+  thu: 5,
+  thurs: 5,
+  thursday: 5,
+  fri: 6,
+  friday: 6,
+  sat: 7,
+  saturday: 7,
+}
+
+function isEveryWeekday(field: string): boolean {
+  return field === '*' || field === '?'
+}
+
+function ordinal(value: string, rules: FieldRules): number | null {
+  const numeric = numberIn(value, rules.minimum, rules.maximum)
+  if (numeric !== null) return numeric
+  return rules.names?.[value.toLowerCase()] ?? null
+}
+
+function validSpecifier(value: string, rules: FieldRules, stepped: boolean): boolean {
+  if (value === '*' || (rules.allowAny && value === '?')) return true
+  const range = value.split('-')
+  if (range.length === 2) {
+    const start = ordinal(range[0], rules)
+    const end = ordinal(range[1], rules)
+    return start !== null && end !== null && start <= end
+  }
+  if (range.length !== 1) return false
+  if (stepped && /^[a-z]+$/i.test(value)) return false
+  return ordinal(value, rules) !== null
+}
+
+function validField(value: string, rules: FieldRules): boolean {
+  return value.split(',').every((segment) => {
+    const period = segment.split('/')
+    if (period.length > 2 || !period[0]) return false
+    if (period.length === 2 && (!/^\d+$/.test(period[1]) || Number(period[1]) === 0)) {
+      return false
+    }
+    return validSpecifier(period[0], rules, period.length === 2)
+  })
+}
+
+export function validateCron(expression: string): string | null {
+  if (!expression.trim()) return 'Enter a cron expression.'
+  const parsed = fields(expression)
+  if (!parsed) return 'Use six fields (sec min hour day month weekday), with an optional year.'
+  const checks: Array<[string, FieldRules]> = [
+    [parsed.sec, { label: 'Seconds', minimum: 0, maximum: 59 }],
+    [parsed.min, { label: 'Minutes', minimum: 0, maximum: 59 }],
+    [parsed.hour, { label: 'Hours', minimum: 0, maximum: 23 }],
+    [parsed.dom, { label: 'Day of month', minimum: 1, maximum: 31, allowAny: true }],
+    [parsed.month, { label: 'Month', minimum: 1, maximum: 12, names: MONTH_NAMES }],
+    [parsed.weekday, { label: 'Weekday', minimum: 1, maximum: 7, allowAny: true, names: WEEKDAY_NAMES }],
+    [parsed.year, { label: 'Year', minimum: 1970, maximum: 2100 }],
+  ]
+  for (const [value, rules] of checks) {
+    if (!validField(value, rules)) return `${rules.label} field is invalid.`
+  }
+  return null
+}
+
+/** The subset both readers below understand: a whole-minute expression with
+    no date arithmetic, where only the weekday can narrow the day. Anything
+    richer is left unlabelled rather than described wrongly. */
+function calendarFields(expression: string): CronFields | null {
+  const parsed = fields(expression)
+  if (!parsed || parsed.year !== '*' || numberIn(parsed.sec, 0, 59) !== 0) return null
+  return parsed.dom === '*' && parsed.month === '*' ? parsed : null
+}
+
+export function describeCron(expression: string): string | null {
+  const parsed = calendarFields(expression)
+  if (!parsed) return null
+
+  const hour = numberIn(parsed.hour, 0, 23)
+  const minute = numberIn(parsed.min, 0, 59)
+  const minuteStep = parsed.hour === '*' ? step(parsed.min, 59) : null
+  let time: string | null = null
+  if (hour !== null && minute !== null) time = `${pad(hour)}:${pad(minute)} UTC`
+  else if (minuteStep !== null) time = `every ${minuteStep} minutes`
+  else if (parsed.hour === '*' && minute !== null) time = `hourly at :${pad(minute)} UTC`
+  if (!time) return null
+
+  if (isEveryWeekday(parsed.weekday)) {
+    return hour !== null ? `every day at ${time}` : time
+  }
+  const ordinals = weekdayOrdinals(parsed.weekday)
+  if (!ordinals || hour === null) return null
+  const names = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+  return `${ordinals.map((ordinal) => names[ordinal - 1]).join(', ')} at ${time}`
+}
+
+/** Weekday ordinals as the Rust `cron` crate counts them: 1 is Sunday
+    through 7 for Saturday, one ahead of the Unix convention most people
+    carry in their head. Lists are understood; ranges and steps are not, and
+    say so by returning null rather than guessing. */
+function weekdayOrdinals(field: string): number[] | null {
+  const ordinals: number[] = []
+  for (const part of field.split(',')) {
+    const token = part.trim().toLowerCase()
+    const named = WEEKDAY_NAMES[token]
+    const ordinal = named ?? numberIn(token, 1, 7)
+    if (ordinal === null || ordinal === undefined) return null
+    ordinals.push(ordinal)
+  }
+  return ordinals.length > 0 ? ordinals : null
+}
+
+export function nextCronRun(expression: string, now: Date): Date | null {
+  const parsed = calendarFields(expression)
+  if (!parsed) return null
+
+  // A weekday schedule: walk forward to the next matching day at that time.
+  if (!isEveryWeekday(parsed.weekday)) {
+    const weekdays = weekdayOrdinals(parsed.weekday)
+    if (!weekdays) return null
+    const hourOfDay = numberIn(parsed.hour, 0, 23)
+    const minuteOfHour = numberIn(parsed.min, 0, 59)
+    if (hourOfDay === null || minuteOfHour === null) return null
+    const candidate = new Date(now)
+    candidate.setUTCSeconds(0, 0)
+    candidate.setUTCHours(hourOfDay, minuteOfHour)
+    for (let day = 0; day <= 7; day += 1) {
+      const probe = new Date(candidate)
+      probe.setUTCDate(candidate.getUTCDate() + day)
+      if (probe <= now) continue
+      if (weekdays.includes(probe.getUTCDay() + 1)) return probe
+    }
+    return null
+  }
+
+  const hour = numberIn(parsed.hour, 0, 23)
+  const minute = numberIn(parsed.min, 0, 59)
+  const next = new Date(now)
+  next.setUTCSeconds(0, 0)
+
+  if (hour !== null && minute !== null) {
+    next.setUTCHours(hour, minute)
+    if (next <= now) next.setUTCDate(next.getUTCDate() + 1)
+    return next
+  }
+  if (parsed.hour === '*') {
+    const interval = step(parsed.min, 59)
+    if (interval !== null) {
+      const current = now.getUTCMinutes()
+      const nextMinute = Math.floor(current / interval) * interval + interval
+      if (nextMinute > 59) {
+        next.setUTCMinutes(0)
+        next.setUTCHours(next.getUTCHours() + 1)
+      } else {
+        next.setUTCMinutes(nextMinute)
+      }
+      return next
+    }
+    if (minute !== null) {
+      next.setUTCMinutes(minute)
+      if (next <= now) next.setUTCHours(next.getUTCHours() + 1)
+      return next
+    }
+  }
+  return null
+}
+
+export function untilLabel(target: Date, now: Date): string {
+  const seconds = Math.max(0, Math.round((target.getTime() - now.getTime()) / 1000))
+  if (seconds < 60) return `in ${seconds}s`
+  const minutes = Math.round(seconds / 60)
+  if (minutes < 60) return `in ${minutes}m`
+  const hours = Math.floor(minutes / 60)
+  const remainder = minutes % 60
+  return remainder ? `in ${hours}h ${remainder}m` : `in ${hours}h`
+}

--- a/cron/ui/src/lib/prompts.ts
+++ b/cron/ui/src/lib/prompts.ts
@@ -1,0 +1,55 @@
+/** The instructions this page sends to a harness agent. Registration is an
+    in-turn intercept — `engine::register_trigger` binds to the session that
+    calls it — so a schedule for a conversation can only be created by an
+    agent inside that conversation. One copy of the dialect rules lives here
+    so the create, replace, and form paths cannot drift apart; every one of
+    them was rejected at least once for the same two reasons. */
+
+const ARGUMENT_SHAPE =
+  '{"trigger_type":"cron","config":{"expression":"0 30 9 * * Mon"},"label":"<concise label>","once":false}'
+
+const DIALECT = [
+  'Arguments, exactly this shape — `config` is a JSON object, never a string:',
+  ARGUMENT_SHAPE,
+  '',
+  'The expression has six fields: second minute hour day-of-month month day-of-week, optionally a seventh year. Five-field Unix expressions are rejected.',
+  'Write the day of week as a name (Mon, Tue, Wed, Thu, Fri, Sat, Sun). The numeric form counts Sunday as 1, so a number meant as Monday fires a day early.',
+  'Times are UTC.',
+]
+
+export function createSchedulePrompt(request: string): string {
+  return [
+    'Create a scheduled task for this conversation by calling engine::register_trigger exactly once.',
+    '',
+    ...DIALECT,
+    'Omit function_id so each fire wakes this conversation, and keep the label short and faithful to the intent.',
+    'Register now and report the subscription_id. Do not only describe the steps.',
+    '',
+    `Request: ${request}`,
+  ].join('\n')
+}
+
+export function replaceSchedulePrompt(subscriptionId: string, request: string): string {
+  return [
+    `Replace scheduled task ${subscriptionId} for this conversation.`,
+    'Inspect the existing subscription if the request does not repeat every unchanged detail.',
+    '',
+    'First register the replacement with engine::register_trigger.',
+    ...DIALECT,
+    `The replacement must return a subscription_id different from "${subscriptionId}". If it returns the same id, the registration was deduplicated: do not unregister it, and report that the task is unchanged.`,
+    `Only after that, call engine::unregister_trigger with {"id":"${subscriptionId}"}.`,
+    'If registering the replacement fails, leave the existing subscription registered. Report both operation results. Do not merely explain the steps.',
+    '',
+    `Requested replacement: ${request}`,
+  ].join('\n')
+}
+
+export function manualSchedulePrompt(registration: unknown): string {
+  return [
+    'Create this scheduled task for this conversation.',
+    'Call engine::register_trigger exactly once with the JSON object below, verbatim. Do not substitute a timer and do not merely explain the call.',
+    'The expression is UTC. Report the returned subscription_id and any registration note.',
+    '',
+    JSON.stringify(registration, null, 2),
+  ].join('\n')
+}

--- a/cron/ui/src/page/detail.tsx
+++ b/cron/ui/src/page/detail.tsx
@@ -1,0 +1,176 @@
+import {
+  Button,
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  JsonHighlight,
+  StatusDot,
+} from '@iii-dev/console-ui'
+import { useState } from 'react'
+import type { SessionCronTask, SystemCronBinding } from '../lib/api'
+import { describeCron, nextCronRun, untilLabel } from '../lib/cron'
+import { cadenceLabel } from './rows'
+import { statusView } from './status'
+
+function formatTimestamp(value: number): string {
+  return `${new Date(value).toISOString().replace('T', ' ').slice(0, 19)} UTC`
+}
+
+function DetailRow({ label, children, mono = false }: { label: string; children: React.ReactNode; mono?: boolean }) {
+  return (
+    <div className="cron-ui-detail-row">
+      <dt className="cron-ui-detail-row-label">{label}</dt>
+      <dd className={mono ? 'cron-ui-detail-row-value mono' : 'cron-ui-detail-row-value'}>{children}</dd>
+    </div>
+  )
+}
+
+export function TaskDetail({
+  task,
+  now,
+  onReplace,
+  onRemove,
+  onCopyId,
+  onOpenConversation,
+}: {
+  task: SessionCronTask
+  now: Date
+  onReplace: () => void
+  onRemove: () => void
+  onCopyId: () => void
+  onOpenConversation: () => void
+}) {
+  const [confirming, setConfirming] = useState(false)
+  const view = statusView(task, now.getTime())
+  const next = nextCronRun(task.expression, now)
+  const payload = task.conditions.length > 0 ? task.conditions : null
+  return (
+    <div className="cron-ui-detail">
+      <header className="cron-ui-detail-head">
+        <h2 className="cron-ui-detail-title">{task.label ?? 'Untitled schedule'}</h2>
+        <span className="cron-ui-status">
+          <StatusDot tone={view.tone} aria-hidden />
+          <span>{view.label}</span>
+        </span>
+      </header>
+
+      <dl className="cron-ui-fields">
+        <DetailRow label="Next run">
+          {next ? `${formatTimestamp(next.getTime())} · ${untilLabel(next, now)}` : 'Not scheduled'}
+        </DetailRow>
+        <DetailRow label="Cadence">{cadenceLabel(task.expression)}</DetailRow>
+        <DetailRow label="Cron expression" mono>
+          {task.expression}
+        </DetailRow>
+        <DetailRow label="Timezone">UTC</DetailRow>
+        <DetailRow label="Target" mono>
+          {task.target ?? 'wake'}
+        </DetailRow>
+        <DetailRow label="Wakes">{task.sessionTitle ?? 'its own session'}</DetailRow>
+        <DetailRow label="Session" mono>
+          {task.sessionId}
+        </DetailRow>
+        <DetailRow label="Runs">
+          {task.once
+            ? `${task.fires} of 1 (runs once)`
+            : task.maxFires !== undefined
+              ? `${task.fires} of ${task.maxFires}`
+              : `${task.fires}`}
+        </DetailRow>
+        {task.expiresAt !== undefined ? <DetailRow label="Expires">{formatTimestamp(task.expiresAt)}</DetailRow> : null}
+        <DetailRow label="Created">{formatTimestamp(task.createdAt)}</DetailRow>
+        <DetailRow label="Subscription" mono>
+          {task.subscriptionId}
+        </DetailRow>
+      </dl>
+
+      {payload ? (
+        <section className="cron-ui-detail-section">
+          <h3 className="cron-ui-detail-subtitle">Conditions</h3>
+          <JsonHighlight code={JSON.stringify(payload, null, 2)} wrap />
+        </section>
+      ) : null}
+
+      <footer className="cron-ui-detail-actions">
+        <Button variant="ghost" onClick={onOpenConversation}>
+          Open conversation
+        </Button>
+        <Button variant="ghost" onClick={onCopyId}>
+          Copy id
+        </Button>
+        <Button variant="ghost" onClick={onReplace}>
+          Replace…
+        </Button>
+        <Button variant="primary" onClick={() => setConfirming(true)}>
+          Unregister
+        </Button>
+      </footer>
+
+      <Dialog open={confirming} onOpenChange={setConfirming}>
+        <DialogContent>
+          <DialogTitle>Unregister this schedule?</DialogTitle>
+          <DialogDescription>
+            {task.label ?? task.subscriptionId} stops firing immediately. This cannot be undone; the schedule has to be
+            created again.
+          </DialogDescription>
+          <div className="cron-ui-detail-actions">
+            <DialogClose asChild>
+              <Button variant="ghost">Keep it</Button>
+            </DialogClose>
+            <Button
+              variant="primary"
+              onClick={() => {
+                setConfirming(false)
+                onRemove()
+              }}
+            >
+              Unregister
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+
+export function BindingDetail({ binding, now }: { binding: SystemCronBinding; now: Date }) {
+  const next = nextCronRun(binding.expression, now)
+  return (
+    <div className="cron-ui-detail">
+      <header className="cron-ui-detail-head">
+        <h2 className="cron-ui-detail-title">{binding.functionId}</h2>
+        <span className="cron-ui-status">
+          <StatusDot tone="accent" aria-hidden />
+          <span>Active</span>
+        </span>
+      </header>
+
+      <dl className="cron-ui-fields">
+        <DetailRow label="Owner">{binding.workerName}</DetailRow>
+        <DetailRow label="Next run">
+          {next ? `${formatTimestamp(next.getTime())} · ${untilLabel(next, now)}` : 'Not scheduled'}
+        </DetailRow>
+        <DetailRow label="Cadence">{describeCron(binding.expression) ?? binding.expression}</DetailRow>
+        <DetailRow label="Cron expression" mono>
+          {binding.expression}
+        </DetailRow>
+        <DetailRow label="Timezone">UTC</DetailRow>
+        {binding.conditionFunctionId ? (
+          <DetailRow label="Condition" mono>
+            {binding.conditionFunctionId}
+          </DetailRow>
+        ) : null}
+        <DetailRow label="Trigger" mono>
+          {binding.id}
+        </DetailRow>
+      </dl>
+
+      <p className="cron-ui-detail-note">
+        This binding belongs to the {binding.workerName} worker. It is shown so the schedule is visible in one place;
+        change it where the worker declares it.
+      </p>
+    </div>
+  )
+}

--- a/cron/ui/src/page/index.tsx
+++ b/cron/ui/src/page/index.tsx
@@ -1,0 +1,877 @@
+import {
+  Button,
+  EmptyState,
+  type Host,
+  IconButton,
+  Input,
+  List,
+  PageBody,
+  PageHeader,
+  PageMain,
+  type PageRenderProps,
+  PageShell,
+  PageSidebar,
+  SegmentedControl,
+  Skeleton,
+  StatusPanel,
+  Table,
+  TableBody,
+  TableFrame,
+  TableHead,
+  TableHeader,
+  TableRow,
+  TableViewport,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+  uiClasses,
+} from '@iii-dev/console-ui'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  allowScheduleCalls,
+  createSchedule,
+  errorMessage,
+  type FunctionSummary,
+  listAllSchedules,
+  listFunctions,
+  listSystemCronBindings,
+  removeSessionCronTask,
+  resolveModel,
+  SCHEDULE_SESSION_METADATA,
+  type SessionCronTask,
+  type SystemCronBinding,
+  sendToSession,
+} from '../lib/api'
+import { nextCronRun } from '../lib/cron'
+import { createSchedulePrompt, manualSchedulePrompt, replaceSchedulePrompt } from '../lib/prompts'
+import { BindingDetail, TaskDetail } from './detail'
+import { ManualTaskForm, type ManualTaskSpec } from './manual-form'
+import { BindingListRow, BindingRow, cadenceLabel, TaskListRow, TaskRow } from './rows'
+import { byNextRun, countByStatus, type Filter, matchesBindingQuery, matchesFilter, matchesQuery } from './status'
+
+type View = 'tasks' | 'bindings'
+type Feedback = { tone: 'success' | 'warn' | 'alert'; message: string }
+type Inspector =
+  | { kind: 'new' }
+  | { kind: 'task'; task: SessionCronTask }
+  | { kind: 'binding'; binding: SystemCronBinding }
+  | null
+
+let mountSequence = 0
+
+/** Bind an engine trigger to a browser-local handler, following the console's
+    own convention: `on()` registers under `<fn>::<browserId>`, so the trigger
+    must target that id, and the trigger is disposed before the handler. */
+function subscribe<T>(
+  host: Host,
+  functionId: string,
+  type: string,
+  config: Record<string, unknown>,
+  onEvent: (event: T) => void,
+): () => void {
+  const offHandler = host.iii.on<T>(functionId, onEvent)
+  const offTrigger = host.iii.registerTrigger({
+    type,
+    function_id: `${functionId}::${host.iii.browserId}`,
+    config,
+  })
+  return () => {
+    try {
+      offTrigger()
+    } finally {
+      offHandler()
+    }
+  }
+}
+
+function ClockIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <circle cx="12" cy="12" r="8.5" stroke="currentColor" strokeWidth="1.7" />
+      <path d="M12 7.5v5l3.3 2" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  )
+}
+
+function RefreshIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path
+        d="M19 8a7.5 7.5 0 1 0 .2 7.7M19 4v4h-4"
+        stroke="currentColor"
+        strokeWidth="1.7"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
+function SearchIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <circle cx="10.8" cy="10.8" r="6.3" stroke="currentColor" strokeWidth="1.7" />
+      <path d="m16 16 4 4" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" />
+    </svg>
+  )
+}
+
+function PlusIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M12 5v14M5 12h14" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+    </svg>
+  )
+}
+
+function ChevronIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="m9 6 6 6-6 6" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  )
+}
+
+function SparkIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 16 16" className={className} aria-hidden="true" fill="currentColor">
+      <path d="M8 1.5l1.2 3.4 3.3 1.2-3.3 1.2L8 10.7 6.8 7.3 3.5 6.1l3.3-1.2L8 1.5zM12.5 10l.6 1.6 1.6.6-1.6.6-.6 1.6-.6-1.6-1.6-.6 1.6-.6.6-1.6z" />
+    </svg>
+  )
+}
+
+function CloseIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="m7 7 10 10M17 7 7 17" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" />
+    </svg>
+  )
+}
+
+export function CronSchedulesPage({
+  host,
+  panelSide = 'left',
+  onRequestClose,
+  conversationId,
+}: { host: Host } & Partial<PageRenderProps>) {
+  const [view, setView] = useState<View>('tasks')
+  const [tasks, setTasks] = useState<SessionCronTask[]>([])
+  const [bindings, setBindings] = useState<SystemCronBinding[]>([])
+  const [functions, setFunctions] = useState<FunctionSummary[]>([])
+  const [tasksLoading, setTasksLoading] = useState(false)
+  const [bindingsLoading, setBindingsLoading] = useState(false)
+  const [tasksError, setTasksError] = useState<string | null>(null)
+  const [bindingsError, setBindingsError] = useState<string | null>(null)
+  const [query, setQuery] = useState('')
+  const [composer, setComposer] = useState('')
+  const [sending, setSending] = useState(false)
+  const [feedback, setFeedback] = useState<Feedback | null>(null)
+  const [inspector, setInspector] = useState<Inspector>(null)
+  const [replacementTask, setReplacementTask] = useState<SessionCronTask | null>(null)
+  const [statusFilter, setStatusFilter] = useState<Filter>('all')
+  const [narrow, setNarrow] = useState(false)
+  const [now, setNow] = useState(() => new Date())
+  /** The schedule session a send is waiting on. `harness::send` resolves only
+      when the whole turn is done, so following its answer would leave the
+      operator on an unrelated chat for the length of a registration.
+      `session::created` fires as soon as the session exists, which is both
+      the moment worth following and the last moment before the turn's first
+      call meets the approval gate. */
+  const awaitedSession = useRef<{ title: string; since: number } | null>(null)
+
+  const instanceId = useRef(++mountSequence)
+  const tasksRequest = useRef(0)
+  const bindingsRequest = useRef(0)
+  const sendRequest = useRef(0)
+  const layoutRef = useRef<HTMLDivElement | null>(null)
+  const inspectorRef = useRef<HTMLElement | null>(null)
+  const lastFocus = useRef<HTMLElement | null>(null)
+  const composerRef = useRef<HTMLInputElement | null>(null)
+  const openConversationRef = useRef<(sessionId: string) => void>(() => {})
+
+  /** A schedule runs in a session of its own, and a session that has never
+      taken a turn inherits no model — so a send has to name one. The operator's
+      last pick is the only defensible source: choosing off the catalogue looks
+      helpful until the guess lands on a model that cannot emit a function call
+      and the whole turn is spent failing to register anything. */
+  const model = resolveModel(host, conversationId)
+
+  const requireModel = (): string | undefined => {
+    if (!model) {
+      setFeedback({
+        tone: 'alert',
+        message: 'No model chosen yet. Pick one in a chat composer, then schedule.',
+      })
+      setSending(false)
+    }
+    return model
+  }
+
+  const openInspector = useCallback((next: Exclude<Inspector, null>) => {
+    lastFocus.current = document.activeElement instanceof HTMLElement ? document.activeElement : null
+    setInspector(next)
+  }, [])
+
+  const closeInspector = useCallback(() => {
+    setInspector(null)
+    const target = lastFocus.current
+    lastFocus.current = null
+    window.requestAnimationFrame(() => {
+      if (target?.isConnected) target.focus()
+    })
+  }, [])
+
+  const refreshTasks = useCallback(async () => {
+    const request = ++tasksRequest.current
+    setTasksLoading(true)
+    try {
+      const next = await listAllSchedules(host, conversationId ?? undefined)
+      if (request !== tasksRequest.current) return
+      setTasks(next)
+      setTasksError(null)
+    } catch (error) {
+      if (request !== tasksRequest.current) return
+      setTasksError(errorMessage(error))
+    } finally {
+      if (request === tasksRequest.current) setTasksLoading(false)
+    }
+  }, [host, conversationId])
+
+  const refreshBindings = useCallback(async () => {
+    const request = ++bindingsRequest.current
+    setBindingsLoading(true)
+    const [bindingsResult, functionsResult] = await Promise.allSettled([
+      listSystemCronBindings(host),
+      listFunctions(host),
+    ])
+    if (request !== bindingsRequest.current) return
+    if (bindingsResult.status === 'fulfilled') {
+      setBindings(bindingsResult.value)
+      setBindingsError(null)
+    } else {
+      setBindingsError(errorMessage(bindingsResult.reason))
+    }
+    if (functionsResult.status === 'fulfilled') setFunctions(functionsResult.value)
+    setBindingsLoading(false)
+  }, [host])
+
+  const refreshAll = useCallback(async () => {
+    await Promise.all([refreshTasks(), refreshBindings()])
+    setNow(new Date())
+  }, [refreshTasks, refreshBindings])
+
+  useEffect(() => {
+    void refreshTasks()
+  }, [refreshTasks])
+
+  useEffect(() => {
+    void refreshBindings()
+  }, [refreshBindings])
+
+  useEffect(() => {
+    // Relative labels move at minute granularity, and a hidden tab moves
+    // nothing anybody can see.
+    const tick = () => {
+      if (!document.hidden) setNow(new Date())
+    }
+    const interval = window.setInterval(tick, 60_000)
+    const onVisible = () => tick()
+    document.addEventListener('visibilitychange', onVisible)
+    return () => {
+      window.clearInterval(interval)
+      document.removeEventListener('visibilitychange', onVisible)
+    }
+  }, [])
+
+  useEffect(() => {
+    const node = layoutRef.current
+    if (!node) return
+    const update = () => setNarrow(node.getBoundingClientRect().width <= 760)
+    update()
+    const observer = new ResizeObserver(update)
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [])
+
+  const inspectorIdentity =
+    inspector?.kind === 'task'
+      ? `task:${inspector.task.subscriptionId}`
+      : inspector?.kind === 'binding'
+        ? `binding:${inspector.binding.id}`
+        : (inspector?.kind ?? '')
+
+  useEffect(() => {
+    if (!narrow || !inspectorIdentity) return
+    const frame = window.requestAnimationFrame(() => {
+      inspectorRef.current
+        ?.querySelector<HTMLElement>('button, input, textarea, [tabindex]:not([tabindex="-1"])')
+        ?.focus()
+    })
+    return () => window.cancelAnimationFrame(frame)
+  }, [narrow, inspectorIdentity])
+
+  useEffect(() => {
+    setInspector((current) => {
+      if (current?.kind === 'task') {
+        const next = tasks.find((task) => task.subscriptionId === current.task.subscriptionId)
+        if (next) return next === current.task ? current : { kind: 'task', task: next }
+        return tasksLoading ? current : null
+      }
+      if (current?.kind === 'binding') {
+        const next = bindings.find((binding) => binding.id === current.binding.id)
+        if (next) return next === current.binding ? current : { kind: 'binding', binding: next }
+        return bindingsLoading ? current : null
+      }
+      return current
+    })
+  }, [tasks, bindings, tasksLoading, bindingsLoading])
+
+  useEffect(
+    () =>
+      subscribe<{ session_id?: string; title?: string; created_at?: number }>(
+        host,
+        `iii::cron_ui_session_created_${instanceId.current}`,
+        'session::created',
+        { metadata: SCHEDULE_SESSION_METADATA },
+        (event) => {
+          const awaited = awaitedSession.current
+          if (!awaited || !event?.session_id) return
+          if (event.title !== awaited.title) return
+          if ((event.created_at ?? 0) < awaited.since) return
+          awaitedSession.current = null
+          void allowScheduleCalls(host, event.session_id)
+          openConversationRef.current(event.session_id)
+        },
+      ),
+    [host],
+  )
+
+  useEffect(() => {
+    // A schedule can be registered from any session, so this listens to all of
+    // them; the doorbell rings twice per change, hence the trailing coalesce.
+    let timer = 0
+    const off = subscribe(
+      host,
+      `iii::cron_ui_triggers_changed_${instanceId.current}`,
+      'harness::triggers-changed',
+      {},
+      () => {
+        window.clearTimeout(timer)
+        timer = window.setTimeout(() => void refreshTasks(), 250)
+      },
+    )
+    return () => {
+      window.clearTimeout(timer)
+      off()
+    }
+  }, [host, refreshTasks])
+
+  const submitNaturalTask = async () => {
+    const taskRequest = composer.trim()
+    if (!taskRequest || sending) return
+    const request = ++sendRequest.current
+    const replacing = replacementTask
+    setSending(true)
+    setFeedback(null)
+    try {
+      const model = requireModel()
+      if (!model) return
+      const instruction = replacing
+        ? replaceSchedulePrompt(replacing.subscriptionId, taskRequest)
+        : createSchedulePrompt(taskRequest)
+
+      if (replacing) {
+        await sendToSession(host, replacing.sessionId, instruction, model)
+        openConversation(replacing.sessionId)
+      } else {
+        const title = taskRequest.slice(0, 72)
+        awaitedSession.current = { title, since: Date.now() }
+        const sessionId = await createSchedule(host, { title, instruction, model })
+        // Usually the subscription got there first; this covers a console too
+        // old to deliver session::created.
+        awaitedSession.current = null
+        openConversation(sessionId)
+      }
+      if (request !== sendRequest.current) return
+      setComposer('')
+      setReplacementTask(null)
+      setFeedback({
+        tone: 'success',
+        message: replacing
+          ? 'Safe replacement request sent. The old task is retired only after the new registration succeeds.'
+          : 'Request sent to Harness. This list updates when the task is registered.',
+      })
+    } catch (error) {
+      if (request !== sendRequest.current) return
+      setFeedback({ tone: 'alert', message: errorMessage(error) })
+    } finally {
+      if (request === sendRequest.current) setSending(false)
+    }
+  }
+
+  const sendManualTask = async (spec: ManualTaskSpec) => {
+    const request = ++sendRequest.current
+    setSending(true)
+    setFeedback(null)
+    try {
+      const registration: Record<string, unknown> = {
+        trigger_type: 'cron',
+        config: { expression: spec.expression },
+        label: spec.label,
+        once: false,
+      }
+      if (spec.maxFires) registration.lifecycle = { max_fires: spec.maxFires }
+      if (spec.delivery === 'call') {
+        registration.function_id = spec.functionId
+        registration.metadata = {
+          payload: spec.payload,
+          event_into: spec.eventInto || '/cron_event',
+        }
+      }
+      const model = requireModel()
+      if (!model) return
+      awaitedSession.current = { title: spec.label, since: Date.now() }
+      const sessionId = await createSchedule(host, {
+        title: spec.label,
+        instruction: manualSchedulePrompt(registration),
+        model,
+      })
+      awaitedSession.current = null
+      openConversation(sessionId)
+      if (request !== sendRequest.current) return
+      closeInspector()
+      setFeedback({
+        tone: 'success',
+        message: 'Registration request sent. Harness will add the task after the active turn completes the call.',
+      })
+    } catch (error) {
+      if (request !== sendRequest.current) return
+      setFeedback({ tone: 'alert', message: errorMessage(error) })
+    } finally {
+      if (request === sendRequest.current) setSending(false)
+    }
+  }
+
+  const requestTaskChange = (task: SessionCronTask) => {
+    if (task.target) {
+      setFeedback({
+        tone: 'warn',
+        message:
+          'Call tasks cannot be replaced safely because Harness does not expose their stored payload template. Remove and recreate this task with the complete call settings.',
+      })
+      return
+    }
+    setView('tasks')
+    setReplacementTask(task)
+    setComposer('')
+    setInspector(null)
+    setFeedback({
+      tone: 'warn',
+      message:
+        'Describe the complete replacement. Harness will retire the old task only after the new registration succeeds.',
+    })
+    window.requestAnimationFrame(() => composerRef.current?.focus())
+  }
+
+  const removeTask = async (task: SessionCronTask) => {
+    try {
+      const removed = await removeSessionCronTask(host, task.sessionId, task.subscriptionId)
+      setFeedback({
+        tone: removed ? 'success' : 'warn',
+        message: removed ? 'Scheduled task removed.' : 'The task was already retired.',
+      })
+      closeInspector()
+      await refreshTasks()
+    } catch (error) {
+      setFeedback({ tone: 'alert', message: errorMessage(error) })
+    }
+  }
+
+  /** Show a schedule's own conversation. Older consoles have no such API, so
+      the page degrades to leaving the workspace alone. */
+  const openConversation = (sessionId: string) => {
+    host.chat?.selectConversation?.(sessionId)
+  }
+  openConversationRef.current = openConversation
+
+  const copyId = async (value: string) => {
+    try {
+      await navigator.clipboard.writeText(value)
+      setFeedback({ tone: 'success', message: 'Subscription id copied.' })
+    } catch {
+      setFeedback({ tone: 'warn', message: 'Could not reach the clipboard.' })
+    }
+  }
+
+  const handleInspectorKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      event.stopPropagation()
+      closeInspector()
+      return
+    }
+    if (!narrow || event.key !== 'Tab' || !inspectorRef.current) return
+    const focusable = [
+      ...inspectorRef.current.querySelectorAll<HTMLElement>(
+        'button, input, textarea, select, [href], [tabindex]:not([tabindex="-1"])',
+      ),
+    ].filter((element) => !element.matches(':disabled') && element.getClientRects().length > 0)
+    if (focusable.length === 0) {
+      event.preventDefault()
+      return
+    }
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault()
+      last.focus()
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault()
+      first.focus()
+    }
+  }
+
+  const counts = countByStatus(tasks, now.getTime())
+  const orderedTasks = useMemo(() => {
+    const runs = new Map(
+      tasks.map((task) => [
+        task.subscriptionId,
+        nextCronRun(task.expression, now)?.getTime() ?? Number.POSITIVE_INFINITY,
+      ]),
+    )
+    return [...tasks]
+      .filter((task) => matchesFilter(task, statusFilter, now.getTime()))
+      .filter((task) => matchesQuery(task, cadenceLabel(task.expression), query))
+      .sort(byNextRun((task) => runs.get(task.subscriptionId) ?? Number.POSITIVE_INFINITY))
+  }, [tasks, statusFilter, query, now])
+
+  const orderedBindings = useMemo(
+    () => bindings.filter((binding) => matchesBindingQuery(binding, query)),
+    [bindings, query],
+  )
+
+  const loading = view === 'tasks' ? tasksLoading : bindingsLoading
+  const error = view === 'tasks' ? tasksError : bindingsError
+  const showDetail = inspector !== null
+  const detailOnly = narrow && showDetail
+
+  const detailBody =
+    inspector === null ? null : inspector.kind === 'new' ? (
+      <ManualTaskForm
+        functions={functions}
+        sending={sending}
+        onClose={closeInspector}
+        onSubmit={(spec) => void sendManualTask(spec)}
+      />
+    ) : inspector.kind === 'task' ? (
+      <TaskDetail
+        key={inspector.task.subscriptionId}
+        task={inspector.task}
+        now={now}
+        onReplace={() => requestTaskChange(inspector.task)}
+        onRemove={() => void removeTask(inspector.task)}
+        onCopyId={() => void copyId(inspector.task.subscriptionId)}
+        onOpenConversation={() => openConversation(inspector.task.sessionId)}
+      />
+    ) : (
+      <BindingDetail binding={inspector.binding} now={now} />
+    )
+
+  const detailScroll = (
+    <section
+      className="cron-ui-detail-scroll"
+      ref={inspectorRef}
+      onKeyDown={handleInspectorKeyDown}
+      aria-label="Schedule details"
+      tabIndex={-1}
+    >
+      {detailBody}
+    </section>
+  )
+
+  return (
+    <PageShell className="cron-ui-shell">
+      <PageHeader
+        icon={<ClockIcon />}
+        title="Cron"
+        description="Schedules and system bindings."
+        actions={
+          <div className="cron-ui-header-actions">
+            <div className="cron-ui-search">
+              <SearchIcon className={uiClasses.icon} />
+              <Input
+                type="search"
+                value={query}
+                onChange={setQuery}
+                placeholder="Search schedules"
+                aria-label="Search schedules"
+                autoComplete="off"
+                spellCheck={false}
+              />
+            </div>
+            <IconButton
+              label="Refresh schedules"
+              onClick={() => void refreshAll()}
+              disabled={tasksLoading || bindingsLoading}
+            >
+              <RefreshIcon className={loading ? `${uiClasses.icon} cron-ui-spin` : uiClasses.icon} />
+            </IconButton>
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={() => {
+                setView('tasks')
+                setReplacementTask(null)
+                openInspector({ kind: 'new' })
+              }}
+            >
+              <PlusIcon />
+              New schedule
+            </Button>
+          </div>
+        }
+        onClose={onRequestClose}
+      />
+      <PageBody side={panelSide}>
+        <PageMain className="cron-ui-main">
+          {detailOnly ? (
+            <section className="cron-ui-detail-page" aria-label="Schedule details">
+              <div className="cron-ui-detail-bar">
+                <Button variant="ghost" size="sm" onClick={closeInspector}>
+                  <ChevronIcon className={`${uiClasses.icon} cron-ui-back`} />
+                  All schedules
+                </Button>
+              </div>
+              {detailScroll}
+            </section>
+          ) : (
+            <div className="cron-ui-content" ref={layoutRef}>
+              <form
+                className="cron-ui-composer"
+                onSubmit={(event) => {
+                  event.preventDefault()
+                  void submitNaturalTask()
+                }}
+              >
+                <SparkIcon className={`${uiClasses.icon} cron-ui-composer-icon`} />
+                <Input
+                  ref={composerRef}
+                  value={composer}
+                  onChange={setComposer}
+                  placeholder={
+                    replacementTask
+                      ? `Describe the replacement for ${replacementTask.label ?? 'this schedule'}…`
+                      : 'Describe a routine to schedule…'
+                  }
+                  aria-label="Describe a routine to schedule"
+                  disabled={sending || !model}
+                />
+                <Button
+                  type="submit"
+                  variant="primary"
+                  size="sm"
+                  disabled={sending || !model || composer.trim().length === 0}
+                >
+                  {sending ? 'Scheduling…' : 'Schedule'}
+                </Button>
+              </form>
+
+              {feedback ? <StatusPanel variant={feedback.tone} headline={feedback.message} /> : null}
+
+              {model ? null : (
+                <StatusPanel
+                  variant="info"
+                  headline="Choose a model before scheduling"
+                  detail="Each schedule runs in a session of its own, which needs a model named up front. Pick one in a chat composer and it is used here too."
+                />
+              )}
+
+              <Tabs value={view} onValueChange={(value) => setView(value as View)}>
+                <div className="cron-ui-toolbar">
+                  <TabsList>
+                    <TabsTrigger value="tasks">
+                      Schedules
+                      <span className="cron-ui-count">{tasks.length}</span>
+                    </TabsTrigger>
+                    <TabsTrigger value="bindings">
+                      System bindings
+                      <span className="cron-ui-count">{bindings.length}</span>
+                    </TabsTrigger>
+                  </TabsList>
+                  {view === 'tasks' ? (
+                    <SegmentedControl
+                      aria-label="Filter by status"
+                      value={statusFilter}
+                      onChange={setStatusFilter}
+                      options={[
+                        { value: 'all', label: `All ${counts.all}`, icon: false },
+                        { value: 'active', label: `Active ${counts.active}`, icon: false },
+                        { value: 'ending', label: `Ending soon ${counts.ending}`, icon: false },
+                        { value: 'finished', label: `Finished ${counts.finished}`, icon: false },
+                      ]}
+                    />
+                  ) : null}
+                </div>
+
+                <TabsContent value="tasks" className="cron-ui-tab-content">
+                  {error ? <StatusPanel variant="alert" headline="Could not read schedules" detail={error} /> : null}
+                  {loading && orderedTasks.length === 0 ? (
+                    <div className="cron-ui-skeletons">
+                      <Skeleton className="cron-ui-skeleton" />
+                      <Skeleton className="cron-ui-skeleton" />
+                      <Skeleton className="cron-ui-skeleton" />
+                    </div>
+                  ) : orderedTasks.length === 0 ? (
+                    <EmptyState
+                      icon={ClockIcon}
+                      title={tasks.length === 0 ? 'No schedules yet' : 'Nothing matches'}
+                      description={
+                        tasks.length === 0
+                          ? 'Describe a routine above, or write the cron expression yourself.'
+                          : 'Change the filter or clear the search to see the rest.'
+                      }
+                      action={
+                        tasks.length === 0
+                          ? {
+                              label: 'New schedule',
+                              onClick: () => {
+                                setReplacementTask(null)
+                                openInspector({ kind: 'new' })
+                              },
+                            }
+                          : undefined
+                      }
+                    />
+                  ) : narrow ? (
+                    <List>
+                      {orderedTasks.map((task) => (
+                        <TaskListRow
+                          key={task.subscriptionId}
+                          task={task}
+                          now={now}
+                          selected={inspector?.kind === 'task' && inspector.task.subscriptionId === task.subscriptionId}
+                          onOpen={() => openInspector({ kind: 'task', task })}
+                        />
+                      ))}
+                    </List>
+                  ) : (
+                    <TableViewport>
+                      <TableFrame>
+                        <Table>
+                          <TableHeader>
+                            <TableRow>
+                              <TableHead>Status</TableHead>
+                              <TableHead>Schedule</TableHead>
+                              <TableHead>Target</TableHead>
+                              <TableHead>Cadence</TableHead>
+                              <TableHead>Next run</TableHead>
+                              <TableHead className="cron-ui-cell-numeric">Runs</TableHead>
+                              <TableHead className="cron-ui-cell-actions">
+                                <span className="cron-ui-sr">Actions</span>
+                              </TableHead>
+                            </TableRow>
+                          </TableHeader>
+                          <TableBody>
+                            {orderedTasks.map((task) => (
+                              <TaskRow
+                                key={task.subscriptionId}
+                                task={task}
+                                now={now}
+                                selected={
+                                  inspector?.kind === 'task' && inspector.task.subscriptionId === task.subscriptionId
+                                }
+                                onOpen={() => openInspector({ kind: 'task', task })}
+                                onReplace={() => requestTaskChange(task)}
+                                onRemove={() => void removeTask(task)}
+                                onCopyId={() => void copyId(task.subscriptionId)}
+                                onOpenConversation={() => openConversation(task.sessionId)}
+                              />
+                            ))}
+                          </TableBody>
+                        </Table>
+                      </TableFrame>
+                    </TableViewport>
+                  )}
+                </TabsContent>
+
+                <TabsContent value="bindings" className="cron-ui-tab-content">
+                  {bindingsError ? (
+                    <StatusPanel variant="alert" headline="Could not read system bindings" detail={bindingsError} />
+                  ) : null}
+                  {orderedBindings.length === 0 ? (
+                    <EmptyState
+                      icon={ClockIcon}
+                      title="No system bindings"
+                      description="Workers that schedule their own functions appear here."
+                    />
+                  ) : narrow ? (
+                    <List>
+                      {orderedBindings.map((binding) => (
+                        <BindingListRow
+                          key={binding.id}
+                          binding={binding}
+                          now={now}
+                          selected={inspector?.kind === 'binding' && inspector.binding.id === binding.id}
+                          onOpen={() => openInspector({ kind: 'binding', binding })}
+                        />
+                      ))}
+                    </List>
+                  ) : (
+                    <TableViewport>
+                      <TableFrame>
+                        <Table>
+                          <TableHeader>
+                            <TableRow>
+                              <TableHead>Status</TableHead>
+                              <TableHead>Owner</TableHead>
+                              <TableHead>Function</TableHead>
+                              <TableHead>Cadence</TableHead>
+                              <TableHead>Next run</TableHead>
+                              <TableHead className="cron-ui-cell-numeric">Runs</TableHead>
+                              <TableHead className="cron-ui-cell-actions">
+                                <span className="cron-ui-sr">Actions</span>
+                              </TableHead>
+                            </TableRow>
+                          </TableHeader>
+                          <TableBody>
+                            {orderedBindings.map((binding) => (
+                              <BindingRow
+                                key={binding.id}
+                                binding={binding}
+                                now={now}
+                                selected={inspector?.kind === 'binding' && inspector.binding.id === binding.id}
+                                onOpen={() => openInspector({ kind: 'binding', binding })}
+                              />
+                            ))}
+                          </TableBody>
+                        </Table>
+                      </TableFrame>
+                    </TableViewport>
+                  )}
+                </TabsContent>
+              </Tabs>
+            </div>
+          )}
+        </PageMain>
+        {showDetail && !narrow ? (
+          <PageSidebar width={380} aria-label="Schedule details">
+            <div className="cron-ui-detail-bar">
+              <span className="cron-ui-detail-eyebrow">
+                {inspector?.kind === 'new'
+                  ? 'New schedule'
+                  : inspector?.kind === 'task'
+                    ? 'Schedule'
+                    : 'System binding'}
+              </span>
+              <IconButton label="Close details" onClick={closeInspector}>
+                <CloseIcon className={uiClasses.icon} />
+              </IconButton>
+            </div>
+            {detailScroll}
+          </PageSidebar>
+        ) : null}
+      </PageBody>
+    </PageShell>
+  )
+}

--- a/cron/ui/src/page/manual-form.tsx
+++ b/cron/ui/src/page/manual-form.tsx
@@ -1,0 +1,257 @@
+import { Button, CodeEditor, Input, Select, Selector, StatusPanel } from '@iii-dev/console-ui'
+import { useMemo, useState } from 'react'
+import { Field, TextArea } from '../components'
+import type { FunctionSummary } from '../lib/api'
+import { describeCron, nextCronRun, validateCron } from '../lib/cron'
+
+export interface ManualTaskSpec {
+  label: string
+  expression: string
+  delivery: 'notify' | 'call'
+  functionId?: string
+  payload?: unknown
+  eventInto?: string
+  maxFires?: number
+}
+
+const PRESETS = [
+  { value: 'hourly', label: 'Every hour', expression: '0 0 * * * *' },
+  { value: 'daily', label: 'Daily at 09:00 UTC', expression: '0 0 9 * * *' },
+  { value: 'weekdays', label: 'Weekdays at 09:00 UTC', expression: '0 0 9 * * 2-6' },
+  { value: 'weekly', label: 'Mondays at 09:00 UTC', expression: '0 0 9 * * 2' },
+  { value: 'custom', label: 'Custom expression', expression: '' },
+] as const
+
+export function ManualTaskForm({
+  functions,
+  sending,
+  onClose,
+  onSubmit,
+}: {
+  functions: FunctionSummary[]
+  sending: boolean
+  onClose: () => void
+  onSubmit: (spec: ManualTaskSpec) => void
+}) {
+  const [label, setLabel] = useState('')
+  const [preset, setPreset] = useState('daily')
+  const [expression, setExpression] = useState('0 0 9 * * *')
+  const [delivery, setDelivery] = useState<'notify' | 'call'>('notify')
+  const [functionId, setFunctionId] = useState<string | undefined>()
+  const [payloadText, setPayloadText] = useState('{}')
+  const [eventInto, setEventInto] = useState('/cron_event')
+  const [maxFires, setMaxFires] = useState('')
+  const [formError, setFormError] = useState<string | null>(null)
+
+  /** What this expression actually means, before it is registered: the plain
+      reading, then the next few literal times. A six-field slip usually looks
+      right and only reveals itself at the first fire. */
+  const expressionError = validateCron(expression)
+  const cadence = expressionError ? null : describeCron(expression)
+  const upcoming = useMemo(() => {
+    if (expressionError) return []
+    const times: string[] = []
+    let cursor = new Date()
+    for (let index = 0; index < 3; index += 1) {
+      const next = nextCronRun(expression, cursor)
+      if (!next) break
+      times.push(`${next.toISOString().slice(0, 16).replace('T', ' ')} UTC`)
+      cursor = next
+    }
+    return times
+  }, [expression, expressionError])
+
+  // Grouped by owning worker, because the catalog is every function on the bus.
+  const functionGroups = useMemo(() => {
+    const byWorker = new Map<string, { value: string; label: string; description?: string }[]>()
+    for (const fn of functions) {
+      const worker = fn.functionId.split('::')[0] ?? 'other'
+      const options = byWorker.get(worker) ?? []
+      options.push({
+        value: fn.functionId,
+        label: fn.functionId,
+        description: fn.description,
+      })
+      byWorker.set(worker, options)
+    }
+    return [...byWorker.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([label, options]) => ({ label, options }))
+  }, [functions])
+
+  const submit = () => {
+    if (!label.trim()) {
+      setFormError('Describe what the task should do.')
+      return
+    }
+    const cronError = validateCron(expression)
+    if (cronError) {
+      setFormError(cronError)
+      return
+    }
+    if (delivery === 'call' && !functionId) {
+      setFormError('Choose the function that should receive each cron event.')
+      return
+    }
+    let payload: unknown
+    if (delivery === 'call') {
+      try {
+        payload = JSON.parse(payloadText)
+      } catch {
+        setFormError('Fixed payload must be valid JSON.')
+        return
+      }
+    }
+    const max = maxFires.trim() ? Number(maxFires) : undefined
+    if (max !== undefined && (!Number.isInteger(max) || max < 1)) {
+      setFormError('Maximum runs must be a positive whole number.')
+      return
+    }
+    setFormError(null)
+    onSubmit({
+      label: label.trim(),
+      expression: expression.trim(),
+      delivery,
+      functionId,
+      payload,
+      eventInto: eventInto.trim(),
+      maxFires: max,
+    })
+  }
+
+  return (
+    <div className="cron-ui-inspector-inner cron-ui-form-panel">
+      <header className="cron-ui-detail-head">
+        <h2 className="cron-ui-detail-title">New schedule</h2>
+      </header>
+      <p className="cron-ui-inspector-copy">
+        The active agent registers the task so Harness can persist ownership, lifecycle, and fire count.
+      </p>
+
+      <Field label="Task" htmlFor="cron-task-label">
+        <TextArea
+          id="cron-task-label"
+          value={label}
+          onChange={setLabel}
+          placeholder="Prepare a daily brief of open work"
+        />
+      </Field>
+
+      <Field label="Schedule">
+        <Select
+          value={preset}
+          options={PRESETS.map((item) => ({ value: item.value, label: item.label }))}
+          onChange={(value) => {
+            setPreset(value)
+            const selected = PRESETS.find((item) => item.value === value)
+            if (selected?.expression) setExpression(selected.expression)
+          }}
+          aria-label="Schedule preset"
+        />
+      </Field>
+
+      <Field
+        label="Cron expression"
+        htmlFor="cron-task-expression"
+        hint={
+          expressionError ?? (
+            <>
+              second minute hour day month weekday, optional year. Times are UTC.
+              {upcoming.length > 0 ? (
+                <>
+                  {' '}
+                  {cadence ? `${cadence}. ` : ''}
+                  Next: {upcoming.join(', ')}.
+                </>
+              ) : null}
+            </>
+          )
+        }
+      >
+        <Input
+          id="cron-task-expression"
+          value={expression}
+          onChange={(value) => {
+            setExpression(value)
+            setPreset('custom')
+          }}
+          placeholder="0 0 9 * * *"
+        />
+      </Field>
+
+      <Field
+        label="Delivery"
+        hint="A conversation wake lets an agent perform the routine. Function calls run mechanically without starting an agent."
+      >
+        <Select
+          value={delivery}
+          options={[
+            { value: 'notify', label: 'Wake a conversation' },
+            { value: 'call', label: 'Call a function' },
+          ]}
+          onChange={(value) => setDelivery(value)}
+          aria-label="Task delivery"
+        />
+      </Field>
+
+      {delivery === 'call' ? (
+        <>
+          <Field label="Target function">
+            <Selector
+              value={functionId}
+              groups={functionGroups}
+              onChange={setFunctionId}
+              placeholder="Choose a function"
+              searchPlaceholder="Search functions"
+              emptyMessage="No function matches"
+              aria-label="Target function"
+            />
+          </Field>
+          <Field
+            label="Event JSON pointer"
+            htmlFor="cron-task-event-path"
+            hint="Where the fire event is written inside the payload."
+          >
+            <Input id="cron-task-event-path" value={eventInto} onChange={setEventInto} placeholder="/cron_event" />
+          </Field>
+          <Field label="Fixed payload" className="cron-ui-editor-field">
+            <CodeEditor
+              value={payloadText}
+              onChange={setPayloadText}
+              language="json"
+              className="cron-ui-code-editor"
+              aria-label="Fixed target payload"
+            />
+          </Field>
+        </>
+      ) : null}
+
+      <Field
+        label="Maximum runs"
+        htmlFor="cron-task-max-runs"
+        hint="Leave empty for a recurring task that runs until removed."
+      >
+        <Input
+          id="cron-task-max-runs"
+          type="number"
+          min={1}
+          step={1}
+          value={maxFires}
+          onChange={setMaxFires}
+          placeholder="unbounded"
+        />
+      </Field>
+
+      {formError ? <StatusPanel variant="alert" headline={formError} /> : null}
+
+      <div className="cron-ui-form-actions">
+        <Button variant="ghost" size="sm" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button variant="primary" size="sm" disabled={sending} onClick={submit}>
+          {sending ? 'Creating…' : 'Create schedule'}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/cron/ui/src/page/rows.tsx
+++ b/cron/ui/src/page/rows.tsx
@@ -1,0 +1,189 @@
+import {
+  Badge,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  IconButton,
+  ListItem,
+  StatusDot,
+  TableCell,
+  TableRow,
+  uiClasses,
+} from '@iii-dev/console-ui'
+import type { SessionCronTask, SystemCronBinding } from '../lib/api'
+import { describeCron, nextCronRun, untilLabel } from '../lib/cron'
+import { statusView } from './status'
+
+export function MoreIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 16 16" className={className} aria-hidden="true" fill="currentColor">
+      <circle cx="8" cy="3.5" r="1.25" />
+      <circle cx="8" cy="8" r="1.25" />
+      <circle cx="8" cy="12.5" r="1.25" />
+    </svg>
+  )
+}
+
+/** A wake has no target function: the fire notifies the session that owns the
+    schedule, which for anything created here is a session of its own. */
+export function targetLabel(task: SessionCronTask): string {
+  return task.target ?? (task.sessionTitle ? `wakes ${task.sessionTitle}` : 'wakes its session')
+}
+
+const cadenceCache = new Map<string, string>()
+
+export function cadenceLabel(expression: string): string {
+  const cached = cadenceCache.get(expression)
+  if (cached !== undefined) return cached
+  const label = describeCron(expression) ?? expression
+  cadenceCache.set(expression, label)
+  return label
+}
+
+function nextRunLabel(expression: string, now: Date): string {
+  const next = nextCronRun(expression, now)
+  return next ? untilLabel(next, now) : 'unknown'
+}
+
+function runsLabel(task: SessionCronTask): string {
+  const cap = task.once ? 1 : task.maxFires
+  return cap === undefined ? `${task.fires}` : `${task.fires} / ${cap}`
+}
+
+export function TaskRow({
+  task,
+  now,
+  selected,
+  onOpen,
+  onReplace,
+  onRemove,
+  onCopyId,
+  onOpenConversation,
+}: {
+  task: SessionCronTask
+  now: Date
+  selected: boolean
+  onOpen: () => void
+  onReplace: () => void
+  onRemove: () => void
+  onCopyId: () => void
+  onOpenConversation: () => void
+}) {
+  const view = statusView(task, now.getTime())
+  return (
+    <TableRow interactive selected={selected} aria-current={selected ? 'true' : undefined} onClick={onOpen}>
+      <TableCell>
+        <span className="cron-ui-status">
+          <StatusDot tone={view.tone} aria-hidden />
+          <span>{view.label}</span>
+        </span>
+      </TableCell>
+      <TableCell className="cron-ui-cell-strong">{task.label ?? 'Untitled schedule'}</TableCell>
+      <TableCell>
+        <Badge className="cron-ui-target">{targetLabel(task)}</Badge>
+      </TableCell>
+      <TableCell>{cadenceLabel(task.expression)}</TableCell>
+      <TableCell>{nextRunLabel(task.expression, now)}</TableCell>
+      <TableCell className="cron-ui-cell-numeric">{runsLabel(task)}</TableCell>
+      <TableCell className="cron-ui-cell-actions">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <IconButton
+              label={`Actions for ${task.label ?? task.subscriptionId}`}
+              onClick={(event: React.MouseEvent) => event.stopPropagation()}
+            >
+              <MoreIcon className={uiClasses.icon} />
+            </IconButton>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onSelect={onOpen}>Open details</DropdownMenuItem>
+            <DropdownMenuItem onSelect={onOpenConversation}>Open conversation</DropdownMenuItem>
+            <DropdownMenuItem onSelect={onReplace}>Replace…</DropdownMenuItem>
+            <DropdownMenuItem onSelect={onCopyId}>Copy subscription id</DropdownMenuItem>
+            <DropdownMenuItem onSelect={onRemove}>Unregister</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </TableCell>
+    </TableRow>
+  )
+}
+
+export function BindingRow({
+  binding,
+  now,
+  selected,
+  onOpen,
+}: {
+  binding: SystemCronBinding
+  now: Date
+  selected: boolean
+  onOpen: () => void
+}) {
+  return (
+    <TableRow interactive selected={selected} aria-current={selected ? 'true' : undefined} onClick={onOpen}>
+      <TableCell>
+        <span className="cron-ui-status">
+          <StatusDot tone="accent" aria-hidden />
+          <span>Active</span>
+        </span>
+      </TableCell>
+      <TableCell className="cron-ui-cell-strong">{binding.workerName}</TableCell>
+      <TableCell>
+        <Badge className="cron-ui-target">{binding.functionId}</Badge>
+      </TableCell>
+      <TableCell>{cadenceLabel(binding.expression)}</TableCell>
+      <TableCell>{nextRunLabel(binding.expression, now)}</TableCell>
+      <TableCell className="cron-ui-cell-numeric">—</TableCell>
+      <TableCell className="cron-ui-cell-actions" />
+    </TableRow>
+  )
+}
+
+/** Narrow panes get a list, not a squeezed table: the name stays readable and
+    the rest collapses into one supporting line. */
+export function TaskListRow({
+  task,
+  now,
+  selected,
+  onOpen,
+}: {
+  task: SessionCronTask
+  now: Date
+  selected: boolean
+  onOpen: () => void
+}) {
+  const view = statusView(task, now.getTime())
+  return (
+    <ListItem
+      selected={selected}
+      onClick={onOpen}
+      leading={<StatusDot tone={view.tone} aria-hidden />}
+      label={task.label ?? 'Untitled schedule'}
+      description={`${cadenceLabel(task.expression)} · ${nextRunLabel(task.expression, now)}`}
+      trailing={<span className="cron-ui-list-meta">{runsLabel(task)}</span>}
+    />
+  )
+}
+
+export function BindingListRow({
+  binding,
+  now,
+  selected,
+  onOpen,
+}: {
+  binding: SystemCronBinding
+  now: Date
+  selected: boolean
+  onOpen: () => void
+}) {
+  return (
+    <ListItem
+      selected={selected}
+      onClick={onOpen}
+      leading={<StatusDot tone="accent" aria-hidden />}
+      label={binding.functionId}
+      description={`${binding.workerName} · ${cadenceLabel(binding.expression)} · ${nextRunLabel(binding.expression, now)}`}
+    />
+  )
+}

--- a/cron/ui/src/page/status.ts
+++ b/cron/ui/src/page/status.ts
@@ -1,0 +1,82 @@
+import type { SessionCronTask, SystemCronBinding } from '../lib/api'
+
+/** What a schedule is doing, from the only facts a subscription carries:
+    its fire count, its cap, and its expiry. There is no paused state in the
+    harness surface and no per-fire outcome, so neither is invented here. */
+export type TaskStatus = 'active' | 'ending' | 'finished'
+
+export interface StatusView {
+  status: TaskStatus
+  label: string
+  tone: 'accent' | 'warn' | 'ink'
+}
+
+/** A schedule about to stop deserves warning before it goes quiet: inside a
+    day of expiry, or one fire from its cap. */
+const ENDING_SOON_MS = 24 * 60 * 60 * 1000
+
+export function taskStatus(task: SessionCronTask, now: number): TaskStatus {
+  const capped = task.once || task.maxFires !== undefined
+  const cap = task.once ? 1 : task.maxFires
+  if (cap !== undefined && task.fires >= cap) return 'finished'
+  if (task.expiresAt !== undefined && task.expiresAt <= now) return 'finished'
+  if (task.expiresAt !== undefined && task.expiresAt - now <= ENDING_SOON_MS) {
+    return 'ending'
+  }
+  if (capped && cap !== undefined && task.fires >= cap - 1) return 'ending'
+  return 'active'
+}
+
+export function statusView(task: SessionCronTask, now: number): StatusView {
+  const status = taskStatus(task, now)
+  if (status === 'finished') return { status, label: 'Finished', tone: 'ink' }
+  if (status === 'ending') return { status, label: 'Ending soon', tone: 'warn' }
+  return { status, label: 'Active', tone: 'accent' }
+}
+
+export type Filter = 'all' | TaskStatus
+
+export function countByStatus(tasks: readonly SessionCronTask[], now: number): Record<Filter, number> {
+  const counts: Record<Filter, number> = {
+    all: tasks.length,
+    active: 0,
+    ending: 0,
+    finished: 0,
+  }
+  for (const task of tasks) counts[taskStatus(task, now)] += 1
+  return counts
+}
+
+export function matchesFilter(task: SessionCronTask, filter: Filter, now: number): boolean {
+  return filter === 'all' || taskStatus(task, now) === filter
+}
+
+/** Free-text match over what an operator can actually read in the row. */
+export function matchesQuery(task: SessionCronTask, cadence: string, query: string): boolean {
+  const needle = query.trim().toLowerCase()
+  if (!needle) return true
+  return [task.label, task.target, task.expression, cadence, task.subscriptionId].some((value) =>
+    (value ?? '').toLowerCase().includes(needle),
+  )
+}
+
+/** The same contract for the bindings tab: every field the row shows. */
+export function matchesBindingQuery(binding: SystemCronBinding, query: string): boolean {
+  const needle = query.trim().toLowerCase()
+  if (!needle) return true
+  return [binding.functionId, binding.workerName, binding.expression, binding.id].some((value) =>
+    value.toLowerCase().includes(needle),
+  )
+}
+
+/** Soonest next run first; a schedule with no computable next run sinks.
+    Takes the run times already computed for the list, because parsing an
+    expression inside a comparator repeats that work log n times per row. */
+export function byNextRun(next: (task: SessionCronTask) => number): (a: SessionCronTask, b: SessionCronTask) => number {
+  return (a, b) => {
+    const left = next(a)
+    const right = next(b)
+    if (left !== right) return left - right
+    return b.createdAt - a.createdAt
+  }
+}

--- a/cron/ui/styles.css
+++ b/cron/ui/styles.css
@@ -1,0 +1,400 @@
+/* Cron console UI. Every selector is scoped to the worker wrapper, every
+   colour comes from a Console token, and layout is the only thing this file
+   owns — the shared primitives carry the rest. */
+
+[data-iii-ui='cron'] .cron-ui-shell {
+  min-width: 0;
+  min-height: 0;
+}
+
+[data-iii-ui='cron'] .cron-ui-sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+/* ── header ─────────────────────────────────────────────────────────── */
+
+[data-iii-ui='cron'] .cron-ui-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+/* The glyph sits inside the field: the shared Input keeps its own surface,
+   focus ring and disabled treatment, and this only makes room for the icon. */
+[data-iii-ui='cron'] .cron-ui-search {
+  position: relative;
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  width: 220px;
+}
+
+[data-iii-ui='cron'] .cron-ui-search > svg {
+  position: absolute;
+  left: 10px;
+  color: var(--color-ink-ghost);
+  pointer-events: none;
+}
+
+[data-iii-ui='cron'] .cron-ui-search input {
+  padding-left: 32px;
+}
+
+[data-iii-ui='cron'] .cron-ui-search input::-webkit-search-cancel-button {
+  appearance: none;
+}
+
+@media (max-width: 640px) {
+  [data-iii-ui='cron'] .cron-ui-search {
+    display: none;
+  }
+}
+
+[data-iii-ui='cron'] .cron-ui-spin {
+  animation: cron-ui-spin 900ms linear infinite;
+}
+
+@keyframes cron-ui-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-iii-ui='cron'] .cron-ui-spin {
+    animation: none;
+  }
+}
+
+/* ── main column ────────────────────────────────────────────────────── */
+
+[data-iii-ui='cron'] .cron-ui-main {
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+[data-iii-ui='cron'] .cron-ui-content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+  min-height: 0;
+  padding: 16px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  flex: 1;
+}
+
+[data-iii-ui='cron'] .cron-ui-composer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-edge);
+  min-width: 0;
+}
+
+[data-iii-ui='cron'] .cron-ui-composer-icon {
+  color: var(--color-accent);
+}
+
+[data-iii-ui='cron'] .cron-ui-composer input {
+  flex: 1;
+  min-width: 0;
+  background: transparent;
+  border: none;
+}
+
+[data-iii-ui='cron'] .cron-ui-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+[data-iii-ui='cron'] .cron-ui-count {
+  margin-inline-start: 6px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-ink-faint);
+}
+
+[data-iii-ui='cron'] .cron-ui-tab-content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+  min-height: 0;
+  padding-top: 12px;
+}
+
+/* ── table ──────────────────────────────────────────────────────────── */
+
+[data-iii-ui='cron'] .cron-ui-cell-strong {
+  color: var(--color-ink);
+  font-weight: 500;
+}
+
+[data-iii-ui='cron'] .cron-ui-cell-numeric {
+  text-align: end;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+[data-iii-ui='cron'] .cron-ui-cell-actions {
+  width: 44px;
+  text-align: end;
+}
+
+[data-iii-ui='cron'] .cron-ui-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+
+[data-iii-ui='cron'] .cron-ui-target {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  max-width: 22ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+[data-iii-ui='cron'] .cron-ui-skeletons {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+[data-iii-ui='cron'] .cron-ui-skeleton {
+  height: 44px;
+  border-radius: 6px;
+}
+
+/* ── detail ─────────────────────────────────────────────────────────── */
+
+[data-iii-ui='cron'] .cron-ui-detail-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 12px;
+  border-block-end: 1px solid var(--color-edge);
+  min-height: 44px;
+}
+
+[data-iii-ui='cron'] .cron-ui-detail-eyebrow {
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-ink-faint);
+}
+
+[data-iii-ui='cron'] .cron-ui-detail-scroll {
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  flex: 1;
+}
+
+[data-iii-ui='cron'] .cron-ui-detail-page {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  flex: 1;
+}
+
+[data-iii-ui='cron'] .cron-ui-back {
+  transform: rotate(90deg);
+}
+
+[data-iii-ui='cron'] .cron-ui-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px;
+  min-width: 0;
+}
+
+[data-iii-ui='cron'] .cron-ui-detail-head {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+[data-iii-ui='cron'] .cron-ui-detail-title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--color-ink);
+  overflow-wrap: anywhere;
+}
+
+[data-iii-ui='cron'] .cron-ui-detail-subtitle {
+  margin: 0 0 6px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-ink-faint);
+}
+
+[data-iii-ui='cron'] .cron-ui-fields {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 10px;
+  margin: 0;
+}
+
+[data-iii-ui='cron'] .cron-ui-detail-row {
+  display: grid;
+  grid-template-columns: 96px minmax(0, 1fr);
+  gap: 10px;
+  align-items: start;
+}
+
+[data-iii-ui='cron'] .cron-ui-detail-row-label {
+  font-size: 12px;
+  color: var(--color-ink-faint);
+}
+
+[data-iii-ui='cron'] .cron-ui-detail-row-value {
+  margin: 0;
+  font-size: 13px;
+  color: var(--color-ink);
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+[data-iii-ui='cron'] .cron-ui-detail-row-value.mono {
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+[data-iii-ui='cron'] .cron-ui-detail-section {
+  min-width: 0;
+}
+
+[data-iii-ui='cron'] .cron-ui-detail-actions,
+[data-iii-ui='cron'] .cron-ui-form-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+[data-iii-ui='cron'] .cron-ui-detail-note {
+  margin: 0;
+  font-size: 12px;
+  color: var(--color-ink-faint);
+  max-width: 68ch;
+}
+
+/* ── manual form ────────────────────────────────────────────────────── */
+
+[data-iii-ui='cron'] .cron-ui-inspector-inner {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  min-width: 0;
+}
+
+[data-iii-ui='cron'] .cron-ui-inspector-copy {
+  margin: 0;
+  font-size: 12px;
+  color: var(--color-ink-faint);
+  max-width: 68ch;
+}
+
+[data-iii-ui='cron'] .cron-ui-textarea {
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 76px;
+  padding: 8px 12px;
+  border: 1px solid transparent;
+  border-radius: 2px;
+  background: var(--color-surface);
+  color: var(--color-ink);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  line-height: 1.5;
+  resize: vertical;
+  transition:
+    border-color var(--motion-duration-control, 120ms),
+    background-color var(--motion-duration-control, 120ms);
+}
+
+[data-iii-ui='cron'] .cron-ui-textarea::placeholder {
+  color: var(--color-ink-ghost);
+}
+
+[data-iii-ui='cron'] .cron-ui-textarea:hover {
+  background: var(--color-surface-hover);
+}
+
+[data-iii-ui='cron'] .cron-ui-textarea:focus {
+  outline: none;
+  border-color: var(--color-rule-focus);
+}
+
+@media (max-width: 640px) {
+  [data-iii-ui='cron'] .cron-ui-content {
+    padding: 12px;
+  }
+
+  [data-iii-ui='cron'] .cron-ui-detail {
+    padding: 12px;
+  }
+
+  [data-iii-ui='cron'] .cron-ui-detail-row {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 2px;
+  }
+}
+
+/* The list rows a narrow pane falls back to: the schedule name stays the
+   primary line and the count sits quietly at the end. */
+[data-iii-ui='cron'] .cron-ui-list-meta {
+  font-family: var(--font-mono);
+  white-space: nowrap;
+}
+
+/* Forms: one column of shared fields, sized for reading rather than for the
+   full width of a wide pane. The inspector column already supplies the
+   padding and stacking. */
+[data-iii-ui='cron'] .cron-ui-form-panel,
+[data-iii-ui='cron'] .cron-ui-form {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 14px;
+  max-width: 560px;
+}
+
+[data-iii-ui='cron'] .cron-ui-form-caption {
+  color: var(--color-ink-ghost);
+  font-size: 11px;
+}
+
+[data-iii-ui='cron'] .cron-ui-editor-field .cron-ui-code-editor {
+  min-height: 132px;
+  border: 1px solid var(--color-rule);
+  border-radius: 2px;
+}

--- a/cron/ui/tsconfig.json
+++ b/cron/ui/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": []
+  },
+  "include": ["page.tsx", "src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -291,6 +291,22 @@ importers:
         specifier: ^5.9.2
         version: 5.9.3
 
+  cron/ui:
+    dependencies:
+      '@iii-dev/console-ui':
+        specifier: workspace:*
+        version: link:../../packages/console-ui
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.17
+      esbuild:
+        specifier: ^0.25.0
+        version: 0.25.12
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.3
+
   database/ui:
     dependencies:
       '@iii-dev/console-ui':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,6 +25,7 @@ packages:
   - pdf/ui
   - state/ui
   - storage/ui
+  - cron/ui
   - shell/ui
   - worktree/ui
   - github/ui


### PR DESCRIPTION
## Why

The cron worker's schedules page (MOT-4503) was reviewed and merged as #840, but into `feat/console-consistency`, not `main`. The page is not on main. This PR brings it to main.

The original squash commit could not be cherry-picked: it predated main's SDK 0.23 migration (#604) and the `onConversationRequested` / `registerTranscriptRenderer` additions, so replaying it would have reverted those. Instead the cron worker's own additions are rebuilt on current main. The console-side plumbing the page relies on (`onConversationRequested`, `selectConversation`, `composerModel`, the transcript renderer registration) is already on main, so this PR touches only `cron/` and the pnpm workspace.

## What

- The `cron` worker gains an injectable console UI: a schedules page (list, detail, manual form) plus a configuration form, registered through `crates/console-ui` (`iii-console-ui`) and the `@iii-dev/console-ui` shared package, following the same pattern as the shell and state pages. `cron/ui` is added to the pnpm workspace; the bundle is built by `build.rs` and embedded in the binary.
- `cron` is bumped to the current SDK: `iii-sdk = 0.23.0-rc.2`, with the trigger-registration call sites moved to `RegisterTriggerInput::new(...)` and `TriggerConfig` gaining the new `namespace` field. Worker version 0.21.5 → 0.22.0.

No `console/`, `packages/`, or `harness/` changes: the console contracts this page needs already exist on main. (The harness `decode_config` robustness fix that was bundled into #840 is not cron-specific and is left out; it can land on its own if wanted.)

## Verification

- `cron` crate: `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, `cargo test` (28).
- `cron/ui`: `tsc --noEmit`, esbuild bundle.
- Rig: binary built and installed; the console registers and serves `cron/page.js` and `cron/styles.css` (`GET /ui/cron/page.js` → 200), and the page mounts.

Linear: MOT-4503
