### PR TITLE
(MOT-4407) feat(shell): split view keeps two columns for added and deleted files

### DIFF
--- a/shell/ui/src/page/ReviewPane.tsx
+++ b/shell/ui/src/page/ReviewPane.tsx
@@ -1327,10 +1327,12 @@ function WholeFileSplit({
 }) {
   const label = wholeFileLabel(change, lines)
   const placeholder = (
-    <div className="shui-whole-file-placeholder" role="status">
-      <FileX aria-hidden />
-      <span className="shui-whole-file-title">{label.title}</span>
-      <span className="shui-whole-file-detail">{label.detail}</span>
+    <div className="shui-whole-file-side">
+      <div className="shui-whole-file-placeholder" role="status">
+        <FileX aria-hidden />
+        <span className="shui-whole-file-title">{label.title}</span>
+        <span className="shui-whole-file-detail">{label.detail}</span>
+      </div>
     </div>
   )
   return (

--- a/shell/ui/src/page/ReviewPane.tsx
+++ b/shell/ui/src/page/ReviewPane.tsx
@@ -6,6 +6,7 @@ import {
 import {
   ChevronRight,
   FileSymlink,
+  FileX,
   Pencil,
   Save,
   X,
@@ -26,6 +27,11 @@ import {
   gutterLineFromPath,
   resolveEditorLine,
 } from './open-line'
+import {
+  type WholeFileChange,
+  wholeFileChange,
+  wholeFileLabel,
+} from './review-split'
 import { richPreviewNode } from './rich-preview'
 import { diffLines, diffTotals } from './diff'
 import { gitHeadBaseline, gitReadSource, gitShowHead } from './git'
@@ -994,6 +1000,10 @@ function ReviewFile({
       entry.path,
     )
   }, [totals, entry.path, onStats])
+  const wholeFile =
+    state.phase === 'ready' && state.image === undefined
+      ? wholeFileChange(state.oldContents, state.newContents)
+      : null
 
   const editable =
     reviewEntryWorktreePath(entry) !== null &&
@@ -1259,6 +1269,26 @@ function ReviewFile({
         </div>
       ) : !editing && totals?.add === 0 && totals.del === 0 ? (
         <div className="shui-review-message">no line changes</div>
+      ) : !editing &&
+        options.diffStyle === 'split' &&
+        wholeFile !== null ? (
+        <WholeFileSplit
+          change={wholeFile}
+          lines={wholeFile === 'deleted' ? (totals?.del ?? 0) : (totals?.add ?? 0)}
+        >
+          <FileDiff
+            key="whole-file"
+            oldFile={{ name: entry.change.from ?? entry.path, contents: state.oldContents }}
+            newFile={{ name: entry.path, contents: state.newContents }}
+            diffStyle="unified"
+            overflow={options.wordWrap ? 'wrap' : 'scroll'}
+            lineDiffType="none"
+            ignoreWhitespace={options.hideWhitespace}
+            expandUnchanged={options.expandUnchanged}
+            disableFileHeader
+            className="shui-review-diff"
+          />
+        </WholeFileSplit>
       ) : (
         <FileDiff
           key={options.diffStyle}
@@ -1281,6 +1311,33 @@ function ReviewFile({
         />
       )}
     </section>
+  )
+}
+
+/** Split layout for a file that exists on one side only: the diff in that
+    column, a placeholder in the other, so split never collapses to unified. */
+function WholeFileSplit({
+  change,
+  lines,
+  children,
+}: {
+  change: WholeFileChange
+  lines: number
+  children: React.ReactNode
+}) {
+  const label = wholeFileLabel(change, lines)
+  const placeholder = (
+    <div className="shui-whole-file-placeholder" role="status">
+      <FileX aria-hidden />
+      <span className="shui-whole-file-title">{label.title}</span>
+      <span className="shui-whole-file-detail">{label.detail}</span>
+    </div>
+  )
+  return (
+    <div className="shui-whole-file-split" data-change={change}>
+      {change === 'deleted' ? children : placeholder}
+      {change === 'deleted' ? placeholder : children}
+    </div>
   )
 }
 

--- a/shell/ui/src/page/__tests__/review-split.test.ts
+++ b/shell/ui/src/page/__tests__/review-split.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { wholeFileChange, wholeFileLabel } from '../review-split'
+
+describe('wholeFileChange', () => {
+  it('names the side that is missing', () => {
+    expect(wholeFileChange('old', '')).toBe('deleted')
+    expect(wholeFileChange('', 'new')).toBe('added')
+  })
+
+  it('is null when both sides exist or both are empty', () => {
+    expect(wholeFileChange('a', 'b')).toBeNull()
+    expect(wholeFileChange('', '')).toBeNull()
+  })
+})
+
+describe('wholeFileLabel', () => {
+  it('reads in natural case with a pluralised count', () => {
+    expect(wholeFileLabel('deleted', 126)).toEqual({
+      title: 'File deleted',
+      detail: '126 lines removed',
+    })
+    expect(wholeFileLabel('added', 1)).toEqual({
+      title: 'New file',
+      detail: '1 line added',
+    })
+  })
+})

--- a/shell/ui/src/page/review-split.ts
+++ b/shell/ui/src/page/review-split.ts
@@ -1,0 +1,26 @@
+export type WholeFileChange = 'added' | 'deleted'
+
+/**
+ * A file that exists on only one side has nothing to show in the other split
+ * column; the caller renders that column as a placeholder instead of letting
+ * the diff collapse into the unified layout.
+ */
+export function wholeFileChange(
+  oldContents: string,
+  newContents: string,
+): WholeFileChange | null {
+  const oldEmpty = oldContents.length === 0
+  const newEmpty = newContents.length === 0
+  if (oldEmpty === newEmpty) return null
+  return oldEmpty ? 'added' : 'deleted'
+}
+
+export function wholeFileLabel(
+  change: WholeFileChange,
+  lines: number,
+): { title: string; detail: string } {
+  const count = `${lines} ${lines === 1 ? 'line' : 'lines'}`
+  return change === 'deleted'
+    ? { title: 'File deleted', detail: `${count} removed` }
+    : { title: 'New file', detail: `${count} added` }
+}

--- a/shell/ui/styles.css
+++ b/shell/ui/styles.css
@@ -1560,6 +1560,42 @@
   width: 16px;
   height: 16px;
 }
+[data-iii-ui="shell"] .shui-whole-file-split {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  column-gap: 1px;
+  background: var(--color-edge);
+}
+[data-iii-ui="shell"] .shui-whole-file-split > * {
+  min-width: 0;
+  background: var(--color-panel);
+}
+[data-iii-ui="shell"] .shui-whole-file-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 32px 16px;
+  background: var(--color-surface);
+  color: var(--color-ink-faint);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  text-align: center;
+}
+[data-iii-ui="shell"] .shui-whole-file-placeholder svg {
+  width: 16px;
+  height: 16px;
+}
+[data-iii-ui="shell"] .shui-whole-file-title {
+  color: var(--color-ink);
+  font-weight: 500;
+}
+[data-iii-ui="shell"] .shui-whole-file-detail {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
 [data-iii-ui="shell"] .shui-review-message {
   display: flex;
   align-items: center;

--- a/shell/ui/styles.css
+++ b/shell/ui/styles.css
@@ -1571,12 +1571,18 @@
   background: var(--color-panel);
 }
 [data-iii-ui="shell"] .shui-whole-file-placeholder {
+  position: sticky;
+  top: 16px;
+  align-self: start;
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
   gap: 6px;
-  padding: 32px 16px;
+  margin: 16px auto;
+  padding: 20px 24px;
+  width: max-content;
+  max-width: calc(100% - 32px);
+  border-radius: 6px;
   background: var(--color-surface);
   color: var(--color-ink-faint);
   font-family: var(--font-sans);

--- a/shell/ui/styles.css
+++ b/shell/ui/styles.css
@@ -1570,10 +1570,14 @@
   min-width: 0;
   background: var(--color-panel);
 }
+[data-iii-ui="shell"] .shui-whole-file-side {
+  position: relative;
+  min-height: 100%;
+  background: var(--color-panel);
+}
 [data-iii-ui="shell"] .shui-whole-file-placeholder {
   position: sticky;
   top: 16px;
-  align-self: start;
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
Refs MOT-4407

## What

In the IDE review pane, a file that exists on one side only (added or deleted) now keeps two columns in split view: the diff in its column and a placeholder card in the other naming the change and the line count.

## Why

`@pierre/diffs` renders a one-sided file identically in `split` and `unified`, so the "Switch to split diff" toggle appeared to do nothing on a turn whose files were all deletions (reported on the live console today).

## How

`shell/ui/src/page/review-split.ts`: `wholeFileChange(old, new)` and `wholeFileLabel(change, lines)`, pure and unit-tested. `ReviewPane` wraps the unified diff in `WholeFileSplit` when the style is split and the change is whole-file; the placeholder is a sticky `surface` card ("File deleted · 40 lines removed" / "New file · N lines added") on its own `panel` column. Modified files are untouched. Editing stays on the regular path.

## Tests

- vitest: `review-split.test.ts` (side detection, pluralised labels); shell/ui 308 tests pass, `tsc` and the esbuild bundle pass.
- Verified on the live console: a deleted `demo/scratch.txt` (+0 −40) shows the left diff and the right placeholder in split, unified unchanged, light theme; sticky card stays in view while scrolling the diff.
