### PR TITLE
Fix ephemeral E2E worker boot config

### DIFF
--- a/.github/scripts/tests/test_harness_e2e_shadow_contract.py
+++ b/.github/scripts/tests/test_harness_e2e_shadow_contract.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 
 SCRIPT = Path(__file__).parents[1] / "harness_e2e_shadow_contract.py"
+RUNNER_SCRIPT = Path(__file__).parents[3] / "harness" / "tests" / "e2e" / "run-shadow-control-ci.sh"
 SPEC = importlib.util.spec_from_file_location("shadow_contract", SCRIPT)
 assert SPEC and SPEC.loader
 MODULE = importlib.util.module_from_spec(SPEC)
@@ -159,6 +160,11 @@ def write_lock(path: Path, workers: dict[str, dict[str, str]]):
 
 
 class ShadowContractTest(unittest.TestCase):
+    def test_ephemeral_runner_writes_workers_to_the_engine_config(self):
+        runner = RUNNER_SCRIPT.read_text()
+        self.assertIn('export III_CONFIG_PATH="$project_config"', runner)
+        self.assertIn('iii.config.yaml config.yaml iii.lock workers.json', runner)
+
     def test_materializes_observe_only_request(self):
         request = MODULE.materialize_request(contract(), catalog())
         self.assertEqual(request["run_contract"]["mode"]["decision"], "observe_only")

--- a/harness/tests/e2e/run-shadow-control-ci.sh
+++ b/harness/tests/e2e/run-shadow-control-ci.sh
@@ -52,6 +52,11 @@ mkdir -p "$project_dir" "$e2e_home" "$artifact_dir/logs" "$artifact_dir/stack"
 export HOME="$e2e_home"
 export XDG_CONFIG_HOME="$e2e_home/.config"
 export PATH="$e2e_home/.local/bin:$e2e_home/.iii/bin:$PATH"
+# The CLI historically defaults to ./config.yaml, while the ephemeral engine
+# is deliberately started with the canonical iii.config.yaml. Pin both sides
+# to the same file; otherwise installs succeed into an unwatched config and
+# no target worker can register.
+export III_CONFIG_PATH="$project_config"
 export HARNESS_E2E_STACK_MODE=registry
 export HARNESS_E2E_STACK_VERSIONS="$stack_versions"
 export HARNESS_E2E_STACK_DIGEST="$stack_digest"
@@ -75,7 +80,7 @@ fail() {
 }
 
 snapshot_stack() {
-  for file in iii.config.yaml iii.lock workers.json; do
+  for file in iii.config.yaml config.yaml iii.lock workers.json; do
     [[ -f "$project_dir/$file" ]] && cp "$project_dir/$file" "$artifact_dir/stack/$file"
   done
   if [[ -f "$project_dir/iii.lock" ]]; then


### PR DESCRIPTION
## Summary
- make the CLI write the same configuration file watched by the ephemeral engine
- preserve both possible config files in the factual bundle
- cover the engine-config binding in the shadow contract tests

## Validation
- `python3 -m pytest .github/scripts/tests/test_harness_e2e_shadow_contract.py -q`
- `python3 -m pytest .github/scripts/tests/test_verify_registry_lock.py -q`
- `bash -n harness/tests/e2e/run-shadow-control-ci.sh`
- production failure bundle diagnosis: worker installs were written to unwatched `config.yaml`, while the engine watched `iii.config.yaml`