### PR TITLE
chore(harness): update cron to 0.21.9

### DIFF
--- a/harness/iii.worker.yaml
+++ b/harness/iii.worker.yaml
@@ -11,7 +11,7 @@ description: Thin durable turn loop that wires session-manager, context-manager,
 dependencies:
   state: "^0.22.2"
   queue: "^0.21.5"
-  cron: "^0.21.7"
+  cron: "^0.21.9"
   configuration: "0.x"
   iii-observability: "^0.21.6"
   iii-stream: "^0.21.6"

--- a/harness/tests/manifest.rs
+++ b/harness/tests/manifest.rs
@@ -86,7 +86,7 @@ fn worker_manifest_uses_the_standalone_cron_worker() {
 
     assert_eq!(
         dependencies.get(serde_yaml::Value::String("cron".into())),
-        Some(&serde_yaml::Value::String("^0.21.7".into()))
+        Some(&serde_yaml::Value::String("^0.21.9".into()))
     );
     assert!(!dependencies.contains_key(serde_yaml::Value::String("iii-cron".into())));
 }


### PR DESCRIPTION
## Summary

- update the harness cron dependency to ^0.21.9
- align the manifest regression test with the released version

## Validation

- cargo test --locked --test manifest
- cargo fmt --check
- git diff --check