### PR TITLE
chore(workers): require stable state and queue releases

### DIFF
--- a/.github/scripts/tests/test_worker_dependency_compatibility.py
+++ b/.github/scripts/tests/test_worker_dependency_compatibility.py
@@ -11,8 +11,8 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 SHARED_DEPENDENCY_RANGES = {
     "configuration": "0.x",
     "llm-router": "^1.0.0",
-    "queue": "^0.21.4",
-    "state": "^0.22.1",
+    "queue": "^0.21.5",
+    "state": "^0.22.2",
 }
 
 

--- a/approval-gate/iii.worker.yaml
+++ b/approval-gate/iii.worker.yaml
@@ -9,7 +9,7 @@ tags: [approval, human-in-the-loop, permissions, policy, security]
 description: Policy and decision surface for human-held function calls — pre_trigger gate, pending inbox, per-session permission settings, and two notification trigger types.
 
 dependencies:
-  state: "^0.22.1"
+  state: "^0.22.2"
   configuration: "0.x"
   iii-directory: "^1.0.0"
   session-manager: "^1.0.0"

--- a/canvas/iii.worker.yaml
+++ b/canvas/iii.worker.yaml
@@ -8,5 +8,5 @@ bin: canvas
 tags: [diagram, mermaid, flowchart, whiteboard, drawing, svg]
 description: Create, edit and render diagrams in the console — stored as editable source, drawn live in chat and on a canvas page.
 dependencies:
-  state: "^0.22.1"
+  state: "^0.22.2"
   configuration: "0.x"

--- a/claude-code/iii.worker.yaml
+++ b/claude-code/iii.worker.yaml
@@ -14,5 +14,5 @@ scripts:
   start: node ./index.mjs
 
 dependencies:
-  state: "^0.22.1"
+  state: "^0.22.2"
   iii-stream: "^0.21.6"

--- a/editor/iii.worker.yaml
+++ b/editor/iii.worker.yaml
@@ -10,5 +10,5 @@ description: A shared code workspace — open buffers, a file tree, unified diff
 
 dependencies:
   shell: "^0.10.3"
-  state: "^0.22.1"
+  state: "^0.22.2"
   configuration: "0.x"

--- a/eval/iii.worker.yaml
+++ b/eval/iii.worker.yaml
@@ -9,7 +9,7 @@ tags: [evaluation, benchmark, sessions, metrics, prompt, system-prompt]
 description: Compare live objective metrics for 2-5 root sessions; retain durable prompt experiments as an advanced surface.
 
 dependencies:
-  state: "^0.22.1"
-  queue: "^0.21.4"
+  state: "^0.22.2"
+  queue: "^0.21.5"
   cron: "^0.21.0"
   iii-observability: "^0.21.6"

--- a/harness/iii.worker.yaml
+++ b/harness/iii.worker.yaml
@@ -9,8 +9,8 @@ tags: [agent, harness, loop, autonomous]
 description: Thin durable turn loop that wires session-manager, context-manager, and llm-router into an agent loop; spawns sub-agents as child sessions.
 
 dependencies:
-  state: "^0.22.1"
-  queue: "^0.21.4"
+  state: "^0.22.2"
+  queue: "^0.21.5"
   cron: "^0.21.0"
   configuration: "0.x"
   iii-observability: "^0.21.6"

--- a/harness/tests/manifest.rs
+++ b/harness/tests/manifest.rs
@@ -54,7 +54,7 @@ fn worker_manifest_uses_the_standalone_queue_worker() {
 
     assert_eq!(
         dependencies.get(serde_yaml::Value::String("queue".into())),
-        Some(&serde_yaml::Value::String("^0.21.4".into()))
+        Some(&serde_yaml::Value::String("^0.21.5".into()))
     );
     assert!(!dependencies.contains_key(serde_yaml::Value::String("iii-queue".into())));
 }
@@ -70,7 +70,7 @@ fn worker_manifest_uses_the_standalone_state_worker() {
 
     assert_eq!(
         dependencies.get(serde_yaml::Value::String("state".into())),
-        Some(&serde_yaml::Value::String("^0.22.1".into()))
+        Some(&serde_yaml::Value::String("^0.22.2".into()))
     );
     assert!(!dependencies.contains_key(serde_yaml::Value::String("iii-state".into())));
 }

--- a/llm-router/iii.worker.yaml
+++ b/llm-router/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, router, models, providers]
 description: One front door + provider protocol in front of every LLM provider.
 
 dependencies:
-  state: "^0.22.1"
+  state: "^0.22.2"
   configuration: "0.x"

--- a/memory-consolidate/iii.worker.yaml
+++ b/memory-consolidate/iii.worker.yaml
@@ -11,4 +11,4 @@ description: Scheduled hygiene for the memory worker — deterministic dedup of 
 dependencies:
   memory: "^0.1.0"
   configuration: "0.x"
-  state: "^0.22.1"
+  state: "^0.22.2"

--- a/memory/iii.worker.yaml
+++ b/memory/iii.worker.yaml
@@ -12,5 +12,5 @@ dependencies:
   configuration: "0.x"
   session-manager: "^1.0.0"
   llm-router: "^1.0.0"
-  state: "^0.22.1"
-  queue: "^0.21.4"
+  state: "^0.22.2"
+  queue: "^0.21.5"

--- a/opencode/iii.worker.yaml
+++ b/opencode/iii.worker.yaml
@@ -14,5 +14,5 @@ scripts:
   start: node ./index.mjs
 
 dependencies:
-  state: "^0.22.1"
+  state: "^0.22.2"
   iii-stream: "^0.21.6"

--- a/openwiki/iii.worker.yaml
+++ b/openwiki/iii.worker.yaml
@@ -14,6 +14,6 @@ scripts:
   start: node ./index.mjs
 
 dependencies:
-  state: "^0.22.1"
+  state: "^0.22.2"
   cron: "^0.21.0"
   llm-router: "^1.0.0"

--- a/pi/iii.worker.yaml
+++ b/pi/iii.worker.yaml
@@ -14,5 +14,5 @@ scripts:
   start: node ./index.mjs
 
 dependencies:
-  state: "^0.22.1"
+  state: "^0.22.2"
   iii-stream: "^0.21.6"

--- a/provider-anthropic/iii.worker.yaml
+++ b/provider-anthropic/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, anthropic, claude, messages, provider]
 description: Anthropic Messages API provider worker; implements provider::anthropic::stream and provider::anthropic::refresh_models behind llm-router.
 
 dependencies:
-  state: "^0.22.1"
+  state: "^0.22.2"
   llm-router: "^1.0.0"

--- a/provider-claude-code/iii.worker.yaml
+++ b/provider-claude-code/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, anthropic, claude, claude-code, subscription, provider]
 description: Claude Code (Pro/Max subscription) Messages API provider worker; implements provider::claude-code::stream and provider::claude-code::refresh_models behind llm-router, using OAuth credentials from the auth-credentials vault or ~/.claude/.credentials.json.
 
 dependencies:
-  state: "^0.22.1"
+  state: "^0.22.2"
   llm-router: "^1.0.0"

--- a/provider-deepseek/iii.worker.yaml
+++ b/provider-deepseek/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, deepseek, chat-completions, provider]
 description: DeepSeek Chat Completions provider worker; implements provider::deepseek::stream and provider::deepseek::refresh_models behind llm-router.
 
 dependencies:
-  state: "^0.22.1"
+  state: "^0.22.2"
   llm-router: "^1.0.0"

--- a/provider-github-copilot/iii.worker.yaml
+++ b/provider-github-copilot/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, github, copilot, subscription, chat-completions, provider]
 description: GitHub Copilot subscription provider worker; sign in with GitHub once and the models the plan grants appear in the picker. Implements provider::github-copilot::stream, refresh_models, and a device-flow login surface behind llm-router.
 
 dependencies:
-  state: "^0.22.1"
+  state: "^0.22.2"
   llm-router: "^1.0.0"

--- a/provider-kimi/iii.worker.yaml
+++ b/provider-kimi/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, kimi, moonshot, chat-completions, provider]
 description: Moonshot (Kimi) Chat Completions provider worker; implements provider::kimi::stream and provider::kimi::refresh_models behind llm-router.
 
 dependencies:
-  state: "^0.22.1"
+  state: "^0.22.2"
   llm-router: "^1.0.0"

--- a/provider-llamacpp/iii.worker.yaml
+++ b/provider-llamacpp/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, llama.cpp, local, open-source, provider]
 description: llama.cpp server (llama-server) Chat Completions provider worker; implements provider::llamacpp::stream and provider::llamacpp::refresh_models behind llm-router.
 
 dependencies:
-  state: "^0.22.1"
+  state: "^0.22.2"
   llm-router: "^1.0.0"

--- a/provider-openai-codex/iii.worker.yaml
+++ b/provider-openai-codex/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, openai, codex, chatgpt, subscription, provider]
 description: OpenAI Codex (ChatGPT subscription) provider; implements provider::openai-codex::stream and provider::openai-codex::refresh_models behind llm-router, sourcing credentials from the auth-credentials vault.
 
 dependencies:
-  state: "^0.22.1"
+  state: "^0.22.2"
   llm-router: "^1.0.0"

--- a/provider-openai/iii.worker.yaml
+++ b/provider-openai/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, openai, responses, chat-completions, provider]
 description: OpenAI Responses provider worker with Chat Completions compatibility; implements provider::openai::stream and provider::openai::refresh_models behind llm-router.
 
 dependencies:
-  state: "^0.22.1"
+  state: "^0.22.2"
   llm-router: "^1.0.0"

--- a/provider-opencode-go/iii.worker.yaml
+++ b/provider-opencode-go/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, opencode, go, chat-completions, subscription, provider]
 description: OpenCode Go Chat Completions provider worker; implements provider::opencode_go::stream and provider::opencode_go::refresh_models behind llm-router.
 
 dependencies:
-  state: "^0.22.1"
+  state: "^0.22.2"
   llm-router: "^1.0.0"

--- a/provider-openrouter/iii.worker.yaml
+++ b/provider-openrouter/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, openrouter, aggregator, chat-completions, provider]
 description: OpenRouter Chat Completions provider worker; one API key in front of every major vendor. Implements provider::openrouter::stream and provider::openrouter::refresh_models behind llm-router.
 
 dependencies:
-  state: "^0.22.1"
+  state: "^0.22.2"
   llm-router: "^1.0.0"

--- a/provider-xai/iii.worker.yaml
+++ b/provider-xai/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, xai, grok, chat-completions, provider]
 description: xAI Chat Completions provider worker; implements provider::xai::stream and provider::xai::refresh_models behind llm-router.
 
 dependencies:
-  state: "^0.22.1"
+  state: "^0.22.2"
   llm-router: "^1.0.0"

--- a/provider-zai/iii.worker.yaml
+++ b/provider-zai/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, zai, glm, chat-completions, provider]
 description: Z.AI Chat Completions provider worker; implements provider::zai::stream and provider::zai::refresh_models behind llm-router.
 
 dependencies:
-  state: "^0.22.1"
+  state: "^0.22.2"
   llm-router: "^1.0.0"

--- a/slack/iii.worker.yaml
+++ b/slack/iii.worker.yaml
@@ -10,6 +10,6 @@ description: Slack as an iii worker — exposes the Slack Web API as slack::* fu
 
 dependencies:
   configuration: "0.x"
-  state: "^0.22.1"
+  state: "^0.22.2"
   harness: "^1.0.0"
   session-manager: "^1.0.0"

--- a/telegram-bot/iii.worker.yaml
+++ b/telegram-bot/iii.worker.yaml
@@ -9,8 +9,8 @@ tags: [telegram, bot, messaging, chat, webhook]
 description: Telegram bridge to the harness stack — polling or webhook ingress, live message edits, approvals, and configurable verbosity.
 
 dependencies:
-  state: "^0.22.1"
-  queue: "^0.21.4"
+  state: "^0.22.2"
+  queue: "^0.21.5"
   configuration: "0.x"
   session-manager: "^1.0.0"
   harness: "^1.0.0"

--- a/worktree/iii.worker.yaml
+++ b/worktree/iii.worker.yaml
@@ -10,5 +10,5 @@ description: Git worktree lifecycle for parallel agents — mint, claim, and tra
 
 dependencies:
   configuration: "0.x"
-  state: "^0.22.1"
+  state: "^0.22.2"
   shell: "^0.7.0"


### PR DESCRIPTION
## Summary

- raise the shared state dependency floor to ^0.22.2 for every consumer
- raise the shared queue dependency floor to ^0.21.5 for every consumer
- update the compatibility regression expectations

## Why

state 0.22.2 and queue 0.21.5 are now available on the latest Registry channel. Aligning every manifest keeps the llm-router and queue consumer graphs on the stable namespace-aware releases.

## Validation

- 207 GitHub script tests passed
- 4 dependency compatibility tests passed after rebasing onto the latest main
- all changed worker manifests passed validate_worker.py
- Registry resolution confirmed state 0.22.2, queue 0.21.5, and llm-router 1.4.11@next
- git diff --check passed