### PR TITLE
(MOT-4518) feat(console): replay workspace writes made before hydration

### DIFF
--- a/console/web/src/hooks/use-workspace-tabs.ts
+++ b/console/web/src/hooks/use-workspace-tabs.ts
@@ -16,7 +16,7 @@
  */
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import {
   type ConsoleConfigValue,
   fetchConsoleConfigValue,
@@ -29,6 +29,7 @@ import {
   parseActiveTabId,
   parseWorkspaceTabs,
   resolveActiveTab,
+  shouldFlushPendingWrite,
   type TabScreen,
   tabColumns,
   type WorkspaceLayoutSource,
@@ -161,8 +162,22 @@ export function useWorkspaceTabs(): UseWorkspaceTabsReturn {
     },
   })
 
+  // A mutation fired before the first server answer arrives (a keyboard
+  // shortcut, a worker's panel-open) must not be lost when `tabs` flips from
+  // the local copy to the server layout. The latest such write is held and
+  // replayed through the server path once hydrated.
+  const pendingWriteRef = useRef<{
+    tabs: WorkspaceTab[]
+    activeTabId: string
+  } | null>(null)
+
   const persist = useCallback(
     (nextTabs: WorkspaceTab[], nextActiveId: string) => {
+      if (layoutSource === 'pending') {
+        pendingWriteRef.current = { tabs: nextTabs, activeTabId: nextActiveId }
+        setLocal({ tabs: nextTabs, activeTabId: nextActiveId })
+        return
+      }
       if (available) {
         const transform = (value: ConsoleConfigValue) =>
           withActiveTabId(withWorkspaceTabs(value, nextTabs), nextActiveId)
@@ -179,8 +194,15 @@ export function useWorkspaceTabs(): UseWorkspaceTabsReturn {
         persistLocal(nextState)
       }
     },
-    [available, mutation, qc],
+    [available, layoutSource, mutation, qc],
   )
+
+  useEffect(() => {
+    const pending = pendingWriteRef.current
+    if (!shouldFlushPendingWrite(layoutSource, pending !== null)) return
+    pendingWriteRef.current = null
+    if (pending !== null) persist(pending.tabs, pending.activeTabId)
+  }, [layoutSource, persist])
 
   const activateTab = useCallback(
     (id: string) => {

--- a/console/web/src/lib/workspace-tabs.test.ts
+++ b/console/web/src/lib/workspace-tabs.test.ts
@@ -9,6 +9,7 @@ import {
   resolveActiveTab,
   screenForView,
   screenLabel,
+  shouldFlushPendingWrite,
   tabColumns,
   tabLabel,
   tabSizes,
@@ -448,5 +449,15 @@ describe('workspaceLayoutSource', () => {
       'local',
       'server',
     ])
+  })
+})
+
+describe('shouldFlushPendingWrite', () => {
+  it('flushes only once hydrated and something is queued', () => {
+    expect(shouldFlushPendingWrite('pending', true)).toBe(false)
+    expect(shouldFlushPendingWrite('pending', false)).toBe(false)
+    expect(shouldFlushPendingWrite('server', false)).toBe(false)
+    expect(shouldFlushPendingWrite('server', true)).toBe(true)
+    expect(shouldFlushPendingWrite('local', true)).toBe(true)
   })
 })

--- a/console/web/src/lib/workspace-tabs.ts
+++ b/console/web/src/lib/workspace-tabs.ts
@@ -360,6 +360,16 @@ export function withActiveTabId(
     it is not (the localStorage copy). */
 export type WorkspaceLayoutSource = 'pending' | 'server' | 'local'
 
+/** A queued pre-hydration write should replay once the layout source is no
+    longer `pending` (server hydrated, or known unavailable) and something is
+    actually queued. */
+export function shouldFlushPendingWrite(
+  source: WorkspaceLayoutSource,
+  hasPending: boolean,
+): boolean {
+  return source !== 'pending' && hasPending
+}
+
 export function workspaceLayoutSource(
   fetched: boolean,
   available: boolean,


### PR DESCRIPTION
## Why

`useWorkspaceTabs` hands out the localStorage copy of the layout before the first server answer arrives, then swaps to the server layout. A mutation in that window — a `workspace.create` keyboard shortcut, a worker's panel-open, a tab click — writes against the local copy and is discarded when the server value lands. #843 guarded the two hash effects with a `layoutSource` flag, but the hook still let every other consumer mutate the soon-to-be-replaced copy.

## What

The hook now holds a pre-hydration write and replays it. While `layoutSource === 'pending'`, `persist` records the intended `{ tabs, activeTabId }` and updates the local view for immediate paint, but does not commit. When the source leaves `pending` (server hydrated, or known unavailable), an effect flushes the held write through the normal `persist` path — a server read-modify-write when the configuration worker is reachable, localStorage otherwise. The flush decision is a pure `shouldFlushPendingWrite(source, hasPending)` with its own test.

The per-effect `layoutSource` guards in `App.tsx` are left in place; this change is additive and covers the consumers those guards do not (shortcuts, panel-open, TabStrip), without touching the hash state machine.

## Verification

- `tsc -b`, biome, vitest 1470 (new: `shouldFlushPendingWrite` truth table).

Stacked on #860 → #843. Merge those first.

Linear: MOT-4518
