### PR TITLE
(MOT-4483) feat(console-ui,shell): shared image viewer with zoom and pan

### DIFF
--- a/console/DESIGN.md
+++ b/console/DESIGN.md
@@ -1748,6 +1748,20 @@ export function SearchField({
 }
 ```
 
+### `ImageViewer`
+
+The only full-screen image surface. Opens from an `ImageThumbnailButton`
+(zoom cursor, "View <name>" label) over a `bg-black/85` overlay in both
+themes; the caption and the controls float as `panel-raised` cards with
+`shadow-floating`. Wheel and pinch zoom about the pointer, drag pans a
+zoomed image inside the stage, double-click toggles fit and actual size;
+`+`/`-` step a zoom ladder, `0` fits, `1` is actual size, arrows pan, Escape
+closes and focus returns to the opener. Zoom steps are instant; fit/actual
+toggles move on `motion-duration-control`. Loading, decode failure, a
+missing source and an oversized data URL each render in the stage without
+freezing the page. Captions are attachment names or relative paths, never
+host paths.
+
 ### Shared recipes and primitives
 
 `@iii-dev/console-ui` exposes `uiClasses` for stable CSS recipes and React

--- a/console/skills/design-console-ui/SKILL.md
+++ b/console/skills/design-console-ui/SKILL.md
@@ -199,6 +199,9 @@ available width changes.
   non-searchable list.
 - Use shared `Tooltip` parts or `IconButton`; do not create local hover timers,
   collision logic, or tooltip portals.
+- Open pictures in the shared `ImageViewer` from an `ImageThumbnailButton`;
+  never build a local lightbox, zoom or pan, and never caption with a host
+  path.
 - Keep a local selector only when its interaction is materially different,
   such as hierarchical drill-in, multi-select, or a persistent command
   palette. Document the exception in the Console UI conformance inventory.

--- a/console/web/DESIGN.md
+++ b/console/web/DESIGN.md
@@ -1748,6 +1748,20 @@ export function SearchField({
 }
 ```
 
+### `ImageViewer`
+
+The only full-screen image surface. Opens from an `ImageThumbnailButton`
+(zoom cursor, "View <name>" label) over a `bg-black/85` overlay in both
+themes; the caption and the controls float as `panel-raised` cards with
+`shadow-floating`. Wheel and pinch zoom about the pointer, drag pans a
+zoomed image inside the stage, double-click toggles fit and actual size;
+`+`/`-` step a zoom ladder, `0` fits, `1` is actual size, arrows pan, Escape
+closes and focus returns to the opener. Zoom steps are instant; fit/actual
+toggles move on `motion-duration-control`. Loading, decode failure, a
+missing source and an oversized data URL each render in the stage without
+freezing the page. Captions are attachment names or relative paths, never
+host paths.
+
 ### Shared recipes and primitives
 
 `@iii-dev/console-ui` exposes `uiClasses` for stable CSS recipes and React

--- a/console/web/public/vendor/console-ui.js
+++ b/console/web/public/vendor/console-ui.js
@@ -38,6 +38,8 @@ export const {
   FileDiff,
   Input,
   IconButton,
+  ImageThumbnailButton,
+  ImageViewer,
   JsonHighlight,
   List,
   ListGroup,

--- a/console/web/src/components/chat/AttachmentChip.tsx
+++ b/console/web/src/components/chat/AttachmentChip.tsx
@@ -1,4 +1,9 @@
-import { Blocks, File, SquareSlash, X } from 'lucide-react'
+import { Blocks, File, Image as ImageIcon, SquareSlash, X } from 'lucide-react'
+import {
+  ImageThumbnailButton,
+  ImageViewer,
+  useImageViewer,
+} from '@/components/ui/ImageViewer'
 import { cn } from '@/lib/utils'
 import type { Attachment } from '@/types/chat'
 
@@ -27,8 +32,9 @@ export function AttachmentChip({
   onRemove,
   className,
 }: AttachmentChipProps) {
-  const isImage = attachment.type.startsWith('image/') && attachment.dataUrl
+  const isImage = attachment.type.startsWith('image/')
   const Icon = chipIcon(attachment.type)
+  const viewer = useImageViewer()
   return (
     <div
       className={cn(
@@ -37,11 +43,31 @@ export function AttachmentChip({
       )}
     >
       {isImage ? (
-        <img
-          src={attachment.dataUrl}
-          alt=""
-          className="size-6 object-cover border border-rule-2"
-        />
+        <>
+          <ImageThumbnailButton
+            title={attachment.name}
+            onClick={viewer.show}
+            className="shrink-0"
+          >
+            {attachment.dataUrl ? (
+              <img
+                src={attachment.dataUrl}
+                alt=""
+                className="size-6 border border-rule-2 object-cover"
+              />
+            ) : (
+              <ImageIcon size={16} aria-hidden className="text-ink-faint" />
+            )}
+          </ImageThumbnailButton>
+          <ImageViewer
+            open={viewer.open}
+            onOpenChange={viewer.setOpen}
+            src={attachment.dataUrl}
+            alt={attachment.name}
+            title={attachment.name}
+            description={`${attachment.type.replace('image/', '')} · ${formatSize(attachment.size)}`}
+          />
+        </>
       ) : (
         <Icon size={16} aria-hidden className="text-ink-faint shrink-0" />
       )}

--- a/console/web/src/components/chat/AttachmentChip.tsx
+++ b/console/web/src/components/chat/AttachmentChip.tsx
@@ -1,4 +1,5 @@
 import { Blocks, File, Image as ImageIcon, SquareSlash, X } from 'lucide-react'
+import { useEffect, useState } from 'react'
 import {
   ImageThumbnailButton,
   ImageViewer,
@@ -32,9 +33,12 @@ export function AttachmentChip({
   onRemove,
   className,
 }: AttachmentChipProps) {
-  const isImage = attachment.type.startsWith('image/')
+  const viewable =
+    attachment.type.startsWith('image/') &&
+    (attachment.dataUrl !== undefined || attachment.file !== undefined)
   const Icon = chipIcon(attachment.type)
   const viewer = useImageViewer()
+  const src = useImageSource(attachment, viewer.open)
   return (
     <div
       className={cn(
@@ -42,7 +46,7 @@ export function AttachmentChip({
         className,
       )}
     >
-      {isImage ? (
+      {viewable ? (
         <>
           <ImageThumbnailButton
             title={attachment.name}
@@ -62,7 +66,7 @@ export function AttachmentChip({
           <ImageViewer
             open={viewer.open}
             onOpenChange={viewer.setOpen}
-            src={attachment.dataUrl}
+            src={src}
             alt={attachment.name}
             title={attachment.name}
             description={`${attachment.type.replace('image/', '')} · ${formatSize(attachment.size)}`}
@@ -87,4 +91,23 @@ export function AttachmentChip({
       ) : null}
     </div>
   )
+}
+
+/** The preview data URL when one was kept, else an object URL over the File while the viewer is open. */
+function useImageSource(
+  attachment: Attachment,
+  open: boolean,
+): string | undefined {
+  const [objectUrl, setObjectUrl] = useState<string | undefined>(undefined)
+  const file = attachment.dataUrl ? undefined : attachment.file
+  useEffect(() => {
+    if (!open || !file) return
+    const url = URL.createObjectURL(file)
+    setObjectUrl(url)
+    return () => {
+      URL.revokeObjectURL(url)
+      setObjectUrl(undefined)
+    }
+  }, [open, file])
+  return attachment.dataUrl ?? objectUrl
 }

--- a/console/web/src/components/chat/scrapling/ScreenshotView.tsx
+++ b/console/web/src/components/chat/scrapling/ScreenshotView.tsx
@@ -86,8 +86,8 @@ export function ScreenshotView({
             alt={caption || `screenshot of ${url || 'page'}`}
             title={
               images.length > 1
-                ? `Screenshot ${i + 1} of ${images.length}`
-                : 'Screenshot'
+                ? `screenshot ${i + 1} of ${images.length} of ${url || 'page'}`
+                : caption || `screenshot of ${url || 'page'}`
             }
             description={url}
           />

--- a/console/web/src/components/chat/scrapling/ScreenshotView.tsx
+++ b/console/web/src/components/chat/scrapling/ScreenshotView.tsx
@@ -5,6 +5,11 @@ import {
   StatusPill,
 } from '@/components/chat/sandbox/shared'
 import {
+  ImageThumbnailButton,
+  ImageViewer,
+  useImageViewer,
+} from '@/components/ui/ImageViewer'
+import {
   safeParseRequest,
   safeParseResponse,
   screenshotRequestSchema,
@@ -74,12 +79,17 @@ export function ScreenshotView({
       </ActionLine>
       <div className="px-3 py-3 space-y-2">
         {images.map((b, i) => (
-          <img
+          <ScreenshotImage
+            // biome-ignore lint/suspicious/noArrayIndexKey: tiles are positional
             key={i}
             src={`data:${b.mime || mime};base64,${b.data}`}
             alt={caption || `screenshot of ${url || 'page'}`}
-            loading="lazy"
-            className="max-w-full max-h-[420px] border border-rule-2 bg-paper-2"
+            title={
+              images.length > 1
+                ? `Screenshot ${i + 1} of ${images.length}`
+                : 'Screenshot'
+            }
+            description={url}
           />
         ))}
         {caption ? (
@@ -89,6 +99,44 @@ export function ScreenshotView({
         ) : null}
       </div>
     </div>
+  )
+}
+
+function ScreenshotImage({
+  src,
+  alt,
+  title,
+  description,
+}: {
+  src: string
+  alt: string
+  title: string
+  description?: string
+}) {
+  const viewer = useImageViewer()
+  return (
+    <>
+      <ImageThumbnailButton
+        title={title}
+        onClick={viewer.show}
+        className="block max-w-full"
+      >
+        <img
+          src={src}
+          alt={alt}
+          loading="lazy"
+          className="max-h-[420px] max-w-full border border-rule-2 bg-paper-2"
+        />
+      </ImageThumbnailButton>
+      <ImageViewer
+        open={viewer.open}
+        onOpenChange={viewer.setOpen}
+        src={src}
+        alt={alt}
+        title={title}
+        description={description}
+      />
+    </>
   )
 }
 

--- a/console/web/src/components/ui/ImageViewer.stories.tsx
+++ b/console/web/src/components/ui/ImageViewer.stories.tsx
@@ -1,0 +1,99 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Button } from './Button'
+import {
+  ImageThumbnailButton,
+  ImageViewer,
+  type ImageViewerProps,
+  useImageViewer,
+} from './ImageViewer'
+
+function svgDataUrl(width: number, height: number, label: string): string {
+  const cells = 8
+  const tiles = Array.from({ length: cells * cells }, (_, i) => {
+    const x = (i % cells) * (width / cells)
+    const y = Math.floor(i / cells) * (height / cells)
+    const fill = (Math.floor(i / cells) + i) % 2 === 0 ? '#b8420f' : '#28a8f7'
+    return `<rect x="${x}" y="${y}" width="${width / cells}" height="${height / cells}" fill="${fill}" opacity="0.35"/>`
+  }).join('')
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}"><rect width="100%" height="100%" fill="#f2f0ed"/>${tiles}<text x="50%" y="50%" font-family="monospace" font-size="${Math.round(width / 18)}" text-anchor="middle" dominant-baseline="middle" fill="#0a0a0a">${label}</text><circle cx="${width * 0.15}" cy="${height * 0.2}" r="${width * 0.03}" fill="#0a0a0a"/></svg>`
+  return `data:image/svg+xml;base64,${btoa(svg)}`
+}
+
+const LARGE = svgDataUrl(3200, 2000, '3200 x 2000')
+const SMALL = svgDataUrl(320, 200, '320 x 200')
+
+function Demo(props: Omit<ImageViewerProps, 'open' | 'onOpenChange'>) {
+  const viewer = useImageViewer()
+  return (
+    <div className="flex flex-col items-start gap-3">
+      <ImageThumbnailButton
+        title={props.title ?? 'image'}
+        onClick={viewer.show}
+      >
+        {props.src ? (
+          <img
+            src={props.src}
+            alt=""
+            className="h-24 w-auto rounded-xs border border-edge"
+          />
+        ) : (
+          <span className="rounded-xs bg-surface px-3 py-2 font-sans text-[12px] text-ink-faint">
+            (no bytes)
+          </span>
+        )}
+      </ImageThumbnailButton>
+      <Button variant="pill" size="sm" onClick={viewer.show}>
+        Open viewer
+      </Button>
+      <ImageViewer
+        open={viewer.open}
+        onOpenChange={viewer.setOpen}
+        {...props}
+      />
+    </div>
+  )
+}
+
+const meta = {
+  title: 'UI/ImageViewer',
+  component: Demo,
+  parameters: { layout: 'padded' },
+} satisfies Meta<typeof Demo>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const LargeImage: Story = {
+  args: {
+    src: LARGE,
+    alt: 'Checkerboard test image',
+    title: 'wireframe-3200.svg',
+    description: 'svg · 14kb',
+  },
+}
+
+export const SmallImage: Story = {
+  args: {
+    src: SMALL,
+    alt: 'Small checkerboard',
+    title: 'icon-320.svg',
+    description: 'svg · 2kb',
+  },
+}
+
+export const Unavailable: Story = {
+  args: {
+    src: null,
+    alt: 'Screenshot that was not kept',
+    title: 'screenshot.png',
+    unavailableReason: 'The image bytes were not kept with this conversation.',
+  },
+}
+
+export const DecodeFailure: Story = {
+  args: {
+    src: 'data:image/png;base64,AAAA',
+    alt: 'Broken image',
+    title: 'broken.png',
+  },
+}

--- a/console/web/src/components/ui/ImageViewer.tsx
+++ b/console/web/src/components/ui/ImageViewer.tsx
@@ -1,0 +1,647 @@
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { ImageOff, Maximize, Scan, X, ZoomIn, ZoomOut } from 'lucide-react'
+import * as React from 'react'
+import { PortalScope } from '@/lib/ui-scope'
+import { cn } from '@/lib/utils'
+import { IconButton } from './IconButton'
+import {
+  centred,
+  clampOffset,
+  clampScale,
+  dataUrlBytes,
+  fitScale,
+  MAX_PREVIEW_BYTES,
+  type PointerPoint,
+  panBy,
+  pinchGeometry,
+  type Size,
+  steppedScale,
+  type ViewTransform,
+  zoomAbout,
+  zoomPercent,
+} from './image-viewer-math'
+
+export interface ImageViewerProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Image source; `null`/`undefined` renders the unavailable state. */
+  src?: string | null
+  /** Accessible description of the picture. */
+  alt: string
+  /** Caption: the attachment name or the file's relative path, never a host path. */
+  title?: string
+  /** Secondary caption, e.g. a byte size or MIME type. */
+  description?: string
+  /** Why the source is unavailable, when it is. */
+  unavailableReason?: string
+  /** Extra controls rendered in the toolbar before Close. */
+  actions?: React.ReactNode
+}
+
+type Phase =
+  | { kind: 'loading' }
+  | { kind: 'ready'; image: Size }
+  | { kind: 'error'; message: string }
+  | { kind: 'unavailable'; message: string }
+
+const KEY_PAN_PX = 48
+
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  )
+}
+
+/** The shared full-screen image viewer; see DESIGN.md for the interaction contract. */
+export function ImageViewer({
+  open,
+  onOpenChange,
+  src,
+  alt,
+  title,
+  description,
+  unavailableReason,
+  actions,
+}: ImageViewerProps) {
+  // Radix returns focus to a DialogTrigger; a controlled viewer has none.
+  const openerRef = React.useRef<HTMLElement | null>(null)
+  React.useLayoutEffect(() => {
+    if (open) {
+      const active = document.activeElement
+      openerRef.current = active instanceof HTMLElement ? active : null
+    }
+  }, [open])
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitive.Portal>
+        <PortalScope>
+          <DialogPrimitive.Overlay className="iii-ui-motion-overlay fixed inset-0 z-50 bg-black/85" />
+          <DialogPrimitive.Content
+            aria-label={title ? `Image: ${title}` : 'Image viewer'}
+            className="iii-ui-motion-panel fixed inset-0 z-50 flex flex-col font-sans text-ink focus-visible:outline-none"
+            onOpenAutoFocus={(event) => {
+              event.preventDefault()
+              const content = event.currentTarget as HTMLElement | null
+              content
+                ?.querySelector<HTMLElement>('[data-image-viewer-root]')
+                ?.focus()
+            }}
+            onCloseAutoFocus={(event) => {
+              event.preventDefault()
+              const opener = openerRef.current
+              if (opener?.isConnected) opener.focus()
+            }}
+          >
+            <DialogPrimitive.Title className="sr-only">
+              {title ?? 'Image'}
+            </DialogPrimitive.Title>
+            <DialogPrimitive.Description className="sr-only">
+              {alt}
+            </DialogPrimitive.Description>
+            {open ? (
+              <Stage
+                src={src ?? null}
+                alt={alt}
+                title={title}
+                description={description}
+                unavailableReason={unavailableReason}
+                actions={actions}
+                onClose={() => onOpenChange(false)}
+              />
+            ) : null}
+          </DialogPrimitive.Content>
+        </PortalScope>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  )
+}
+
+interface StageProps {
+  src: string | null
+  alt: string
+  title?: string
+  description?: string
+  unavailableReason?: string
+  actions?: React.ReactNode
+  onClose: () => void
+}
+
+function Stage({
+  src,
+  alt,
+  title,
+  description,
+  unavailableReason,
+  actions,
+  onClose,
+}: StageProps) {
+  const stageRef = React.useRef<HTMLDivElement>(null)
+  const imageRef = React.useRef<HTMLImageElement>(null)
+  const viewRef = React.useRef<ViewTransform>(centred(1))
+  const frameRef = React.useRef<number | null>(null)
+  const pointersRef = React.useRef<Map<number, PointerPoint>>(new Map())
+  const gestureRef = React.useRef<{
+    kind: 'pan' | 'pinch'
+    startView: ViewTransform
+    startDistance: number
+    startMid: { x: number; y: number }
+    last: { x: number; y: number }
+    moved: boolean
+  } | null>(null)
+  const [phase, setPhase] = React.useState<Phase>(() =>
+    initialPhase(src, unavailableReason),
+  )
+  const [stageSize, setStageSize] = React.useState<Size>({
+    width: 0,
+    height: 0,
+  })
+  const [percent, setPercent] = React.useState('')
+  const [animated, setAnimated] = React.useState(false)
+  const [dragging, setDragging] = React.useState(false)
+
+  const image = phase.kind === 'ready' ? phase.image : null
+  const fit = image ? fitScale(image, stageSize) : 1
+
+  React.useEffect(() => {
+    setPhase(initialPhase(src, unavailableReason))
+  }, [src, unavailableReason])
+
+  React.useLayoutEffect(() => {
+    const stage = stageRef.current
+    if (!stage) return
+    const measure = () =>
+      setStageSize({ width: stage.clientWidth, height: stage.clientHeight })
+    measure()
+    if (typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(measure)
+    observer.observe(stage)
+    return () => observer.disconnect()
+  }, [])
+
+  const paint = React.useCallback(() => {
+    frameRef.current = null
+    const el = imageRef.current
+    if (!el) return
+    const view = viewRef.current
+    el.style.transform = `translate(${view.x}px, ${view.y}px) scale(${view.scale})`
+    setPercent(zoomPercent(view.scale))
+  }, [])
+
+  const schedulePaint = React.useCallback(() => {
+    if (frameRef.current !== null) return
+    frameRef.current = requestAnimationFrame(paint)
+  }, [paint])
+
+  React.useEffect(
+    () => () => {
+      if (frameRef.current !== null) cancelAnimationFrame(frameRef.current)
+    },
+    [],
+  )
+
+  const apply = React.useCallback(
+    (view: ViewTransform, animate = false) => {
+      viewRef.current = view
+      setAnimated(animate && !prefersReducedMotion())
+      schedulePaint()
+    },
+    [schedulePaint],
+  )
+
+  // A loaded image, or a resized stage, starts from fit.
+  const fitKey = image ? `${image.width}x${image.height}` : ''
+  const lastFitKeyRef = React.useRef('')
+  React.useLayoutEffect(() => {
+    if (!image || stageSize.width === 0) return
+    if (lastFitKeyRef.current === fitKey) {
+      apply(clampOffset(viewRef.current, image, stageSize))
+      return
+    }
+    lastFitKeyRef.current = fitKey
+    apply(centred(fit))
+  }, [image, stageSize, fit, fitKey, apply])
+
+  const stagePoint = React.useCallback((clientX: number, clientY: number) => {
+    const rect = stageRef.current?.getBoundingClientRect()
+    if (!rect) return { x: 0, y: 0 }
+    return {
+      x: clientX - rect.left - rect.width / 2,
+      y: clientY - rect.top - rect.height / 2,
+    }
+  }, [])
+
+  const zoomTo = React.useCallback(
+    (scale: number, focus = { x: 0, y: 0 }, animate = false) => {
+      if (!image) return
+      apply(
+        zoomAbout(viewRef.current, scale, focus, image, stageSize, fit),
+        animate,
+      )
+    },
+    [apply, image, stageSize, fit],
+  )
+
+  const zoomStep = React.useCallback(
+    (direction: 1 | -1) => {
+      zoomTo(steppedScale(viewRef.current.scale, direction))
+    },
+    [zoomTo],
+  )
+
+  const toggleFitActual = React.useCallback(
+    (focus = { x: 0, y: 0 }) => {
+      const atFit = Math.abs(viewRef.current.scale - fit) < 1e-3
+      zoomTo(atFit && fit < 1 ? 1 : fit, focus, true)
+    },
+    [fit, zoomTo],
+  )
+
+  // Native non-passive listener: React's synthetic wheel cannot preventDefault.
+  React.useEffect(() => {
+    const stage = stageRef.current
+    if (!stage) return
+    const onWheel = (event: WheelEvent) => {
+      event.preventDefault()
+      if (!image) return
+      const factor = Math.exp(-event.deltaY * (event.ctrlKey ? 0.01 : 0.002))
+      zoomTo(
+        viewRef.current.scale * factor,
+        stagePoint(event.clientX, event.clientY),
+      )
+    }
+    stage.addEventListener('wheel', onWheel, { passive: false })
+    return () => stage.removeEventListener('wheel', onWheel)
+  }, [image, stagePoint, zoomTo])
+
+  const onPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!image || event.button !== 0) return
+    event.currentTarget.setPointerCapture(event.pointerId)
+    pointersRef.current.set(event.pointerId, {
+      id: event.pointerId,
+      x: event.clientX,
+      y: event.clientY,
+    })
+    const points = [...pointersRef.current.values()]
+    const pinch = pinchGeometry(points)
+    if (pinch) {
+      gestureRef.current = {
+        kind: 'pinch',
+        startView: viewRef.current,
+        startDistance: pinch.distance,
+        startMid: stagePoint(pinch.midpoint.x, pinch.midpoint.y),
+        last: pinch.midpoint,
+        moved: true,
+      }
+      return
+    }
+    gestureRef.current = {
+      kind: 'pan',
+      startView: viewRef.current,
+      startDistance: 0,
+      startMid: { x: 0, y: 0 },
+      last: { x: event.clientX, y: event.clientY },
+      moved: false,
+    }
+  }
+
+  const onPointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    const gesture = gestureRef.current
+    if (!gesture || !image) return
+    const point = pointersRef.current.get(event.pointerId)
+    if (!point) return
+    point.x = event.clientX
+    point.y = event.clientY
+    if (gesture.kind === 'pinch') {
+      const pinch = pinchGeometry([...pointersRef.current.values()])
+      if (!pinch || gesture.startDistance === 0) return
+      const scale = clampScale(
+        gesture.startView.scale * (pinch.distance / gesture.startDistance),
+        fit,
+      )
+      const mid = stagePoint(pinch.midpoint.x, pinch.midpoint.y)
+      const zoomed = zoomAbout(
+        gesture.startView,
+        scale,
+        gesture.startMid,
+        image,
+        stageSize,
+        fit,
+      )
+      apply(
+        panBy(
+          zoomed,
+          mid.x - gesture.startMid.x,
+          mid.y - gesture.startMid.y,
+          image,
+          stageSize,
+        ),
+      )
+      return
+    }
+    const dx = event.clientX - gesture.last.x
+    const dy = event.clientY - gesture.last.y
+    gesture.last = { x: event.clientX, y: event.clientY }
+    if (!gesture.moved && Math.hypot(dx, dy) < 3) return
+    if (!gesture.moved) {
+      gesture.moved = true
+      setDragging(true)
+    }
+    apply(panBy(viewRef.current, dx, dy, image, stageSize))
+  }
+
+  const onPointerUp = (event: React.PointerEvent<HTMLDivElement>) => {
+    pointersRef.current.delete(event.pointerId)
+    try {
+      event.currentTarget.releasePointerCapture(event.pointerId)
+    } catch {
+      // Already released.
+    }
+    const gesture = gestureRef.current
+    if (pointersRef.current.size === 0) {
+      gestureRef.current = null
+      setDragging(false)
+      return
+    }
+    if (gesture?.kind === 'pinch' && pointersRef.current.size === 1) {
+      const [remaining] = pointersRef.current.values()
+      gestureRef.current = {
+        kind: 'pan',
+        startView: viewRef.current,
+        startDistance: 0,
+        startMid: { x: 0, y: 0 },
+        last: { x: remaining.x, y: remaining.y },
+        moved: true,
+      }
+    }
+  }
+
+  const onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!image) return
+    const target = event.target as HTMLElement
+    if (
+      target.tagName === 'BUTTON' &&
+      (event.key === ' ' || event.key === 'Enter')
+    ) {
+      return
+    }
+    switch (event.key) {
+      case '+':
+      case '=':
+        zoomStep(1)
+        break
+      case '-':
+      case '_':
+        zoomStep(-1)
+        break
+      case '0':
+        zoomTo(fit)
+        break
+      case '1':
+        zoomTo(1)
+        break
+      case 'ArrowLeft':
+        apply(panBy(viewRef.current, KEY_PAN_PX, 0, image, stageSize))
+        break
+      case 'ArrowRight':
+        apply(panBy(viewRef.current, -KEY_PAN_PX, 0, image, stageSize))
+        break
+      case 'ArrowUp':
+        apply(panBy(viewRef.current, 0, KEY_PAN_PX, image, stageSize))
+        break
+      case 'ArrowDown':
+        apply(panBy(viewRef.current, 0, -KEY_PAN_PX, image, stageSize))
+        break
+      default:
+        return
+    }
+    event.preventDefault()
+  }
+
+  const onLoad = (event: React.SyntheticEvent<HTMLImageElement>) => {
+    const el = event.currentTarget
+    const size = { width: el.naturalWidth, height: el.naturalHeight }
+    if (size.width === 0 || size.height === 0) {
+      setPhase({ kind: 'error', message: 'The image could not be decoded.' })
+      return
+    }
+    const decode = el.decode ? el.decode() : Promise.resolve()
+    decode
+      .then(() => setPhase({ kind: 'ready', image: size }))
+      .catch(() =>
+        setPhase({ kind: 'error', message: 'The image could not be decoded.' }),
+      )
+  }
+
+  const zoomable = image !== null
+  const pannable =
+    zoomable &&
+    (image.width * viewRef.current.scale > stageSize.width ||
+      image.height * viewRef.current.scale > stageSize.height)
+
+  return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: focusable root (tabIndex -1) that owns the viewer keys.
+    <div
+      data-image-viewer-root
+      tabIndex={-1}
+      className="relative flex min-h-0 flex-1 flex-col outline-none"
+      onKeyDown={onKeyDown}
+    >
+      <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex flex-col items-end gap-2 p-3 sm:flex-row sm:items-start sm:justify-between sm:gap-3 sm:p-4">
+        <div className="pointer-events-auto order-2 max-w-full min-w-0 rounded-md bg-panel-raised/95 px-3 py-2 shadow-floating sm:order-1 sm:max-w-[40%]">
+          <div className="truncate font-sans text-[13px] font-medium text-ink">
+            {title ?? 'Image'}
+          </div>
+          {description || image ? (
+            <div className="truncate font-mono text-[11px] text-ink-faint tabular-nums">
+              {[image ? `${image.width} × ${image.height}` : null, description]
+                .filter(Boolean)
+                .join(' · ')}
+            </div>
+          ) : null}
+        </div>
+        <div className="pointer-events-auto order-1 flex shrink-0 items-center gap-0.5 rounded-md bg-panel-raised/95 p-1 shadow-floating sm:order-2">
+          <IconButton
+            label="Zoom out"
+            tooltip="Zoom out (-)"
+            disabled={!zoomable}
+            onClick={() => zoomStep(-1)}
+            className="size-11 sm:size-[30px]"
+          >
+            <ZoomOut aria-hidden />
+          </IconButton>
+          <output
+            aria-live="polite"
+            aria-label="Zoom"
+            className="min-w-[3.5rem] text-center font-mono text-[12px] text-ink tabular-nums"
+          >
+            {zoomable ? percent : '–'}
+          </output>
+          <IconButton
+            label="Zoom in"
+            tooltip="Zoom in (+)"
+            disabled={!zoomable}
+            onClick={() => zoomStep(1)}
+            className="size-11 sm:size-[30px]"
+          >
+            <ZoomIn aria-hidden />
+          </IconButton>
+          <IconButton
+            label="Fit to screen"
+            tooltip="Fit to screen (0)"
+            disabled={!zoomable}
+            onClick={() => zoomTo(fit, { x: 0, y: 0 }, true)}
+            className="size-11 sm:size-[30px]"
+          >
+            <Maximize aria-hidden />
+          </IconButton>
+          <IconButton
+            label="Actual size"
+            tooltip="Actual size (1)"
+            disabled={!zoomable}
+            onClick={() => zoomTo(1, { x: 0, y: 0 }, true)}
+            className="size-11 sm:size-[30px]"
+          >
+            <Scan aria-hidden />
+          </IconButton>
+          {actions}
+          <IconButton
+            label="Close"
+            tooltip="Close (Esc)"
+            onClick={onClose}
+            className="size-11 sm:size-[30px]"
+          >
+            <X aria-hidden />
+          </IconButton>
+        </div>
+      </div>
+
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: pointer surface; the keyboard lives on the dialog content above. */}
+      <div
+        ref={stageRef}
+        data-image-viewer-stage
+        className={cn(
+          'relative flex min-h-0 flex-1 select-none items-center justify-center overflow-hidden',
+          zoomable && (pannable || dragging)
+            ? dragging
+              ? 'cursor-grabbing'
+              : 'cursor-grab'
+            : 'cursor-default',
+        )}
+        style={{ touchAction: 'none' }}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerUp}
+        onDoubleClick={(event) => {
+          if (!image) return
+          toggleFitActual(stagePoint(event.clientX, event.clientY))
+        }}
+      >
+        {src && phase.kind !== 'unavailable' ? (
+          <img
+            ref={imageRef}
+            src={src}
+            alt={alt}
+            draggable={false}
+            onLoad={onLoad}
+            onError={() =>
+              setPhase({
+                kind: 'error',
+                message: 'The image could not be loaded.',
+              })
+            }
+            className={cn(
+              'max-w-none origin-center select-none',
+              phase.kind === 'ready' ? 'opacity-100' : 'opacity-0',
+              animated &&
+                'transition-transform duration-(--motion-duration-control) ease-(--motion-ease-standard)',
+            )}
+            style={{ willChange: 'transform' }}
+            onTransitionEnd={() => setAnimated(false)}
+          />
+        ) : null}
+        {phase.kind === 'loading' ? (
+          <div
+            role="status"
+            className="absolute rounded-md bg-panel-raised/95 px-3 py-2 font-sans text-[12px] text-ink-faint shadow-floating"
+          >
+            Loading image…
+          </div>
+        ) : null}
+        {phase.kind === 'error' || phase.kind === 'unavailable' ? (
+          <div
+            role="status"
+            className="absolute flex max-w-sm flex-col items-center gap-2 rounded-md bg-panel-raised px-5 py-4 text-center shadow-floating"
+          >
+            <ImageOff aria-hidden className="size-5 text-ink-faint" />
+            <div className="font-sans text-[13px] font-medium text-ink">
+              {phase.kind === 'error'
+                ? 'Cannot show this image'
+                : 'Image not available'}
+            </div>
+            <div className="font-sans text-[12px] text-ink-faint">
+              {phase.message}
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+function initialPhase(src: string | null, unavailableReason?: string): Phase {
+  if (!src) {
+    return {
+      kind: 'unavailable',
+      message:
+        unavailableReason ?? 'The image bytes were not kept with this item.',
+    }
+  }
+  const bytes = dataUrlBytes(src)
+  if (bytes !== null && bytes > MAX_PREVIEW_BYTES) {
+    return {
+      kind: 'unavailable',
+      message: `This image is ${(bytes / (1024 * 1024)).toFixed(0)} MB, above the ${MAX_PREVIEW_BYTES / (1024 * 1024)} MB preview limit.`,
+    }
+  }
+  return { kind: 'loading' }
+}
+
+export interface ImageThumbnailButtonProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'title'> {
+  /** What opens: the viewer's caption. */
+  title: string
+}
+
+/** The opener: a button around a thumbnail, with the zoom cursor and a name. */
+export const ImageThumbnailButton = React.forwardRef<
+  HTMLButtonElement,
+  ImageThumbnailButtonProps
+>(({ title, className, children, ...props }, ref) => (
+  <button
+    ref={ref}
+    type="button"
+    aria-label={`View ${title}`}
+    title={`View ${title}`}
+    className={cn(
+      'inline-flex cursor-zoom-in items-center justify-center rounded-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus',
+      className,
+    )}
+    {...props}
+  >
+    {children}
+  </button>
+))
+ImageThumbnailButton.displayName = 'ImageThumbnailButton'
+
+/** Open/close state plus the opener wiring for one image. */
+export function useImageViewer(): {
+  open: boolean
+  setOpen: (open: boolean) => void
+  show: () => void
+} {
+  const [open, setOpen] = React.useState(false)
+  const show = React.useCallback(() => setOpen(true), [])
+  return { open, setOpen, show }
+}

--- a/console/web/src/components/ui/ImageViewer.tsx
+++ b/console/web/src/components/ui/ImageViewer.tsx
@@ -17,6 +17,7 @@ import {
   type Size,
   steppedScale,
   type ViewTransform,
+  wheelDeltaPixels,
   zoomAbout,
   zoomPercent,
 } from './image-viewer-math'
@@ -44,12 +45,48 @@ type Phase =
   | { kind: 'error'; message: string }
   | { kind: 'unavailable'; message: string }
 
+type Gesture =
+  | {
+      kind: 'pan'
+      press: { x: number; y: number }
+      last: { x: number; y: number }
+      moved: boolean
+    }
+  | {
+      kind: 'pinch'
+      startView: ViewTransform
+      startDistance: number
+      startMid: { x: number; y: number }
+    }
+
 const KEY_PAN_PX = 48
+const DRAG_SLOP_PX = 3
+const ANNOUNCE_DELAY_MS = 250
+const FALLBACK_INTRINSIC: Size = { width: 300, height: 150 }
 
 function prefersReducedMotion(): boolean {
   return (
     typeof window !== 'undefined' &&
     window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  )
+}
+
+function releasePointer(el: HTMLElement, pointerId: number): void {
+  try {
+    el.releasePointerCapture(pointerId)
+  } catch {
+    return
+  }
+}
+
+function isEditable(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false
+  const tag = target.tagName
+  return (
+    tag === 'INPUT' ||
+    tag === 'TEXTAREA' ||
+    tag === 'SELECT' ||
+    target.isContentEditable
   )
 }
 
@@ -64,7 +101,6 @@ export function ImageViewer({
   unavailableReason,
   actions,
 }: ImageViewerProps) {
-  // Radix returns focus to a DialogTrigger; a controlled viewer has none.
   const openerRef = React.useRef<HTMLElement | null>(null)
   React.useLayoutEffect(() => {
     if (open) {
@@ -78,7 +114,6 @@ export function ImageViewer({
         <PortalScope>
           <DialogPrimitive.Overlay className="iii-ui-motion-overlay fixed inset-0 z-50 bg-black/85" />
           <DialogPrimitive.Content
-            aria-label={title ? `Image: ${title}` : 'Image viewer'}
             className="iii-ui-motion-panel fixed inset-0 z-50 flex flex-col font-sans text-ink focus-visible:outline-none"
             onOpenAutoFocus={(event) => {
               event.preventDefault()
@@ -94,22 +129,20 @@ export function ImageViewer({
             }}
           >
             <DialogPrimitive.Title className="sr-only">
-              {title ?? 'Image'}
+              {title ? `Image viewer: ${title}` : 'Image viewer'}
             </DialogPrimitive.Title>
             <DialogPrimitive.Description className="sr-only">
               {alt}
             </DialogPrimitive.Description>
-            {open ? (
-              <Stage
-                src={src ?? null}
-                alt={alt}
-                title={title}
-                description={description}
-                unavailableReason={unavailableReason}
-                actions={actions}
-                onClose={() => onOpenChange(false)}
-              />
-            ) : null}
+            <Stage
+              src={src ?? null}
+              alt={alt}
+              title={title}
+              description={description}
+              unavailableReason={unavailableReason}
+              actions={actions}
+              onClose={() => onOpenChange(false)}
+            />
           </DialogPrimitive.Content>
         </PortalScope>
       </DialogPrimitive.Portal>
@@ -141,14 +174,8 @@ function Stage({
   const viewRef = React.useRef<ViewTransform>(centred(1))
   const frameRef = React.useRef<number | null>(null)
   const pointersRef = React.useRef<Map<number, PointerPoint>>(new Map())
-  const gestureRef = React.useRef<{
-    kind: 'pan' | 'pinch'
-    startView: ViewTransform
-    startDistance: number
-    startMid: { x: number; y: number }
-    last: { x: number; y: number }
-    moved: boolean
-  } | null>(null)
+  const gestureRef = React.useRef<Gesture | null>(null)
+  const loadGenerationRef = React.useRef(0)
   const [phase, setPhase] = React.useState<Phase>(() =>
     initialPhase(src, unavailableReason),
   )
@@ -156,26 +183,39 @@ function Stage({
     width: 0,
     height: 0,
   })
-  const [percent, setPercent] = React.useState('')
   const [scale, setScale] = React.useState(1)
+  const [announced, setAnnounced] = React.useState('')
   const [animated, setAnimated] = React.useState(false)
   const [dragging, setDragging] = React.useState(false)
 
   const image = phase.kind === 'ready' ? phase.image : null
   const fit = image ? fitScale(image, stageSize) : 1
 
+  const firstPhaseRef = React.useRef(true)
   React.useEffect(() => {
+    if (firstPhaseRef.current) {
+      firstPhaseRef.current = false
+      return
+    }
+    loadGenerationRef.current += 1
     setPhase(initialPhase(src, unavailableReason))
   }, [src, unavailableReason])
 
   React.useLayoutEffect(() => {
     const stage = stageRef.current
     if (!stage) return
-    const measure = () =>
-      setStageSize({ width: stage.clientWidth, height: stage.clientHeight })
-    measure()
+    const commit = (width: number, height: number) =>
+      setStageSize((current) =>
+        current.width === width && current.height === height
+          ? current
+          : { width, height },
+      )
+    commit(stage.clientWidth, stage.clientHeight)
     if (typeof ResizeObserver === 'undefined') return
-    const observer = new ResizeObserver(measure)
+    const observer = new ResizeObserver((entries) => {
+      const rect = entries[0]?.contentRect
+      if (rect) commit(Math.round(rect.width), Math.round(rect.height))
+    })
     observer.observe(stage)
     return () => observer.disconnect()
   }, [])
@@ -186,7 +226,6 @@ function Stage({
     if (!el) return
     const view = viewRef.current
     el.style.transform = `translate(${view.x}px, ${view.y}px) scale(${view.scale})`
-    setPercent(zoomPercent(view.scale))
     setScale(view.scale)
   }, [])
 
@@ -202,6 +241,15 @@ function Stage({
     [],
   )
 
+  React.useEffect(() => {
+    if (!image) return
+    const timer = window.setTimeout(
+      () => setAnnounced(zoomPercent(scale)),
+      ANNOUNCE_DELAY_MS,
+    )
+    return () => window.clearTimeout(timer)
+  }, [scale, image])
+
   const apply = React.useCallback(
     (view: ViewTransform, animate = false) => {
       viewRef.current = view
@@ -211,12 +259,14 @@ function Stage({
     [schedulePaint],
   )
 
-  // A loaded image, or a resized stage, starts from fit.
   const fitKey = image ? `${image.width}x${image.height}` : ''
   const lastFitKeyRef = React.useRef('')
+  const lastFitRef = React.useRef(1)
   React.useLayoutEffect(() => {
     if (!image || stageSize.width === 0) return
-    if (lastFitKeyRef.current === fitKey) {
+    const wasAtFit = Math.abs(viewRef.current.scale - lastFitRef.current) < 1e-3
+    lastFitRef.current = fit
+    if (lastFitKeyRef.current === fitKey && !wasAtFit) {
       apply(clampOffset(viewRef.current, image, stageSize))
       return
     }
@@ -259,14 +309,18 @@ function Stage({
     [fit, zoomTo],
   )
 
-  // Native non-passive listener: React's synthetic wheel cannot preventDefault.
   React.useEffect(() => {
     const stage = stageRef.current
     if (!stage) return
     const onWheel = (event: WheelEvent) => {
       event.preventDefault()
       if (!image) return
-      const factor = Math.exp(-event.deltaY * (event.ctrlKey ? 0.01 : 0.002))
+      const delta = wheelDeltaPixels(
+        event.deltaY,
+        event.deltaMode,
+        stage.clientHeight,
+      )
+      const factor = Math.exp(-delta * (event.ctrlKey ? 0.01 : 0.002))
       zoomTo(
         viewRef.current.scale * factor,
         stagePoint(event.clientX, event.clientY),
@@ -284,25 +338,21 @@ function Stage({
       x: event.clientX,
       y: event.clientY,
     })
-    const points = [...pointersRef.current.values()]
-    const pinch = pinchGeometry(points)
+    const pinch = pinchGeometry([...pointersRef.current.values()])
     if (pinch) {
       gestureRef.current = {
         kind: 'pinch',
         startView: viewRef.current,
         startDistance: pinch.distance,
         startMid: stagePoint(pinch.midpoint.x, pinch.midpoint.y),
-        last: pinch.midpoint,
-        moved: true,
       }
       return
     }
+    const point = { x: event.clientX, y: event.clientY }
     gestureRef.current = {
       kind: 'pan',
-      startView: viewRef.current,
-      startDistance: 0,
-      startMid: { x: 0, y: 0 },
-      last: { x: event.clientX, y: event.clientY },
+      press: point,
+      last: point,
       moved: false,
     }
   }
@@ -341,24 +391,24 @@ function Stage({
       )
       return
     }
-    const dx = event.clientX - gesture.last.x
-    const dy = event.clientY - gesture.last.y
-    gesture.last = { x: event.clientX, y: event.clientY }
-    if (!gesture.moved && Math.hypot(dx, dy) < 3) return
     if (!gesture.moved) {
+      const travelled = Math.hypot(
+        event.clientX - gesture.press.x,
+        event.clientY - gesture.press.y,
+      )
+      if (travelled < DRAG_SLOP_PX) return
       gesture.moved = true
       setDragging(true)
     }
+    const dx = event.clientX - gesture.last.x
+    const dy = event.clientY - gesture.last.y
+    gesture.last = { x: event.clientX, y: event.clientY }
     apply(panBy(viewRef.current, dx, dy, image, stageSize))
   }
 
   const onPointerUp = (event: React.PointerEvent<HTMLDivElement>) => {
-    pointersRef.current.delete(event.pointerId)
-    try {
-      event.currentTarget.releasePointerCapture(event.pointerId)
-    } catch {
-      // Already released.
-    }
+    if (!pointersRef.current.delete(event.pointerId)) return
+    releasePointer(event.currentTarget, event.pointerId)
     const gesture = gestureRef.current
     if (pointersRef.current.size === 0) {
       gestureRef.current = null
@@ -367,12 +417,11 @@ function Stage({
     }
     if (gesture?.kind === 'pinch' && pointersRef.current.size === 1) {
       const [remaining] = pointersRef.current.values()
+      const point = { x: remaining.x, y: remaining.y }
       gestureRef.current = {
         kind: 'pan',
-        startView: viewRef.current,
-        startDistance: 0,
-        startMid: { x: 0, y: 0 },
-        last: { x: remaining.x, y: remaining.y },
+        press: point,
+        last: point,
         moved: true,
       }
     }
@@ -380,13 +429,8 @@ function Stage({
 
   const onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (!image) return
-    const target = event.target as HTMLElement
-    if (
-      target.tagName === 'BUTTON' &&
-      (event.key === ' ' || event.key === 'Enter')
-    ) {
-      return
-    }
+    if (event.metaKey || event.ctrlKey || event.altKey) return
+    if (isEditable(event.target)) return
     switch (event.key) {
       case '+':
       case '=':
@@ -397,10 +441,10 @@ function Stage({
         zoomStep(-1)
         break
       case '0':
-        zoomTo(fit)
+        zoomTo(fit, { x: 0, y: 0 }, true)
         break
       case '1':
-        zoomTo(1)
+        zoomTo(1, { x: 0, y: 0 }, true)
         break
       case 'ArrowLeft':
         apply(panBy(viewRef.current, KEY_PAN_PX, 0, image, stageSize))
@@ -422,17 +466,23 @@ function Stage({
 
   const onLoad = (event: React.SyntheticEvent<HTMLImageElement>) => {
     const el = event.currentTarget
-    const size = { width: el.naturalWidth, height: el.naturalHeight }
-    if (size.width === 0 || size.height === 0) {
-      setPhase({ kind: 'error', message: 'The image could not be decoded.' })
-      return
-    }
+    const generation = loadGenerationRef.current
+    const intrinsic =
+      el.naturalWidth > 0 && el.naturalHeight > 0
+        ? { width: el.naturalWidth, height: el.naturalHeight }
+        : el.width > 0 && el.height > 0
+          ? { width: el.width, height: el.height }
+          : FALLBACK_INTRINSIC
     const decode = el.decode ? el.decode() : Promise.resolve()
     decode
-      .then(() => setPhase({ kind: 'ready', image: size }))
-      .catch(() =>
-        setPhase({ kind: 'error', message: 'The image could not be decoded.' }),
-      )
+      .then(() => {
+        if (generation !== loadGenerationRef.current) return
+        setPhase({ kind: 'ready', image: intrinsic })
+      })
+      .catch(() => {
+        if (generation !== loadGenerationRef.current) return
+        setPhase({ kind: 'error', message: 'The image could not be decoded.' })
+      })
   }
 
   const zoomable = image !== null
@@ -440,8 +490,8 @@ function Stage({
   const atActual = Math.abs(scale - 1) < 1e-3
   const pannable =
     zoomable &&
-    (image.width * viewRef.current.scale > stageSize.width ||
-      image.height * viewRef.current.scale > stageSize.height)
+    (image.width * scale > stageSize.width ||
+      image.height * scale > stageSize.height)
 
   return (
     // biome-ignore lint/a11y/noStaticElementInteractions: focusable root (tabIndex -1) that owns the viewer keys.
@@ -475,12 +525,15 @@ function Stage({
             <ZoomOut aria-hidden />
           </IconButton>
           <output
-            aria-live="polite"
+            aria-live="off"
             aria-label="Zoom"
             className="min-w-[3.5rem] text-center font-mono text-[12px] text-ink tabular-nums"
           >
-            {zoomable ? percent : '–'}
+            {zoomable ? zoomPercent(scale) : '–'}
           </output>
+          <span role="status" aria-live="polite" className="sr-only">
+            {zoomable ? `Zoom ${announced}` : ''}
+          </span>
           <IconButton
             label="Zoom in"
             tooltip="Zoom in (+)"
@@ -528,7 +581,7 @@ function Stage({
         </div>
       </div>
 
-      {/* biome-ignore lint/a11y/noStaticElementInteractions: pointer surface; the keyboard lives on the dialog content above. */}
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: pointer surface; the keyboard lives on the root above. */}
       <div
         ref={stageRef}
         data-image-viewer-stage
@@ -635,9 +688,8 @@ export const ImageThumbnailButton = React.forwardRef<
     ref={ref}
     type="button"
     aria-label={`View ${title}`}
-    title={`View ${title}`}
     className={cn(
-      'inline-flex cursor-zoom-in items-center justify-center rounded-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus',
+      'iii-ui-motion-control inline-flex cursor-zoom-in items-center justify-center rounded-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus',
       className,
     )}
     {...props}

--- a/console/web/src/components/ui/ImageViewer.tsx
+++ b/console/web/src/components/ui/ImageViewer.tsx
@@ -1,5 +1,5 @@
 import * as DialogPrimitive from '@radix-ui/react-dialog'
-import { ImageOff, Maximize, Scan, X, ZoomIn, ZoomOut } from 'lucide-react'
+import { ImageOff, Maximize, X, ZoomIn, ZoomOut } from 'lucide-react'
 import * as React from 'react'
 import { PortalScope } from '@/lib/ui-scope'
 import { cn } from '@/lib/utils'
@@ -157,6 +157,7 @@ function Stage({
     height: 0,
   })
   const [percent, setPercent] = React.useState('')
+  const [scale, setScale] = React.useState(1)
   const [animated, setAnimated] = React.useState(false)
   const [dragging, setDragging] = React.useState(false)
 
@@ -186,6 +187,7 @@ function Stage({
     const view = viewRef.current
     el.style.transform = `translate(${view.x}px, ${view.y}px) scale(${view.scale})`
     setPercent(zoomPercent(view.scale))
+    setScale(view.scale)
   }, [])
 
   const schedulePaint = React.useCallback(() => {
@@ -434,6 +436,8 @@ function Stage({
   }
 
   const zoomable = image !== null
+  const atFit = Math.abs(scale - fit) < 1e-3
+  const atActual = Math.abs(scale - 1) < 1e-3
   const pannable =
     zoomable &&
     (image.width * viewRef.current.scale > stageSize.width ||
@@ -490,8 +494,12 @@ function Stage({
             label="Fit to screen"
             tooltip="Fit to screen (0)"
             disabled={!zoomable}
+            aria-pressed={zoomable && atFit}
             onClick={() => zoomTo(fit, { x: 0, y: 0 }, true)}
-            className="size-11 sm:size-[30px]"
+            className={cn(
+              'size-11 sm:size-[30px]',
+              zoomable && atFit && 'bg-surface-selected text-ink',
+            )}
           >
             <Maximize aria-hidden />
           </IconButton>
@@ -499,10 +507,14 @@ function Stage({
             label="Actual size"
             tooltip="Actual size (1)"
             disabled={!zoomable}
+            aria-pressed={zoomable && atActual}
             onClick={() => zoomTo(1, { x: 0, y: 0 }, true)}
-            className="size-11 sm:size-[30px]"
+            className={cn(
+              'size-11 sm:size-[30px] font-mono text-[11px] font-semibold tracking-tight',
+              zoomable && atActual && 'bg-surface-selected text-ink',
+            )}
           >
-            <Scan aria-hidden />
+            <span aria-hidden>1:1</span>
           </IconButton>
           {actions}
           <IconButton

--- a/console/web/src/components/ui/image-viewer-math.test.ts
+++ b/console/web/src/components/ui/image-viewer-math.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest'
+import {
+  centred,
+  clampOffset,
+  clampScale,
+  dataUrlBytes,
+  fitScale,
+  MAX_PREVIEW_BYTES,
+  MAX_SCALE,
+  MIN_SCALE,
+  panBy,
+  pinchGeometry,
+  steppedScale,
+  zoomAbout,
+  zoomPercent,
+} from './image-viewer-math'
+
+const stage = { width: 1000, height: 600 }
+
+describe('fitScale', () => {
+  it('contains a large image on its longer side', () => {
+    expect(fitScale({ width: 4000, height: 1200 }, stage)).toBeCloseTo(0.25)
+    expect(fitScale({ width: 1000, height: 2400 }, stage)).toBeCloseTo(0.25)
+  })
+
+  it('never upscales a small image past its natural size', () => {
+    expect(fitScale({ width: 200, height: 100 }, stage)).toBe(1)
+  })
+
+  it('falls back to 1 for a degenerate stage or image', () => {
+    expect(fitScale({ width: 0, height: 0 }, stage)).toBe(1)
+    expect(fitScale({ width: 10, height: 10 }, { width: 0, height: 0 })).toBe(1)
+  })
+})
+
+describe('clampScale', () => {
+  it('stays inside the global bounds and never below fit', () => {
+    expect(clampScale(100, 0.5)).toBe(MAX_SCALE)
+    expect(clampScale(0.0001, 0.5)).toBe(MIN_SCALE)
+    expect(clampScale(0.01, 0.02)).toBe(0.02)
+    expect(clampScale(Number.NaN, 0.3)).toBe(0.3)
+  })
+})
+
+describe('clampOffset', () => {
+  it('keeps a small image centred', () => {
+    const view = clampOffset(
+      { scale: 1, x: 300, y: -200 },
+      { width: 200, height: 100 },
+      stage,
+    )
+    expect(view).toEqual({ scale: 1, x: 0, y: 0 })
+  })
+
+  it('lets a large image pan only until its edge meets the stage edge', () => {
+    const image = { width: 2000, height: 600 }
+    const view = clampOffset({ scale: 1, x: 900, y: 50 }, image, stage)
+    expect(view.x).toBe(500)
+    expect(view.y).toBe(0)
+    expect(clampOffset({ scale: 1, x: -900, y: 0 }, image, stage).x).toBe(-500)
+  })
+})
+
+describe('zoomAbout', () => {
+  const image = { width: 2000, height: 2000 }
+
+  it('keeps the image point under the focus in place', () => {
+    const before = centred(0.3)
+    const focus = { x: 100, y: -50 }
+    const after = zoomAbout(before, 0.6, focus, image, stage, 0.3)
+    // The point under focus maps to image-space (focus - x) / scale; it must
+    // be the same image point before and after the zoom.
+    const imageBefore = {
+      x: (focus.x - before.x) / before.scale,
+      y: (focus.y - before.y) / before.scale,
+    }
+    const imageAfter = {
+      x: (focus.x - after.x) / after.scale,
+      y: (focus.y - after.y) / after.scale,
+    }
+    expect(imageAfter.x).toBeCloseTo(imageBefore.x)
+    expect(imageAfter.y).toBeCloseTo(imageBefore.y)
+  })
+
+  it('zooming out to fit recentres', () => {
+    const zoomed = zoomAbout(
+      centred(0.3),
+      2,
+      { x: 300, y: 200 },
+      image,
+      stage,
+      0.3,
+    )
+    expect(zoomed.x).not.toBe(0)
+    const back = zoomAbout(zoomed, 0.3, { x: 0, y: 0 }, image, stage, 0.3)
+    expect(back).toEqual({ scale: 0.3, x: 0, y: 0 })
+  })
+})
+
+describe('panBy', () => {
+  it('moves and clamps', () => {
+    const image = { width: 2000, height: 2000 }
+    const view = panBy(centred(1), -10_000, 25, image, stage)
+    expect(view.x).toBe(-500)
+    expect(view.y).toBe(25)
+  })
+})
+
+describe('steppedScale', () => {
+  it('walks the ladder in both directions', () => {
+    expect(steppedScale(1, 1)).toBe(1.25)
+    expect(steppedScale(1, -1)).toBe(0.75)
+    expect(steppedScale(0.3, 1)).toBe(0.33)
+    expect(steppedScale(0.3, -1)).toBe(0.25)
+  })
+
+  it('keeps going past the ladder ends without leaving the bounds', () => {
+    expect(steppedScale(32, 1)).toBe(MAX_SCALE)
+    expect(steppedScale(0.05, -1)).toBe(MIN_SCALE)
+  })
+})
+
+describe('pinchGeometry', () => {
+  it('needs two pointers and reports distance and midpoint', () => {
+    expect(pinchGeometry([{ id: 1, x: 0, y: 0 }])).toBeNull()
+    expect(
+      pinchGeometry([
+        { id: 1, x: 0, y: 0 },
+        { id: 2, x: 30, y: 40 },
+      ]),
+    ).toEqual({ distance: 50, midpoint: { x: 15, y: 20 } })
+  })
+})
+
+describe('dataUrlBytes', () => {
+  it('sizes base64 payloads and ignores other sources', () => {
+    expect(dataUrlBytes('data:image/png;base64,AAAA')).toBe(3)
+    expect(dataUrlBytes('data:image/png;base64,AAA=')).toBe(2)
+    expect(dataUrlBytes('data:text/plain,hello')).toBe(5)
+    expect(dataUrlBytes('blob:http://x/y')).toBeNull()
+    expect(MAX_PREVIEW_BYTES).toBeGreaterThan(32 * 1024 * 1024)
+  })
+})
+
+describe('zoomPercent', () => {
+  it('rounds to whole percent', () => {
+    expect(zoomPercent(0.333)).toBe('33%')
+    expect(zoomPercent(2)).toBe('200%')
+  })
+})

--- a/console/web/src/components/ui/image-viewer-math.test.ts
+++ b/console/web/src/components/ui/image-viewer-math.test.ts
@@ -11,6 +11,7 @@ import {
   panBy,
   pinchGeometry,
   steppedScale,
+  wheelDeltaPixels,
   zoomAbout,
   zoomPercent,
 } from './image-viewer-math'
@@ -68,8 +69,6 @@ describe('zoomAbout', () => {
     const before = centred(0.3)
     const focus = { x: 100, y: -50 }
     const after = zoomAbout(before, 0.6, focus, image, stage, 0.3)
-    // The point under focus maps to image-space (focus - x) / scale; it must
-    // be the same image point before and after the zoom.
     const imageBefore = {
       x: (focus.x - before.x) / before.scale,
       y: (focus.y - before.y) / before.scale,
@@ -114,9 +113,10 @@ describe('steppedScale', () => {
     expect(steppedScale(0.3, -1)).toBe(0.25)
   })
 
-  it('keeps going past the ladder ends without leaving the bounds', () => {
-    expect(steppedScale(32, 1)).toBe(MAX_SCALE)
-    expect(steppedScale(0.05, -1)).toBe(MIN_SCALE)
+  it('keeps stepping past the ladder ends so a tiny fit stays reachable', () => {
+    expect(steppedScale(32, 1)).toBeCloseTo(40)
+    expect(steppedScale(0.05, -1)).toBeCloseTo(0.04)
+    expect(clampScale(steppedScale(0.045, -1), 0.045)).toBe(0.045)
   })
 })
 
@@ -139,6 +139,14 @@ describe('dataUrlBytes', () => {
     expect(dataUrlBytes('data:text/plain,hello')).toBe(5)
     expect(dataUrlBytes('blob:http://x/y')).toBeNull()
     expect(MAX_PREVIEW_BYTES).toBeGreaterThan(32 * 1024 * 1024)
+  })
+})
+
+describe('wheelDeltaPixels', () => {
+  it('scales line and page deltas into pixels', () => {
+    expect(wheelDeltaPixels(100, 0, 800)).toBe(100)
+    expect(wheelDeltaPixels(3, 1, 800)).toBe(48)
+    expect(wheelDeltaPixels(1, 2, 800)).toBe(800)
   })
 })
 

--- a/console/web/src/components/ui/image-viewer-math.ts
+++ b/console/web/src/components/ui/image-viewer-math.ts
@@ -39,9 +39,13 @@ export function clampOffset(
   const maxY = Math.max(0, (height - stage.height) / 2)
   return {
     scale: view.scale,
-    x: Math.min(maxX, Math.max(-maxX, view.x)) + 0,
-    y: Math.min(maxY, Math.max(-maxY, view.y)) + 0,
+    x: withoutNegativeZero(Math.min(maxX, Math.max(-maxX, view.x))),
+    y: withoutNegativeZero(Math.min(maxY, Math.max(-maxY, view.y))),
   }
+}
+
+function withoutNegativeZero(value: number): number {
+  return Object.is(value, -0) ? 0 : value
 }
 
 /** Zoom so the image point under `focus` (stage-centre coordinates) stays put. */
@@ -85,19 +89,37 @@ export function zoomPercent(scale: number): string {
   return `${Math.round(scale * 100)}%`
 }
 
-/** Zoom steps snap to a readable ladder around 100% instead of drifting. */
+const ZOOM_LADDER = [
+  0.05, 0.1, 0.15, 0.25, 0.33, 0.5, 0.67, 0.75, 1, 1.25, 1.5, 2, 3, 4, 6, 8, 12,
+  16, 24, 32,
+] as const
+
+/**
+ * Zoom steps snap to a readable ladder around 100%. Past either end the step
+ * is geometric and unclamped: the caller clamps against the fit, which may sit
+ * below the ladder for very tall or wide images.
+ */
 export function steppedScale(scale: number, direction: 1 | -1): number {
-  const ladder = [
-    0.05, 0.1, 0.15, 0.25, 0.33, 0.5, 0.67, 0.75, 1, 1.25, 1.5, 2, 3, 4, 6, 8,
-    12, 16, 24, 32,
-  ]
   const epsilon = 1e-6
   if (direction === 1) {
-    const next = ladder.find((step) => step > scale + epsilon)
-    return next ?? Math.min(MAX_SCALE, scale * ZOOM_STEP)
+    const next = ZOOM_LADDER.find((step) => step > scale + epsilon)
+    return next ?? scale * ZOOM_STEP
   }
-  const previous = [...ladder].reverse().find((step) => step < scale - epsilon)
-  return previous ?? Math.max(MIN_SCALE, scale / ZOOM_STEP)
+  for (let i = ZOOM_LADDER.length - 1; i >= 0; i -= 1) {
+    if (ZOOM_LADDER[i] < scale - epsilon) return ZOOM_LADDER[i]
+  }
+  return scale / ZOOM_STEP
+}
+
+/** Wheel deltas in pixels whatever deltaMode the browser reports. */
+export function wheelDeltaPixels(
+  delta: number,
+  deltaMode: number,
+  pageHeight: number,
+): number {
+  if (deltaMode === 1) return delta * 16
+  if (deltaMode === 2) return delta * Math.max(pageHeight, 1)
+  return delta
 }
 
 export interface PointerPoint {

--- a/console/web/src/components/ui/image-viewer-math.ts
+++ b/console/web/src/components/ui/image-viewer-math.ts
@@ -1,0 +1,134 @@
+export interface Size {
+  width: number
+  height: number
+}
+
+/** Scale and translation of the image's centre relative to the stage's centre. */
+export interface ViewTransform {
+  scale: number
+  x: number
+  y: number
+}
+
+export const MIN_SCALE = 0.05
+export const MAX_SCALE = 32
+export const ZOOM_STEP = 1.25
+
+/** Contain the image in the stage without upscaling past its natural size. */
+export function fitScale(image: Size, stage: Size): number {
+  if (image.width <= 0 || image.height <= 0) return 1
+  if (stage.width <= 0 || stage.height <= 0) return 1
+  return Math.min(stage.width / image.width, stage.height / image.height, 1)
+}
+
+export function clampScale(scale: number, fit: number): number {
+  const min = Math.min(MIN_SCALE, fit)
+  if (!Number.isFinite(scale)) return fit
+  return Math.min(MAX_SCALE, Math.max(min, scale))
+}
+
+/** A side shorter than the stage stays centred; a longer one never leaves a gap. */
+export function clampOffset(
+  view: ViewTransform,
+  image: Size,
+  stage: Size,
+): ViewTransform {
+  const width = image.width * view.scale
+  const height = image.height * view.scale
+  const maxX = Math.max(0, (width - stage.width) / 2)
+  const maxY = Math.max(0, (height - stage.height) / 2)
+  return {
+    scale: view.scale,
+    x: Math.min(maxX, Math.max(-maxX, view.x)) + 0,
+    y: Math.min(maxY, Math.max(-maxY, view.y)) + 0,
+  }
+}
+
+/** Zoom so the image point under `focus` (stage-centre coordinates) stays put. */
+export function zoomAbout(
+  view: ViewTransform,
+  nextScale: number,
+  focus: { x: number; y: number },
+  image: Size,
+  stage: Size,
+  fit: number,
+): ViewTransform {
+  const scale = clampScale(nextScale, fit)
+  const ratio = scale / view.scale
+  return clampOffset(
+    {
+      scale,
+      x: focus.x - (focus.x - view.x) * ratio,
+      y: focus.y - (focus.y - view.y) * ratio,
+    },
+    image,
+    stage,
+  )
+}
+
+export function panBy(
+  view: ViewTransform,
+  dx: number,
+  dy: number,
+  image: Size,
+  stage: Size,
+): ViewTransform {
+  return clampOffset({ ...view, x: view.x + dx, y: view.y + dy }, image, stage)
+}
+
+/** Centred at `scale`. */
+export function centred(scale: number): ViewTransform {
+  return { scale, x: 0, y: 0 }
+}
+
+export function zoomPercent(scale: number): string {
+  return `${Math.round(scale * 100)}%`
+}
+
+/** Zoom steps snap to a readable ladder around 100% instead of drifting. */
+export function steppedScale(scale: number, direction: 1 | -1): number {
+  const ladder = [
+    0.05, 0.1, 0.15, 0.25, 0.33, 0.5, 0.67, 0.75, 1, 1.25, 1.5, 2, 3, 4, 6, 8,
+    12, 16, 24, 32,
+  ]
+  const epsilon = 1e-6
+  if (direction === 1) {
+    const next = ladder.find((step) => step > scale + epsilon)
+    return next ?? Math.min(MAX_SCALE, scale * ZOOM_STEP)
+  }
+  const previous = [...ladder].reverse().find((step) => step < scale - epsilon)
+  return previous ?? Math.max(MIN_SCALE, scale / ZOOM_STEP)
+}
+
+export interface PointerPoint {
+  id: number
+  x: number
+  y: number
+}
+
+/** Distance and midpoint of a two-pointer gesture. */
+export function pinchGeometry(points: PointerPoint[]): {
+  distance: number
+  midpoint: { x: number; y: number }
+} | null {
+  if (points.length < 2) return null
+  const [a, b] = points
+  return {
+    distance: Math.hypot(b.x - a.x, b.y - a.y),
+    midpoint: { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 },
+  }
+}
+
+/** A data URL this size or larger is refused rather than decoded. */
+export const MAX_PREVIEW_BYTES = 48 * 1024 * 1024
+
+export function dataUrlBytes(src: string): number | null {
+  if (!src.startsWith('data:')) return null
+  const comma = src.indexOf(',')
+  if (comma < 0) return null
+  const header = src.slice(0, comma)
+  const payload = src.length - comma - 1
+  if (!header.includes(';base64')) return payload
+  const padding = src.endsWith('==') ? 2 : src.endsWith('=') ? 1 : 0
+  return Math.floor((payload * 3) / 4) - padding
+}

--- a/console/web/src/lib/console-api.ts
+++ b/console/web/src/lib/console-api.ts
@@ -42,6 +42,7 @@ import { EmptyState } from '@/components/ui/EmptyState'
 import { ErrorBoundary } from '@/components/ui/ErrorBoundary'
 import { FileDiff } from '@/components/ui/FileDiff'
 import { IconButton } from '@/components/ui/IconButton'
+import { ImageThumbnailButton, ImageViewer } from '@/components/ui/ImageViewer'
 import { Input } from '@/components/ui/Input'
 import { List, ListGroup, ListGroupLabel, ListItem } from '@/components/ui/List'
 import { MarkdownPreview } from '@/components/ui/MarkdownPreview'
@@ -128,6 +129,8 @@ export const components: ConsoleApi['components'] = {
   ErrorBoundary,
   FileDiff,
   IconButton,
+  ImageThumbnailButton,
+  ImageViewer,
   Input,
   List,
   ListGroup,

--- a/console/web/src/lib/console-ui-conformance.test.ts
+++ b/console/web/src/lib/console-ui-conformance.test.ts
@@ -52,6 +52,7 @@ import { EmptyState } from '@/components/ui/EmptyState'
 import { ErrorBoundary } from '@/components/ui/ErrorBoundary'
 import { FileDiff } from '@/components/ui/FileDiff'
 import { IconButton } from '@/components/ui/IconButton'
+import { ImageThumbnailButton, ImageViewer } from '@/components/ui/ImageViewer'
 import { Input } from '@/components/ui/Input'
 import { List, ListGroup, ListGroupLabel, ListItem } from '@/components/ui/List'
 import { MarkdownPreview } from '@/components/ui/MarkdownPreview'
@@ -137,6 +138,8 @@ const conformance: {
   ErrorBoundary: typeof ConsoleUi.ErrorBoundary
   FileDiff: typeof ConsoleUi.FileDiff
   IconButton: typeof ConsoleUi.IconButton
+  ImageThumbnailButton: typeof ConsoleUi.ImageThumbnailButton
+  ImageViewer: typeof ConsoleUi.ImageViewer
   Input: typeof ConsoleUi.Input
   JsonHighlight: typeof ConsoleUi.JsonHighlight
   List: typeof ConsoleUi.List
@@ -209,6 +212,8 @@ const conformance: {
   ErrorBoundary,
   FileDiff,
   IconButton,
+  ImageThumbnailButton,
+  ImageViewer,
   Input,
   JsonHighlight,
   List,

--- a/docs/sops/console-ui-conformance.md
+++ b/docs/sops/console-ui-conformance.md
@@ -16,6 +16,10 @@ or the selection/motion rules change.
   and semantic icons by default.
 - Overlays: shared `Tooltip`, `Dialog`, `DropdownMenu`, `Select`, `Selector`,
   and `BottomSheet` preserve injected worker scope through their portals.
+- Images: a picture the user may want to inspect opens the shared
+  `ImageViewer` through an `ImageThumbnailButton`; no worker ships its own
+  lightbox, zoom or pan. Captions carry the attachment name or a relative
+  path, never a host path.
 - Selection: neutral `surface-selected` + `ink`, with an optional neutral
   `edge`. Accent is reserved for primary actions, form focus, live activity,
   and semantic domain data.

--- a/packages/console-ui/README.md
+++ b/packages/console-ui/README.md
@@ -70,6 +70,11 @@ Use the shared contracts for repeated Console interactions:
 - Shared `Tooltip`, `Dialog`, `DropdownMenu`, `Select`, and `Selector` portals
   preserve an injected worker's `data-iii-ui` scope. `IconButton` combines an
   accessible label with the shared tooltip contract.
+- `ImageViewer` is the one full-screen image surface: wheel and pinch zoom
+  about the pointer, drag pans, double-click toggles fit and actual size,
+  `+`/`-`/`0`/`1` and arrows on the keyboard, Escape closes and focus returns
+  to the opener. Wrap the thumbnail in `ImageThumbnailButton` and pass a
+  caption that is an attachment name or a relative path.
 - `PageSidebar` owns sidebar collapse motion, stable focus/ARIA, pointer and
   keyboard resize, best-effort persistence, and container breakpoints in the
   Console host. Workers provide navigation content and declarative limits;

--- a/packages/console-ui/component-names.mjs
+++ b/packages/console-ui/component-names.mjs
@@ -41,6 +41,8 @@ export const componentNames = [
   'FileDiff',
   'Input',
   'IconButton',
+  'ImageThumbnailButton',
+  'ImageViewer',
   'JsonHighlight',
   'List',
   'ListGroup',

--- a/packages/console-ui/index.d.ts
+++ b/packages/console-ui/index.d.ts
@@ -554,6 +554,39 @@ export declare const TableCaption: React.ComponentType<
   React.HTMLAttributes<HTMLTableCaptionElement> & React.RefAttributes<HTMLTableCaptionElement>
 >
 
+export interface ImageViewerProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Image source; `null`/`undefined` renders the unavailable state. */
+  src?: string | null
+  /** Accessible description of the picture. */
+  alt: string
+  /** Caption: the attachment name or the file's relative path, never a host path. */
+  title?: string
+  /** Secondary caption, e.g. a byte size or MIME type. */
+  description?: string
+  /** Why the source is unavailable, when it is. */
+  unavailableReason?: string
+  /** Extra controls rendered in the toolbar before Close. */
+  actions?: React.ReactNode
+}
+/**
+ * Full-screen image viewer: wheel/pinch zoom about the pointer, drag pans,
+ * double-click toggles fit and actual size, `+`/`-`/`0`/`1` and arrows on the
+ * keyboard, Escape closes and focus returns to the opener. Handles loading,
+ * decode failure, missing source and oversized data URLs without freezing.
+ */
+export declare const ImageViewer: React.ComponentType<ImageViewerProps>
+export interface ImageThumbnailButtonProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'title'> {
+  /** What opens: the viewer's caption. */
+  title: string
+}
+/** The opener around a thumbnail: zoom cursor, accessible "View <title>" name. */
+export declare const ImageThumbnailButton: React.ComponentType<
+  ImageThumbnailButtonProps & React.RefAttributes<HTMLButtonElement>
+>
+
 export interface IconButtonProps extends Omit<ButtonProps, 'size'> {
   /** Required accessible name; also the default tooltip content. */
   label: string

--- a/shell/ui/src/page/EditorPane.tsx
+++ b/shell/ui/src/page/EditorPane.tsx
@@ -12,6 +12,8 @@ import {
   type CodeEditorHandle,
   type Host,
   IconButton,
+  ImageThumbnailButton,
+  ImageViewer,
 } from '@iii-dev/console-ui'
 import { Code, Eye } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
@@ -307,7 +309,7 @@ export function EditorPane({
   return (
     <div className="shui-main-pane">
       <div className="shui-editor-head">
-        <span className="path" title={absPath}>
+        <span className="path" title={relPath}>
           {relPath}
         </span>
         {dirty ? <span className="shui-dirty" title="unsaved changes" /> : null}
@@ -351,9 +353,11 @@ export function EditorPane({
         ) : pane.phase === 'error' ? (
           <div className="shui-side-note warn">{pane.message}</div>
         ) : entry?.image ? (
-          <div className="shui-image-wrap">
-            <img src={entry.image} alt={relPath} />
-          </div>
+          <ImagePreview
+            src={entry.image}
+            name={relPath}
+            description={entry.size != null ? formatBytes(entry.size) : undefined}
+          />
         ) : showPreview ? (
           <div className="shui-editor-preview">{richPreviewNode(relPath, draft)}</div>
         ) : (
@@ -369,6 +373,34 @@ export function EditorPane({
           />
         )}
       </div>
+    </div>
+  )
+}
+
+/** A raster file in the editor body; the picture opens the shared viewer. */
+export function ImagePreview({
+  src,
+  name,
+  description,
+}: {
+  src: string
+  name: string
+  description?: string
+}) {
+  const [open, setOpen] = useState(false)
+  return (
+    <div className="shui-image-wrap">
+      <ImageThumbnailButton title={name} onClick={() => setOpen(true)}>
+        <img src={src} alt={name} />
+      </ImageThumbnailButton>
+      <ImageViewer
+        open={open}
+        onOpenChange={setOpen}
+        src={src}
+        alt={name}
+        title={name}
+        description={description}
+      />
     </div>
   )
 }

--- a/shell/ui/src/page/EditorPane.tsx
+++ b/shell/ui/src/page/EditorPane.tsx
@@ -12,8 +12,6 @@ import {
   type CodeEditorHandle,
   type Host,
   IconButton,
-  ImageThumbnailButton,
-  ImageViewer,
 } from '@iii-dev/console-ui'
 import { Code, Eye } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
@@ -24,6 +22,7 @@ import {
   coderWriteFile,
   joinPath,
 } from './coder'
+import { ImagePreview } from './image-preview'
 import { isRichPreviewPath, richPreviewNode } from './rich-preview'
 
 /** File-extension → Monaco language id (unknown ids render plain). */
@@ -373,34 +372,6 @@ export function EditorPane({
           />
         )}
       </div>
-    </div>
-  )
-}
-
-/** A raster file in the editor body; the picture opens the shared viewer. */
-export function ImagePreview({
-  src,
-  name,
-  description,
-}: {
-  src: string
-  name: string
-  description?: string
-}) {
-  const [open, setOpen] = useState(false)
-  return (
-    <div className="shui-image-wrap">
-      <ImageThumbnailButton title={name} onClick={() => setOpen(true)}>
-        <img src={src} alt={name} />
-      </ImageThumbnailButton>
-      <ImageViewer
-        open={open}
-        onOpenChange={setOpen}
-        src={src}
-        alt={name}
-        title={name}
-        description={description}
-      />
     </div>
   )
 }

--- a/shell/ui/src/page/ReviewPane.tsx
+++ b/shell/ui/src/page/ReviewPane.tsx
@@ -19,7 +19,8 @@ import {
   joinPath,
   type ReadFileResponse,
 } from './coder'
-import { ImagePreview, imageMimeFromPath } from './EditorPane'
+import { imageMimeFromPath } from './EditorPane'
+import { ImagePreview } from './image-preview'
 import { FileTypeIcon } from './file-type-icon'
 import {
   firstChangedLine,
@@ -1290,7 +1291,7 @@ function richPreviewFor(
 ): React.ReactNode | null {
   if (state.image !== undefined) {
     return state.image === null ? null : (
-      <ImagePreview src={state.image} name={path} />
+      <ImagePreview src={state.image} name={path} inline />
     )
   }
   return richPreviewNode(path, state.newContents)

--- a/shell/ui/src/page/ReviewPane.tsx
+++ b/shell/ui/src/page/ReviewPane.tsx
@@ -19,7 +19,7 @@ import {
   joinPath,
   type ReadFileResponse,
 } from './coder'
-import { imageMimeFromPath } from './EditorPane'
+import { ImagePreview, imageMimeFromPath } from './EditorPane'
 import { FileTypeIcon } from './file-type-icon'
 import {
   firstChangedLine,
@@ -1290,7 +1290,7 @@ function richPreviewFor(
 ): React.ReactNode | null {
   if (state.image !== undefined) {
     return state.image === null ? null : (
-      <img className="shui-rich-preview-image" src={state.image} alt={`preview ${path}`} />
+      <ImagePreview src={state.image} name={path} />
     )
   }
   return richPreviewNode(path, state.newContents)

--- a/shell/ui/src/page/image-preview.tsx
+++ b/shell/ui/src/page/image-preview.tsx
@@ -1,0 +1,48 @@
+import * as ConsoleUi from '@iii-dev/console-ui'
+import { useState } from 'react'
+
+/** A picture in the editor body or a review row; it opens the shared viewer
+    where the running console provides one. */
+export function ImagePreview({
+  src,
+  name,
+  description,
+  inline = false,
+}: {
+  src: string
+  name: string
+  description?: string
+  /** Inside a flowing list (review rows): cap the height instead of filling a pane. */
+  inline?: boolean
+}) {
+  const [open, setOpen] = useState(false)
+  const ThumbnailButton = ConsoleUi.ImageThumbnailButton
+  const Viewer = ConsoleUi.ImageViewer
+  const wrapClass = inline ? 'shui-image-wrap shui-image-wrap--inline' : 'shui-image-wrap'
+  if (!ThumbnailButton || !Viewer) {
+    return (
+      <div className={wrapClass}>
+        <img src={src} alt={name} />
+      </div>
+    )
+  }
+  return (
+    <div className={wrapClass}>
+      <ThumbnailButton
+        title={name}
+        onClick={() => setOpen(true)}
+        className="shui-image-thumb"
+      >
+        <img src={src} alt={name} />
+      </ThumbnailButton>
+      <Viewer
+        open={open}
+        onOpenChange={setOpen}
+        src={src}
+        alt={name}
+        title={name}
+        description={description}
+      />
+    </div>
+  )
+}

--- a/shell/ui/src/page/rich-preview.tsx
+++ b/shell/ui/src/page/rich-preview.tsx
@@ -1,5 +1,6 @@
 import { Markdown } from '@iii-dev/console-ui'
 import type React from 'react'
+import { ImagePreview } from './image-preview'
 
 export function isRichPreviewPath(path: string): boolean {
   const lower = path.toLowerCase()
@@ -19,7 +20,7 @@ export function richPreviewNode(path: string, contents: string): React.ReactNode
   }
   if (lower.endsWith('.svg')) {
     const src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(contents)}`
-    return <img className="shui-rich-preview-image" src={src} alt={`preview ${path}`} />
+    return <ImagePreview src={src} name={path} inline />
   }
   if (lower.endsWith('.md') || lower.endsWith('.markdown')) {
     return (

--- a/shell/ui/styles.css
+++ b/shell/ui/styles.css
@@ -465,6 +465,12 @@
   justify-content: center;
   padding: 16px;
 }
+[data-iii-ui="shell"] .shui-image-wrap button {
+  display: flex;
+  max-width: 100%;
+  max-height: 100%;
+  min-height: 0;
+}
 [data-iii-ui="shell"] .shui-image-wrap img {
   max-width: 100%;
   max-height: 100%;

--- a/shell/ui/styles.css
+++ b/shell/ui/styles.css
@@ -465,11 +465,25 @@
   justify-content: center;
   padding: 16px;
 }
-[data-iii-ui="shell"] .shui-image-wrap button {
+[data-iii-ui="shell"] .shui-image-thumb {
   display: flex;
   max-width: 100%;
   max-height: 100%;
   min-height: 0;
+}
+[data-iii-ui="shell"] .shui-image-wrap--inline {
+  flex: none;
+  display: block;
+  padding: 20px;
+  text-align: center;
+}
+[data-iii-ui="shell"] .shui-image-wrap--inline .shui-image-thumb {
+  display: inline-flex;
+}
+[data-iii-ui="shell"] .shui-image-wrap--inline img {
+  max-height: 70vh;
+  border: none;
+  background: transparent;
 }
 [data-iii-ui="shell"] .shui-image-wrap img {
   max-width: 100%;


### PR DESCRIPTION
Fixes MOT-4483
Refs MOT-4455, MOT-4407

## What

One shared full-screen image viewer in `@iii-dev/console-ui`, opened from chat attachment chips, scrapling screenshot results, and the IDE's editor and review panes. Zoom in, out, fit and actual size; pan a zoomed image without dragging the workspace; Escape, the close control and focus restoration return the user to the image they opened.

## Why

The console had no way to look at a picture: `AttachmentChip` rendered a 24 px `<img>` with no click, `ScreenshotView` a static `<img>`, and the IDE's `EditorPane`/`ReviewPane` a contained `<img>` with no zoom. None had an `onError` path. `EditorPane` also exposed the absolute host path in the file-name tooltip.

## How

**`components/ui/ImageViewer.tsx`** (exported, with `ImageThumbnailButton` and `useImageViewer`): Radix Dialog through `PortalScope` so injected workers keep their `data-iii-ui` scope; a controlled viewer has no `DialogTrigger`, so it records the opener on open and restores focus to it on close (Radix would otherwise land on `body`). The stage keeps the transform in a ref and paints on `requestAnimationFrame`; wheel is a native non-passive listener (zoom about the pointer, trackpad pinch arrives as ctrl+wheel); pointer capture drives pan and a two-pointer pinch (`touch-action: none`); double-click toggles fit and actual size about the click point; `+`/`-` walk a zoom ladder, `0` fits, `1` is actual size, arrows pan, Escape closes; the zoom percent is a live `output`. Zoom steps and gestures are instant, the fit/actual toggle moves on `motion-duration-control` and is instant under reduced motion. States: loading, decode failure (`onError` and `img.decode()`), unavailable (no bytes, e.g. a reloaded conversation), and an oversized data URL refused above 48 MB before decoding. Captions are the attachment name or the relative path.

**`components/ui/image-viewer-math.ts`**: pure `fitScale` (contain, never upscale), `clampScale`, `clampOffset` (short side centred, long side never leaves a gap), `zoomAbout`, `panBy`, `steppedScale`, `pinchGeometry`, `dataUrlBytes`.

**Adoption**: `AttachmentChip` wraps the thumbnail in the opener (image chips without bytes open the unavailable state), `ScreenshotView` opens each tile, the IDE's `EditorPane` and `ReviewPane` share one `ImagePreview` that opens the viewer, and the editor tooltip now shows the relative path.

**Surface**: `console-api.ts` components record, `packages/console-ui` manifest + `index.d.ts`, vendor shim, README, `docs/sops/console-ui-conformance.md`, `console/DESIGN.md`, and the `design-console-ui` skill.

## Tests

- vitest: 14 unit tests on the math (fit, clamp, zoom-about-focus invariant, pan, ladder, pinch, data URL sizing); console-ui surface parity; 1590 tests pass.
- Storybook `UI/ImageViewer`: large image, small image (fit capped at 100%), unavailable, decode failure. Verified live in light and dark at 1280 px and 375 px: fit at open, `+` to 50%, `1` to 100%, arrow pan, `0` back to fit, wheel zoom about the cursor, double-click toggle about the click point, Escape and the Close button both return focus to the opener.
- `console/web`: typecheck, vitest, production build and Storybook build pass. `shell/ui`: tsc, vitest (305) and the esbuild bundle pass; `cargo build` on the shell crate embeds the rebuilt UI. `cargo test` on the console crate passes.

## Decisions

- Built on Radix Dialog rather than a bespoke overlay so the focus trap, Escape and scroll lock come from the same place as every other overlay.
- Fit never upscales past 100%; "Actual size" and "Fit" coincide for small images.
- No download action: the console has no file-save surface today and the original bytes are never duplicated (MOT-4455 owns transport).
- Live screencast viewports (browser and computer workers) are interactive surfaces, not pictures, and keep their own rendering.
