### PR TITLE
chore(workers): require llm-router 1.4.12

### DIFF
--- a/.github/scripts/tests/test_worker_dependency_compatibility.py
+++ b/.github/scripts/tests/test_worker_dependency_compatibility.py
@@ -10,7 +10,7 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[3]
 SHARED_DEPENDENCY_RANGES = {
     "configuration": "0.x",
-    "llm-router": "^1.0.0",
+    "llm-router": "^1.4.12",
     "queue": "^0.21.5",
     "state": "^0.22.2",
 }

--- a/context-manager/iii.worker.yaml
+++ b/context-manager/iii.worker.yaml
@@ -10,4 +10,4 @@ description: Turns a raw conversation history plus a target model into a model-r
 
 dependencies:
   configuration: "0.x"
-  llm-router: "^1.0.0"
+  llm-router: "^1.4.12"

--- a/harness/iii.worker.yaml
+++ b/harness/iii.worker.yaml
@@ -16,7 +16,7 @@ dependencies:
   iii-observability: "^0.21.6"
   iii-stream: "^0.21.6"
   iii-directory: "^1.2.0"
-  llm-router: "^1.0.0"
+  llm-router: "^1.4.12"
   session-manager: "^1.0.0"
   context-manager: "^1.0.0"
   provider-anthropic: "^1.0.0"

--- a/memory/iii.worker.yaml
+++ b/memory/iii.worker.yaml
@@ -11,6 +11,6 @@ description: Durable cross-session agent memory — named banks of always-inject
 dependencies:
   configuration: "0.x"
   session-manager: "^1.0.0"
-  llm-router: "^1.0.0"
+  llm-router: "^1.4.12"
   state: "^0.22.2"
   queue: "^0.21.5"

--- a/openwiki/iii.worker.yaml
+++ b/openwiki/iii.worker.yaml
@@ -16,4 +16,4 @@ scripts:
 dependencies:
   state: "^0.22.2"
   cron: "^0.21.0"
-  llm-router: "^1.0.0"
+  llm-router: "^1.4.12"

--- a/provider-anthropic/iii.worker.yaml
+++ b/provider-anthropic/iii.worker.yaml
@@ -10,4 +10,4 @@ description: Anthropic Messages API provider worker; implements provider::anthro
 
 dependencies:
   state: "^0.22.2"
-  llm-router: "^1.0.0"
+  llm-router: "^1.4.12"

--- a/provider-claude-code/iii.worker.yaml
+++ b/provider-claude-code/iii.worker.yaml
@@ -10,4 +10,4 @@ description: Claude Code (Pro/Max subscription) Messages API provider worker; im
 
 dependencies:
   state: "^0.22.2"
-  llm-router: "^1.0.0"
+  llm-router: "^1.4.12"

--- a/provider-deepseek/iii.worker.yaml
+++ b/provider-deepseek/iii.worker.yaml
@@ -10,4 +10,4 @@ description: DeepSeek Chat Completions provider worker; implements provider::dee
 
 dependencies:
   state: "^0.22.2"
-  llm-router: "^1.0.0"
+  llm-router: "^1.4.12"

--- a/provider-github-copilot/iii.worker.yaml
+++ b/provider-github-copilot/iii.worker.yaml
@@ -10,4 +10,4 @@ description: GitHub Copilot subscription provider worker; sign in with GitHub on
 
 dependencies:
   state: "^0.22.2"
-  llm-router: "^1.0.0"
+  llm-router: "^1.4.12"

--- a/provider-kimi/iii.worker.yaml
+++ b/provider-kimi/iii.worker.yaml
@@ -10,4 +10,4 @@ description: Moonshot (Kimi) Chat Completions provider worker; implements provid
 
 dependencies:
   state: "^0.22.2"
-  llm-router: "^1.0.0"
+  llm-router: "^1.4.12"

--- a/provider-llamacpp/iii.worker.yaml
+++ b/provider-llamacpp/iii.worker.yaml
@@ -10,4 +10,4 @@ description: llama.cpp server (llama-server) Chat Completions provider worker; i
 
 dependencies:
   state: "^0.22.2"
-  llm-router: "^1.0.0"
+  llm-router: "^1.4.12"

--- a/provider-openai-codex/iii.worker.yaml
+++ b/provider-openai-codex/iii.worker.yaml
@@ -10,4 +10,4 @@ description: OpenAI Codex (ChatGPT subscription) provider; implements provider::
 
 dependencies:
   state: "^0.22.2"
-  llm-router: "^1.0.0"
+  llm-router: "^1.4.12"

--- a/provider-openai/iii.worker.yaml
+++ b/provider-openai/iii.worker.yaml
@@ -10,4 +10,4 @@ description: OpenAI Responses provider worker with Chat Completions compatibilit
 
 dependencies:
   state: "^0.22.2"
-  llm-router: "^1.0.0"
+  llm-router: "^1.4.12"

--- a/provider-opencode-go/iii.worker.yaml
+++ b/provider-opencode-go/iii.worker.yaml
@@ -10,4 +10,4 @@ description: OpenCode Go Chat Completions provider worker; implements provider::
 
 dependencies:
   state: "^0.22.2"
-  llm-router: "^1.0.0"
+  llm-router: "^1.4.12"

--- a/provider-openrouter/iii.worker.yaml
+++ b/provider-openrouter/iii.worker.yaml
@@ -10,4 +10,4 @@ description: OpenRouter Chat Completions provider worker; one API key in front o
 
 dependencies:
   state: "^0.22.2"
-  llm-router: "^1.0.0"
+  llm-router: "^1.4.12"

--- a/provider-xai/iii.worker.yaml
+++ b/provider-xai/iii.worker.yaml
@@ -10,4 +10,4 @@ description: xAI Chat Completions provider worker; implements provider::xai::str
 
 dependencies:
   state: "^0.22.2"
-  llm-router: "^1.0.0"
+  llm-router: "^1.4.12"

--- a/provider-zai/iii.worker.yaml
+++ b/provider-zai/iii.worker.yaml
@@ -10,4 +10,4 @@ description: Z.AI Chat Completions provider worker; implements provider::zai::st
 
 dependencies:
   state: "^0.22.2"
-  llm-router: "^1.0.0"
+  llm-router: "^1.4.12"


### PR DESCRIPTION
## Summary

- require `llm-router ^1.4.12` across all 16 dependent workers
- align the shared dependency compatibility regression with the new minimum

## Why

The stable `llm-router 1.4.12` release includes the updated state dependency and namespace-aware routing fixes. Pinning the compatible minimum prevents provider and harness installs from resolving older router releases.

## Validation

- 213 GitHub script tests and 3 subtests passed
- all 16 changed worker manifests passed `validate_worker.py`
- Registry resolution confirmed `llm-router ^1.4.12` resolves to `1.4.12` with `state 0.22.2`
- `git diff --check` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the shared LLM routing component to version 1.4.12 across supported workers and providers.
  * Aligned compatibility checks with the updated version requirement.

* **Bug Fixes**
  * Improved consistency and compatibility of LLM routing across integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->