### PR TITLE
(MOT-4503) fix(cron): restore default configuration routing

### DIFF
--- a/cron/src/configuration.rs
+++ b/cron/src/configuration.rs
@@ -165,12 +165,15 @@ async fn trigger_with_retry(
     let mut last_err = String::new();
     for attempt in 1..=CONFIG_RETRIES {
         match iii
-            .trigger(TriggerRequest {
-                function_id: function_id.to_string(),
-                payload: payload.clone(),
-                action: None,
-                timeout_ms: Some(timeout_ms),
-            })
+            .trigger(
+                TriggerRequest {
+                    function_id: function_id.to_string(),
+                    payload: payload.clone(),
+                    action: None,
+                    timeout_ms: Some(timeout_ms),
+                }
+                .namespace("default"),
+            )
             .await
         {
             Ok(v) => return Ok(v),

--- a/cron/tests/common/engine.rs
+++ b/cron/tests/common/engine.rs
@@ -44,9 +44,15 @@ fn require_or_skip(connected: Option<Arc<IIIClient>>) -> Option<Arc<IIIClient>> 
     None
 }
 
-async fn try_connect_raw() -> Option<Arc<IIIClient>> {
+async fn try_connect_raw(namespace: Option<&str>) -> Option<Arc<IIIClient>> {
     let url = ws_url();
-    let iii = Arc::new(register_worker(&url, InitOptions::default()));
+    let iii = Arc::new(register_worker(
+        &url,
+        InitOptions {
+            namespace: namespace.map(str::to_owned),
+            ..InitOptions::default()
+        },
+    ));
 
     for _ in 0..20 {
         tokio::time::sleep(Duration::from_millis(250)).await;
@@ -70,12 +76,16 @@ async fn try_connect_raw() -> Option<Arc<IIIClient>> {
 }
 
 pub async fn connect_fresh() -> Option<Arc<IIIClient>> {
-    require_or_skip(try_connect_raw().await)
+    require_or_skip(try_connect_raw(None).await)
+}
+
+pub async fn connect_fresh_in_namespace(namespace: &str) -> Option<Arc<IIIClient>> {
+    require_or_skip(try_connect_raw(Some(namespace)).await)
 }
 
 pub async fn get_or_init() -> Option<Arc<IIIClient>> {
     ENGINE
-        .get_or_init(|| async { require_or_skip(try_connect_raw().await) })
+        .get_or_init(|| async { require_or_skip(try_connect_raw(None).await) })
         .await
         .clone()
 }

--- a/cron/tests/e2e_schedule.rs
+++ b/cron/tests/e2e_schedule.rs
@@ -11,6 +11,23 @@ use common::engine;
 
 #[tokio::test]
 #[serial]
+async fn configuration_calls_reach_default_from_a_custom_namespace() {
+    let Some(iii) = engine::connect_fresh_in_namespace("cron-e2e-custom-namespace").await else {
+        return;
+    };
+
+    iii_cron::configuration::register_config(&iii, None)
+        .await
+        .expect("configuration::register should resolve in default");
+    iii_cron::configuration::fetch_config(&iii)
+        .await
+        .expect("configuration::get should resolve in default");
+
+    iii.shutdown_async().await;
+}
+
+#[tokio::test]
+#[serial]
 async fn cron_trigger_fires_bound_function_with_parity_payload() {
     let Some(iii) = engine::get_or_init().await else {
         return;


### PR DESCRIPTION
## Summary

- route cron configuration calls to the built-in provider in the `default` namespace
- preserve the cron worker and its registered functions in the project namespace
- add an engine-backed regression test for configuration calls from a custom namespace

## Root cause

The cron configuration refactor removed the explicit namespace override. With `III_NAMESPACE` set, `configuration::get` and `configuration::register` inherited the project namespace even though the built-in provider is registered in `default`. Cron exited after its retry limit, and compose stopped the dependent harness worker.

## Validation

- `cargo fmt --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked`
- `III_E2E_REQUIRE=1 cargo test --locked --test e2e_schedule configuration_calls_reach_default_from_a_custom_namespace -- --exact --nocapture`

Refs MOT-4503

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trigger handling by routing trigger requests through the default namespace.
  * Enhanced configuration access so settings registered in custom namespaces can be retrieved consistently from the default namespace.
  * Improved reliability when connecting to and initializing scheduled task engines across namespaces.

* **Tests**
  * Added end-to-end coverage for configuration registration and retrieval across namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->