### PR TITLE
(MOT-4504) fix(iii-directory): remove harness dependency cycle

### DIFF
--- a/.github/scripts/tests/test_worker_dependency_compatibility.py
+++ b/.github/scripts/tests/test_worker_dependency_compatibility.py
@@ -1,4 +1,4 @@
-"""Regression tests for shared worker dependency ranges."""
+"""Regression tests for worker dependency compatibility."""
 from __future__ import annotations
 
 import tomllib
@@ -20,6 +20,36 @@ def dependencies(worker: str) -> dict[str, str]:
     manifest = REPO_ROOT / worker / "iii.worker.yaml"
     data = yaml.safe_load(manifest.read_text(encoding="utf-8"))
     return data.get("dependencies", {})
+
+
+def test_worker_dependency_graph_is_acyclic() -> None:
+    workers = {
+        manifest.parent.name
+        for manifest in REPO_ROOT.glob("*/iii.worker.yaml")
+    }
+    graph = {
+        worker: set(dependencies(worker)).intersection(workers)
+        for worker in workers
+    }
+    visiting: list[str] = []
+    visited: set[str] = set()
+
+    def visit(worker: str) -> None:
+        if worker in visited:
+            return
+        if worker in visiting:
+            start = visiting.index(worker)
+            cycle = [*visiting[start:], worker]
+            raise AssertionError(f"worker dependency cycle: {' -> '.join(cycle)}")
+
+        visiting.append(worker)
+        for dependency in sorted(graph[worker]):
+            visit(dependency)
+        visiting.pop()
+        visited.add(worker)
+
+    for worker in sorted(workers):
+        visit(worker)
 
 
 def test_shared_dependencies_use_compatible_ranges() -> None:

--- a/iii-directory/iii.worker.yaml
+++ b/iii-directory/iii.worker.yaml
@@ -10,4 +10,3 @@ description: Engine introspection (functions / triggers / workers), workers regi
 
 dependencies:
   configuration: "0.x"
-  harness: "^1.0.0"


### PR DESCRIPTION
## Summary

- remove the `harness` dependency from the `iii-directory` worker manifest
- add a repository-wide regression that rejects cycles between local worker dependencies

## Why

`harness` already depends on `iii-directory`. Adding the reverse dependency made `iii-directory@next` fail Registry resolution with `dependency_cycle: iii-directory -> harness -> iii-directory`. The pre-generate hook does not require a hard dependency: its recoverable trigger binding remains pending until the harness registers the trigger type, and the optional Console preview already handles an unavailable harness.

## Validation

- 214 GitHub script tests and 3 subtests passed
- `validate_worker.py` passed for `iii-directory`
- `git diff --check` passed

Refs MOT-4504

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an unnecessary worker dependency.

* **Tests**
  * Added validation to detect circular dependencies between workers.
  * Improved dependency compatibility test documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->