### PR TITLE
Avoid retrying ephemeral stack replacements

### DIFF
--- a/.github/scripts/tests/test_harness_e2e_shadow_contract.py
+++ b/.github/scripts/tests/test_harness_e2e_shadow_contract.py
@@ -175,7 +175,7 @@ class ShadowContractTest(unittest.TestCase):
 
     def test_ephemeral_runner_keeps_the_bootstrapped_target_binary_and_checks_runtime_identity(self):
         runner = RUNNER_SCRIPT.read_text()
-        self.assertIn('install_exact_stack stack-bootstrap "$exact_stack_versions" true', runner)
+        self.assertIn('install_exact_stack stack-bootstrap "$exact_stack_versions" false', runner)
         self.assertIn('install_exact_stack stack-repin "$exact_stack_versions" false', runner)
         self.assertIn('verify_target_harness_runtime', runner)
         self.assertIn('harness runtime version mismatch:', runner)

--- a/crates/provider-integration-testkit/Cargo.lock
+++ b/crates/provider-integration-testkit/Cargo.lock
@@ -1048,7 +1048,7 @@ checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "llm-router"
-version = "1.4.11"
+version = "1.4.12"
 dependencies = [
  "async-trait",
  "clap",

--- a/harness/tests/e2e/run-shadow-control-ci.sh
+++ b/harness/tests/e2e/run-shadow-control-ci.sh
@@ -239,7 +239,10 @@ if [[ "$contract_schema" == 2 ]]; then
     --argjson runtime "$runtime_versions" \
     --argjson target "$stack_versions" \
     '$runtime + $target')
-  install_exact_stack stack-bootstrap "$exact_stack_versions" true
+  # Every job has a fresh HOME and project directory, so there is no prior
+  # target artifact to replace. Avoid force here: a transient Registry retry
+  # would otherwise restart every worker that the first batch already booted.
+  install_exact_stack stack-bootstrap "$exact_stack_versions" false
 else
   support=("database@latest" "storage@latest" "fp@latest" "web@latest")
   declare -A providers=()

--- a/provider-anthropic/Cargo.lock
+++ b/provider-anthropic/Cargo.lock
@@ -996,7 +996,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.11"
+version = "1.4.12"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-claude-code/Cargo.lock
+++ b/provider-claude-code/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.11"
+version = "1.4.12"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-deepseek/Cargo.lock
+++ b/provider-deepseek/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.11"
+version = "1.4.12"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-github-copilot/Cargo.lock
+++ b/provider-github-copilot/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.11"
+version = "1.4.12"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-kimi/Cargo.lock
+++ b/provider-kimi/Cargo.lock
@@ -943,7 +943,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.11"
+version = "1.4.12"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-llamacpp/Cargo.lock
+++ b/provider-llamacpp/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.11"
+version = "1.4.12"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-openai-codex/Cargo.lock
+++ b/provider-openai-codex/Cargo.lock
@@ -1008,7 +1008,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.11"
+version = "1.4.12"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-openai/Cargo.lock
+++ b/provider-openai/Cargo.lock
@@ -996,7 +996,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.11"
+version = "1.4.12"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-opencode-go/Cargo.lock
+++ b/provider-opencode-go/Cargo.lock
@@ -976,7 +976,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.11"
+version = "1.4.12"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-openrouter/Cargo.lock
+++ b/provider-openrouter/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.11"
+version = "1.4.12"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-xai/Cargo.lock
+++ b/provider-xai/Cargo.lock
@@ -996,7 +996,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.11"
+version = "1.4.12"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-zai/Cargo.lock
+++ b/provider-zai/Cargo.lock
@@ -996,7 +996,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.11"
+version = "1.4.12"
 dependencies = [
  "async-trait",
  "clap",


### PR DESCRIPTION
## Summary

- avoid `--force` in the fresh ephemeral stack bootstrap
- prevent a retry after a transient Registry error from restarting workers that already booted
- retain the fail-closed runtime version verification added in #867

## Validation

- `bash -n harness/tests/e2e/run-shadow-control-ci.sh`
- `python3 .github/scripts/tests/test_harness_e2e_shadow_contract.py`
- `PYTHONPATH=.github/scripts python3 -m unittest discover -s .github/scripts/tests -p "test_*.py"`