### PR TITLE
(MOT-4493) fix(llm-router,providers,harness): one terminal result for truncated provider streams

### DIFF
--- a/crates/provider-integration-testkit/Cargo.lock
+++ b/crates/provider-integration-testkit/Cargo.lock
@@ -1326,7 +1326,7 @@ dependencies = [
 
 [[package]]
 name = "provider-anthropic"
-version = "1.2.7"
+version = "1.2.8"
 dependencies = [
  "clap",
  "futures",
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "provider-claude-code"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "clap",
  "futures",
@@ -1360,7 +1360,7 @@ dependencies = [
 
 [[package]]
 name = "provider-deepseek"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "clap",
  "futures",
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "provider-kimi"
-version = "1.1.4"
+version = "1.1.5"
 dependencies = [
  "clap",
  "futures",
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "provider-openai"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "clap",
  "futures",
@@ -1435,7 +1435,7 @@ dependencies = [
 
 [[package]]
 name = "provider-openai-codex"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -1472,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "provider-xai"
-version = "1.3.3"
+version = "1.3.4"
 dependencies = [
  "clap",
  "futures",
@@ -1489,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "provider-zai"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "clap",
  "futures",

--- a/crates/provider-integration-testkit/src/contract.rs
+++ b/crates/provider-integration-testkit/src/contract.rs
@@ -438,10 +438,15 @@ fn assert_truncated_partial(frames: &[Value]) -> anyhow::Result<()> {
             .any(|block| block["type"] == "text" && block["text"] == "partial contract"),
         "truncated error must keep the streamed text: {last}"
     );
-    for block in content
+    let function_calls: Vec<_> = content
         .iter()
         .filter(|block| block["type"] == "function_call")
-    {
+        .collect();
+    anyhow::ensure!(
+        !function_calls.is_empty(),
+        "truncated error must keep the unfinished function call: {last}"
+    );
+    for block in function_calls {
         let arguments = &block["arguments"];
         anyhow::ensure!(
             arguments.get("_partial").is_some() || arguments.get("_raw").is_some(),

--- a/crates/provider-integration-testkit/src/contract.rs
+++ b/crates/provider-integration-testkit/src/contract.rs
@@ -11,7 +11,7 @@ use llm_router::register::register_router;
 use serde_json::{json, Value};
 
 use crate::case::{CredentialMode, ProtocolFamily, ProviderCase};
-use crate::protocol::{auth_response, happy_sse, quota_response};
+use crate::protocol::{auth_response, happy_sse, quota_response, truncated_sse};
 use crate::runtime::{call, test_init_options, Engine};
 use crate::stub::{CapturedRequest, StubResponse, StubUpstream};
 
@@ -287,6 +287,41 @@ pub(crate) async fn run_contract(case: ProviderCase) -> anyhow::Result<()> {
         "transient retry count mismatch"
     );
 
+    // A cut inside function-call arguments: one transient error, no retry
+    // after forwarded content, and the next call succeeds without a restart.
+    stub.clear_requests();
+    stub.respond([StubResponse::sse(truncated_sse(case.family))]);
+    let truncated = chat(&engine.url, case, case.model, "contract-truncated").await?;
+    anyhow::ensure!(
+        truncated.response["ok"] == false,
+        "truncated response: {}",
+        truncated.response
+    );
+    assert_error_kind(&truncated.frames, "transient")?;
+    assert_truncated_partial(&truncated.frames)?;
+    anyhow::ensure!(
+        truncated
+            .frames
+            .iter()
+            .filter(|frame| is_terminal(frame))
+            .count()
+            == 1,
+        "truncated stream must end in exactly one terminal frame"
+    );
+    anyhow::ensure!(
+        stub.post_requests().len() == 1,
+        "truncated stream was retried after content reached the caller"
+    );
+    stub.clear_requests();
+    stub.respond([StubResponse::sse(happy_sse(case.family))]);
+    let recovered = chat(&engine.url, case, case.model, "contract-after-truncation").await?;
+    anyhow::ensure!(
+        recovered.response["ok"] == true,
+        "call after truncation: {}",
+        recovered.response
+    );
+    assert_terminal(&recovered.frames, "done")?;
+
     // Router abort reaches the provider and cancels the in-flight HTTP body.
     stub.clear_requests();
     let cancelled = Arc::new(AtomicBool::new(false));
@@ -362,6 +397,7 @@ fn write_contract_result(case: ProviderCase) -> anyhow::Result<()> {
             "model-change",
             "quota-no-retry",
             "transient-retry",
+            "truncated-stream-no-retry",
             "abort",
             "auth-no-retry"
         ]
@@ -377,6 +413,41 @@ fn write_contract_result(case: ProviderCase) -> anyhow::Result<()> {
 fn assert_terminal(frames: &[Value], expected: &str) -> anyhow::Result<()> {
     let last = frames.last().context("stream emitted no frames")?;
     anyhow::ensure!(last["type"] == expected, "terminal frame: {last}");
+    Ok(())
+}
+
+fn is_terminal(frame: &Value) -> bool {
+    matches!(frame["type"].as_str(), Some("done") | Some("error"))
+}
+
+fn assert_truncated_partial(frames: &[Value]) -> anyhow::Result<()> {
+    let last = frames
+        .last()
+        .context("truncated stream emitted no frames")?;
+    let message = last["error"]["error_message"].as_str().unwrap_or_default();
+    anyhow::ensure!(
+        message.contains("stream truncated") && message.contains("phase=sse-decode"),
+        "truncation error must name the decode phase: {last}"
+    );
+    let content = last["error"]["content"]
+        .as_array()
+        .context("truncated error carries no content")?;
+    anyhow::ensure!(
+        content
+            .iter()
+            .any(|block| block["type"] == "text" && block["text"] == "partial contract"),
+        "truncated error must keep the streamed text: {last}"
+    );
+    for block in content
+        .iter()
+        .filter(|block| block["type"] == "function_call")
+    {
+        let arguments = &block["arguments"];
+        anyhow::ensure!(
+            arguments.get("_partial").is_some() || arguments.get("_raw").is_some(),
+            "a cut function call must carry degraded arguments: {block}"
+        );
+    }
     Ok(())
 }
 

--- a/crates/provider-integration-testkit/src/protocol.rs
+++ b/crates/provider-integration-testkit/src/protocol.rs
@@ -33,6 +33,37 @@ pub(crate) fn happy_sse(family: ProtocolFamily) -> &'static str {
     }
 }
 
+/// A body that closes inside a function call's arguments after text streamed.
+pub(crate) fn truncated_sse(family: ProtocolFamily) -> &'static str {
+    match family {
+        ProtocolFamily::AnthropicMessages => concat!(
+            "event: message_start\n",
+            "data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":12}}}\n\n",
+            "event: content_block_start\n",
+            "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",
+            "event: content_block_delta\n",
+            "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"partial contract\"}}\n\n",
+            "event: content_block_stop\n",
+            "data: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+            "event: content_block_start\n",
+            "data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_cut\",\"name\":\"contract__probe\",\"input\":{}}}\n\n",
+            "event: content_block_delta\n",
+            "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"value\\\":\\\"ex\"}}\n\n"
+        ),
+        ProtocolFamily::OpenAiChatCompletions => concat!(
+            "data: {\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\"}}]}\n\n",
+            "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"partial contract\"}}]}\n\n",
+            "data: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_cut\",\"type\":\"function\",\"function\":{\"name\":\"contract__probe\",\"arguments\":\"\"}}]}}]}\n\n",
+            "data: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"value\\\":\\\"ex\"}}]}}]}\n\n"
+        ),
+        ProtocolFamily::OpenAiResponses => concat!(
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"partial contract\"}\n\n",
+            "data: {\"type\":\"response.output_item.added\",\"output_index\":1,\"item\":{\"type\":\"function_call\",\"call_id\":\"call_cut\",\"name\":\"contract__probe\",\"arguments\":\"\"}}\n\n",
+            "data: {\"type\":\"response.function_call_arguments.delta\",\"output_index\":1,\"delta\":\"{\\\"value\\\":\\\"ex\"}\n\n"
+        ),
+    }
+}
+
 pub(crate) fn models_body(family: ProtocolFamily) -> &'static str {
     match family {
         ProtocolFamily::AnthropicMessages => {

--- a/harness/src/trigger.rs
+++ b/harness/src/trigger.rs
@@ -189,6 +189,14 @@ pub fn wrapper_without_target_result(arguments: &Value) -> ResultData {
     }
 }
 
+/// Salvaged (`_partial`/`_raw`) or non-object arguments must never reach dispatch.
+pub fn arguments_degraded(arguments: &Value) -> bool {
+    match arguments {
+        Value::Object(map) => map.contains_key("_partial") || map.contains_key("_raw"),
+        _ => true,
+    }
+}
+
 /// Provider-degraded arguments (a stream that died or hit max_tokens
 /// mid-args, salvaged to a `"_partial": true` prefix or a raw `{"_raw": …}`
 /// evidence object) must never execute: the salvage preserves evidence for
@@ -322,6 +330,19 @@ mod tests {
         assert!(truncated_arguments_result("state::set", &args).is_error);
         // Short args pass through whole.
         assert_eq!(arguments_preview(&json!({"a": 1})), r#"{"a":1}"#);
+    }
+
+    #[test]
+    fn degraded_arguments_cover_markers_and_non_objects() {
+        assert!(arguments_degraded(
+            &json!({ "_partial": true, "path": "/tmp" })
+        ));
+        assert!(arguments_degraded(&json!({ "_raw": "{\"path\":\"/tm" })));
+        assert!(arguments_degraded(&Value::Null));
+        assert!(arguments_degraded(&json!("{}")));
+        assert!(arguments_degraded(&json!([1, 2])));
+        assert!(!arguments_degraded(&json!({})));
+        assert!(!arguments_degraded(&json!({ "path": "/tmp" })));
     }
 
     #[test]

--- a/harness/src/turn_loop.rs
+++ b/harness/src/turn_loop.rs
@@ -1059,11 +1059,12 @@ pub async fn run_step(
 
             // Provider-degraded arguments: a stream that died or was cut by
             // max_tokens mid-args arrives as a salvaged `"_partial": true`
-            // prefix or a raw `{"_raw": …}` evidence object (the router's
-            // degraded_arguments). Executing partial intent is worse than
-            // failing — the complete-looking leading fields may be missing
-            // the constraints the model was still writing.
-            if call.arguments.get("_partial").is_some() || call.arguments.get("_raw").is_some() {
+            // prefix, a raw `{"_raw": …}` evidence object (the router's
+            // degraded_arguments), or no object at all. Executing partial
+            // intent is worse than failing — the complete-looking leading
+            // fields may be missing the constraints the model was still
+            // writing.
+            if trigger::arguments_degraded(&call.arguments) {
                 let data = trigger::truncated_arguments_result(&call.function_id, &call.arguments);
                 let entry_id = ids::function_result_entry_id(&record.turn_id, &call.id);
                 append_function_result(

--- a/harness/tests/integration/README.md
+++ b/harness/tests/integration/README.md
@@ -31,6 +31,7 @@ No provider key or network access is required.
 | INT-021 | `router-midstream-terminal-error` | direct | partial content and keepalive noise followed by one permanent router error preserve the partial, fail exactly once, and leave no pending work |
 | INT-022 | `idempotency-key-collision` | direct | distinct idempotency keys whose punctuation previously collapsed retain two durable user messages and turns |
 | INT-023 | `function-call-id-collision` | direct | distinct function-call ids whose punctuation previously collapsed retain both executed function results |
+| INT-024 | `truncated-function-call-stream` | direct | a provider stream cut inside function-call arguments keeps the partial text, never executes the degraded call, resumes once, and runs the re-issued call exactly once |
 | UI-001 | `console-streamed-text` | playground | a message sent by the Console streams to durable completion |
 | UI-002 | `multi-turn-traces` | playground | a native function turn and a Console turn expose distinct traces and function-call events |
 | UI-003 | `console-anthropic-messages-error` | playground | an Anthropic Messages permanent provider failure is shown and the chat recovers |

--- a/harness/tests/integration/README.md
+++ b/harness/tests/integration/README.md
@@ -31,7 +31,7 @@ No provider key or network access is required.
 | INT-021 | `router-midstream-terminal-error` | direct | partial content and keepalive noise followed by one permanent router error preserve the partial, fail exactly once, and leave no pending work |
 | INT-022 | `idempotency-key-collision` | direct | distinct idempotency keys whose punctuation previously collapsed retain two durable user messages and turns |
 | INT-023 | `function-call-id-collision` | direct | distinct function-call ids whose punctuation previously collapsed retain both executed function results |
-| INT-024 | `truncated-function-call-stream` | direct | a provider stream cut inside function-call arguments keeps the partial text, never executes the degraded call, resumes once, and runs the re-issued call exactly once |
+| INT-024 | `truncated-function-call-stream` | direct | a provider stream cut inside function-call arguments keeps the partial text, never executes the degraded call, resumes once, runs the re-issued call exactly once, and a follow-up on the same session is answered without a restart |
 | UI-001 | `console-streamed-text` | playground | a message sent by the Console streams to durable completion |
 | UI-002 | `multi-turn-traces` | playground | a native function turn and a Console turn expose distinct traces and function-call events |
 | UI-003 | `console-anthropic-messages-error` | playground | an Anthropic Messages permanent provider failure is shown and the chat recovers |

--- a/harness/tests/integration/src/fixtures/tests.rs
+++ b/harness/tests/integration/src/fixtures/tests.rs
@@ -29,6 +29,7 @@ fn all_selection_returns_the_checked_in_fixtures() {
             "INT-021",
             "INT-022",
             "INT-023",
+            "INT-024",
             "UI-001",
             "UI-002",
             "UI-003",
@@ -42,7 +43,7 @@ fn all_selection_returns_the_checked_in_fixtures() {
             .iter()
             .filter(|fixture| fixture.driver == crate::scenarios::ScenarioDriver::Direct)
             .count(),
-        19
+        20
     );
 }
 

--- a/harness/tests/integration/src/scenarios/dsl.rs
+++ b/harness/tests/integration/src/scenarios/dsl.rs
@@ -748,6 +748,14 @@ enum ResponseKind {
         message: String,
         kind: ErrorKind,
     },
+    TruncatedFunctionCall {
+        text: String,
+        call_id: String,
+        function_id: String,
+        argument_delta: String,
+        degraded_arguments: Value,
+        message: String,
+    },
 }
 
 impl Response {
@@ -797,6 +805,35 @@ impl Response {
                 chunks: chunks.into_iter().map(Into::into).collect(),
                 message: message.to_string(),
                 kind,
+            },
+            usage: usage(input_tokens, output_tokens),
+        }
+    }
+
+    /// A body cut mid-arguments: text, an open call, part of its arguments,
+    /// then one transient error whose partial carries the call degraded.
+    pub(super) fn truncated_function_call(
+        text: &str,
+        call_id: &str,
+        function: &ControlledFunction,
+        degraded_arguments: Value,
+        message: &str,
+        input_tokens: u64,
+        output_tokens: u64,
+    ) -> Self {
+        let argument_delta = degraded_arguments
+            .get("_raw")
+            .and_then(Value::as_str)
+            .unwrap_or("{")
+            .to_string();
+        Self {
+            kind: ResponseKind::TruncatedFunctionCall {
+                text: text.to_string(),
+                call_id: call_id.to_string(),
+                function_id: function.id().to_string(),
+                argument_delta,
+                degraded_arguments,
+                message: message.to_string(),
             },
             usage: usage(input_tokens, output_tokens),
         }
@@ -941,6 +978,32 @@ impl Response {
                 false,
                 Some(ErrorShape {
                     code: error_kind_code(kind).to_string(),
+                    message,
+                }),
+            ),
+            ResponseKind::TruncatedFunctionCall {
+                text,
+                call_id,
+                function_id,
+                argument_delta,
+                degraded_arguments,
+                message,
+            } => (
+                truncated_function_call_frames(
+                    &text,
+                    &call_id,
+                    &function_id,
+                    &argument_delta,
+                    degraded_arguments,
+                    &message,
+                    &usage,
+                    model,
+                    timestamp,
+                ),
+                StopReason::Error,
+                false,
+                Some(ErrorShape {
+                    code: error_kind_code(ErrorKind::Transient).to_string(),
                     message,
                 }),
             ),
@@ -1263,6 +1326,90 @@ fn streamed_error_frames(
         AssistantMessageEvent::Error { error },
     ]);
     frames
+}
+
+#[allow(clippy::too_many_arguments)]
+fn truncated_function_call_frames(
+    text: &str,
+    call_id: &str,
+    function_id: &str,
+    argument_delta: &str,
+    degraded_arguments: Value,
+    message: &str,
+    usage: &Usage,
+    model: &ModelFixtureV1,
+    timestamp: i64,
+) -> Vec<AssistantMessageEvent> {
+    let text_block = ContentBlock::Text {
+        text: text.to_string(),
+    };
+    let open_call = ContentBlock::FunctionCall {
+        id: call_id.to_string(),
+        function_id: function_id.to_string(),
+        arguments: json!({}),
+    };
+    let mut error = assistant_message(
+        vec![
+            text_block.clone(),
+            ContentBlock::FunctionCall {
+                id: call_id.to_string(),
+                function_id: function_id.to_string(),
+                arguments: degraded_arguments,
+            },
+        ],
+        StopReason::Error,
+        Some(usage.clone()),
+        model,
+        timestamp,
+    );
+    error.error_message = Some(message.to_string());
+    error.error_kind = Some(ErrorKind::Transient);
+
+    vec![
+        AssistantMessageEvent::Start {
+            partial: assistant_message(Vec::new(), StopReason::End, None, model, timestamp),
+        },
+        AssistantMessageEvent::TextStart {
+            partial: assistant_message(
+                vec![ContentBlock::Text {
+                    text: String::new(),
+                }],
+                StopReason::End,
+                None,
+                model,
+                timestamp,
+            ),
+        },
+        AssistantMessageEvent::TextDelta {
+            partial: None,
+            delta: text.to_string(),
+        },
+        AssistantMessageEvent::TextEnd {
+            partial: assistant_message(
+                vec![text_block.clone()],
+                StopReason::End,
+                None,
+                model,
+                timestamp,
+            ),
+        },
+        AssistantMessageEvent::FunctioncallStart {
+            partial: assistant_message(
+                vec![text_block, open_call],
+                StopReason::End,
+                None,
+                model,
+                timestamp,
+            ),
+        },
+        AssistantMessageEvent::FunctioncallDelta {
+            partial: None,
+            delta: argument_delta.to_string(),
+            id: call_id.to_string(),
+        },
+        AssistantMessageEvent::Ping,
+        AssistantMessageEvent::Error { error },
+    ]
 }
 
 fn error_kind_code(kind: ErrorKind) -> &'static str {

--- a/harness/tests/integration/src/scenarios/dsl.rs
+++ b/harness/tests/integration/src/scenarios/dsl.rs
@@ -728,6 +728,17 @@ pub(super) struct Response {
     usage: Usage,
 }
 
+/// The call a cut stream leaves behind: what streamed, and what the provider
+/// salvaged from it.
+pub(super) struct TruncatedCall<'a> {
+    pub(super) call_id: &'a str,
+    pub(super) function: &'a ControlledFunction,
+    /// The argument bytes delivered before the cut, as the delta frame.
+    pub(super) argument_delta: &'a str,
+    /// The provider's degraded arguments (`_partial` or `_raw`).
+    pub(super) degraded_arguments: Value,
+}
+
 enum ResponseKind {
     StreamedText {
         text: String,
@@ -810,29 +821,23 @@ impl Response {
         }
     }
 
-    /// A body cut mid-arguments: text, an open call, part of its arguments,
-    /// then one transient error whose partial carries the call degraded.
+    /// A body cut mid-arguments: text, an open call, the argument bytes the
+    /// stream delivered, then one transient error whose partial carries the
+    /// call with the provider's degraded arguments.
     pub(super) fn truncated_function_call(
         text: &str,
-        call_id: &str,
-        function: &ControlledFunction,
-        degraded_arguments: Value,
+        cut: TruncatedCall<'_>,
         message: &str,
         input_tokens: u64,
         output_tokens: u64,
     ) -> Self {
-        let argument_delta = degraded_arguments
-            .get("_raw")
-            .and_then(Value::as_str)
-            .unwrap_or("{")
-            .to_string();
         Self {
             kind: ResponseKind::TruncatedFunctionCall {
                 text: text.to_string(),
-                call_id: call_id.to_string(),
-                function_id: function.id().to_string(),
-                argument_delta,
-                degraded_arguments,
+                call_id: cut.call_id.to_string(),
+                function_id: cut.function.id().to_string(),
+                argument_delta: cut.argument_delta.to_string(),
+                degraded_arguments: cut.degraded_arguments,
                 message: message.to_string(),
             },
             usage: usage(input_tokens, output_tokens),

--- a/harness/tests/integration/src/scenarios/mod.rs
+++ b/harness/tests/integration/src/scenarios/mod.rs
@@ -23,6 +23,7 @@ mod state_worker_sidecar;
 mod stop_cancel_cascade;
 mod streamed_text;
 mod timer_wake;
+mod truncated_function_call_stream;
 mod wake_expiry_notice;
 
 use crate::evidence_data::RunEvidence;
@@ -60,6 +61,7 @@ pub fn all() -> Vec<ScenarioFixture> {
         stop_cancel_cascade::scenario(),
         queued_message_edit_unqueue::scenario(),
         streamed_text::scenario(),
+        truncated_function_call_stream::scenario(),
         wake_expiry_notice::scenario(),
         timer_wake::scenario(),
     ];
@@ -74,7 +76,7 @@ mod tests {
     #[test]
     fn every_fixture_is_unique_and_valid() {
         let fixtures = all();
-        assert_eq!(fixtures.len(), 25);
+        assert_eq!(fixtures.len(), 26);
         let mut slugs = std::collections::BTreeSet::new();
         let mut ids = std::collections::BTreeSet::new();
         for fixture in fixtures {

--- a/harness/tests/integration/src/scenarios/truncated_function_call_stream.rs
+++ b/harness/tests/integration/src/scenarios/truncated_function_call_stream.rs
@@ -1,0 +1,204 @@
+//! INT-024 — a provider stream cut inside a function call's arguments never
+//! executes the call and never poisons the session.
+//!
+//! The scripted router streams text, opens a function call, delivers part of
+//! its arguments, then ends the way every provider now ends a body cut
+//! mid-arguments: one transient error frame whose partial carries the call
+//! with degraded arguments. The Harness must keep the useful text, refuse to
+//! dispatch the degraded call, resume once, and finish the turn with the
+//! re-issued call executed exactly once. The same session then serves a second
+//! turn without any restart.
+
+use serde_json::{json, Value};
+
+use super::dsl::{
+    ControlledFunction, Generation, Message, Model, Request, Response, Scenario, Send,
+};
+use super::ScenarioDriver;
+use crate::fixtures::ScenarioFixture;
+
+const ID: &str = "INT-024";
+const SLUG: &str = "truncated-function-call-stream";
+const MESSAGE: &str = "Record the expected value once.";
+const PARTIAL: &str = "Recording now.";
+const CUT_CALL_ID: &str = "call-cut";
+const CALL_ID: &str = "call-complete";
+const ERROR: &str = "fixture stream truncated: the body ended inside a function call's arguments [phase=sse-decode reason=open_function_call]";
+
+pub(super) fn scenario() -> ScenarioFixture {
+    let model = Model::scripted("fixture-model");
+    let record = ControlledFunction::new(
+        "{{run_id}}::record",
+        "Record one integration fixture value.",
+    )
+    .request_schema(json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": { "value": { "type": "string" } },
+        "required": ["value"]
+    }))
+    .returns_text("recorded");
+    let arguments = json!({ "value": "expected" });
+
+    Scenario::new(
+        ID,
+        SLUG,
+        "A stream cut inside function-call arguments keeps the partial text, never executes the degraded call, resumes once, and runs the re-issued call exactly once.",
+        ScenarioDriver::Direct,
+        model.clone(),
+    )
+    .send(
+        Send::message(MESSAGE)
+            .idempotency_key("{{run_id}}:integration-024")
+            .allow_function(&record),
+    )
+    .function(record.clone())
+    .terminal_turn_statuses(["completed"])
+    .generation(
+        Generation::new(1)
+            .expect(
+                Request::new()
+                    .turn_request()
+                    .system_prompt_sha256("{{system_prompt_sha256}}")
+                    .messages_exact([Message::user(MESSAGE)])
+                    .tools_exact([record.tool()]),
+            )
+            .respond(Response::truncated_function_call(
+                PARTIAL,
+                CUT_CALL_ID,
+                &record,
+                json!({ "_raw": "{\"value\":\"exp" }),
+                ERROR,
+                8,
+                3,
+            )),
+    )
+    .generation(
+        Generation::new(2)
+            .expect(
+                Request::new()
+                    .turn_request()
+                    .system_prompt_sha256("{{system_prompt_sha256}}")
+                    .messages_subset([Message::user(MESSAGE)])
+                    .tools_exact([record.tool()]),
+            )
+            .respond(Response::function_call(
+                CALL_ID,
+                &record,
+                arguments.clone(),
+                20,
+                4,
+            )),
+    )
+    .generation(
+        Generation::new(3)
+            .expect(
+                Request::new()
+                    .turn_request()
+                    .system_prompt_sha256("{{system_prompt_sha256}}")
+                    .messages_subset([Message::user(MESSAGE)])
+                    .tools_exact([record.tool()]),
+            )
+            .respond(Response::text("recorded once", 30, 2)),
+    )
+    .verify(|run| {
+        run.expect_assistant_texts([PARTIAL, "recorded once"])?;
+        run.expect_function_calls("record", 1)?;
+        run.expect_call_payload("record", json!({ "value": "expected" }))?;
+        run.expect_no_duplicate_messages()?;
+
+        let cut_results = run
+            .transcript
+            .iter()
+            .filter_map(|item| item.get("message"))
+            .filter(|message| {
+                message.get("role").and_then(Value::as_str) == Some("function_result")
+                    && message.get("function_call_id").and_then(Value::as_str) == Some(CUT_CALL_ID)
+            })
+            .count();
+        anyhow::ensure!(
+            cut_results == 0,
+            "the cut call must never produce a function result: {:?}",
+            run.transcript
+        );
+        anyhow::ensure!(
+            run.status.get("transient_resumes").and_then(Value::as_u64) == Some(1),
+            "the cut stream must resume exactly once: {}",
+            run.status
+        );
+        anyhow::ensure!(
+            run.status.get("result_error").is_none_or(Value::is_null),
+            "a recovered turn must not keep a terminal error: {}",
+            run.status
+        );
+        let recoveries = run
+            .transcript
+            .iter()
+            .filter_map(|item| item.get("custom"))
+            .filter(|custom| custom.get("custom_type").and_then(Value::as_str) == Some("recovery"))
+            .filter_map(|custom| custom.pointer("/data/status").and_then(Value::as_str))
+            .collect::<Vec<_>>();
+        anyhow::ensure!(
+            recoveries == ["recovering", "recovered"],
+            "recovery records must show one recovering/recovered pair: {recoveries:?}"
+        );
+        anyhow::ensure!(
+            run.router_evidence
+                .get("calls")
+                .and_then(Value::as_array)
+                .is_some_and(|calls| calls.len() == 3),
+            "the turn must consume exactly three generations: {}",
+            run.router_evidence
+        );
+        Ok(())
+    })
+    .scenario_timeout_ms(60_000)
+    .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::frames::{AssistantMessageEvent, ContentBlock, ErrorKind, StopReason};
+
+    #[test]
+    fn fixture_ends_the_cut_stream_in_one_transient_error_with_a_degraded_call() {
+        let fixture = scenario();
+        fixture.validate().unwrap();
+        assert_eq!(fixture.expected_turn_statuses, ["completed"]);
+
+        let generation = &fixture.script.generations[0];
+        assert_eq!(
+            generation
+                .frames
+                .iter()
+                .filter(|frame| frame.is_terminal())
+                .count(),
+            1
+        );
+        assert!(generation
+            .frames
+            .iter()
+            .any(|frame| matches!(frame, AssistantMessageEvent::FunctioncallDelta { .. })));
+        let Some(AssistantMessageEvent::Error { error }) = generation.frames.last() else {
+            panic!("the cut stream must end in an error frame")
+        };
+        assert_eq!(error.stop_reason, StopReason::Error);
+        assert_eq!(error.error_kind, Some(ErrorKind::Transient));
+        assert_eq!(error.error_message.as_deref(), Some(ERROR));
+        let degraded = error.content.iter().find_map(|block| match block {
+            ContentBlock::FunctionCall { arguments, .. } => Some(arguments),
+            _ => None,
+        });
+        assert!(degraded.is_some_and(|arguments| arguments.get("_raw").is_some()));
+        assert!(!generation.response.ok);
+        assert_eq!(
+            generation
+                .response
+                .error
+                .as_ref()
+                .map(|error| error.code.as_str()),
+            Some("transient")
+        );
+    }
+}

--- a/harness/tests/integration/src/scenarios/truncated_function_call_stream.rs
+++ b/harness/tests/integration/src/scenarios/truncated_function_call_stream.rs
@@ -6,13 +6,15 @@
 //! mid-arguments: one transient error frame whose partial carries the call
 //! with degraded arguments. The Harness must keep the useful text, refuse to
 //! dispatch the degraded call, resume once, and finish the turn with the
-//! re-issued call executed exactly once. The same session then serves a second
-//! turn without any restart.
+//! re-issued call executed exactly once. A follow-up message steered into the
+//! same session during the final generation is then answered without any
+//! restart of the provider, router, Harness or Console.
 
 use serde_json::{json, Value};
 
 use super::dsl::{
     ControlledFunction, Generation, Message, Model, Request, Response, Scenario, Send,
+    TruncatedCall,
 };
 use super::ScenarioDriver;
 use crate::fixtures::ScenarioFixture;
@@ -23,6 +25,8 @@ const MESSAGE: &str = "Record the expected value once.";
 const PARTIAL: &str = "Recording now.";
 const CUT_CALL_ID: &str = "call-cut";
 const CALL_ID: &str = "call-complete";
+const FOLLOW_UP: &str = "Now confirm the session still works.";
+const FOLLOW_UP_REPLY: &str = "still working";
 const ERROR: &str = "fixture stream truncated: the body ended inside a function call's arguments [phase=sse-decode reason=open_function_call]";
 
 pub(super) fn scenario() -> ScenarioFixture {
@@ -43,7 +47,7 @@ pub(super) fn scenario() -> ScenarioFixture {
     Scenario::new(
         ID,
         SLUG,
-        "A stream cut inside function-call arguments keeps the partial text, never executes the degraded call, resumes once, and runs the re-issued call exactly once.",
+        "A stream cut inside function-call arguments keeps the partial text, never executes the degraded call, resumes once, runs the re-issued call exactly once, and the same session answers a follow-up without a restart.",
         ScenarioDriver::Direct,
         model.clone(),
     )
@@ -65,9 +69,12 @@ pub(super) fn scenario() -> ScenarioFixture {
             )
             .respond(Response::truncated_function_call(
                 PARTIAL,
-                CUT_CALL_ID,
-                &record,
-                json!({ "_raw": "{\"value\":\"exp" }),
+                TruncatedCall {
+                    call_id: CUT_CALL_ID,
+                    function: &record,
+                    argument_delta: "{\"value\":\"exp",
+                    degraded_arguments: json!({ "_raw": "{\"value\":\"exp" }),
+                },
                 ERROR,
                 8,
                 3,
@@ -91,6 +98,9 @@ pub(super) fn scenario() -> ScenarioFixture {
             )),
     )
     .generation(
+        // The follow-up parks while this generation streams and is delivered
+        // by the completed path's steering check as the next step of the
+        // same session.
         Generation::new(3)
             .expect(
                 Request::new()
@@ -99,10 +109,34 @@ pub(super) fn scenario() -> ScenarioFixture {
                     .messages_subset([Message::user(MESSAGE)])
                     .tools_exact([record.tool()]),
             )
+            .parked_message(FOLLOW_UP)
             .respond(Response::text("recorded once", 30, 2)),
     )
+    .generation(
+        Generation::new(4)
+            .expect(
+                Request::new()
+                    .turn_request()
+                    .system_prompt_sha256("{{system_prompt_sha256}}")
+                    .messages_subset([Message::user(MESSAGE)])
+                    .tools_exact([record.tool()]),
+            )
+            .respond(Response::text(FOLLOW_UP_REPLY, 40, 2)),
+    )
     .verify(|run| {
-        run.expect_assistant_texts([PARTIAL, "recorded once"])?;
+        run.expect_assistant_texts([PARTIAL, "recorded once", FOLLOW_UP_REPLY])?;
+        anyhow::ensure!(
+            run.transcript.iter().any(|item| {
+                item.get("message")
+                    .and_then(|m| m.get("content"))
+                    .and_then(Value::as_array)
+                    .is_some_and(|blocks| {
+                        blocks.iter().any(|b| b.get("text").and_then(Value::as_str) == Some(FOLLOW_UP))
+                    })
+            }),
+            "the follow-up message must land in the same session: {:?}",
+            run.transcript
+        );
         run.expect_function_calls("record", 1)?;
         run.expect_call_payload("record", json!({ "value": "expected" }))?;
         run.expect_no_duplicate_messages()?;
@@ -146,8 +180,8 @@ pub(super) fn scenario() -> ScenarioFixture {
             run.router_evidence
                 .get("calls")
                 .and_then(Value::as_array)
-                .is_some_and(|calls| calls.len() == 3),
-            "the turn must consume exactly three generations: {}",
+                .is_some_and(|calls| calls.len() == 4),
+            "recovery and the follow-up must consume exactly four generations: {}",
             run.router_evidence
         );
         Ok(())

--- a/llm-router/src/provider_scaffold/sse_transport.rs
+++ b/llm-router/src/provider_scaffold/sse_transport.rs
@@ -2,7 +2,8 @@
 //! error-chain flattening, cross-chunk UTF-8 buffering, CRLF
 //! normalization, and `\n\n`-delimited block draining. Decoding the
 //! blocks into events stays provider-specific (the closure).
-use crate::types::events::AssistantMessageEvent;
+use crate::types::events::{AssistantMessageEvent, ErrorKind, StopReason};
+use crate::types::messages::AssistantMessage;
 use tokio::sync::mpsc;
 
 /// Flatten an error and its `source()` chain into one string. reqwest's
@@ -98,9 +99,372 @@ where
     false
 }
 
+/// The slice of a provider's decoder state the end-of-stream policy needs.
+pub trait StreamEndView {
+    /// `finish_reason`, `message_stop`, or `response.completed` arrived.
+    fn saw_terminator(&self) -> bool;
+    /// Text, thinking, or a function call started.
+    fn has_content(&self) -> bool;
+    /// A call block never closed, or its arguments are not one complete JSON object.
+    fn has_unfinished_call(&self) -> bool;
+}
+
+/// Whether a body close without a protocol terminator may count as complete
+/// (Chat Completions gateways sometimes skip `[DONE]`; Messages never skips `message_stop`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CloseFraming {
+    Accepted,
+    Rejected,
+}
+
+/// Why a stream counts as cut short.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Truncation {
+    /// The body ended inside an SSE block or inside a `data:` JSON payload.
+    PartialFrame { bytes: usize },
+    /// A function call's arguments never closed.
+    OpenFunctionCall,
+    /// No content arrived before the body closed.
+    Empty,
+    /// The protocol requires a terminator and none arrived.
+    NoTerminator,
+}
+
+impl Truncation {
+    /// Stable, greppable tag for logs and error details.
+    pub fn tag(self) -> &'static str {
+        match self {
+            Truncation::PartialFrame { .. } => "partial_frame",
+            Truncation::OpenFunctionCall => "open_function_call",
+            Truncation::Empty => "empty",
+            Truncation::NoTerminator => "no_terminator",
+        }
+    }
+
+    pub fn describe(self) -> String {
+        match self {
+            Truncation::PartialFrame { bytes } => {
+                format!("the body ended inside an event frame ({bytes} undecoded bytes)")
+            }
+            Truncation::OpenFunctionCall => {
+                "the body ended inside a function call's arguments".to_string()
+            }
+            Truncation::Empty => "the body ended before any output".to_string(),
+            Truncation::NoTerminator => "the body ended before the completion event".to_string(),
+        }
+    }
+}
+
+/// Outcome of the end-of-stream policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamEnd {
+    Complete,
+    Truncated(Truncation),
+}
+
+/// How the undecoded tail of the body was handled by [`flush_tail`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TailFlush {
+    /// Decoding the tail forwarded a terminal event; the caller is done.
+    Terminal,
+    /// Nothing was left, or the tail decoded as a complete block.
+    Clean,
+    /// The tail is an unterminated frame; it was not decoded.
+    Partial { bytes: usize },
+}
+
+/// True when `tail` has no `data:` line or its payload is not complete JSON (nor `[DONE]`).
+pub fn tail_frame_is_partial(tail: &str) -> bool {
+    let tail = tail.trim();
+    if tail.is_empty() {
+        return false;
+    }
+    let Some(data) = tail
+        .lines()
+        .filter_map(|l| l.strip_prefix("data:"))
+        .next_back()
+    else {
+        return true;
+    };
+    let data = data.trim();
+    if data == "[DONE]" {
+        return false;
+    }
+    serde_json::from_str::<serde_json::Value>(data).is_err()
+}
+
+/// Decode the body's undelimited tail; an unterminated frame is reported, not dropped.
+pub async fn flush_tail<F>(
+    text: &mut String,
+    tx: &mpsc::Sender<AssistantMessageEvent>,
+    handle_block: &mut F,
+) -> TailFlush
+where
+    F: FnMut(&str) -> Vec<AssistantMessageEvent>,
+{
+    normalize_crlf(text);
+    if text.trim().is_empty() {
+        text.clear();
+        return TailFlush::Clean;
+    }
+    if tail_frame_is_partial(text) {
+        let bytes = text.trim().len();
+        text.clear();
+        return TailFlush::Partial { bytes };
+    }
+    let mut block = std::mem::take(text);
+    block.push_str("\n\n");
+    if drain_sse_blocks(&mut block, tx, handle_block).await {
+        TailFlush::Terminal
+    } else {
+        TailFlush::Clean
+    }
+}
+
+/// One end-of-stream policy for every provider.
+pub fn classify_stream_end(
+    state: &dyn StreamEndView,
+    tail: TailFlush,
+    framing: CloseFraming,
+) -> StreamEnd {
+    if state.saw_terminator() {
+        return StreamEnd::Complete;
+    }
+    if let TailFlush::Partial { bytes } = tail {
+        return StreamEnd::Truncated(Truncation::PartialFrame { bytes });
+    }
+    if state.has_unfinished_call() {
+        return StreamEnd::Truncated(Truncation::OpenFunctionCall);
+    }
+    if !state.has_content() {
+        return StreamEnd::Truncated(Truncation::Empty);
+    }
+    match framing {
+        CloseFraming::Accepted => StreamEnd::Complete,
+        CloseFraming::Rejected => StreamEnd::Truncated(Truncation::NoTerminator),
+    }
+}
+
+/// The terminal error frame for a cut stream; keeps the partial, names the phase, logs no payload.
+pub fn truncated_stream_error(
+    mut partial: AssistantMessage,
+    provider: &str,
+    truncation: Truncation,
+) -> AssistantMessageEvent {
+    let message = format!(
+        "{provider} stream truncated: {} [phase=sse-decode reason={}]",
+        truncation.describe(),
+        truncation.tag()
+    );
+    tracing::warn!(
+        provider,
+        model = %partial.model,
+        phase = "sse-decode",
+        reason = truncation.tag(),
+        content_blocks = partial.content.len(),
+        "provider stream truncated"
+    );
+    partial.stop_reason = StopReason::Error;
+    partial.error_message = Some(message);
+    partial.error_kind = Some(ErrorKind::Transient);
+    AssistantMessageEvent::Error { error: partial }
+}
+
+/// True when `args_json` is not (yet) one complete JSON object.
+pub fn arguments_incomplete(args_json: &str) -> bool {
+    if args_json.trim().is_empty() {
+        return false;
+    }
+    !matches!(
+        serde_json::from_str::<serde_json::Value>(args_json),
+        Ok(serde_json::Value::Object(_))
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct View {
+        terminator: bool,
+        content: bool,
+        open_call: bool,
+    }
+
+    impl StreamEndView for View {
+        fn saw_terminator(&self) -> bool {
+            self.terminator
+        }
+        fn has_content(&self) -> bool {
+            self.content
+        }
+        fn has_unfinished_call(&self) -> bool {
+            self.open_call
+        }
+    }
+
+    fn view(terminator: bool, content: bool, open_call: bool) -> View {
+        View {
+            terminator,
+            content,
+            open_call,
+        }
+    }
+
+    #[test]
+    fn tail_partial_detection() {
+        assert!(!tail_frame_is_partial(""));
+        assert!(!tail_frame_is_partial("\n  \n"));
+        assert!(!tail_frame_is_partial("data: [DONE]"));
+        assert!(!tail_frame_is_partial("data: {\"choices\":[]}"));
+        assert!(!tail_frame_is_partial("event: x\ndata: {\"a\":1}\n"));
+        assert!(tail_frame_is_partial(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"he"
+        ));
+        assert!(tail_frame_is_partial("dat"));
+        assert!(tail_frame_is_partial("event: content_block_delta\n"));
+    }
+
+    #[tokio::test]
+    async fn flush_tail_decodes_a_block_missing_its_blank_line() {
+        let (tx, mut rx) = mpsc::channel(8);
+        let mut text = "data: {\"a\":1}".to_string();
+        let mut seen = Vec::new();
+        let flush = flush_tail(&mut text, &tx, &mut |block: &str| {
+            seen.push(block.to_string());
+            vec![AssistantMessageEvent::Ping]
+        })
+        .await;
+        assert_eq!(flush, TailFlush::Clean);
+        assert_eq!(seen, vec!["data: {\"a\":1}\n\n"]);
+        assert!(text.is_empty());
+        assert!(matches!(rx.try_recv(), Ok(AssistantMessageEvent::Ping)));
+    }
+
+    #[tokio::test]
+    async fn flush_tail_reports_an_unterminated_frame_without_decoding() {
+        let (tx, _rx) = mpsc::channel(8);
+        let mut text =
+            "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"function\":{\"argu".to_string();
+        let bytes = text.len();
+        let mut calls = 0;
+        let flush = flush_tail(&mut text, &tx, &mut |_block: &str| {
+            calls += 1;
+            vec![]
+        })
+        .await;
+        assert_eq!(flush, TailFlush::Partial { bytes });
+        assert_eq!(calls, 0);
+        assert!(text.is_empty());
+    }
+
+    #[tokio::test]
+    async fn flush_tail_surfaces_a_terminal_from_the_tail() {
+        let (tx, _rx) = mpsc::channel(8);
+        let mut text = "data: [DONE]".to_string();
+        let flush = flush_tail(&mut text, &tx, &mut |_block: &str| {
+            vec![AssistantMessageEvent::Done {
+                message: empty("m"),
+            }]
+        })
+        .await;
+        assert_eq!(flush, TailFlush::Terminal);
+    }
+
+    #[test]
+    fn terminator_wins_over_everything() {
+        let end = classify_stream_end(
+            &view(true, false, true),
+            TailFlush::Partial { bytes: 9 },
+            CloseFraming::Rejected,
+        );
+        assert_eq!(end, StreamEnd::Complete);
+    }
+
+    #[test]
+    fn partial_frame_is_a_cut() {
+        let end = classify_stream_end(
+            &view(false, true, false),
+            TailFlush::Partial { bytes: 9 },
+            CloseFraming::Accepted,
+        );
+        assert_eq!(
+            end,
+            StreamEnd::Truncated(Truncation::PartialFrame { bytes: 9 })
+        );
+    }
+
+    #[test]
+    fn open_function_call_is_a_cut_even_with_close_framing() {
+        let end = classify_stream_end(
+            &view(false, true, true),
+            TailFlush::Clean,
+            CloseFraming::Accepted,
+        );
+        assert_eq!(end, StreamEnd::Truncated(Truncation::OpenFunctionCall));
+    }
+
+    #[test]
+    fn empty_body_is_a_cut() {
+        let end = classify_stream_end(
+            &view(false, false, false),
+            TailFlush::Clean,
+            CloseFraming::Accepted,
+        );
+        assert_eq!(end, StreamEnd::Truncated(Truncation::Empty));
+    }
+
+    #[test]
+    fn text_only_close_depends_on_framing() {
+        let accepted = classify_stream_end(
+            &view(false, true, false),
+            TailFlush::Clean,
+            CloseFraming::Accepted,
+        );
+        assert_eq!(accepted, StreamEnd::Complete);
+        let rejected = classify_stream_end(
+            &view(false, true, false),
+            TailFlush::Clean,
+            CloseFraming::Rejected,
+        );
+        assert_eq!(rejected, StreamEnd::Truncated(Truncation::NoTerminator));
+    }
+
+    #[test]
+    fn arguments_completeness() {
+        assert!(!arguments_incomplete(""));
+        assert!(!arguments_incomplete("{}"));
+        assert!(!arguments_incomplete("{\"path\":\"/tmp\"}"));
+        assert!(arguments_incomplete("{\"path\":\"/tm"));
+        assert!(arguments_incomplete("[1,2]"));
+        assert!(arguments_incomplete("\"text\""));
+    }
+
+    #[test]
+    fn truncated_error_keeps_partial_content_and_names_the_phase() {
+        let mut partial = empty("gpt-test");
+        partial.content = vec![crate::types::content::ContentBlock::Text {
+            text: "partial".into(),
+        }];
+        let ev = truncated_stream_error(partial, "openai", Truncation::OpenFunctionCall);
+        let AssistantMessageEvent::Error { error } = ev else {
+            panic!("want error");
+        };
+        assert_eq!(error.stop_reason, StopReason::Error);
+        assert_eq!(error.error_kind, Some(ErrorKind::Transient));
+        assert_eq!(error.content.len(), 1);
+        let message = error.error_message.unwrap();
+        assert!(
+            message.starts_with("openai stream truncated: "),
+            "{message}"
+        );
+        assert!(message.contains("phase=sse-decode"), "{message}");
+        assert!(message.contains("reason=open_function_call"), "{message}");
+    }
+
+    fn empty(model: &str) -> AssistantMessage {
+        crate::chat::synthesize::empty_partial(model, "test-provider", 0)
+    }
 
     #[test]
     fn utf8_split_across_chunks_is_preserved() {

--- a/provider-anthropic/src/sse.rs
+++ b/provider-anthropic/src/sse.rs
@@ -5,6 +5,7 @@
 use crate::errors::classify;
 use crate::wire::names::decode_tool_name;
 use crate::{now_ms, PROVIDER_ID};
+use llm_router::provider_scaffold::sse_transport::{arguments_incomplete, StreamEndView};
 use llm_router::types::content::ContentBlock;
 use llm_router::types::events::{AssistantMessageEvent, ErrorKind, StopReason, Usage};
 use llm_router::types::messages::{AssistantMessage, AssistantRoleTag};
@@ -143,6 +144,29 @@ fn build_content(state: &PartialState) -> Vec<ContentBlock> {
         push_block_content(&mut out, state, kind, idx);
     }
     out
+}
+
+impl StreamEndView for PartialState {
+    fn saw_terminator(&self) -> bool {
+        self.saw_message_stop
+    }
+
+    fn has_content(&self) -> bool {
+        !self.text_blocks.is_empty()
+            || !self.thinking_blocks.is_empty()
+            || !self.redacted_blocks.is_empty()
+            || !self.function_calls.is_empty()
+    }
+
+    fn has_unfinished_call(&self) -> bool {
+        self.block_slots
+            .iter()
+            .any(|slot| matches!(slot, Some(BlockSlot::ToolUse(_))))
+            || self
+                .function_calls
+                .iter()
+                .any(|tc| arguments_incomplete(&tc.args_json))
+    }
 }
 
 pub fn build_partial(state: &PartialState, model: &str) -> AssistantMessage {

--- a/provider-anthropic/src/upstream.rs
+++ b/provider-anthropic/src/upstream.rs
@@ -6,9 +6,11 @@ use crate::sse::{
     build_partial, handle_sse_event, synthetic_error_event, synthetic_error_event_from_state,
     PartialState,
 };
+use crate::PROVIDER_ID;
 use futures::StreamExt;
 use llm_router::provider_scaffold::sse_transport::{
-    append_utf8_chunk, drain_sse_blocks, error_chain,
+    append_utf8_chunk, classify_stream_end, drain_sse_blocks, error_chain, tail_frame_is_partial,
+    truncated_stream_error, CloseFraming, StreamEnd, TailFlush,
 };
 use llm_router::types::events::{AssistantMessageEvent, ErrorKind};
 use serde_json::Value;
@@ -135,27 +137,31 @@ async fn run_upstream(
         text.push_str(&String::from_utf8_lossy(&byte_buf));
         byte_buf.clear();
     }
-    if !text.trim().is_empty() {
-        let remainder = std::mem::take(&mut text);
-        let _ = drain_blocks(&mut (remainder + "\n\n"), &mut state, &args.model, &tx).await;
-    }
-
-    if state.saw_message_stop {
-        let _ = tx
-            .send(AssistantMessageEvent::Done {
-                message: build_partial(&state, &args.model),
-            })
-            .await;
+    // A final block missing only its blank line still decodes; a cut frame is reported.
+    let tail = if tail_frame_is_partial(&text) {
+        TailFlush::Partial {
+            bytes: text.trim().len(),
+        }
+    } else if text.trim().is_empty() {
+        TailFlush::Clean
     } else {
-        let _ = tx
-            .send(synthetic_error_event_from_state(
-                &state,
-                "anthropic stream ended before message_stop",
-                &args.model,
-                ErrorKind::Transient,
-            ))
-            .await;
-    }
+        let remainder = std::mem::take(&mut text);
+        if drain_blocks(&mut (remainder + "\n\n"), &mut state, &args.model, &tx).await {
+            return;
+        }
+        TailFlush::Clean
+    };
+
+    // Messages always ends with message_stop, so close framing is never accepted.
+    let event = match classify_stream_end(&state, tail, CloseFraming::Rejected) {
+        StreamEnd::Complete => AssistantMessageEvent::Done {
+            message: build_partial(&state, &args.model),
+        },
+        StreamEnd::Truncated(truncation) => {
+            truncated_stream_error(build_partial(&state, &args.model), PROVIDER_ID, truncation)
+        }
+    };
+    let _ = tx.send(event).await;
 }
 
 #[cfg(test)]
@@ -262,10 +268,9 @@ mod tests {
         match events.last() {
             Some(AssistantMessageEvent::Error { error }) => {
                 assert_eq!(error.error_kind, Some(ErrorKind::Transient));
-                assert!(error
-                    .error_message
-                    .as_deref()
-                    .is_some_and(|m| m.contains("message_stop")));
+                let message = error.error_message.as_deref().unwrap_or_default();
+                assert!(message.contains("stream truncated"), "{message}");
+                assert!(message.contains("reason=no_terminator"), "{message}");
             }
             other => panic!("want error, got {other:?}"),
         }
@@ -300,6 +305,88 @@ mod tests {
                 assert_eq!(error.error_kind, Some(ErrorKind::Transient));
             }
             other => panic!("want error, got {other:?}"),
+        }
+    }
+
+    const TRUNCATED_MID_ARGUMENTS: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\nevent: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":3}}}\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Listing\"}}\n\nevent: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_1\",\"name\":\"shell__fs__ls\",\"input\":{}}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"path\\\":\\\"/tm\"}}\n\n";
+
+    const TRUNCATED_MID_FRAME: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\nevent: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":3}}}\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" wor";
+
+    const FINAL_BLOCK_WITHOUT_BLANK_LINE: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\nevent: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":3}}}\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello\"}}\n\nevent: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\nevent: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":2}}\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"}";
+
+    fn single_terminal_error(
+        events: &[AssistantMessageEvent],
+    ) -> &llm_router::types::messages::AssistantMessage {
+        assert_eq!(
+            events.iter().filter(|e| e.is_terminal()).count(),
+            1,
+            "{events:?}"
+        );
+        match events.last() {
+            Some(AssistantMessageEvent::Error { error }) => error,
+            other => panic!("want error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_cut_inside_function_call_arguments_ends_as_one_error() {
+        let url = stub(TRUNCATED_MID_ARGUMENTS).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        assert_eq!(error.error_kind, Some(ErrorKind::Transient));
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("stream truncated"), "{message}");
+        assert!(message.contains("reason=open_function_call"), "{message}");
+        assert!(error.content.iter().any(
+            |b| matches!(b, llm_router::types::content::ContentBlock::Text { text } if text == "Listing")
+        ));
+        let call = error.content.iter().find_map(|b| match b {
+            llm_router::types::content::ContentBlock::FunctionCall { arguments, .. } => {
+                Some(arguments)
+            }
+            _ => None,
+        });
+        let arguments = call.expect("function call block kept as evidence");
+        assert!(
+            arguments.get("_partial").is_some() || arguments.get("_raw").is_some(),
+            "arguments must be marked degraded: {arguments}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_cut_inside_an_event_frame_ends_as_one_error() {
+        let url = stub(TRUNCATED_MID_FRAME).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        assert_eq!(error.error_kind, Some(ErrorKind::Transient));
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("reason=partial_frame"), "{message}");
+        assert!(error.content.iter().any(
+            |b| matches!(b, llm_router::types::content::ContentBlock::Text { text } if text == "Hello")
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn empty_stream_ends_as_one_error_not_an_empty_done() {
+        let url =
+            stub("HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\n")
+                .await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("reason=empty"), "{message}");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn final_block_without_blank_line_still_completes() {
+        let url = stub(FINAL_BLOCK_WITHOUT_BLANK_LINE).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        assert_eq!(events.iter().filter(|e| e.is_terminal()).count(), 1);
+        match events.last() {
+            Some(AssistantMessageEvent::Done { message }) => {
+                assert_eq!(message.native_stop_reason.as_deref(), Some("end_turn"));
+            }
+            other => panic!("want done, got {other:?}"),
         }
     }
 

--- a/provider-claude-code/src/sse.rs
+++ b/provider-claude-code/src/sse.rs
@@ -5,6 +5,7 @@
 use crate::errors::classify;
 use crate::wire::names::decode_tool_name;
 use crate::{now_ms, PROVIDER_ID};
+use llm_router::provider_scaffold::sse_transport::{arguments_incomplete, StreamEndView};
 use llm_router::types::content::ContentBlock;
 use llm_router::types::events::{AssistantMessageEvent, ErrorKind, StopReason, Usage};
 use llm_router::types::messages::{AssistantMessage, AssistantRoleTag};
@@ -143,6 +144,29 @@ fn build_content(state: &PartialState) -> Vec<ContentBlock> {
         push_block_content(&mut out, state, kind, idx);
     }
     out
+}
+
+impl StreamEndView for PartialState {
+    fn saw_terminator(&self) -> bool {
+        self.saw_message_stop
+    }
+
+    fn has_content(&self) -> bool {
+        !self.text_blocks.is_empty()
+            || !self.thinking_blocks.is_empty()
+            || !self.redacted_blocks.is_empty()
+            || !self.function_calls.is_empty()
+    }
+
+    fn has_unfinished_call(&self) -> bool {
+        self.block_slots
+            .iter()
+            .any(|slot| matches!(slot, Some(BlockSlot::ToolUse(_))))
+            || self
+                .function_calls
+                .iter()
+                .any(|tc| arguments_incomplete(&tc.args_json))
+    }
 }
 
 pub fn build_partial(state: &PartialState, model: &str) -> AssistantMessage {

--- a/provider-claude-code/src/upstream.rs
+++ b/provider-claude-code/src/upstream.rs
@@ -6,9 +6,11 @@ use crate::sse::{
     build_partial, handle_sse_event, synthetic_error_event, synthetic_error_event_from_state,
     PartialState,
 };
+use crate::PROVIDER_ID;
 use futures::StreamExt;
 use llm_router::provider_scaffold::sse_transport::{
-    append_utf8_chunk, drain_sse_blocks, error_chain,
+    append_utf8_chunk, classify_stream_end, drain_sse_blocks, error_chain, tail_frame_is_partial,
+    truncated_stream_error, CloseFraming, StreamEnd, TailFlush,
 };
 use llm_router::types::events::{AssistantMessageEvent, ErrorKind};
 use serde_json::Value;
@@ -135,32 +137,31 @@ async fn run_upstream(
         text.push_str(&String::from_utf8_lossy(&byte_buf));
         byte_buf.clear();
     }
-    if !text.trim().is_empty() {
+    // A final block missing only its blank line still decodes; a cut frame is reported.
+    let tail = if tail_frame_is_partial(&text) {
+        TailFlush::Partial {
+            bytes: text.trim().len(),
+        }
+    } else if text.trim().is_empty() {
+        TailFlush::Clean
+    } else {
         let remainder = std::mem::take(&mut text);
-        // A terminal event can arrive in the final, undelimited chunk. If the
-        // flush forwards one, stop — otherwise the branch below emits a second
-        // terminal frame, breaking the single-terminal contract.
         if drain_blocks(&mut (remainder + "\n\n"), &mut state, &args.model, &tx).await {
             return;
         }
-    }
+        TailFlush::Clean
+    };
 
-    if state.saw_message_stop {
-        let _ = tx
-            .send(AssistantMessageEvent::Done {
-                message: build_partial(&state, &args.model),
-            })
-            .await;
-    } else {
-        let _ = tx
-            .send(synthetic_error_event_from_state(
-                &state,
-                "claude-code stream ended before message_stop",
-                &args.model,
-                ErrorKind::Transient,
-            ))
-            .await;
-    }
+    // Messages always ends with message_stop, so close framing is never accepted.
+    let event = match classify_stream_end(&state, tail, CloseFraming::Rejected) {
+        StreamEnd::Complete => AssistantMessageEvent::Done {
+            message: build_partial(&state, &args.model),
+        },
+        StreamEnd::Truncated(truncation) => {
+            truncated_stream_error(build_partial(&state, &args.model), PROVIDER_ID, truncation)
+        }
+    };
+    let _ = tx.send(event).await;
 }
 
 #[cfg(test)]
@@ -293,10 +294,9 @@ mod tests {
         match events.last() {
             Some(AssistantMessageEvent::Error { error }) => {
                 assert_eq!(error.error_kind, Some(ErrorKind::Transient));
-                assert!(error
-                    .error_message
-                    .as_deref()
-                    .is_some_and(|m| m.contains("message_stop")));
+                let message = error.error_message.as_deref().unwrap_or_default();
+                assert!(message.contains("stream truncated"), "{message}");
+                assert!(message.contains("reason=no_terminator"), "{message}");
             }
             other => panic!("want error, got {other:?}"),
         }
@@ -331,6 +331,88 @@ mod tests {
                 assert_eq!(error.error_kind, Some(ErrorKind::Transient));
             }
             other => panic!("want error, got {other:?}"),
+        }
+    }
+
+    const TRUNCATED_MID_ARGUMENTS: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\nevent: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":3}}}\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Listing\"}}\n\nevent: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_1\",\"name\":\"shell__fs__ls\",\"input\":{}}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"path\\\":\\\"/tm\"}}\n\n";
+
+    const TRUNCATED_MID_FRAME: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\nevent: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":3}}}\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" wor";
+
+    const FINAL_BLOCK_WITHOUT_BLANK_LINE: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\nevent: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":3}}}\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello\"}}\n\nevent: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\nevent: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":2}}\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"}";
+
+    fn single_terminal_error(
+        events: &[AssistantMessageEvent],
+    ) -> &llm_router::types::messages::AssistantMessage {
+        assert_eq!(
+            events.iter().filter(|e| e.is_terminal()).count(),
+            1,
+            "{events:?}"
+        );
+        match events.last() {
+            Some(AssistantMessageEvent::Error { error }) => error,
+            other => panic!("want error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_cut_inside_function_call_arguments_ends_as_one_error() {
+        let url = stub(TRUNCATED_MID_ARGUMENTS).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        assert_eq!(error.error_kind, Some(ErrorKind::Transient));
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("stream truncated"), "{message}");
+        assert!(message.contains("reason=open_function_call"), "{message}");
+        assert!(error.content.iter().any(
+            |b| matches!(b, llm_router::types::content::ContentBlock::Text { text } if text == "Listing")
+        ));
+        let call = error.content.iter().find_map(|b| match b {
+            llm_router::types::content::ContentBlock::FunctionCall { arguments, .. } => {
+                Some(arguments)
+            }
+            _ => None,
+        });
+        let arguments = call.expect("function call block kept as evidence");
+        assert!(
+            arguments.get("_partial").is_some() || arguments.get("_raw").is_some(),
+            "arguments must be marked degraded: {arguments}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_cut_inside_an_event_frame_ends_as_one_error() {
+        let url = stub(TRUNCATED_MID_FRAME).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        assert_eq!(error.error_kind, Some(ErrorKind::Transient));
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("reason=partial_frame"), "{message}");
+        assert!(error.content.iter().any(
+            |b| matches!(b, llm_router::types::content::ContentBlock::Text { text } if text == "Hello")
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn empty_stream_ends_as_one_error_not_an_empty_done() {
+        let url =
+            stub("HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\n")
+                .await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("reason=empty"), "{message}");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn final_block_without_blank_line_still_completes() {
+        let url = stub(FINAL_BLOCK_WITHOUT_BLANK_LINE).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        assert_eq!(events.iter().filter(|e| e.is_terminal()).count(), 1);
+        match events.last() {
+            Some(AssistantMessageEvent::Done { message }) => {
+                assert_eq!(message.native_stop_reason.as_deref(), Some("end_turn"));
+            }
+            other => panic!("want done, got {other:?}"),
         }
     }
 

--- a/provider-deepseek/src/sse.rs
+++ b/provider-deepseek/src/sse.rs
@@ -4,6 +4,7 @@
 use crate::errors::classify;
 use crate::wire::names::decode_tool_name;
 use crate::{now_ms, PROVIDER_ID};
+use llm_router::provider_scaffold::sse_transport::{arguments_incomplete, StreamEndView};
 use llm_router::types::content::ContentBlock;
 use llm_router::types::events::{AssistantMessageEvent, ErrorKind, StopReason, Usage};
 use llm_router::types::messages::{AssistantMessage, AssistantRoleTag};
@@ -47,6 +48,7 @@ pub struct PartialState {
     native_stop_reason: Option<String>,
     error_message: Option<String>,
     warnings: Vec<String>,
+    terminated: bool,
 }
 
 impl PartialState {
@@ -60,6 +62,7 @@ impl PartialState {
             native_stop_reason: None,
             error_message: None,
             warnings,
+            terminated: false,
         }
     }
 
@@ -109,6 +112,28 @@ impl PartialState {
             Segment::Call(c) => c,
             _ => unreachable!("slot came from call_slot / a Call push"),
         }
+    }
+}
+
+impl StreamEndView for PartialState {
+    fn saw_terminator(&self) -> bool {
+        self.terminated
+    }
+
+    fn has_content(&self) -> bool {
+        !self.segments.is_empty()
+    }
+
+    fn has_unfinished_call(&self) -> bool {
+        let open_call = self
+            .open
+            .and_then(|i| self.segments.get(i))
+            .is_some_and(|s| matches!(s, Segment::Call(_)));
+        open_call
+            || self.segments.iter().any(|s| match s {
+                Segment::Call(c) => arguments_incomplete(&c.args_json),
+                _ => false,
+            })
     }
 }
 
@@ -416,6 +441,7 @@ pub fn handle_chunk(
 
     if let Some(finish) = choice.get("finish_reason").and_then(Value::as_str) {
         state.stop_reason = map_finish_reason(finish);
+        state.terminated = true;
         state.native_stop_reason = Some(finish.to_string());
         if finish == "content_filter" {
             state.warnings.push(

--- a/provider-deepseek/src/upstream.rs
+++ b/provider-deepseek/src/upstream.rs
@@ -4,9 +4,11 @@
 //! which drops the reqwest response mid-body and closes the connection.
 use crate::errors::classify;
 use crate::sse::{build_final, build_partial, handle_chunk, synthetic_error_event, PartialState};
+use crate::PROVIDER_ID;
 use futures::StreamExt;
 use llm_router::provider_scaffold::sse_transport::{
-    append_utf8_chunk, drain_sse_blocks, error_chain,
+    append_utf8_chunk, classify_stream_end, drain_sse_blocks, error_chain, flush_tail,
+    truncated_stream_error, CloseFraming, StreamEnd, TailFlush,
 };
 use llm_router::types::events::{AssistantMessageEvent, ErrorKind};
 use serde_json::Value;
@@ -102,9 +104,8 @@ async fn run_upstream(
 
     let mut stream = resp.bytes_stream();
     let mut buf = String::new();
-    // Cross-chunk UTF-8 buffering: transport chunk boundaries are arbitrary,
-    // so a multi-byte character (DeepSeek output is frequently CJK) can split
-    // across chunks — a per-chunk lossy decode would corrupt it into U+FFFD.
+    // Cross-chunk UTF-8 buffering: network chunks split multibyte
+    // codepoints, and a per-chunk lossy conversion corrupts them to U+FFFD.
     let mut byte_buf = Vec::new();
     // Block decoder: [DONE] closes the stream (Stop + Done, Done terminal);
     // anything else parses and runs the chunk state machine.
@@ -153,12 +154,23 @@ async fn run_upstream(
             return; // terminal forwarded, or receiver dropped → abort upstream
         }
     }
-    // Stream ended without [DONE] (connection close framing): still terminal.
-    let _ = tx
-        .send(AssistantMessageEvent::Done {
+    // Body closed: one terminal frame, decided by the shared end-of-stream policy.
+    let tail = flush_tail(&mut buf, &tx, &mut |block: &str| {
+        decode(block, &mut state, &args.model)
+    })
+    .await;
+    if tail == TailFlush::Terminal {
+        return;
+    }
+    let event = match classify_stream_end(&state, tail, CloseFraming::Accepted) {
+        StreamEnd::Complete => AssistantMessageEvent::Done {
             message: build_final(&state, &args.model),
-        })
-        .await;
+        },
+        StreamEnd::Truncated(truncation) => {
+            truncated_stream_error(build_final(&state, &args.model), PROVIDER_ID, truncation)
+        }
+    };
+    let _ = tx.send(event).await;
 }
 
 #[cfg(test)]
@@ -321,6 +333,88 @@ mod tests {
                 assert!(
                     matches!(&message.content[0], llm_router::types::content::ContentBlock::Text { text } if text == "Hi")
                 );
+            }
+            other => panic!("want done, got {other:?}"),
+        }
+    }
+
+    const TRUNCATED_MID_ARGUMENTS: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Listing\"}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"shell__fs__ls\",\"arguments\":\"\"}}]}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"path\\\":\\\"/tm\"}}]}}]}\n\n";
+
+    const TRUNCATED_MID_FRAME: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\" wor";
+
+    const FINAL_BLOCK_WITHOUT_BLANK_LINE: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}";
+
+    fn single_terminal_error(
+        events: &[AssistantMessageEvent],
+    ) -> &llm_router::types::messages::AssistantMessage {
+        assert_eq!(
+            events.iter().filter(|e| e.is_terminal()).count(),
+            1,
+            "{events:?}"
+        );
+        match events.last() {
+            Some(AssistantMessageEvent::Error { error }) => error,
+            other => panic!("want error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_cut_inside_function_call_arguments_ends_as_one_error() {
+        let url = stub(TRUNCATED_MID_ARGUMENTS).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        assert_eq!(error.error_kind, Some(ErrorKind::Transient));
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("stream truncated"), "{message}");
+        assert!(message.contains("reason=open_function_call"), "{message}");
+        assert!(error.content.iter().any(
+            |b| matches!(b, llm_router::types::content::ContentBlock::Text { text } if text == "Listing")
+        ));
+        let call = error.content.iter().find_map(|b| match b {
+            llm_router::types::content::ContentBlock::FunctionCall { arguments, .. } => {
+                Some(arguments)
+            }
+            _ => None,
+        });
+        let arguments = call.expect("function call block kept as evidence");
+        assert!(
+            arguments.get("_partial").is_some() || arguments.get("_raw").is_some(),
+            "arguments must be marked degraded: {arguments}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_cut_inside_an_event_frame_ends_as_one_error() {
+        let url = stub(TRUNCATED_MID_FRAME).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        assert_eq!(error.error_kind, Some(ErrorKind::Transient));
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("reason=partial_frame"), "{message}");
+        assert!(error.content.iter().any(
+            |b| matches!(b, llm_router::types::content::ContentBlock::Text { text } if text == "Hello")
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn empty_stream_ends_as_one_error_not_an_empty_done() {
+        let url =
+            stub("HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\n")
+                .await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("reason=empty"), "{message}");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn final_block_without_blank_line_still_completes() {
+        let url = stub(FINAL_BLOCK_WITHOUT_BLANK_LINE).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        assert_eq!(events.iter().filter(|e| e.is_terminal()).count(), 1);
+        match events.last() {
+            Some(AssistantMessageEvent::Done { message }) => {
+                assert_eq!(message.native_stop_reason.as_deref(), Some("stop"));
             }
             other => panic!("want done, got {other:?}"),
         }

--- a/provider-github-copilot/src/sse.rs
+++ b/provider-github-copilot/src/sse.rs
@@ -9,6 +9,7 @@
 use crate::errors::classify;
 use crate::wire::names::decode_tool_name;
 use crate::{now_ms, PROVIDER_ID};
+use llm_router::provider_scaffold::sse_transport::{arguments_incomplete, StreamEndView};
 use llm_router::types::content::ContentBlock;
 use llm_router::types::events::{AssistantMessageEvent, ErrorKind, StopReason, Usage};
 use llm_router::types::messages::{AssistantMessage, AssistantRoleTag};
@@ -43,6 +44,7 @@ pub struct PartialState {
     native_stop_reason: Option<String>,
     error_message: Option<String>,
     warnings: Vec<String>,
+    terminated: bool,
 }
 
 impl PartialState {
@@ -58,11 +60,30 @@ impl PartialState {
             native_stop_reason: None,
             error_message: None,
             warnings,
+            terminated: false,
         }
     }
 
     pub fn stop_reason(&self) -> StopReason {
         self.stop_reason
+    }
+}
+
+impl StreamEndView for PartialState {
+    fn saw_terminator(&self) -> bool {
+        self.terminated
+    }
+
+    fn has_content(&self) -> bool {
+        !self.text.is_empty() || !self.thinking.is_empty() || !self.function_calls.is_empty()
+    }
+
+    fn has_unfinished_call(&self) -> bool {
+        matches!(self.open_block, Some(OpenBlock::Call(_)))
+            || self
+                .function_calls
+                .iter()
+                .any(|fc| arguments_incomplete(&fc.args_json))
     }
 }
 
@@ -104,7 +125,13 @@ fn build_content(state: &PartialState) -> Vec<ContentBlock> {
         let arguments = if fc.args_json.is_empty() {
             serde_json::json!({})
         } else {
-            serde_json::from_str(&fc.args_json).unwrap_or(Value::Null)
+            // Unparseable args (mid-stream partials, malformed JSON) degrade
+            // to the salvaged leading fields or `{"_raw": …}` — always an
+            // object (replay-safe) that preserves the evidence.
+            serde_json::from_str(&fc.args_json)
+                .ok()
+                .filter(Value::is_object)
+                .unwrap_or_else(|| llm_router::types::messages::degraded_arguments(&fc.args_json))
         };
         out.push(ContentBlock::FunctionCall {
             id: fc.id.clone(),
@@ -348,6 +375,7 @@ pub fn handle_chunk(
 
     if let Some(finish) = choice.get("finish_reason").and_then(Value::as_str) {
         state.stop_reason = map_finish_reason(finish);
+        state.terminated = true;
         state.native_stop_reason = Some(finish.to_string());
         if finish == "content_filter" {
             state.warnings.push(

--- a/provider-github-copilot/src/upstream.rs
+++ b/provider-github-copilot/src/upstream.rs
@@ -3,7 +3,12 @@
 //! which drops the reqwest response mid-body and closes the connection.
 use crate::errors::classify;
 use crate::sse::{build_final, build_partial, handle_chunk, synthetic_error_event, PartialState};
+use crate::PROVIDER_ID;
 use futures::StreamExt;
+use llm_router::provider_scaffold::sse_transport::{
+    append_utf8_chunk, classify_stream_end, drain_sse_blocks, error_chain, flush_tail,
+    truncated_stream_error, CloseFraming, StreamEnd, TailFlush,
+};
 use llm_router::types::events::{AssistantMessageEvent, ErrorKind};
 use serde_json::Value;
 use tokio::sync::mpsc;
@@ -58,23 +63,6 @@ fn data_line(block: &str) -> Option<&str> {
         .next_back()
 }
 
-/// Earliest complete-SSE-block boundary in the byte buffer: `(end_index,
-/// separator_len)` for `\n\n` or `\r\n\r\n`, whichever comes first. Byte-level
-/// so a multibyte UTF-8 character split across network chunks is never
-/// decoded early (several vendors stream CJK-heavy content).
-fn find_block_end(buf: &[u8]) -> Option<(usize, usize)> {
-    let lf = buf.windows(2).position(|w| w == b"\n\n").map(|i| (i, 2));
-    let crlf = buf
-        .windows(4)
-        .position(|w| w == b"\r\n\r\n")
-        .map(|i| (i, 4));
-    match (lf, crlf) {
-        (Some(a), Some(b)) => Some(if a.0 <= b.0 { a } else { b }),
-        (a, None) => a,
-        (None, b) => b,
-    }
-}
-
 async fn run_upstream(
     client: reqwest::Client,
     args: UpstreamArgs,
@@ -89,7 +77,7 @@ async fn run_upstream(
         Err(e) => {
             let _ = tx
                 .send(synthetic_error_event(
-                    &format!("copilot fetch failed: {e}"),
+                    &format!("copilot fetch failed: {}", error_chain(&e)),
                     &args.model,
                     ErrorKind::Transient,
                 ))
@@ -127,9 +115,34 @@ async fn run_upstream(
     }
 
     let mut stream = resp.bytes_stream();
-    // Byte buffer, decoded only per complete block: a multibyte character or
-    // block separator split across chunks stays buffered until whole.
-    let mut buf: Vec<u8> = Vec::new();
+    let mut buf = String::new();
+    // Cross-chunk UTF-8 buffering: network chunks split multibyte
+    // codepoints, and a per-chunk lossy conversion corrupts them to U+FFFD.
+    let mut byte_buf = Vec::new();
+    // Block decoder: [DONE] closes the stream (Stop + Done, Done terminal);
+    // anything else parses and runs the chunk state machine.
+    let decode =
+        |data_block: &str, state: &mut PartialState, model: &str| -> Vec<AssistantMessageEvent> {
+            let Some(data) = data_line(data_block) else {
+                return vec![];
+            };
+            if data == "[DONE]" {
+                return vec![
+                    AssistantMessageEvent::Stop {
+                        stop_reason: state.stop_reason(),
+                        error_message: None,
+                        error_kind: None,
+                    },
+                    AssistantMessageEvent::Done {
+                        message: build_final(state, model),
+                    },
+                ];
+            }
+            let Ok(parsed) = serde_json::from_str::<Value>(data) else {
+                return vec![];
+            };
+            handle_chunk(&parsed, state, model)
+        };
     while let Some(chunk) = stream.next().await {
         let chunk = match chunk {
             Ok(c) => c,
@@ -144,7 +157,7 @@ async fn run_upstream(
                 return;
             }
         };
-        buf.extend_from_slice(&chunk);
+        append_utf8_chunk(&mut byte_buf, &mut buf, &chunk);
         if buf.len() > MAX_SSE_BUFFER {
             let _ = tx
                 .send(synthetic_error_event(
@@ -155,55 +168,31 @@ async fn run_upstream(
                 .await;
             return;
         }
-        while let Some((end, sep_len)) = find_block_end(&buf) {
-            let raw: Vec<u8> = buf.drain(..end + sep_len).collect();
-            let block = String::from_utf8_lossy(&raw);
-            let Some(data) = data_line(&block) else {
-                continue;
-            };
-            if data == "[DONE]" {
-                let _ = tx
-                    .send(AssistantMessageEvent::Stop {
-                        stop_reason: state.stop_reason(),
-                        error_message: None,
-                        error_kind: None,
-                    })
-                    .await;
-                let _ = tx
-                    .send(AssistantMessageEvent::Done {
-                        message: build_final(&state, &args.model),
-                    })
-                    .await;
-                return;
-            }
-            let Ok(parsed) = serde_json::from_str::<Value>(data) else {
-                continue;
-            };
-            for ev in handle_chunk(&parsed, &mut state, &args.model) {
-                let terminal = ev.is_terminal();
-                if tx.send(ev).await.is_err() {
-                    return; // receiver dropped → abort upstream
-                }
-                if terminal {
-                    return; // exactly one terminal event
-                }
-            }
+        if drain_sse_blocks(&mut buf, &tx, &mut |block: &str| {
+            decode(block, &mut state, &args.model)
+        })
+        .await
+        {
+            return; // terminal forwarded, or receiver dropped → abort upstream
         }
     }
-    // Stream ended without [DONE] (connection close framing): still terminal,
-    // and still preceded by Stop so both endings look the same downstream.
-    let _ = tx
-        .send(AssistantMessageEvent::Stop {
-            stop_reason: state.stop_reason(),
-            error_message: None,
-            error_kind: None,
-        })
-        .await;
-    let _ = tx
-        .send(AssistantMessageEvent::Done {
+    // Body closed: one terminal frame, decided by the shared end-of-stream policy.
+    let tail = flush_tail(&mut buf, &tx, &mut |block: &str| {
+        decode(block, &mut state, &args.model)
+    })
+    .await;
+    if tail == TailFlush::Terminal {
+        return;
+    }
+    let event = match classify_stream_end(&state, tail, CloseFraming::Accepted) {
+        StreamEnd::Complete => AssistantMessageEvent::Done {
             message: build_final(&state, &args.model),
-        })
-        .await;
+        },
+        StreamEnd::Truncated(truncation) => {
+            truncated_stream_error(build_final(&state, &args.model), PROVIDER_ID, truncation)
+        }
+    };
+    let _ = tx.send(event).await;
 }
 
 #[cfg(test)]
@@ -350,18 +339,6 @@ mod tests {
     }
 
     #[test]
-    fn block_end_handles_lf_and_crlf_separators() {
-        assert_eq!(find_block_end(b"data: x\n\nrest"), Some((7, 2)));
-        assert_eq!(find_block_end(b"data: x\r\n\r\nrest"), Some((7, 4)));
-        // earliest boundary wins when both framings appear
-        assert_eq!(find_block_end(b"a\n\nb\r\n\r\nc"), Some((1, 2)));
-        assert_eq!(find_block_end(b"a\r\n\r\nb\n\nc"), Some((1, 4)));
-        // incomplete block: no boundary yet
-        assert_eq!(find_block_end(b"data: partial\n"), None);
-        assert_eq!(find_block_end(b"data: partial\r\n"), None);
-    }
-
-    #[test]
     fn data_line_accepts_bare_and_spaced_prefixes_and_crlf() {
         assert_eq!(data_line("data: hello\n"), Some("hello"));
         assert_eq!(data_line("data:hello\n"), Some("hello"));
@@ -382,6 +359,88 @@ mod tests {
                 assert!(
                     matches!(&message.content[0], llm_router::types::content::ContentBlock::Text { text } if text == "你好，世界")
                 );
+                assert_eq!(message.native_stop_reason.as_deref(), Some("stop"));
+            }
+            other => panic!("want done, got {other:?}"),
+        }
+    }
+
+    const TRUNCATED_MID_ARGUMENTS: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Listing\"}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"shell__fs__ls\",\"arguments\":\"\"}}]}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"path\\\":\\\"/tm\"}}]}}]}\n\n";
+
+    const TRUNCATED_MID_FRAME: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\" wor";
+
+    const FINAL_BLOCK_WITHOUT_BLANK_LINE: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}";
+
+    fn single_terminal_error(
+        events: &[AssistantMessageEvent],
+    ) -> &llm_router::types::messages::AssistantMessage {
+        assert_eq!(
+            events.iter().filter(|e| e.is_terminal()).count(),
+            1,
+            "{events:?}"
+        );
+        match events.last() {
+            Some(AssistantMessageEvent::Error { error }) => error,
+            other => panic!("want error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_cut_inside_function_call_arguments_ends_as_one_error() {
+        let url = stub(TRUNCATED_MID_ARGUMENTS).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        assert_eq!(error.error_kind, Some(ErrorKind::Transient));
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("stream truncated"), "{message}");
+        assert!(message.contains("reason=open_function_call"), "{message}");
+        assert!(error.content.iter().any(
+            |b| matches!(b, llm_router::types::content::ContentBlock::Text { text } if text == "Listing")
+        ));
+        let call = error.content.iter().find_map(|b| match b {
+            llm_router::types::content::ContentBlock::FunctionCall { arguments, .. } => {
+                Some(arguments)
+            }
+            _ => None,
+        });
+        let arguments = call.expect("function call block kept as evidence");
+        assert!(
+            arguments.get("_partial").is_some() || arguments.get("_raw").is_some(),
+            "arguments must be marked degraded: {arguments}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_cut_inside_an_event_frame_ends_as_one_error() {
+        let url = stub(TRUNCATED_MID_FRAME).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        assert_eq!(error.error_kind, Some(ErrorKind::Transient));
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("reason=partial_frame"), "{message}");
+        assert!(error.content.iter().any(
+            |b| matches!(b, llm_router::types::content::ContentBlock::Text { text } if text == "Hello")
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn empty_stream_ends_as_one_error_not_an_empty_done() {
+        let url =
+            stub("HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\n")
+                .await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("reason=empty"), "{message}");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn final_block_without_blank_line_still_completes() {
+        let url = stub(FINAL_BLOCK_WITHOUT_BLANK_LINE).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        assert_eq!(events.iter().filter(|e| e.is_terminal()).count(), 1);
+        match events.last() {
+            Some(AssistantMessageEvent::Done { message }) => {
                 assert_eq!(message.native_stop_reason.as_deref(), Some("stop"));
             }
             other => panic!("want done, got {other:?}"),

--- a/provider-kimi/src/sse.rs
+++ b/provider-kimi/src/sse.rs
@@ -9,6 +9,7 @@
 use crate::errors::classify;
 use crate::wire::names::decode_tool_name;
 use crate::{now_ms, PROVIDER_ID};
+use llm_router::provider_scaffold::sse_transport::{arguments_incomplete, StreamEndView};
 use llm_router::types::content::ContentBlock;
 use llm_router::types::events::{AssistantMessageEvent, ErrorKind, StopReason, Usage};
 use llm_router::types::messages::{AssistantMessage, AssistantRoleTag};
@@ -39,6 +40,7 @@ pub struct PartialState {
     native_stop_reason: Option<String>,
     error_message: Option<String>,
     warnings: Vec<String>,
+    terminated: bool,
 }
 
 impl PartialState {
@@ -54,11 +56,30 @@ impl PartialState {
             native_stop_reason: None,
             error_message: None,
             warnings,
+            terminated: false,
         }
     }
 
     pub fn stop_reason(&self) -> StopReason {
         self.stop_reason
+    }
+}
+
+impl StreamEndView for PartialState {
+    fn saw_terminator(&self) -> bool {
+        self.terminated
+    }
+
+    fn has_content(&self) -> bool {
+        !self.text.is_empty() || !self.thinking.is_empty() || !self.function_calls.is_empty()
+    }
+
+    fn has_unfinished_call(&self) -> bool {
+        matches!(self.open_block, Some(OpenBlock::Call(_)))
+            || self
+                .function_calls
+                .iter()
+                .any(|fc| arguments_incomplete(&fc.args_json))
     }
 }
 
@@ -100,7 +121,13 @@ fn build_content(state: &PartialState) -> Vec<ContentBlock> {
         let arguments = if fc.args_json.is_empty() {
             serde_json::json!({})
         } else {
-            serde_json::from_str(&fc.args_json).unwrap_or(Value::Null)
+            // Unparseable args (mid-stream partials, malformed JSON) degrade
+            // to the salvaged leading fields or `{"_raw": …}` — always an
+            // object (replay-safe) that preserves the evidence.
+            serde_json::from_str(&fc.args_json)
+                .ok()
+                .filter(Value::is_object)
+                .unwrap_or_else(|| llm_router::types::messages::degraded_arguments(&fc.args_json))
         };
         out.push(ContentBlock::FunctionCall {
             id: fc.id.clone(),
@@ -327,6 +354,7 @@ pub fn handle_chunk(
 
     if let Some(finish) = choice.get("finish_reason").and_then(Value::as_str) {
         state.stop_reason = map_finish_reason(finish);
+        state.terminated = true;
         state.native_stop_reason = Some(finish.to_string());
         if finish == "content_filter" {
             state

--- a/provider-kimi/src/upstream.rs
+++ b/provider-kimi/src/upstream.rs
@@ -3,7 +3,12 @@
 //! which drops the reqwest response mid-body and closes the connection.
 use crate::errors::classify;
 use crate::sse::{build_final, build_partial, handle_chunk, synthetic_error_event, PartialState};
+use crate::PROVIDER_ID;
 use futures::StreamExt;
+use llm_router::provider_scaffold::sse_transport::{
+    append_utf8_chunk, classify_stream_end, drain_sse_blocks, error_chain, flush_tail,
+    truncated_stream_error, CloseFraming, StreamEnd, TailFlush,
+};
 use llm_router::types::events::{AssistantMessageEvent, ErrorKind};
 use serde_json::Value;
 use tokio::sync::mpsc;
@@ -59,7 +64,7 @@ async fn run_upstream(
         Err(e) => {
             let _ = tx
                 .send(synthetic_error_event(
-                    &format!("kimi fetch failed: {e}"),
+                    &format!("kimi fetch failed: {}", error_chain(&e)),
                     &args.model,
                     ErrorKind::Transient,
                 ))
@@ -96,6 +101,33 @@ async fn run_upstream(
 
     let mut stream = resp.bytes_stream();
     let mut buf = String::new();
+    // Cross-chunk UTF-8 buffering: network chunks split multibyte
+    // codepoints, and a per-chunk lossy conversion corrupts them to U+FFFD.
+    let mut byte_buf = Vec::new();
+    // Block decoder: [DONE] closes the stream (Stop + Done, Done terminal);
+    // anything else parses and runs the chunk state machine.
+    let decode =
+        |data_block: &str, state: &mut PartialState, model: &str| -> Vec<AssistantMessageEvent> {
+            let Some(data) = data_line(data_block) else {
+                return vec![];
+            };
+            if data == "[DONE]" {
+                return vec![
+                    AssistantMessageEvent::Stop {
+                        stop_reason: state.stop_reason(),
+                        error_message: None,
+                        error_kind: None,
+                    },
+                    AssistantMessageEvent::Done {
+                        message: build_final(state, model),
+                    },
+                ];
+            }
+            let Ok(parsed) = serde_json::from_str::<Value>(data) else {
+                return vec![];
+            };
+            handle_chunk(&parsed, state, model)
+        };
     while let Some(chunk) = stream.next().await {
         let chunk = match chunk {
             Ok(c) => c,
@@ -110,47 +142,32 @@ async fn run_upstream(
                 return;
             }
         };
-        buf.push_str(&String::from_utf8_lossy(&chunk));
-        while let Some(idx) = buf.find("\n\n") {
-            let block: String = buf.drain(..idx + 2).collect();
-            let Some(data) = data_line(&block) else {
-                continue;
-            };
-            if data == "[DONE]" {
-                let _ = tx
-                    .send(AssistantMessageEvent::Stop {
-                        stop_reason: state.stop_reason(),
-                        error_message: None,
-                        error_kind: None,
-                    })
-                    .await;
-                let _ = tx
-                    .send(AssistantMessageEvent::Done {
-                        message: build_final(&state, &args.model),
-                    })
-                    .await;
-                return;
-            }
-            let Ok(parsed) = serde_json::from_str::<Value>(data) else {
-                continue;
-            };
-            for ev in handle_chunk(&parsed, &mut state, &args.model) {
-                let terminal = ev.is_terminal();
-                if tx.send(ev).await.is_err() {
-                    return; // receiver dropped → abort upstream
-                }
-                if terminal {
-                    return; // exactly one terminal event
-                }
-            }
+        append_utf8_chunk(&mut byte_buf, &mut buf, &chunk);
+        if drain_sse_blocks(&mut buf, &tx, &mut |block: &str| {
+            decode(block, &mut state, &args.model)
+        })
+        .await
+        {
+            return; // terminal forwarded, or receiver dropped → abort upstream
         }
     }
-    // Stream ended without [DONE] (connection close framing): still terminal.
-    let _ = tx
-        .send(AssistantMessageEvent::Done {
+    // Body closed: one terminal frame, decided by the shared end-of-stream policy.
+    let tail = flush_tail(&mut buf, &tx, &mut |block: &str| {
+        decode(block, &mut state, &args.model)
+    })
+    .await;
+    if tail == TailFlush::Terminal {
+        return;
+    }
+    let event = match classify_stream_end(&state, tail, CloseFraming::Accepted) {
+        StreamEnd::Complete => AssistantMessageEvent::Done {
             message: build_final(&state, &args.model),
-        })
-        .await;
+        },
+        StreamEnd::Truncated(truncation) => {
+            truncated_stream_error(build_final(&state, &args.model), PROVIDER_ID, truncation)
+        }
+    };
+    let _ = tx.send(event).await;
 }
 
 #[cfg(test)]
@@ -270,6 +287,88 @@ mod tests {
                 assert!(
                     matches!(&message.content[0], llm_router::types::content::ContentBlock::Text { text } if text == "Hi")
                 );
+            }
+            other => panic!("want done, got {other:?}"),
+        }
+    }
+
+    const TRUNCATED_MID_ARGUMENTS: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Listing\"}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"shell__fs__ls\",\"arguments\":\"\"}}]}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"path\\\":\\\"/tm\"}}]}}]}\n\n";
+
+    const TRUNCATED_MID_FRAME: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\" wor";
+
+    const FINAL_BLOCK_WITHOUT_BLANK_LINE: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}";
+
+    fn single_terminal_error(
+        events: &[AssistantMessageEvent],
+    ) -> &llm_router::types::messages::AssistantMessage {
+        assert_eq!(
+            events.iter().filter(|e| e.is_terminal()).count(),
+            1,
+            "{events:?}"
+        );
+        match events.last() {
+            Some(AssistantMessageEvent::Error { error }) => error,
+            other => panic!("want error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_cut_inside_function_call_arguments_ends_as_one_error() {
+        let url = stub(TRUNCATED_MID_ARGUMENTS).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        assert_eq!(error.error_kind, Some(ErrorKind::Transient));
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("stream truncated"), "{message}");
+        assert!(message.contains("reason=open_function_call"), "{message}");
+        assert!(error.content.iter().any(
+            |b| matches!(b, llm_router::types::content::ContentBlock::Text { text } if text == "Listing")
+        ));
+        let call = error.content.iter().find_map(|b| match b {
+            llm_router::types::content::ContentBlock::FunctionCall { arguments, .. } => {
+                Some(arguments)
+            }
+            _ => None,
+        });
+        let arguments = call.expect("function call block kept as evidence");
+        assert!(
+            arguments.get("_partial").is_some() || arguments.get("_raw").is_some(),
+            "arguments must be marked degraded: {arguments}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_cut_inside_an_event_frame_ends_as_one_error() {
+        let url = stub(TRUNCATED_MID_FRAME).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        assert_eq!(error.error_kind, Some(ErrorKind::Transient));
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("reason=partial_frame"), "{message}");
+        assert!(error.content.iter().any(
+            |b| matches!(b, llm_router::types::content::ContentBlock::Text { text } if text == "Hello")
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn empty_stream_ends_as_one_error_not_an_empty_done() {
+        let url =
+            stub("HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\n")
+                .await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("reason=empty"), "{message}");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn final_block_without_blank_line_still_completes() {
+        let url = stub(FINAL_BLOCK_WITHOUT_BLANK_LINE).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        assert_eq!(events.iter().filter(|e| e.is_terminal()).count(), 1);
+        match events.last() {
+            Some(AssistantMessageEvent::Done { message }) => {
+                assert_eq!(message.native_stop_reason.as_deref(), Some("stop"));
             }
             other => panic!("want done, got {other:?}"),
         }

--- a/provider-llamacpp/src/sse.rs
+++ b/provider-llamacpp/src/sse.rs
@@ -4,6 +4,7 @@
 use crate::errors::classify;
 use crate::wire::names::decode_tool_name;
 use crate::{now_ms, PROVIDER_ID};
+use llm_router::provider_scaffold::sse_transport::{arguments_incomplete, StreamEndView};
 use llm_router::types::content::ContentBlock;
 use llm_router::types::events::{AssistantMessageEvent, ErrorKind, StopReason, Usage};
 use llm_router::types::messages::{AssistantMessage, AssistantRoleTag};
@@ -36,6 +37,7 @@ pub struct PartialState {
     native_stop_reason: Option<String>,
     error_message: Option<String>,
     warnings: Vec<String>,
+    terminated: bool,
 }
 
 impl PartialState {
@@ -51,11 +53,30 @@ impl PartialState {
             native_stop_reason: None,
             error_message: None,
             warnings,
+            terminated: false,
         }
     }
 
     pub fn stop_reason(&self) -> StopReason {
         self.stop_reason
+    }
+}
+
+impl StreamEndView for PartialState {
+    fn saw_terminator(&self) -> bool {
+        self.terminated
+    }
+
+    fn has_content(&self) -> bool {
+        !self.text.is_empty() || !self.thinking.is_empty() || !self.function_calls.is_empty()
+    }
+
+    fn has_unfinished_call(&self) -> bool {
+        matches!(self.open_block, Some(OpenBlock::Call(_)))
+            || self
+                .function_calls
+                .iter()
+                .any(|fc| arguments_incomplete(&fc.args_json))
     }
 }
 
@@ -337,6 +358,7 @@ pub fn handle_chunk(
 
     if let Some(finish) = choice.get("finish_reason").and_then(Value::as_str) {
         state.stop_reason = map_finish_reason(finish);
+        state.terminated = true;
         state.native_stop_reason = Some(finish.to_string());
         close_open_block(state, model, &mut events);
     }

--- a/provider-llamacpp/src/upstream.rs
+++ b/provider-llamacpp/src/upstream.rs
@@ -4,9 +4,11 @@
 //! which drops the reqwest response mid-body and closes the connection.
 use crate::errors::classify;
 use crate::sse::{build_final, build_partial, handle_chunk, synthetic_error_event, PartialState};
+use crate::PROVIDER_ID;
 use futures::StreamExt;
 use llm_router::provider_scaffold::sse_transport::{
-    append_utf8_chunk, drain_sse_blocks, error_chain,
+    append_utf8_chunk, classify_stream_end, drain_sse_blocks, error_chain, flush_tail,
+    truncated_stream_error, CloseFraming, StreamEnd, TailFlush,
 };
 use llm_router::types::events::{AssistantMessageEvent, ErrorKind};
 use serde_json::Value;
@@ -100,16 +102,14 @@ async fn run_upstream(
 
     let mut stream = resp.bytes_stream();
     let mut buf = String::new();
-    // Cross-chunk UTF-8 buffering: transport chunk boundaries are arbitrary,
-    // so a multi-byte character (a locally-hosted model's output may be CJK
-    // or other non-ASCII text) can split across chunks — a per-chunk lossy
-    // decode would corrupt it into U+FFFD.
-    let mut byte_buf: Vec<u8> = Vec::new();
+    // Cross-chunk UTF-8 buffering: network chunks split multibyte
+    // codepoints, and a per-chunk lossy conversion corrupts them to U+FFFD.
+    let mut byte_buf = Vec::new();
     // Block decoder: [DONE] closes the stream (Stop + Done, Done terminal);
     // anything else parses and runs the chunk state machine.
     let decode =
-        |block: &str, state: &mut PartialState, model: &str| -> Vec<AssistantMessageEvent> {
-            let Some(data) = data_line(block) else {
+        |data_block: &str, state: &mut PartialState, model: &str| -> Vec<AssistantMessageEvent> {
+            let Some(data) = data_line(data_block) else {
                 return vec![];
             };
             if data == "[DONE]" {
@@ -152,12 +152,23 @@ async fn run_upstream(
             return; // terminal forwarded, or receiver dropped → abort upstream
         }
     }
-    // Stream ended without [DONE] (connection close framing): still terminal.
-    let _ = tx
-        .send(AssistantMessageEvent::Done {
+    // Body closed: one terminal frame, decided by the shared end-of-stream policy.
+    let tail = flush_tail(&mut buf, &tx, &mut |block: &str| {
+        decode(block, &mut state, &args.model)
+    })
+    .await;
+    if tail == TailFlush::Terminal {
+        return;
+    }
+    let event = match classify_stream_end(&state, tail, CloseFraming::Accepted) {
+        StreamEnd::Complete => AssistantMessageEvent::Done {
             message: build_final(&state, &args.model),
-        })
-        .await;
+        },
+        StreamEnd::Truncated(truncation) => {
+            truncated_stream_error(build_final(&state, &args.model), PROVIDER_ID, truncation)
+        }
+    };
+    let _ = tx.send(event).await;
 }
 
 #[cfg(test)]
@@ -301,6 +312,88 @@ mod tests {
                 assert!(
                     matches!(&message.content[0], llm_router::types::content::ContentBlock::Text { text } if text == "Hi")
                 );
+            }
+            other => panic!("want done, got {other:?}"),
+        }
+    }
+
+    const TRUNCATED_MID_ARGUMENTS: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Listing\"}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"shell__fs__ls\",\"arguments\":\"\"}}]}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"path\\\":\\\"/tm\"}}]}}]}\n\n";
+
+    const TRUNCATED_MID_FRAME: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\" wor";
+
+    const FINAL_BLOCK_WITHOUT_BLANK_LINE: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}";
+
+    fn single_terminal_error(
+        events: &[AssistantMessageEvent],
+    ) -> &llm_router::types::messages::AssistantMessage {
+        assert_eq!(
+            events.iter().filter(|e| e.is_terminal()).count(),
+            1,
+            "{events:?}"
+        );
+        match events.last() {
+            Some(AssistantMessageEvent::Error { error }) => error,
+            other => panic!("want error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_cut_inside_function_call_arguments_ends_as_one_error() {
+        let url = stub(TRUNCATED_MID_ARGUMENTS).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        assert_eq!(error.error_kind, Some(ErrorKind::Transient));
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("stream truncated"), "{message}");
+        assert!(message.contains("reason=open_function_call"), "{message}");
+        assert!(error.content.iter().any(
+            |b| matches!(b, llm_router::types::content::ContentBlock::Text { text } if text == "Listing")
+        ));
+        let call = error.content.iter().find_map(|b| match b {
+            llm_router::types::content::ContentBlock::FunctionCall { arguments, .. } => {
+                Some(arguments)
+            }
+            _ => None,
+        });
+        let arguments = call.expect("function call block kept as evidence");
+        assert!(
+            arguments.get("_partial").is_some() || arguments.get("_raw").is_some(),
+            "arguments must be marked degraded: {arguments}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_cut_inside_an_event_frame_ends_as_one_error() {
+        let url = stub(TRUNCATED_MID_FRAME).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        assert_eq!(error.error_kind, Some(ErrorKind::Transient));
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("reason=partial_frame"), "{message}");
+        assert!(error.content.iter().any(
+            |b| matches!(b, llm_router::types::content::ContentBlock::Text { text } if text == "Hello")
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn empty_stream_ends_as_one_error_not_an_empty_done() {
+        let url =
+            stub("HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\n")
+                .await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("reason=empty"), "{message}");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn final_block_without_blank_line_still_completes() {
+        let url = stub(FINAL_BLOCK_WITHOUT_BLANK_LINE).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        assert_eq!(events.iter().filter(|e| e.is_terminal()).count(), 1);
+        match events.last() {
+            Some(AssistantMessageEvent::Done { message }) => {
+                assert_eq!(message.native_stop_reason.as_deref(), Some("stop"));
             }
             other => panic!("want done, got {other:?}"),
         }

--- a/provider-openai-codex/src/sse.rs
+++ b/provider-openai-codex/src/sse.rs
@@ -5,6 +5,7 @@
 //! Unknown event types are ignored (forward-compat: the backend adds events).
 use crate::wire::names::decode_tool_name;
 use crate::{now_ms, PROVIDER_ID};
+use llm_router::provider_scaffold::sse_transport::{arguments_incomplete, StreamEndView};
 use llm_router::types::content::ContentBlock;
 use llm_router::types::events::{AssistantMessageEvent, ErrorKind, StopReason, Usage};
 use llm_router::types::messages::{AssistantMessage, AssistantRoleTag};
@@ -34,6 +35,7 @@ pub struct PartialState {
     stop_reason: StopReason,
     error_message: Option<String>,
     warnings: Vec<String>,
+    terminated: bool,
 }
 
 impl PartialState {
@@ -48,6 +50,7 @@ impl PartialState {
             stop_reason: StopReason::End,
             error_message: None,
             warnings,
+            terminated: false,
         }
     }
 
@@ -59,6 +62,24 @@ impl PartialState {
     /// distinguishes legitimate close-framing from a truncated/empty stream.
     pub fn has_content(&self) -> bool {
         !self.text.is_empty() || !self.thinking.is_empty() || !self.tool_calls.is_empty()
+    }
+}
+
+impl StreamEndView for PartialState {
+    fn saw_terminator(&self) -> bool {
+        self.terminated
+    }
+
+    fn has_content(&self) -> bool {
+        PartialState::has_content(self)
+    }
+
+    fn has_unfinished_call(&self) -> bool {
+        self.open_block == Some(OpenBlock::Call)
+            || self
+                .tool_calls
+                .iter()
+                .any(|tc| arguments_incomplete(&tc.args_json))
     }
 }
 
@@ -342,6 +363,7 @@ pub fn handle_chunk(
             });
         }
         n if n.contains("completed") => {
+            state.terminated = true;
             merge_usage(chunk, &mut state.usage);
             state.usage_seen = state.usage != Usage::default();
             state.stop_reason = if state.tool_calls.is_empty() {

--- a/provider-openai-codex/src/upstream.rs
+++ b/provider-openai-codex/src/upstream.rs
@@ -3,9 +3,11 @@
 //! which drops the reqwest response mid-body and closes the connection.
 use crate::errors::classify;
 use crate::sse::{build_final, build_partial, handle_chunk, synthetic_error_event, PartialState};
+use crate::PROVIDER_ID;
 use futures::StreamExt;
 use llm_router::provider_scaffold::sse_transport::{
-    append_utf8_chunk, drain_sse_blocks, error_chain,
+    append_utf8_chunk, classify_stream_end, drain_sse_blocks, error_chain, flush_tail,
+    truncated_stream_error, CloseFraming, StreamEnd, TailFlush,
 };
 use llm_router::types::events::{AssistantMessageEvent, ErrorKind};
 use serde_json::Value;
@@ -149,26 +151,23 @@ async fn run_upstream(
             return; // terminal forwarded, or receiver dropped → abort upstream
         }
     }
-    // Stream ended without [DONE]. With output accumulated this is
-    // legitimate connection-close framing: still terminal. With NOTHING
-    // accumulated the stream was truncated (or spoke only unrecognized
-    // events) — an empty `done` would end the run with an empty "successful"
-    // response, so surface a retryable error instead (MOT-3855).
-    if state.has_content() {
-        let _ = tx
-            .send(AssistantMessageEvent::Done {
-                message: build_final(&state, &args.model),
-            })
-            .await;
-    } else {
-        let _ = tx
-            .send(synthetic_error_event(
-                "codex stream ended without output or a completion event",
-                &args.model,
-                ErrorKind::Transient,
-            ))
-            .await;
+    // Body closed: one terminal frame, decided by the shared end-of-stream policy.
+    let tail = flush_tail(&mut buf, &tx, &mut |block: &str| {
+        decode(block, &mut state, &args.model)
+    })
+    .await;
+    if tail == TailFlush::Terminal {
+        return;
     }
+    let event = match classify_stream_end(&state, tail, CloseFraming::Accepted) {
+        StreamEnd::Complete => AssistantMessageEvent::Done {
+            message: build_final(&state, &args.model),
+        },
+        StreamEnd::Truncated(truncation) => {
+            truncated_stream_error(build_final(&state, &args.model), PROVIDER_ID, truncation)
+        }
+    };
+    let _ = tx.send(event).await;
 }
 
 #[cfg(test)]
@@ -330,6 +329,90 @@ mod tests {
             other => panic!("want error, got {other:?}"),
         }
         assert_eq!(events.iter().filter(|e| e.is_terminal()).count(), 1);
+    }
+
+    const TRUNCATED_MID_ARGUMENTS: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"Listing\"}\n\ndata: {\"type\":\"response.output_item.added\",\"output_index\":1,\"item\":{\"type\":\"function_call\",\"call_id\":\"call_1\",\"name\":\"shell__fs__ls\",\"arguments\":\"\"}}\n\ndata: {\"type\":\"response.function_call_arguments.delta\",\"output_index\":1,\"delta\":\"{\\\"path\\\":\\\"/tm\"}\n\n";
+
+    const TRUNCATED_MID_FRAME: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"Hello\"}\n\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\" wor";
+
+    const FINAL_BLOCK_WITHOUT_BLANK_LINE: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"Hello\"}\n\ndata: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}";
+
+    fn single_terminal_error(
+        events: &[AssistantMessageEvent],
+    ) -> &llm_router::types::messages::AssistantMessage {
+        assert_eq!(
+            events.iter().filter(|e| e.is_terminal()).count(),
+            1,
+            "{events:?}"
+        );
+        match events.last() {
+            Some(AssistantMessageEvent::Error { error }) => error,
+            other => panic!("want error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_cut_inside_function_call_arguments_ends_as_one_error() {
+        let url = stub(TRUNCATED_MID_ARGUMENTS).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        assert_eq!(error.error_kind, Some(ErrorKind::Transient));
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("stream truncated"), "{message}");
+        assert!(message.contains("reason=open_function_call"), "{message}");
+        assert!(error.content.iter().any(
+            |b| matches!(b, llm_router::types::content::ContentBlock::Text { text } if text == "Listing")
+        ));
+        let call = error.content.iter().find_map(|b| match b {
+            llm_router::types::content::ContentBlock::FunctionCall { arguments, .. } => {
+                Some(arguments)
+            }
+            _ => None,
+        });
+        let arguments = call.expect("function call block kept as evidence");
+        assert!(
+            arguments.get("_partial").is_some() || arguments.get("_raw").is_some(),
+            "arguments must be marked degraded: {arguments}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_cut_inside_an_event_frame_ends_as_one_error() {
+        let url = stub(TRUNCATED_MID_FRAME).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        assert_eq!(error.error_kind, Some(ErrorKind::Transient));
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("reason=partial_frame"), "{message}");
+        assert!(error.content.iter().any(
+            |b| matches!(b, llm_router::types::content::ContentBlock::Text { text } if text == "Hello")
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn empty_stream_ends_as_one_error_not_an_empty_done() {
+        let url =
+            stub("HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\n")
+                .await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("reason=empty"), "{message}");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn final_block_without_blank_line_still_completes() {
+        let url = stub(FINAL_BLOCK_WITHOUT_BLANK_LINE).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        assert_eq!(events.iter().filter(|e| e.is_terminal()).count(), 1);
+        match events.last() {
+            Some(AssistantMessageEvent::Done { message }) => {
+                assert!(
+                    matches!(&message.content[0], llm_router::types::content::ContentBlock::Text { text } if text == "Hello")
+                );
+            }
+            other => panic!("want done, got {other:?}"),
+        }
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/provider-openai/src/sse.rs
+++ b/provider-openai/src/sse.rs
@@ -3,6 +3,7 @@
 use crate::errors::classify;
 use crate::wire::names::decode_tool_name;
 use crate::{now_ms, PROVIDER_ID};
+use llm_router::provider_scaffold::sse_transport::{arguments_incomplete, StreamEndView};
 use llm_router::types::content::ContentBlock;
 use llm_router::types::events::{AssistantMessageEvent, ErrorKind, StopReason, Usage};
 use llm_router::types::messages::{AssistantMessage, AssistantRoleTag};
@@ -33,6 +34,7 @@ pub struct PartialState {
     native_stop_reason: Option<String>,
     error_message: Option<String>,
     warnings: Vec<String>,
+    terminated: bool,
 }
 
 impl PartialState {
@@ -48,6 +50,7 @@ impl PartialState {
             native_stop_reason: None,
             error_message: None,
             warnings,
+            terminated: false,
         }
     }
 
@@ -57,6 +60,24 @@ impl PartialState {
 
     pub fn has_content(&self) -> bool {
         !self.text.is_empty() || !self.thinking.is_empty() || !self.function_calls.is_empty()
+    }
+}
+
+impl StreamEndView for PartialState {
+    fn saw_terminator(&self) -> bool {
+        self.terminated
+    }
+
+    fn has_content(&self) -> bool {
+        PartialState::has_content(self)
+    }
+
+    fn has_unfinished_call(&self) -> bool {
+        matches!(self.open_block, Some(OpenBlock::Call(_)))
+            || self
+                .function_calls
+                .iter()
+                .any(|fc| arguments_incomplete(&fc.args_json))
     }
 }
 
@@ -315,6 +336,7 @@ pub fn handle_chunk(
     }
 
     if let Some(finish) = choice.get("finish_reason").and_then(Value::as_str) {
+        state.terminated = true;
         state.stop_reason = map_finish_reason(finish);
         state.native_stop_reason = Some(finish.to_string());
         if finish == "content_filter" {
@@ -488,6 +510,7 @@ fn handle_responses_event(
             }
         }
         "response.completed" => {
+            state.terminated = true;
             responses_usage(event, state);
             state.stop_reason = if state.function_calls.is_empty() {
                 StopReason::End
@@ -505,6 +528,7 @@ fn handle_responses_event(
             });
         }
         "response.incomplete" => {
+            state.terminated = true;
             responses_usage(event, state);
             let reason = event
                 .pointer("/response/incomplete_details/reason")

--- a/provider-openai/src/upstream.rs
+++ b/provider-openai/src/upstream.rs
@@ -4,9 +4,11 @@
 //! which drops the reqwest response mid-body and closes the connection.
 use crate::errors::classify;
 use crate::sse::{build_final, build_partial, handle_chunk, synthetic_error_event, PartialState};
+use crate::PROVIDER_ID;
 use futures::StreamExt;
 use llm_router::provider_scaffold::sse_transport::{
-    append_utf8_chunk, drain_sse_blocks, error_chain,
+    append_utf8_chunk, classify_stream_end, drain_sse_blocks, error_chain, flush_tail,
+    truncated_stream_error, CloseFraming, StreamEnd, TailFlush,
 };
 use llm_router::types::events::{AssistantMessageEvent, ErrorKind};
 use serde_json::Value;
@@ -150,23 +152,23 @@ async fn run_upstream(
             return; // terminal forwarded, or receiver dropped → abort upstream
         }
     }
-    // Responses usually terminates with `response.completed`; compatible
-    // gateways may instead close the connection after their final delta.
-    if state.has_content() {
-        let _ = tx
-            .send(AssistantMessageEvent::Done {
-                message: build_final(&state, &args.model),
-            })
-            .await;
-    } else {
-        let _ = tx
-            .send(synthetic_error_event(
-                "openai stream ended without output or a completion event",
-                &args.model,
-                ErrorKind::Transient,
-            ))
-            .await;
+    // Body closed: one terminal frame, decided by the shared end-of-stream policy.
+    let tail = flush_tail(&mut buf, &tx, &mut |block: &str| {
+        decode(block, &mut state, &args.model)
+    })
+    .await;
+    if tail == TailFlush::Terminal {
+        return;
     }
+    let event = match classify_stream_end(&state, tail, CloseFraming::Accepted) {
+        StreamEnd::Complete => AssistantMessageEvent::Done {
+            message: build_final(&state, &args.model),
+        },
+        StreamEnd::Truncated(truncation) => {
+            truncated_stream_error(build_final(&state, &args.model), PROVIDER_ID, truncation)
+        }
+    };
+    let _ = tx.send(event).await;
 }
 
 #[cfg(test)]
@@ -349,6 +351,88 @@ mod tests {
                 assert!(
                     matches!(&message.content[0], llm_router::types::content::ContentBlock::Text { text } if text == "Hi")
                 );
+            }
+            other => panic!("want done, got {other:?}"),
+        }
+    }
+
+    const TRUNCATED_MID_ARGUMENTS: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Listing\"}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"shell__fs__ls\",\"arguments\":\"\"}}]}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"path\\\":\\\"/tm\"}}]}}]}\n\n";
+
+    const TRUNCATED_MID_FRAME: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\" wor";
+
+    const FINAL_BLOCK_WITHOUT_BLANK_LINE: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}";
+
+    fn single_terminal_error(
+        events: &[AssistantMessageEvent],
+    ) -> &llm_router::types::messages::AssistantMessage {
+        assert_eq!(
+            events.iter().filter(|e| e.is_terminal()).count(),
+            1,
+            "{events:?}"
+        );
+        match events.last() {
+            Some(AssistantMessageEvent::Error { error }) => error,
+            other => panic!("want error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_cut_inside_function_call_arguments_ends_as_one_error() {
+        let url = stub(TRUNCATED_MID_ARGUMENTS).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        assert_eq!(error.error_kind, Some(ErrorKind::Transient));
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("stream truncated"), "{message}");
+        assert!(message.contains("reason=open_function_call"), "{message}");
+        assert!(error.content.iter().any(
+            |b| matches!(b, llm_router::types::content::ContentBlock::Text { text } if text == "Listing")
+        ));
+        let call = error.content.iter().find_map(|b| match b {
+            llm_router::types::content::ContentBlock::FunctionCall { arguments, .. } => {
+                Some(arguments)
+            }
+            _ => None,
+        });
+        let arguments = call.expect("function call block kept as evidence");
+        assert!(
+            arguments.get("_partial").is_some() || arguments.get("_raw").is_some(),
+            "arguments must be marked degraded: {arguments}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_cut_inside_an_event_frame_ends_as_one_error() {
+        let url = stub(TRUNCATED_MID_FRAME).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        assert_eq!(error.error_kind, Some(ErrorKind::Transient));
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("reason=partial_frame"), "{message}");
+        assert!(error.content.iter().any(
+            |b| matches!(b, llm_router::types::content::ContentBlock::Text { text } if text == "Hello")
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn empty_stream_ends_as_one_error_not_an_empty_done() {
+        let url =
+            stub("HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\n")
+                .await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("reason=empty"), "{message}");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn final_block_without_blank_line_still_completes() {
+        let url = stub(FINAL_BLOCK_WITHOUT_BLANK_LINE).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        assert_eq!(events.iter().filter(|e| e.is_terminal()).count(), 1);
+        match events.last() {
+            Some(AssistantMessageEvent::Done { message }) => {
+                assert_eq!(message.native_stop_reason.as_deref(), Some("stop"));
             }
             other => panic!("want done, got {other:?}"),
         }

--- a/provider-opencode-go/src/sse.rs
+++ b/provider-opencode-go/src/sse.rs
@@ -3,6 +3,7 @@
 use crate::errors::classify;
 use crate::wire::names::decode_tool_name;
 use crate::{now_ms, PROVIDER_ID};
+use llm_router::provider_scaffold::sse_transport::{arguments_incomplete, StreamEndView};
 use llm_router::types::content::ContentBlock;
 use llm_router::types::events::{AssistantMessageEvent, ErrorKind, StopReason, Usage};
 use llm_router::types::messages::{AssistantMessage, AssistantRoleTag};
@@ -37,6 +38,7 @@ pub struct PartialState {
     native_stop_reason: Option<String>,
     error_message: Option<String>,
     warnings: Vec<String>,
+    terminated: bool,
 }
 
 impl PartialState {
@@ -52,6 +54,7 @@ impl PartialState {
             native_stop_reason: None,
             error_message: None,
             warnings,
+            terminated: false,
         }
     }
 
@@ -61,6 +64,24 @@ impl PartialState {
 
     pub fn has_content(&self) -> bool {
         !self.text.is_empty() || !self.thinking.is_empty() || !self.function_calls.is_empty()
+    }
+}
+
+impl StreamEndView for PartialState {
+    fn saw_terminator(&self) -> bool {
+        self.terminated
+    }
+
+    fn has_content(&self) -> bool {
+        !self.text.is_empty() || !self.thinking.is_empty() || !self.function_calls.is_empty()
+    }
+
+    fn has_unfinished_call(&self) -> bool {
+        matches!(self.open_block, Some(OpenBlock::Call(_)))
+            || self
+                .function_calls
+                .iter()
+                .any(|fc| arguments_incomplete(&fc.args_json))
     }
 }
 
@@ -320,6 +341,7 @@ pub fn handle_chunk(
 
     if let Some(finish) = choice.get("finish_reason").and_then(Value::as_str) {
         state.stop_reason = map_finish_reason(finish);
+        state.terminated = true;
         state.native_stop_reason = Some(finish.to_string());
         if finish == "content_filter" {
             state.warnings.push(

--- a/provider-opencode-go/src/upstream.rs
+++ b/provider-opencode-go/src/upstream.rs
@@ -3,9 +3,11 @@
 //! which drops the reqwest response mid-body and closes the connection.
 use crate::errors::classify;
 use crate::sse::{build_final, build_partial, handle_chunk, synthetic_error_event, PartialState};
+use crate::PROVIDER_ID;
 use futures::StreamExt;
 use llm_router::provider_scaffold::sse_transport::{
-    append_utf8_chunk, drain_sse_blocks, error_chain,
+    append_utf8_chunk, classify_stream_end, drain_sse_blocks, error_chain, flush_tail,
+    truncated_stream_error, CloseFraming, StreamEnd, TailFlush,
 };
 use llm_router::types::events::{AssistantMessageEvent, ErrorKind};
 use serde_json::Value;
@@ -112,7 +114,11 @@ async fn run_upstream(
 
     let mut stream = resp.bytes_stream();
     let mut buf = String::new();
+    // Cross-chunk UTF-8 buffering: network chunks split multibyte
+    // codepoints, and a per-chunk lossy conversion corrupts them to U+FFFD.
     let mut byte_buf = Vec::new();
+    // Block decoder: [DONE] closes the stream (Stop + Done, Done terminal);
+    // anything else parses and runs the chunk state machine.
     let decode =
         |data_block: &str, state: &mut PartialState, model: &str| -> Vec<AssistantMessageEvent> {
             let Some(data) = data_line(data_block) else {
@@ -158,24 +164,23 @@ async fn run_upstream(
             return; // terminal forwarded, or receiver dropped → abort upstream
         }
     }
-    // Compatible gateways may close the connection after their final delta.
-    if state.has_content() {
-        tracing::debug!("stream ended; emitting done");
-        let _ = tx
-            .send(AssistantMessageEvent::Done {
-                message: build_final(&state, &args.model),
-            })
-            .await;
-    } else {
-        tracing::debug!("stream ended; emitting error");
-        let _ = tx
-            .send(synthetic_error_event(
-                "opencode_go stream ended without output or a completion event",
-                &args.model,
-                ErrorKind::Transient,
-            ))
-            .await;
+    // Body closed: one terminal frame, decided by the shared end-of-stream policy.
+    let tail = flush_tail(&mut buf, &tx, &mut |block: &str| {
+        decode(block, &mut state, &args.model)
+    })
+    .await;
+    if tail == TailFlush::Terminal {
+        return;
     }
+    let event = match classify_stream_end(&state, tail, CloseFraming::Accepted) {
+        StreamEnd::Complete => AssistantMessageEvent::Done {
+            message: build_final(&state, &args.model),
+        },
+        StreamEnd::Truncated(truncation) => {
+            truncated_stream_error(build_final(&state, &args.model), PROVIDER_ID, truncation)
+        }
+    };
+    let _ = tx.send(event).await;
 }
 
 #[cfg(test)]
@@ -311,6 +316,88 @@ mod tests {
                 assert!(
                     matches!(&message.content[0], llm_router::types::content::ContentBlock::Text { text } if text == "Hi")
                 );
+            }
+            other => panic!("want done, got {other:?}"),
+        }
+    }
+
+    const TRUNCATED_MID_ARGUMENTS: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Listing\"}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"shell__fs__ls\",\"arguments\":\"\"}}]}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"path\\\":\\\"/tm\"}}]}}]}\n\n";
+
+    const TRUNCATED_MID_FRAME: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\" wor";
+
+    const FINAL_BLOCK_WITHOUT_BLANK_LINE: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}";
+
+    fn single_terminal_error(
+        events: &[AssistantMessageEvent],
+    ) -> &llm_router::types::messages::AssistantMessage {
+        assert_eq!(
+            events.iter().filter(|e| e.is_terminal()).count(),
+            1,
+            "{events:?}"
+        );
+        match events.last() {
+            Some(AssistantMessageEvent::Error { error }) => error,
+            other => panic!("want error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_cut_inside_function_call_arguments_ends_as_one_error() {
+        let url = stub(TRUNCATED_MID_ARGUMENTS).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        assert_eq!(error.error_kind, Some(ErrorKind::Transient));
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("stream truncated"), "{message}");
+        assert!(message.contains("reason=open_function_call"), "{message}");
+        assert!(error.content.iter().any(
+            |b| matches!(b, llm_router::types::content::ContentBlock::Text { text } if text == "Listing")
+        ));
+        let call = error.content.iter().find_map(|b| match b {
+            llm_router::types::content::ContentBlock::FunctionCall { arguments, .. } => {
+                Some(arguments)
+            }
+            _ => None,
+        });
+        let arguments = call.expect("function call block kept as evidence");
+        assert!(
+            arguments.get("_partial").is_some() || arguments.get("_raw").is_some(),
+            "arguments must be marked degraded: {arguments}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_cut_inside_an_event_frame_ends_as_one_error() {
+        let url = stub(TRUNCATED_MID_FRAME).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        assert_eq!(error.error_kind, Some(ErrorKind::Transient));
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("reason=partial_frame"), "{message}");
+        assert!(error.content.iter().any(
+            |b| matches!(b, llm_router::types::content::ContentBlock::Text { text } if text == "Hello")
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn empty_stream_ends_as_one_error_not_an_empty_done() {
+        let url =
+            stub("HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\n")
+                .await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("reason=empty"), "{message}");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn final_block_without_blank_line_still_completes() {
+        let url = stub(FINAL_BLOCK_WITHOUT_BLANK_LINE).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        assert_eq!(events.iter().filter(|e| e.is_terminal()).count(), 1);
+        match events.last() {
+            Some(AssistantMessageEvent::Done { message }) => {
+                assert_eq!(message.native_stop_reason.as_deref(), Some("stop"));
             }
             other => panic!("want done, got {other:?}"),
         }

--- a/provider-openrouter/src/sse.rs
+++ b/provider-openrouter/src/sse.rs
@@ -13,6 +13,7 @@
 use crate::errors::classify;
 use crate::wire::names::decode_tool_name;
 use crate::{now_ms, PROVIDER_ID};
+use llm_router::provider_scaffold::sse_transport::{arguments_incomplete, StreamEndView};
 use llm_router::types::content::ContentBlock;
 use llm_router::types::events::{AssistantMessageEvent, ErrorKind, StopReason, Usage};
 use llm_router::types::messages::{AssistantMessage, AssistantRoleTag};
@@ -47,6 +48,7 @@ pub struct PartialState {
     native_stop_reason: Option<String>,
     error_message: Option<String>,
     warnings: Vec<String>,
+    terminated: bool,
 }
 
 impl PartialState {
@@ -62,11 +64,30 @@ impl PartialState {
             native_stop_reason: None,
             error_message: None,
             warnings,
+            terminated: false,
         }
     }
 
     pub fn stop_reason(&self) -> StopReason {
         self.stop_reason
+    }
+}
+
+impl StreamEndView for PartialState {
+    fn saw_terminator(&self) -> bool {
+        self.terminated
+    }
+
+    fn has_content(&self) -> bool {
+        !self.text.is_empty() || !self.thinking.is_empty() || !self.function_calls.is_empty()
+    }
+
+    fn has_unfinished_call(&self) -> bool {
+        matches!(self.open_block, Some(OpenBlock::Call(_)))
+            || self
+                .function_calls
+                .iter()
+                .any(|fc| arguments_incomplete(&fc.args_json))
     }
 }
 
@@ -108,7 +129,13 @@ fn build_content(state: &PartialState) -> Vec<ContentBlock> {
         let arguments = if fc.args_json.is_empty() {
             serde_json::json!({})
         } else {
-            serde_json::from_str(&fc.args_json).unwrap_or(Value::Null)
+            // Unparseable args (mid-stream partials, malformed JSON) degrade
+            // to the salvaged leading fields or `{"_raw": …}` — always an
+            // object (replay-safe) that preserves the evidence.
+            serde_json::from_str(&fc.args_json)
+                .ok()
+                .filter(Value::is_object)
+                .unwrap_or_else(|| llm_router::types::messages::degraded_arguments(&fc.args_json))
         };
         out.push(ContentBlock::FunctionCall {
             id: fc.id.clone(),
@@ -352,6 +379,7 @@ pub fn handle_chunk(
 
     if let Some(finish) = choice.get("finish_reason").and_then(Value::as_str) {
         state.stop_reason = map_finish_reason(finish);
+        state.terminated = true;
         state.native_stop_reason = Some(finish.to_string());
         if finish == "content_filter" {
             state.warnings.push(

--- a/provider-openrouter/src/upstream.rs
+++ b/provider-openrouter/src/upstream.rs
@@ -3,7 +3,12 @@
 //! which drops the reqwest response mid-body and closes the connection.
 use crate::errors::classify;
 use crate::sse::{build_final, build_partial, handle_chunk, synthetic_error_event, PartialState};
+use crate::PROVIDER_ID;
 use futures::StreamExt;
+use llm_router::provider_scaffold::sse_transport::{
+    append_utf8_chunk, classify_stream_end, drain_sse_blocks, error_chain, flush_tail,
+    truncated_stream_error, CloseFraming, StreamEnd, TailFlush,
+};
 use llm_router::types::events::{AssistantMessageEvent, ErrorKind};
 use serde_json::Value;
 use tokio::sync::mpsc;
@@ -49,23 +54,6 @@ fn data_line(block: &str) -> Option<&str> {
         .next_back()
 }
 
-/// Earliest complete-SSE-block boundary in the byte buffer: `(end_index,
-/// separator_len)` for `\n\n` or `\r\n\r\n`, whichever comes first. Byte-level
-/// so a multibyte UTF-8 character split across network chunks is never
-/// decoded early (OpenRouter fronts many CJK-heavy models).
-fn find_block_end(buf: &[u8]) -> Option<(usize, usize)> {
-    let lf = buf.windows(2).position(|w| w == b"\n\n").map(|i| (i, 2));
-    let crlf = buf
-        .windows(4)
-        .position(|w| w == b"\r\n\r\n")
-        .map(|i| (i, 4));
-    match (lf, crlf) {
-        (Some(a), Some(b)) => Some(if a.0 <= b.0 { a } else { b }),
-        (a, None) => a,
-        (None, b) => b,
-    }
-}
-
 async fn run_upstream(
     client: reqwest::Client,
     args: UpstreamArgs,
@@ -80,7 +68,7 @@ async fn run_upstream(
         Err(e) => {
             let _ = tx
                 .send(synthetic_error_event(
-                    &format!("openrouter fetch failed: {e}"),
+                    &format!("openrouter fetch failed: {}", error_chain(&e)),
                     &args.model,
                     ErrorKind::Transient,
                 ))
@@ -116,9 +104,34 @@ async fn run_upstream(
     }
 
     let mut stream = resp.bytes_stream();
-    // Byte buffer, decoded only per complete block: a multibyte character or
-    // block separator split across chunks stays buffered until whole.
-    let mut buf: Vec<u8> = Vec::new();
+    let mut buf = String::new();
+    // Cross-chunk UTF-8 buffering: network chunks split multibyte
+    // codepoints, and a per-chunk lossy conversion corrupts them to U+FFFD.
+    let mut byte_buf = Vec::new();
+    // Block decoder: [DONE] closes the stream (Stop + Done, Done terminal);
+    // anything else parses and runs the chunk state machine.
+    let decode =
+        |data_block: &str, state: &mut PartialState, model: &str| -> Vec<AssistantMessageEvent> {
+            let Some(data) = data_line(data_block) else {
+                return vec![];
+            };
+            if data == "[DONE]" {
+                return vec![
+                    AssistantMessageEvent::Stop {
+                        stop_reason: state.stop_reason(),
+                        error_message: None,
+                        error_kind: None,
+                    },
+                    AssistantMessageEvent::Done {
+                        message: build_final(state, model),
+                    },
+                ];
+            }
+            let Ok(parsed) = serde_json::from_str::<Value>(data) else {
+                return vec![];
+            };
+            handle_chunk(&parsed, state, model)
+        };
     while let Some(chunk) = stream.next().await {
         let chunk = match chunk {
             Ok(c) => c,
@@ -133,48 +146,32 @@ async fn run_upstream(
                 return;
             }
         };
-        buf.extend_from_slice(&chunk);
-        while let Some((end, sep_len)) = find_block_end(&buf) {
-            let raw: Vec<u8> = buf.drain(..end + sep_len).collect();
-            let block = String::from_utf8_lossy(&raw);
-            let Some(data) = data_line(&block) else {
-                continue;
-            };
-            if data == "[DONE]" {
-                let _ = tx
-                    .send(AssistantMessageEvent::Stop {
-                        stop_reason: state.stop_reason(),
-                        error_message: None,
-                        error_kind: None,
-                    })
-                    .await;
-                let _ = tx
-                    .send(AssistantMessageEvent::Done {
-                        message: build_final(&state, &args.model),
-                    })
-                    .await;
-                return;
-            }
-            let Ok(parsed) = serde_json::from_str::<Value>(data) else {
-                continue;
-            };
-            for ev in handle_chunk(&parsed, &mut state, &args.model) {
-                let terminal = ev.is_terminal();
-                if tx.send(ev).await.is_err() {
-                    return; // receiver dropped → abort upstream
-                }
-                if terminal {
-                    return; // exactly one terminal event
-                }
-            }
+        append_utf8_chunk(&mut byte_buf, &mut buf, &chunk);
+        if drain_sse_blocks(&mut buf, &tx, &mut |block: &str| {
+            decode(block, &mut state, &args.model)
+        })
+        .await
+        {
+            return; // terminal forwarded, or receiver dropped → abort upstream
         }
     }
-    // Stream ended without [DONE] (connection close framing): still terminal.
-    let _ = tx
-        .send(AssistantMessageEvent::Done {
+    // Body closed: one terminal frame, decided by the shared end-of-stream policy.
+    let tail = flush_tail(&mut buf, &tx, &mut |block: &str| {
+        decode(block, &mut state, &args.model)
+    })
+    .await;
+    if tail == TailFlush::Terminal {
+        return;
+    }
+    let event = match classify_stream_end(&state, tail, CloseFraming::Accepted) {
+        StreamEnd::Complete => AssistantMessageEvent::Done {
             message: build_final(&state, &args.model),
-        })
-        .await;
+        },
+        StreamEnd::Truncated(truncation) => {
+            truncated_stream_error(build_final(&state, &args.model), PROVIDER_ID, truncation)
+        }
+    };
+    let _ = tx.send(event).await;
 }
 
 #[cfg(test)]
@@ -300,18 +297,6 @@ mod tests {
     }
 
     #[test]
-    fn block_end_handles_lf_and_crlf_separators() {
-        assert_eq!(find_block_end(b"data: x\n\nrest"), Some((7, 2)));
-        assert_eq!(find_block_end(b"data: x\r\n\r\nrest"), Some((7, 4)));
-        // earliest boundary wins when both framings appear
-        assert_eq!(find_block_end(b"a\n\nb\r\n\r\nc"), Some((1, 2)));
-        assert_eq!(find_block_end(b"a\r\n\r\nb\n\nc"), Some((1, 4)));
-        // incomplete block: no boundary yet
-        assert_eq!(find_block_end(b"data: partial\n"), None);
-        assert_eq!(find_block_end(b"data: partial\r\n"), None);
-    }
-
-    #[test]
     fn data_line_accepts_bare_and_spaced_prefixes_and_crlf() {
         assert_eq!(data_line("data: hello\n"), Some("hello"));
         assert_eq!(data_line("data:hello\n"), Some("hello"));
@@ -332,6 +317,88 @@ mod tests {
                 assert!(
                     matches!(&message.content[0], llm_router::types::content::ContentBlock::Text { text } if text == "你好，世界")
                 );
+                assert_eq!(message.native_stop_reason.as_deref(), Some("stop"));
+            }
+            other => panic!("want done, got {other:?}"),
+        }
+    }
+
+    const TRUNCATED_MID_ARGUMENTS: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Listing\"}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"shell__fs__ls\",\"arguments\":\"\"}}]}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"path\\\":\\\"/tm\"}}]}}]}\n\n";
+
+    const TRUNCATED_MID_FRAME: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\" wor";
+
+    const FINAL_BLOCK_WITHOUT_BLANK_LINE: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}";
+
+    fn single_terminal_error(
+        events: &[AssistantMessageEvent],
+    ) -> &llm_router::types::messages::AssistantMessage {
+        assert_eq!(
+            events.iter().filter(|e| e.is_terminal()).count(),
+            1,
+            "{events:?}"
+        );
+        match events.last() {
+            Some(AssistantMessageEvent::Error { error }) => error,
+            other => panic!("want error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_cut_inside_function_call_arguments_ends_as_one_error() {
+        let url = stub(TRUNCATED_MID_ARGUMENTS).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        assert_eq!(error.error_kind, Some(ErrorKind::Transient));
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("stream truncated"), "{message}");
+        assert!(message.contains("reason=open_function_call"), "{message}");
+        assert!(error.content.iter().any(
+            |b| matches!(b, llm_router::types::content::ContentBlock::Text { text } if text == "Listing")
+        ));
+        let call = error.content.iter().find_map(|b| match b {
+            llm_router::types::content::ContentBlock::FunctionCall { arguments, .. } => {
+                Some(arguments)
+            }
+            _ => None,
+        });
+        let arguments = call.expect("function call block kept as evidence");
+        assert!(
+            arguments.get("_partial").is_some() || arguments.get("_raw").is_some(),
+            "arguments must be marked degraded: {arguments}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_cut_inside_an_event_frame_ends_as_one_error() {
+        let url = stub(TRUNCATED_MID_FRAME).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        assert_eq!(error.error_kind, Some(ErrorKind::Transient));
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("reason=partial_frame"), "{message}");
+        assert!(error.content.iter().any(
+            |b| matches!(b, llm_router::types::content::ContentBlock::Text { text } if text == "Hello")
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn empty_stream_ends_as_one_error_not_an_empty_done() {
+        let url =
+            stub("HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\n")
+                .await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("reason=empty"), "{message}");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn final_block_without_blank_line_still_completes() {
+        let url = stub(FINAL_BLOCK_WITHOUT_BLANK_LINE).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        assert_eq!(events.iter().filter(|e| e.is_terminal()).count(), 1);
+        match events.last() {
+            Some(AssistantMessageEvent::Done { message }) => {
                 assert_eq!(message.native_stop_reason.as_deref(), Some("stop"));
             }
             other => panic!("want done, got {other:?}"),

--- a/provider-xai/src/sse.rs
+++ b/provider-xai/src/sse.rs
@@ -4,6 +4,7 @@
 use crate::errors::classify;
 use crate::wire::names::decode_tool_name;
 use crate::{now_ms, PROVIDER_ID};
+use llm_router::provider_scaffold::sse_transport::{arguments_incomplete, StreamEndView};
 use llm_router::types::content::ContentBlock;
 use llm_router::types::events::{AssistantMessageEvent, ErrorKind, StopReason, Usage};
 use llm_router::types::messages::{AssistantMessage, AssistantRoleTag};
@@ -35,6 +36,7 @@ pub struct PartialState {
     native_stop_reason: Option<String>,
     error_message: Option<String>,
     warnings: Vec<String>,
+    terminated: bool,
 }
 
 impl PartialState {
@@ -50,11 +52,30 @@ impl PartialState {
             native_stop_reason: None,
             error_message: None,
             warnings,
+            terminated: false,
         }
     }
 
     pub fn stop_reason(&self) -> StopReason {
         self.stop_reason
+    }
+}
+
+impl StreamEndView for PartialState {
+    fn saw_terminator(&self) -> bool {
+        self.terminated
+    }
+
+    fn has_content(&self) -> bool {
+        !self.text.is_empty() || !self.thinking.is_empty() || !self.function_calls.is_empty()
+    }
+
+    fn has_unfinished_call(&self) -> bool {
+        matches!(self.open_block, Some(OpenBlock::Call(_)))
+            || self
+                .function_calls
+                .iter()
+                .any(|fc| arguments_incomplete(&fc.args_json))
     }
 }
 
@@ -329,6 +350,7 @@ pub fn handle_chunk(
 
     if let Some(finish) = choice.get("finish_reason").and_then(Value::as_str) {
         state.stop_reason = map_finish_reason(finish);
+        state.terminated = true;
         state.native_stop_reason = Some(finish.to_string());
         if finish == "content_filter" {
             state

--- a/provider-xai/src/upstream.rs
+++ b/provider-xai/src/upstream.rs
@@ -3,9 +3,11 @@
 //! which drops the reqwest response mid-body and closes the connection.
 use crate::errors::classify;
 use crate::sse::{build_final, build_partial, handle_chunk, synthetic_error_event, PartialState};
+use crate::PROVIDER_ID;
 use futures::StreamExt;
 use llm_router::provider_scaffold::sse_transport::{
-    append_utf8_chunk, drain_sse_blocks, error_chain,
+    append_utf8_chunk, classify_stream_end, drain_sse_blocks, error_chain, flush_tail,
+    truncated_stream_error, CloseFraming, StreamEnd, TailFlush,
 };
 use llm_router::types::events::{AssistantMessageEvent, ErrorKind};
 use serde_json::Value;
@@ -149,12 +151,23 @@ async fn run_upstream(
             return; // terminal forwarded, or receiver dropped → abort upstream
         }
     }
-    // Stream ended without [DONE] (connection close framing): still terminal.
-    let _ = tx
-        .send(AssistantMessageEvent::Done {
+    // Body closed: one terminal frame, decided by the shared end-of-stream policy.
+    let tail = flush_tail(&mut buf, &tx, &mut |block: &str| {
+        decode(block, &mut state, &args.model)
+    })
+    .await;
+    if tail == TailFlush::Terminal {
+        return;
+    }
+    let event = match classify_stream_end(&state, tail, CloseFraming::Accepted) {
+        StreamEnd::Complete => AssistantMessageEvent::Done {
             message: build_final(&state, &args.model),
-        })
-        .await;
+        },
+        StreamEnd::Truncated(truncation) => {
+            truncated_stream_error(build_final(&state, &args.model), PROVIDER_ID, truncation)
+        }
+    };
+    let _ = tx.send(event).await;
 }
 
 #[cfg(test)]
@@ -295,6 +308,88 @@ mod tests {
                 assert!(
                     matches!(&message.content[0], llm_router::types::content::ContentBlock::Text { text } if text == "Hi")
                 );
+            }
+            other => panic!("want done, got {other:?}"),
+        }
+    }
+
+    const TRUNCATED_MID_ARGUMENTS: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Listing\"}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"shell__fs__ls\",\"arguments\":\"\"}}]}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"path\\\":\\\"/tm\"}}]}}]}\n\n";
+
+    const TRUNCATED_MID_FRAME: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\" wor";
+
+    const FINAL_BLOCK_WITHOUT_BLANK_LINE: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}";
+
+    fn single_terminal_error(
+        events: &[AssistantMessageEvent],
+    ) -> &llm_router::types::messages::AssistantMessage {
+        assert_eq!(
+            events.iter().filter(|e| e.is_terminal()).count(),
+            1,
+            "{events:?}"
+        );
+        match events.last() {
+            Some(AssistantMessageEvent::Error { error }) => error,
+            other => panic!("want error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_cut_inside_function_call_arguments_ends_as_one_error() {
+        let url = stub(TRUNCATED_MID_ARGUMENTS).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        assert_eq!(error.error_kind, Some(ErrorKind::Transient));
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("stream truncated"), "{message}");
+        assert!(message.contains("reason=open_function_call"), "{message}");
+        assert!(error.content.iter().any(
+            |b| matches!(b, llm_router::types::content::ContentBlock::Text { text } if text == "Listing")
+        ));
+        let call = error.content.iter().find_map(|b| match b {
+            llm_router::types::content::ContentBlock::FunctionCall { arguments, .. } => {
+                Some(arguments)
+            }
+            _ => None,
+        });
+        let arguments = call.expect("function call block kept as evidence");
+        assert!(
+            arguments.get("_partial").is_some() || arguments.get("_raw").is_some(),
+            "arguments must be marked degraded: {arguments}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_cut_inside_an_event_frame_ends_as_one_error() {
+        let url = stub(TRUNCATED_MID_FRAME).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        assert_eq!(error.error_kind, Some(ErrorKind::Transient));
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("reason=partial_frame"), "{message}");
+        assert!(error.content.iter().any(
+            |b| matches!(b, llm_router::types::content::ContentBlock::Text { text } if text == "Hello")
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn empty_stream_ends_as_one_error_not_an_empty_done() {
+        let url =
+            stub("HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\n")
+                .await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("reason=empty"), "{message}");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn final_block_without_blank_line_still_completes() {
+        let url = stub(FINAL_BLOCK_WITHOUT_BLANK_LINE).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        assert_eq!(events.iter().filter(|e| e.is_terminal()).count(), 1);
+        match events.last() {
+            Some(AssistantMessageEvent::Done { message }) => {
+                assert_eq!(message.native_stop_reason.as_deref(), Some("stop"));
             }
             other => panic!("want done, got {other:?}"),
         }

--- a/provider-zai/src/sse.rs
+++ b/provider-zai/src/sse.rs
@@ -4,6 +4,7 @@
 use crate::errors::classify;
 use crate::wire::names::decode_tool_name;
 use crate::{now_ms, PROVIDER_ID};
+use llm_router::provider_scaffold::sse_transport::{arguments_incomplete, StreamEndView};
 use llm_router::types::content::ContentBlock;
 use llm_router::types::events::{AssistantMessageEvent, ErrorKind, StopReason, Usage};
 use llm_router::types::messages::{AssistantMessage, AssistantRoleTag};
@@ -35,6 +36,7 @@ pub struct PartialState {
     native_stop_reason: Option<String>,
     error_message: Option<String>,
     warnings: Vec<String>,
+    terminated: bool,
 }
 
 impl PartialState {
@@ -50,11 +52,30 @@ impl PartialState {
             native_stop_reason: None,
             error_message: None,
             warnings,
+            terminated: false,
         }
     }
 
     pub fn stop_reason(&self) -> StopReason {
         self.stop_reason
+    }
+}
+
+impl StreamEndView for PartialState {
+    fn saw_terminator(&self) -> bool {
+        self.terminated
+    }
+
+    fn has_content(&self) -> bool {
+        !self.text.is_empty() || !self.thinking.is_empty() || !self.function_calls.is_empty()
+    }
+
+    fn has_unfinished_call(&self) -> bool {
+        matches!(self.open_block, Some(OpenBlock::Call(_)))
+            || self
+                .function_calls
+                .iter()
+                .any(|fc| arguments_incomplete(&fc.args_json))
     }
 }
 
@@ -336,6 +357,7 @@ pub fn handle_chunk(
 
     if let Some(finish) = choice.get("finish_reason").and_then(Value::as_str) {
         state.stop_reason = map_finish_reason(finish);
+        state.terminated = true;
         state.native_stop_reason = Some(finish.to_string());
         if finish == "content_filter" {
             state

--- a/provider-zai/src/upstream.rs
+++ b/provider-zai/src/upstream.rs
@@ -4,9 +4,11 @@
 //! which drops the reqwest response mid-body and closes the connection.
 use crate::errors::classify;
 use crate::sse::{build_final, build_partial, handle_chunk, synthetic_error_event, PartialState};
+use crate::PROVIDER_ID;
 use futures::StreamExt;
 use llm_router::provider_scaffold::sse_transport::{
-    append_utf8_chunk, drain_sse_blocks, error_chain,
+    append_utf8_chunk, classify_stream_end, drain_sse_blocks, error_chain, flush_tail,
+    truncated_stream_error, CloseFraming, StreamEnd, TailFlush,
 };
 use llm_router::types::events::{AssistantMessageEvent, ErrorKind};
 use serde_json::Value;
@@ -100,9 +102,8 @@ async fn run_upstream(
 
     let mut stream = resp.bytes_stream();
     let mut buf = String::new();
-    // Cross-chunk UTF-8 buffering: transport chunk boundaries are arbitrary,
-    // so a multi-byte character (GLM output is frequently CJK) can split
-    // across chunks — a per-chunk lossy decode would corrupt it into U+FFFD.
+    // Cross-chunk UTF-8 buffering: network chunks split multibyte
+    // codepoints, and a per-chunk lossy conversion corrupts them to U+FFFD.
     let mut byte_buf = Vec::new();
     // Block decoder: [DONE] closes the stream (Stop + Done, Done terminal);
     // anything else parses and runs the chunk state machine.
@@ -151,12 +152,23 @@ async fn run_upstream(
             return; // terminal forwarded, or receiver dropped → abort upstream
         }
     }
-    // Stream ended without [DONE] (connection close framing): still terminal.
-    let _ = tx
-        .send(AssistantMessageEvent::Done {
+    // Body closed: one terminal frame, decided by the shared end-of-stream policy.
+    let tail = flush_tail(&mut buf, &tx, &mut |block: &str| {
+        decode(block, &mut state, &args.model)
+    })
+    .await;
+    if tail == TailFlush::Terminal {
+        return;
+    }
+    let event = match classify_stream_end(&state, tail, CloseFraming::Accepted) {
+        StreamEnd::Complete => AssistantMessageEvent::Done {
             message: build_final(&state, &args.model),
-        })
-        .await;
+        },
+        StreamEnd::Truncated(truncation) => {
+            truncated_stream_error(build_final(&state, &args.model), PROVIDER_ID, truncation)
+        }
+    };
+    let _ = tx.send(event).await;
 }
 
 #[cfg(test)]
@@ -297,6 +309,88 @@ mod tests {
                 assert!(
                     matches!(&message.content[0], llm_router::types::content::ContentBlock::Text { text } if text == "Hi")
                 );
+            }
+            other => panic!("want done, got {other:?}"),
+        }
+    }
+
+    const TRUNCATED_MID_ARGUMENTS: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Listing\"}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"shell__fs__ls\",\"arguments\":\"\"}}]}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"path\\\":\\\"/tm\"}}]}}]}\n\n";
+
+    const TRUNCATED_MID_FRAME: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\" wor";
+
+    const FINAL_BLOCK_WITHOUT_BLANK_LINE: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}";
+
+    fn single_terminal_error(
+        events: &[AssistantMessageEvent],
+    ) -> &llm_router::types::messages::AssistantMessage {
+        assert_eq!(
+            events.iter().filter(|e| e.is_terminal()).count(),
+            1,
+            "{events:?}"
+        );
+        match events.last() {
+            Some(AssistantMessageEvent::Error { error }) => error,
+            other => panic!("want error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_cut_inside_function_call_arguments_ends_as_one_error() {
+        let url = stub(TRUNCATED_MID_ARGUMENTS).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        assert_eq!(error.error_kind, Some(ErrorKind::Transient));
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("stream truncated"), "{message}");
+        assert!(message.contains("reason=open_function_call"), "{message}");
+        assert!(error.content.iter().any(
+            |b| matches!(b, llm_router::types::content::ContentBlock::Text { text } if text == "Listing")
+        ));
+        let call = error.content.iter().find_map(|b| match b {
+            llm_router::types::content::ContentBlock::FunctionCall { arguments, .. } => {
+                Some(arguments)
+            }
+            _ => None,
+        });
+        let arguments = call.expect("function call block kept as evidence");
+        assert!(
+            arguments.get("_partial").is_some() || arguments.get("_raw").is_some(),
+            "arguments must be marked degraded: {arguments}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_cut_inside_an_event_frame_ends_as_one_error() {
+        let url = stub(TRUNCATED_MID_FRAME).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        assert_eq!(error.error_kind, Some(ErrorKind::Transient));
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("reason=partial_frame"), "{message}");
+        assert!(error.content.iter().any(
+            |b| matches!(b, llm_router::types::content::ContentBlock::Text { text } if text == "Hello")
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn empty_stream_ends_as_one_error_not_an_empty_done() {
+        let url =
+            stub("HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\n")
+                .await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        let error = single_terminal_error(&events);
+        let message = error.error_message.as_deref().unwrap_or_default();
+        assert!(message.contains("reason=empty"), "{message}");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn final_block_without_blank_line_still_completes() {
+        let url = stub(FINAL_BLOCK_WITHOUT_BLANK_LINE).await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        assert_eq!(events.iter().filter(|e| e.is_terminal()).count(), 1);
+        match events.last() {
+            Some(AssistantMessageEvent::Done { message }) => {
+                assert_eq!(message.native_stop_reason.as_deref(), Some("stop"));
             }
             other => panic!("want done, got {other:?}"),
         }


### PR DESCRIPTION
Fixes MOT-4493

## What

A provider stream that ends inside a JSON object or event frame now fails that turn with one clear terminal error and nothing else: the session, the provider worker and the router keep serving the next call.

## Why

Three providers (kimi, github-copilot, openrouter) parsed tool-call arguments with `unwrap_or(Value::Null)` and closed a cut body as a successful `done`. A call with `arguments: null` slipped past both harness guards (`_partial`/`_raw` and the abort-only null filter) and reached dispatch. Seven providers emitted an unconditional `done` on any body close, so an empty or cut stream became an empty successful assistant turn. A partial trailing frame left in the buffer was silently dropped at EOF by every provider on the shared transport.

## How

**llm-router `provider_scaffold::sse_transport`** gains the shared end-of-stream contract: `StreamEndView` (what a provider's decoder state knows at body close), `flush_tail` (decodes a final block that only lacks its blank line, reports an unterminated frame instead of dropping it), `classify_stream_end` (terminator wins; partial frame, open function call, or empty body is a cut; text-only close framing is accepted only where the protocol tolerates it), and `truncated_stream_error` (keeps the partial on the error frame, names `phase=sse-decode` and a stable `reason=` tag in the message and in a `tracing::warn!` with provider/model only, no payload).

**All 12 providers** implement `StreamEndView` and end the body through that policy. Anthropic and claude-code reject close framing (Messages always ends with `message_stop`); the Chat Completions and Responses providers accept a clean text-only close, which keeps the MOT-3855 behaviour for gateways that skip `[DONE]`. kimi, github-copilot and openrouter move onto the shared `drain_sse_blocks` transport, `degraded_arguments`, and `error_chain` for fetch failures. Anthropic also loses a double-terminal: a `message_stop` decoded from the undelimited tail used to be followed by a second `done`.

**harness** `trigger::arguments_degraded` refuses `_partial`, `_raw`, and any non-object arguments before dispatch on every stop reason, not only `Aborted`. Retry stays where it was: the router retries only before the first forwarded frame, and the harness transient resume keeps the partial, appends the recovery record and the nudge, and the per-call checkpoints prevent a re-dispatch.

## Tests

- `sse_transport` unit tests for tail detection, flush, the classification matrix, and the error frame shape.
- Every provider: four new upstream tests against the one-shot TCP stub (cut inside function-call arguments, cut inside an event frame, empty body, final block without a blank line still completes). Anthropic's existing truncation test asserts the new message.
- `provider-integration-testkit`: a `truncated-stream-no-retry` scenario per protocol family (real engine, router and provider; loopback HTTP). Run locally with the local engine for anthropic, openai, openai-codex and kimi.
- harness `INT-024 truncated-function-call-stream`: the scripted router cuts a stream mid-arguments; the harness keeps the partial text, never produces a function result for the cut call, resumes once, runs the re-issued call exactly once and completes the turn. Run locally against the full stack (pass), alongside INT-002, INT-003 and INT-021 (pass).
- `cargo fmt`, `cargo clippy --all-targets -- -D warnings` and `cargo test` on llm-router, harness, harness-integration, the testkit (all features) and all 12 provider crates.

Pre-existing and unrelated: `provider-opencode-go` `tests/integration.rs::upstream_401_surfaces_as_auth_expired_error_frame` fails on `main` too (expects `auth_expired`, router now returns `router/provider_auth_expired`).

## Decisions

- Close framing stays accepted for text-only Chat Completions and Responses bodies. Making it a cut would regress gateways that close after the final delta; the structured cases (open call, partial frame, empty body) are strict everywhere.
- No new wire field. The phase rides the error message (`[phase=sse-decode reason=open_function_call]`) and the tracing fields, so MOT-4492 can map it onto its taxonomy without a schema change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Incomplete streaming responses now produce a clear transient error instead of being reported as successfully completed.
  * Partial assistant text is preserved when a stream ends unexpectedly.
  * Interrupted function calls are prevented from executing with incomplete arguments.
  * Requests can resume once after a truncated stream, with the reissued function call executed exactly once.
  * Final SSE data blocks without a trailing blank line are handled correctly.
  * Empty and partially framed streams now receive consistent error handling across supported providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->