### PR TITLE
(MOT-4522) fix(console): group the default traces view by session id, not name

### DIFF
--- a/console/src/configuration.rs
+++ b/console/src/configuration.rs
@@ -108,8 +108,11 @@ fn schema() -> Value {
 /// Out-of-the-box preferences seeded when the entry has never been
 /// configured.
 ///
-/// - `views`: `view-sessions` groups traces by session and labels rows with
-///   the tag message; `activeViewId` selects it out of the box, and the
+/// - `views`: `view-sessions` groups traces by `iii.session.id` (stamped on
+///   every harness turn span, so no trace is dropped for lacking it — the
+///   engine's `group_by` skips spans without the grouping attribute, and
+///   `iii.session.name` only exists once a session has a title) and labels
+///   rows with the tag message; `activeViewId` selects it out of the box, and the
 ///   frontend falls back to the same id when the pointer is absent
 ///   (`DEFAULT_VIEW_ID` in web tracesViews.ts — keep the id in sync).
 /// - `followTurns`: follow the active chat's live turn — on out of the box
@@ -122,7 +125,7 @@ fn default_value() -> Value {
             "views": [{
                 "id": "view-sessions",
                 "name": "sessions",
-                "groupBy": "iii.session.name",
+                "groupBy": "iii.session.id",
                 "hiddenFunctions": [],
                 "label": { "mode": "attribute", "attribute": "iii.tag.message" },
                 "filters": {}
@@ -372,6 +375,19 @@ mod tests {
         let section = &s["properties"]["injectableUi"]["properties"]["disabledWorkers"];
         assert_eq!(section["type"], "array");
         assert_eq!(section["items"]["type"], "string");
+    }
+
+    #[test]
+    fn seed_groups_sessions_by_id_not_name() {
+        // Grouping must key on `iii.session.id` — the engine's `group_by`
+        // drops spans lacking the attribute, and `iii.session.name` is only
+        // stamped once a session has a title, which hid every untitled
+        // session's traces from the default view.
+        let v = default_value();
+        let view = &v["traces"]["views"][0];
+        assert_eq!(view["id"], "view-sessions");
+        assert_eq!(view["groupBy"], "iii.session.id");
+        assert_eq!(v["traces"]["activeViewId"], "view-sessions");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The seeded `view-sessions` view groups by `iii.session.name`, but `engine::traces::group_by` **drops spans that lack the grouping attribute** — and `iii.session.name` is only stamped on a turn's spans when the session has a title (`harness/src/functions/turn.rs` reads the title; nothing generates one). Every untitled session — all `harness::send` sessions without `session.title`, all console chats — is invisible in the default view.

Reproduced on a fresh iii 0.23.0-rc.4 project (console 1.9.11): 423 traces / 17 sessions in store, the default view showed **1 group** (the single titled session) while the header counted all 423. Identical in two separate browsers, since the view lives in the server-side `console` configuration entry — the user has to clear the view by hand in every fresh install.

## Fix

Seed `groupBy: iii.session.id` (stamped on every harness turn span) instead. This matches the frontend's own convention: `defaultLabelAttribute('iii.session.id')` in `web/src/pages/TracesV2/lib/groupTraces.ts` already resolves session-id groups to an `iii.session.name` heading, degrading to the raw id when untitled. Row labels keep `iii.tag.message`.

Verified in the same rc.4 setup: switching the live view to the session preset shows all 17 groups.

Adds a regression test pinning the seeded `groupBy`. Only fresh installations are affected — registration seeds the default only when no `console` entry is stored yet.

https://claude.ai/code/session_01DF7Bo45WpbDU3Nd19fBY9d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default Traces view to group traces by session ID for more consistent grouping.
  * Ensured the correct default view and active-view selection are applied.
  * Added regression coverage to verify the updated behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes MOT-4522