### PR TITLE
Fix engine-managed E2E lock verification

### DIFF
--- a/.github/scripts/harness_e2e_shadow_contract.py
+++ b/.github/scripts/harness_e2e_shadow_contract.py
@@ -19,6 +19,22 @@ VERSION = re.compile(
     r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
 )
 
+# These workers are hosted by the pinned iii engine rather than installed from
+# the Registry. `iii worker add` intentionally reports them as built-in, so a
+# Registry resolution of a transitive dependency cannot force their internal
+# version. Their observed lock entries remain evidence, while the exact CLI
+# pin is the reproducibility boundary for their runtime implementation.
+ENGINE_MANAGED_WORKERS = frozenset(
+    {
+        "configuration",
+        "iii-observability",
+        "iii-state",
+        "iii-stream",
+        "iii-worker-manager",
+        "iii-worker-ops",
+    }
+)
+
 
 def load_object(path: Path, label: str) -> dict[str, Any]:
     value = json.loads(path.read_text())
@@ -415,13 +431,31 @@ def verify_lock(contract: dict[str, Any], lock_path: Path) -> dict[str, Any]:
         runtime_digest = None
 
     expected = {**expected_runtime, **expected_target, contract["runner"]["registry_worker"]: contract["runner"]["registry_ref"]}
+    engine_managed = {
+        worker
+        for worker in expected
+        if worker in ENGINE_MANAGED_WORKERS
+        and isinstance(workers.get(worker), dict)
+        and workers[worker].get("type") == "engine"
+        and worker != contract["runner"]["registry_worker"]
+    }
     mismatches = [
         f"{worker}: expected {version}, resolved {observed.get(worker, 'missing')}"
         for worker, version in sorted(expected.items())
-        if observed.get(worker) != version
+        if observed.get(worker) != version and worker not in engine_managed
     ]
     if mismatches:
         raise ValueError("stack_version_mismatch: " + "; ".join(mismatches))
+
+    registry_pins = {worker: version for worker, version in expected.items() if worker not in engine_managed}
+    engine_managed_evidence = {
+        worker: {
+            "declared_version": expected[worker],
+            "observed_version": observed[worker],
+            "lock_type": workers[worker]["type"],
+        }
+        for worker in sorted(engine_managed)
+    }
 
     target_stack = v2_target_member(contract, target, "stack") if contract["schema_version"] == 2 else None
     return {
@@ -445,6 +479,16 @@ def verify_lock(contract: dict[str, Any], lock_path: Path) -> dict[str, Any]:
         "runner": {
             **contract["runner"],
             "observed_version": observed[contract["runner"]["registry_worker"]],
+        },
+        "verification": {
+            "registry_pins": {
+                "expected_versions": dict(sorted(registry_pins.items())),
+                "observed_versions": {worker: observed[worker] for worker in sorted(registry_pins)},
+            },
+            "engine_managed": {
+                "runtime_cli": contract.get("runtime", {}).get("cli"),
+                "workers": engine_managed_evidence,
+            },
         },
         "lock": {
             "sha256": f"sha256:{hashlib.sha256(lock_path.read_bytes()).hexdigest()}",

--- a/.github/scripts/tests/test_harness_e2e_shadow_contract.py
+++ b/.github/scripts/tests/test_harness_e2e_shadow_contract.py
@@ -132,6 +132,32 @@ def manual_v2_catalog():
     }
 
 
+def manual_v2_contract_with_versions(versions: dict[str, str]):
+    changed = manual_v2_contract()
+    stack_digest = MODULE.canonical_sha256(versions)
+    changed["target"]["stack_versions"] = versions
+    changed["target"]["stack_digest"] = stack_digest
+    changed["target"]["stack"]["requested_versions"] = versions
+    changed["target"]["stack"]["resolved_versions"] = versions
+    changed["target"]["stack"]["resolution_sha256"] = stack_digest
+    changed["target"]["stack"]["provenance"] = [
+        {"worker": worker, "version": version} for worker, version in sorted(versions.items())
+    ]
+    changed["target"]["stack"]["provenance"][0].update(
+        {
+            "source_sha": "b" * 40,
+            "operation_id": "33333333-3333-4333-8333-333333333333",
+        }
+    )
+    changed["runtime"]["stack_versions"] = versions
+    changed["runtime"]["stack_digest"] = stack_digest
+    return changed
+
+
+def write_lock(path: Path, workers: dict[str, dict[str, str]]):
+    path.write_text(json.dumps({"version": 1, "workers": workers}))
+
+
 class ShadowContractTest(unittest.TestCase):
     def test_materializes_observe_only_request(self):
         request = MODULE.materialize_request(contract(), catalog())
@@ -166,6 +192,61 @@ class ShadowContractTest(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "resolution_sha256 does not match"):
             MODULE.validate_contract(changed)
+
+    def test_verify_lock_records_engine_managed_workers_from_the_pinned_runtime(self):
+        versions = {"harness": "1.9.0", "iii-observability": "0.22.1", "state": "0.22.1"}
+        changed = manual_v2_contract_with_versions(versions)
+        with tempfile.TemporaryDirectory() as directory:
+            lock_path = Path(directory) / "iii.lock"
+            write_lock(
+                lock_path,
+                {
+                    "harness": {"version": "1.9.0", "type": "binary"},
+                    "iii-observability": {"version": "0.21.8", "type": "engine"},
+                    "state": {"version": "0.22.1", "type": "binary"},
+                    "harness-e2e": {"version": "0.1.0-experimental", "type": "binary"},
+                },
+            )
+            manifest = MODULE.verify_lock(changed, lock_path)
+
+        engine_worker = manifest["verification"]["engine_managed"]["workers"]["iii-observability"]
+        self.assertEqual(engine_worker["declared_version"], "0.22.1")
+        self.assertEqual(engine_worker["observed_version"], "0.21.8")
+        self.assertEqual(manifest["verification"]["registry_pins"]["observed_versions"]["state"], "0.22.1")
+
+    def test_verify_lock_still_rejects_a_registry_worker_version_drift(self):
+        versions = {"harness": "1.9.0", "iii-observability": "0.22.1", "state": "0.22.1"}
+        changed = manual_v2_contract_with_versions(versions)
+        with tempfile.TemporaryDirectory() as directory:
+            lock_path = Path(directory) / "iii.lock"
+            write_lock(
+                lock_path,
+                {
+                    "harness": {"version": "1.9.0", "type": "binary"},
+                    "iii-observability": {"version": "0.21.8", "type": "engine"},
+                    "state": {"version": "0.22.0", "type": "binary"},
+                    "harness-e2e": {"version": "0.1.0-experimental", "type": "binary"},
+                },
+            )
+            with self.assertRaisesRegex(ValueError, "stack_version_mismatch: state"):
+                MODULE.verify_lock(changed, lock_path)
+
+    def test_verify_lock_does_not_bypass_an_engine_managed_name_with_a_registry_record(self):
+        versions = {"harness": "1.9.0", "iii-observability": "0.22.1", "state": "0.22.1"}
+        changed = manual_v2_contract_with_versions(versions)
+        with tempfile.TemporaryDirectory() as directory:
+            lock_path = Path(directory) / "iii.lock"
+            write_lock(
+                lock_path,
+                {
+                    "harness": {"version": "1.9.0", "type": "binary"},
+                    "iii-observability": {"version": "0.21.8", "type": "binary"},
+                    "state": {"version": "0.22.1", "type": "binary"},
+                    "harness-e2e": {"version": "0.1.0-experimental", "type": "binary"},
+                },
+            )
+            with self.assertRaisesRegex(ValueError, "stack_version_mismatch: iii-observability"):
+                MODULE.verify_lock(changed, lock_path)
 
     def test_packages_raw_file_digests(self):
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Summary
- keep exact lock verification for Registry-installed workers
- treat verified engine-managed workers as runtime evidence under the exact CLI pin
- record declared and observed runtime versions in the stack manifest

## Validation
- `python3 -m pytest .github/scripts/tests/test_harness_e2e_shadow_contract.py -q`
- `python3 -m pytest .github/scripts/tests/test_verify_registry_lock.py -q`
- `bash -n harness/tests/e2e/run-shadow-control-ci.sh`
- replayed the production failure bundle through `verify-lock` successfully