### PR TITLE
(MOT-4528) feat(console,workers): the keyboard reaches every page through ⌘K, gated on worker presence

### DIFF
--- a/a2ui/ui/page.tsx
+++ b/a2ui/ui/page.tsx
@@ -1,4 +1,5 @@
 import type { Host } from '@iii-dev/console-ui'
+import { listSurfaces } from './src/data'
 import { A2uiPage } from './src/page'
 import { createA2uiTriggerRenderer } from './src/trigger-renderer'
 
@@ -9,4 +10,45 @@ export default function setup(host: Host) {
     render: (props) => <A2uiPage host={host} {...props} />,
   })
   host.functionTriggers.register(createA2uiTriggerRenderer(host))
+
+  host.palette?.registerSource({
+    id: 'surfaces',
+    title: 'A2UI surfaces',
+    kind: 'item',
+    minQuery: 2,
+    async search(query, { conversationId, signal }) {
+      if (!conversationId) return []
+      const { surfaces } = await listSurfaces(host, conversationId)
+      if (signal.aborted) return []
+      const needle = query.toLowerCase()
+      return surfaces
+        .filter(
+          (surface) =>
+            surface.title.toLowerCase().includes(needle) ||
+            surface.surface_id.toLowerCase().includes(needle),
+        )
+        .slice(0, 30)
+        .map((surface) => ({
+          id: surface.surface_id,
+          title: surface.title || surface.surface_id,
+          detail: `${surface.component_count} components`,
+          keywords: [surface.surface_id],
+          run: () =>
+            host.panels?.open({
+              pageId: 'a2ui',
+              context: { surfaceId: surface.surface_id },
+            }),
+        }))
+    },
+  })
+
+  host.commands?.register('a2ui', [
+    {
+      id: 'open',
+      title: 'Open A2UI',
+      detail: 'Generative interfaces for this conversation',
+      keywords: ['surfaces', 'generative ui', 'interface'],
+      run: () => host.panels?.open({ pageId: 'a2ui', context: {} }),
+    },
+  ])
 }

--- a/a2ui/ui/src/page.tsx
+++ b/a2ui/ui/src/page.tsx
@@ -1,5 +1,3 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
-import { strToU8, zipSync } from 'fflate'
 import {
   Badge,
   Button,
@@ -10,24 +8,47 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
   EmptyState,
+  type Host,
   List,
   ListItem,
   PageBody,
   PageHeader,
   PageMain,
+  type PageRenderProps,
   PageShell,
   PageSidebar,
   StatusPanel,
-  type Host,
-  type PageRenderProps,
 } from '@iii-dev/console-ui'
-import { exportCode, exportSurface, getSurface, listSurfaces, listTemplates, mutateSurface } from './data'
+import { strToU8, zipSync } from 'fflate'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  exportCode,
+  exportSurface,
+  getSurface,
+  listSurfaces,
+  listTemplates,
+  mutateSurface,
+} from './data'
 import { useSurfaceEvents } from './live'
 import { Surface } from './surface'
-import type { SurfaceExport, SurfaceRecord, SurfaceSummary, SurfaceTemplate } from './types'
-import { writeCodeBundle, type WorkspaceExport } from './workspace'
+import type {
+  SurfaceExport,
+  SurfaceRecord,
+  SurfaceSummary,
+  SurfaceTemplate,
+} from './types'
+import { type WorkspaceExport, writeCodeBundle } from './workspace'
 
-export function A2uiPage({ host, panelSide, tabId, onRequestClose, conversationId, workingDir }: PageRenderProps & { host: Host }) {
+export function A2uiPage({
+  host,
+  panelSide,
+  tabId,
+  onRequestClose,
+  conversationId,
+  workingDir,
+  commands,
+  panelContext,
+}: PageRenderProps & { host: Host }) {
   const [surfaces, setSurfaces] = useState<SurfaceSummary[]>([])
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [selected, setSelected] = useState<SurfaceRecord | null>(null)
@@ -35,8 +56,21 @@ export function A2uiPage({ host, panelSide, tabId, onRequestClose, conversationI
   const [exporting, setExporting] = useState(false)
   const [templates, setTemplates] = useState<SurfaceTemplate[]>([])
   const [error, setError] = useState<string | null>(null)
-  const [workspaceExport, setWorkspaceExport] = useState<WorkspaceExport | null>(null)
+  const [workspaceExport, setWorkspaceExport] =
+    useState<WorkspaceExport | null>(null)
   const importInput = useRef<HTMLInputElement>(null)
+  // A palette row (or any panels.open caller) names a surface to show.
+  const appliedContextRef = useRef(0)
+  useEffect(() => {
+    if (!panelContext || panelContext.id === appliedContextRef.current) return
+    appliedContextRef.current = panelContext.id
+    const context = panelContext.context
+    const surfaceId =
+      context && typeof context === 'object' && !Array.isArray(context)
+        ? (context as Record<string, unknown>).surfaceId
+        : null
+    if (typeof surfaceId === 'string' && surfaceId) setSelectedId(surfaceId)
+  }, [panelContext])
 
   const refresh = useCallback(async () => {
     if (!conversationId) {
@@ -74,7 +108,11 @@ export function A2uiPage({ host, panelSide, tabId, onRequestClose, conversationI
     let alive = true
     void getSurface(host, conversationId, selectedId)
       .then((surface) => alive && setSelected(surface))
-      .catch((cause) => alive && setError(cause instanceof Error ? cause.message : String(cause)))
+      .catch(
+        (cause) =>
+          alive &&
+          setError(cause instanceof Error ? cause.message : String(cause)),
+      )
     return () => {
       alive = false
     }
@@ -84,7 +122,11 @@ export function A2uiPage({ host, panelSide, tabId, onRequestClose, conversationI
     if (!conversationId || !selected) return
     setExporting(true)
     try {
-      const portable = await exportSurface(host, conversationId, selected.surface_id)
+      const portable = await exportSurface(
+        host,
+        conversationId,
+        selected.surface_id,
+      )
       downloadText(
         `${JSON.stringify(portable, null, 2)}\n`,
         `${safeFileName(selected.surface_id)}.a2ui.json`,
@@ -101,13 +143,22 @@ export function A2uiPage({ host, panelSide, tabId, onRequestClose, conversationI
   const writeReactApp = useCallback(async () => {
     if (!conversationId || !selected) return
     if (!workingDir) {
-      setError('Choose a working directory in Harness before writing the React app.')
+      setError(
+        'Choose a working directory in Harness before writing the React app.',
+      )
       return
     }
     setExporting(true)
     try {
-      const bundle = await exportCode(host, conversationId, selected.surface_id, 'react')
-      setWorkspaceExport(await writeCodeBundle(host, workingDir, bundle, selected.revision))
+      const bundle = await exportCode(
+        host,
+        conversationId,
+        selected.surface_id,
+        'react',
+      )
+      setWorkspaceExport(
+        await writeCodeBundle(host, workingDir, bundle, selected.revision),
+      )
       setError(null)
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : String(cause))
@@ -138,9 +189,16 @@ export function A2uiPage({ host, panelSide, tabId, onRequestClose, conversationI
       if (!conversationId || !selected) return
       setExporting(true)
       try {
-        const bundle = await exportCode(host, conversationId, selected.surface_id, target)
+        const bundle = await exportCode(
+          host,
+          conversationId,
+          selected.surface_id,
+          target,
+        )
         const archive = zipSync(
-          Object.fromEntries(bundle.files.map((file) => [file.path, strToU8(file.content)])),
+          Object.fromEntries(
+            bundle.files.map((file) => [file.path, strToU8(file.content)]),
+          ),
         )
         downloadBytes(
           archive,
@@ -162,17 +220,88 @@ export function A2uiPage({ host, panelSide, tabId, onRequestClose, conversationI
       if (!file || !conversationId) return
       void file
         .text()
-        .then((text) => run('a2ui::surface::import', { package: JSON.parse(text) as SurfaceExport }))
-        .catch((cause) => setError(cause instanceof Error ? cause.message : String(cause)))
+        .then((text) =>
+          run('a2ui::surface::import', {
+            package: JSON.parse(text) as SurfaceExport,
+          }),
+        )
+        .catch((cause) =>
+          setError(cause instanceof Error ? cause.message : String(cause)),
+        )
     },
     [conversationId, run],
+  )
+
+  // The page's primary verbs, for the palette and for the keyboard while
+  // this pane has focus — all wrap the actions already reachable from the
+  // sidebar/menu above.
+  useEffect(
+    () =>
+      commands?.register([
+        {
+          id: 'new-from-template',
+          title: 'New from template',
+          detail: 'Create a surface from the first saved template',
+          keywords: ['create', 'template'],
+          shortcut: 'N',
+          enabled: () => templates.length > 0,
+          run: () => {
+            const template = templates[0]
+            if (!template) return
+            void run('a2ui::template::apply', {
+              template_id: template.template_id,
+              surface_id: `template-${safeFileName(template.template_id).slice(0, 80)}-${Date.now()}`,
+            })
+          },
+        },
+        {
+          id: 'undo',
+          title: 'Undo latest change',
+          detail: 'Restore the previous saved revision',
+          shortcut: 'Z',
+          enabled: () => selected !== null && selected.history.length > 0,
+          run: () => {
+            if (selected)
+              void run('a2ui::surface::undo', {
+                surface_id: selected.surface_id,
+              })
+          },
+        },
+        {
+          id: 'pin',
+          title: 'Pin/unpin interface',
+          detail: 'Keep this surface at the top of the library',
+          shortcut: 'P',
+          enabled: () => selected !== null,
+          run: () => {
+            if (selected)
+              void run('a2ui::surface::pin', {
+                surface_id: selected.surface_id,
+                pinned: !selected.pinned,
+              })
+          },
+        },
+        {
+          id: 'export-react',
+          title: 'Write React app to workspace',
+          detail: 'Create a complete editable React app as workspace files',
+          shortcut: 'E',
+          enabled: () => selected !== null && !!workingDir,
+          run: () => void writeReactApp(),
+        },
+      ]),
+    [commands, templates, selected, run, writeReactApp, workingDir],
   )
 
   return (
     <PageShell className="a2ui-page">
       <PageHeader
         title="A2UI"
-        description={<span className="a2ui-page-description">Generative interfaces for this conversation</span>}
+        description={
+          <span className="a2ui-page-description">
+            Generative interfaces for this conversation
+          </span>
+        }
         actions={<Badge variant="accent">v0.9.1</Badge>}
         onClose={onRequestClose}
       />
@@ -195,16 +324,23 @@ export function A2uiPage({ host, panelSide, tabId, onRequestClose, conversationI
           className="a2ui-sidebar"
         >
           {!conversationId ? (
-            <div className="a2ui-note">Open the page beside a Harness conversation.</div>
+            <div className="a2ui-note">
+              Open the page beside a Harness conversation.
+            </div>
           ) : surfaces.length === 0 ? (
-            <div className="a2ui-note">{loading ? 'Loading…' : 'Ask the agent to create an interface.'}</div>
+            <div className="a2ui-note">
+              {loading ? 'Loading…' : 'Ask the agent to create an interface.'}
+            </div>
           ) : (
             <List className="a2ui-list">
-              {surfaces.map((surface) => (
+              {surfaces.map((surface, index) => (
                 <ListItem
                   key={surface.surface_id}
+                  data-autofocus={index === 0 ? '' : undefined}
                   selected={selectedId === surface.surface_id}
-                  label={<span className="a2ui-list-title">{surface.title}</span>}
+                  label={
+                    <span className="a2ui-list-title">{surface.title}</span>
+                  }
                   description={
                     <span className="a2ui-list-meta">
                       {surface.component_count} components · r{surface.revision}
@@ -239,6 +375,7 @@ export function A2uiPage({ host, panelSide, tabId, onRequestClose, conversationI
               variant="ghost"
               size="sm"
               disabled={!conversationId}
+              data-autofocus={surfaces.length === 0 ? '' : undefined}
               onClick={() => importInput.current?.click()}
             >
               Import JSON
@@ -276,8 +413,12 @@ export function A2uiPage({ host, panelSide, tabId, onRequestClose, conversationI
                   aria-label={`delete template ${template.title}`}
                   title="Delete this saved template"
                   onClick={() => {
-                    if (window.confirm(`Delete template “${template.title}”?`)) {
-                      void run('a2ui::template::delete', { template_id: template.template_id })
+                    if (
+                      window.confirm(`Delete template “${template.title}”?`)
+                    ) {
+                      void run('a2ui::template::delete', {
+                        template_id: template.template_id,
+                      })
                     }
                   }}
                 >
@@ -288,7 +429,11 @@ export function A2uiPage({ host, panelSide, tabId, onRequestClose, conversationI
           </div>
           {error ? (
             <div className="a2ui-page-error" role="alert">
-              <StatusPanel variant="alert" headline="A2UI page error" detail={error} />
+              <StatusPanel
+                variant="alert"
+                headline="A2UI page error"
+                detail={error}
+              />
               <Button variant="ghost" size="sm" onClick={() => setError(null)}>
                 Dismiss
               </Button>
@@ -298,10 +443,14 @@ export function A2uiPage({ host, panelSide, tabId, onRequestClose, conversationI
             <div className="a2ui-workspace-export" role="status">
               <div>
                 <strong>React app ready in the workspace</strong>
-                <span title={workspaceExport.directory}>{workspaceExport.directory}</span>
+                <span title={workspaceExport.directory}>
+                  {workspaceExport.directory}
+                </span>
                 <small>
                   {workspaceExport.written} files written
-                  {workspaceExport.existing > 0 ? ` · ${workspaceExport.existing} existing files preserved` : ''}
+                  {workspaceExport.existing > 0
+                    ? ` · ${workspaceExport.existing} existing files preserved`
+                    : ''}
                   {' · '}run it in Shell, then open the local URL in Browser
                 </small>
               </div>
@@ -319,14 +468,21 @@ export function A2uiPage({ host, panelSide, tabId, onRequestClose, conversationI
                 <div className="a2ui-surface-title">
                   <h2 title={selected.title}>{selected.title}</h2>
                   <div className="a2ui-surface-meta">
-                    <span title={selected.surface_id}>{selected.surface_id}</span>
+                    <span title={selected.surface_id}>
+                      {selected.surface_id}
+                    </span>
                     <Badge>r{selected.revision}</Badge>
                   </div>
                 </div>
                 <div className="a2ui-surface-actions">
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
-                      <Button variant="ghost" size="sm" disabled={exporting} aria-label="surface actions">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        disabled={exporting}
+                        aria-label="surface actions"
+                      >
                         {exporting ? 'Working…' : 'Actions'}
                       </Button>
                     </DropdownMenuTrigger>
@@ -381,22 +537,47 @@ export function A2uiPage({ host, panelSide, tabId, onRequestClose, conversationI
                       <DropdownMenuLabel>Workspace</DropdownMenuLabel>
                       <DropdownMenuItem
                         disabled={!workingDir}
-                        title={workingDir ? 'Create a complete editable React app as workspace files' : 'Choose a working directory in Harness first'}
+                        title={
+                          workingDir
+                            ? 'Create a complete editable React app as workspace files'
+                            : 'Choose a working directory in Harness first'
+                        }
                         onSelect={() => void writeReactApp()}
                       >
                         Write React app to workspace
                       </DropdownMenuItem>
                       <DropdownMenuSeparator />
                       <DropdownMenuLabel>Export</DropdownMenuLabel>
-                      <DropdownMenuItem title="Portable A2UI data for re-import" onSelect={() => void downloadSelected()}>Download JSON package</DropdownMenuItem>
-                      <DropdownMenuItem title="ZIP with a complete runnable React app" onSelect={() => void downloadCode('react')}>Download React app ZIP</DropdownMenuItem>
-                      <DropdownMenuItem title="ZIP with an iii worker template that serves this surface as data" onSelect={() => void downloadCode('worker')}>Download data worker template</DropdownMenuItem>
+                      <DropdownMenuItem
+                        title="Portable A2UI data for re-import"
+                        onSelect={() => void downloadSelected()}
+                      >
+                        Download JSON package
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        title="ZIP with a complete runnable React app"
+                        onSelect={() => void downloadCode('react')}
+                      >
+                        Download React app ZIP
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        title="ZIP with an iii worker template that serves this surface as data"
+                        onSelect={() => void downloadCode('worker')}
+                      >
+                        Download data worker template
+                      </DropdownMenuItem>
                       <DropdownMenuSeparator />
                       <DropdownMenuItem
                         title="Permanently remove this surface"
                         onSelect={() => {
-                          if (window.confirm(`Delete surface “${selected.title}”?`)) {
-                            void run('a2ui::surface::delete', { surface_id: selected.surface_id })
+                          if (
+                            window.confirm(
+                              `Delete surface “${selected.title}”?`,
+                            )
+                          ) {
+                            void run('a2ui::surface::delete', {
+                              surface_id: selected.surface_id,
+                            })
                           }
                         }}
                       >
@@ -423,7 +604,9 @@ export function A2uiPage({ host, panelSide, tabId, onRequestClose, conversationI
 }
 
 function safeFileName(value: string): string {
-  return value.replace(/[^a-z0-9._-]+/gi, '-').replace(/^-+|-+$/g, '') || 'surface'
+  return (
+    value.replace(/[^a-z0-9._-]+/gi, '-').replace(/^-+|-+$/g, '') || 'surface'
+  )
 }
 
 function downloadText(content: string, name: string, type: string) {

--- a/browser/ui/page.tsx
+++ b/browser/ui/page.tsx
@@ -20,9 +20,13 @@
 
 import type { Host } from '@iii-dev/console-ui'
 import { BrowserConfigForm } from './src/configuration'
-import { createBrowserRenderer, createBrowserScreenshotRenderer } from './src/function-trigger-message'
+import {
+  createBrowserRenderer,
+  createBrowserScreenshotRenderer,
+} from './src/function-trigger-message'
 import { createScraplingRenderer } from './src/function-trigger-message/scrapling'
 import { BrowserPage } from './src/page'
+import { registerBrowserPalette } from './src/page/palette'
 
 export default function setup(host: Host) {
   host.pages.register({
@@ -30,6 +34,8 @@ export default function setup(host: Host) {
     title: 'browser',
     render: (props) => <BrowserPage host={host} {...props} />,
   })
+
+  registerBrowserPalette(host)
 
   host.configForms.register('browser', BrowserConfigForm, { layout: 'full' })
 

--- a/browser/ui/src/page/SessionRail.tsx
+++ b/browser/ui/src/page/SessionRail.tsx
@@ -8,6 +8,7 @@
  * color alone.
  */
 
+import type { KeyboardEvent } from 'react'
 import type { BrowserSessionInfo } from '../lib/browser'
 import { cn } from '../lib/cn'
 import { formatMtime } from '../lib/format'
@@ -59,8 +60,23 @@ export function SessionRail({
     )
   }
 
+  // Cheap roving nav: arrow keys step focus between sibling session rows.
+  const onKeyDown = (event: KeyboardEvent<HTMLUListElement>) => {
+    if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return
+    const rows = Array.from(
+      event.currentTarget.querySelectorAll<HTMLButtonElement>(
+        'button.br-ui-rail-row',
+      ),
+    )
+    const index = rows.indexOf(document.activeElement as HTMLButtonElement)
+    if (index === -1) return
+    event.preventDefault()
+    const next = index + (event.key === 'ArrowDown' ? 1 : -1)
+    rows[Math.max(0, Math.min(rows.length - 1, next))]?.focus()
+  }
+
   return (
-    <ul className="br-ui-nav-list">
+    <ul className="br-ui-nav-list" onKeyDown={onKeyDown}>
       {sessions.map((session) => {
         const selected = session.session_id === selectedId
         return (

--- a/browser/ui/src/page/SessionView.tsx
+++ b/browser/ui/src/page/SessionView.tsx
@@ -19,6 +19,7 @@
  */
 
 import { Button, type Host, Input, SegmentedControl } from '@iii-dev/console-ui'
+import type { RefObject } from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import {
   BROWSER_PICKED_TRIGGER,
@@ -57,6 +58,14 @@ const TYPE_FLUSH_MS = 200
 type FeedPane = 'console' | 'network'
 type NarrowPane = 'viewport' | FeedPane
 
+/** Verbs the page's commands reach through a ref, since they close over
+ * this component's session-local state. */
+export interface SessionActions {
+  stop: () => void
+  toggleInspect: () => void
+  focusUrl: () => void
+}
+
 const FEED_PANES: readonly FeedPane[] = ['console', 'network']
 const NARROW_PANES: readonly NarrowPane[] = ['viewport', 'console', 'network']
 
@@ -94,6 +103,9 @@ interface SessionViewProps {
   narrow: boolean
   /** Stable workspace-tab id — namespaces persisted UI state. */
   tabId: string
+  /** Populated with this session's stop/inspect/focus-url verbs while
+   * mounted, so the page's commands can reach them. */
+  actionsRef?: RefObject<SessionActions | null>
   onBack: () => void
   onSessionsRefresh: () => void
   onStopped: () => void
@@ -106,6 +118,7 @@ export function SessionView({
   enabled,
   narrow,
   tabId,
+  actionsRef,
   onBack,
   onSessionsRefresh,
   onStopped,
@@ -346,6 +359,20 @@ export function SessionView({
     })
   }, [host, sessionId, runAction, onSessionsRefresh, onStopped])
 
+  const urlInputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (!actionsRef) return
+    actionsRef.current = {
+      stop: handleStop,
+      toggleInspect: togglePick,
+      focusUrl: () => urlInputRef.current?.focus(),
+    }
+    return () => {
+      actionsRef.current = null
+    }
+  }, [actionsRef, handleStop, togglePick])
+
   const displayName =
     session.title?.trim() || hostOf(session.url) || 'about:blank'
   const feedPane: FeedPane = narrow
@@ -525,6 +552,7 @@ export function SessionView({
               <div className="br-ui-address">
                 <Globe size={16} aria-hidden className="br-ui-address-icon" />
                 <Input
+                  ref={urlInputRef}
                   name="browser-url"
                   value={urlDraft}
                   onChange={setUrlDraft}

--- a/browser/ui/src/page/index.tsx
+++ b/browser/ui/src/page/index.tsx
@@ -44,7 +44,7 @@ import {
   useContainerNarrow,
 } from '../lib/widgets'
 import { SessionRail } from './SessionRail'
-import { SessionView } from './SessionView'
+import { type SessionActions, SessionView } from './SessionView'
 import { useBrowserSessionsLive } from './useBrowserSessionsLive'
 
 /** Container width (px) below which the page collapses to the drill-in
@@ -56,6 +56,8 @@ export function BrowserPage({
   panelSide = 'left',
   tabId = '',
   onRequestClose,
+  panelContext,
+  commands,
 }: { host: Host } & Partial<PageRenderProps>) {
   const [configOpen, setConfigOpen] = useState(false)
   const ConfigurationDialog = host.components.WorkerConfigurationDialog as
@@ -128,7 +130,7 @@ export function BrowserPage({
 
   const [starting, setStarting] = useState(false)
   const [startError, setStartError] = useState<string | null>(null)
-  const handleNewSession = async () => {
+  const handleNewSession = useCallback(async () => {
     if (starting) return
     setStarting(true)
     try {
@@ -145,12 +147,73 @@ export function BrowserPage({
     } finally {
       setStarting(false)
     }
-  }
+  }, [host, refresh, starting])
 
   const openSession = useCallback((sessionId: string) => {
     setSelectedId(sessionId)
     setDrilled(true)
   }, [])
+
+  // Per-session verbs (stop / inspect / focus url) live inside SessionView;
+  // this ref lets page-level commands reach the mounted session's handlers
+  // without lifting their state up.
+  const sessionActionsRef = useRef<SessionActions | null>(null)
+
+  // A palette "sessions" row (or any other host.panels.open caller) selects
+  // a session by id through the standard panelContext channel.
+  const appliedContextRef = useRef(0)
+  useEffect(() => {
+    if (!panelContext || panelContext.id === appliedContextRef.current) return
+    appliedContextRef.current = panelContext.id
+    const context = panelContext.context
+    const sessionId =
+      context && typeof context === 'object' && !Array.isArray(context)
+        ? (context as Record<string, unknown>).sessionId
+        : null
+    if (typeof sessionId === 'string' && sessionId) openSession(sessionId)
+  }, [panelContext, openSession])
+
+  useEffect(
+    () =>
+      commands?.register([
+        {
+          id: 'new-session',
+          title: 'New session',
+          detail: 'Start a browser session',
+          keywords: ['start', 'chromium'],
+          shortcut: 'N',
+          run: () => void handleNewSession(),
+        },
+        {
+          id: 'stop-session',
+          title: 'Stop session',
+          detail: 'Stop the selected browser session',
+          keywords: ['close', 'end'],
+          shortcut: 'X',
+          enabled: () => selected !== null,
+          run: () => sessionActionsRef.current?.stop(),
+        },
+        {
+          id: 'toggle-inspect',
+          title: 'Toggle inspect',
+          detail: 'Pick an element to copy it to the clipboard',
+          keywords: ['pick', 'inspect', 'element'],
+          shortcut: 'I',
+          enabled: () => selected !== null,
+          run: () => sessionActionsRef.current?.toggleInspect(),
+        },
+        {
+          id: 'focus-url',
+          title: 'Focus the address bar',
+          detail: 'Type a url to navigate the selected session',
+          keywords: ['address', 'navigate', 'url'],
+          shortcut: 'L',
+          enabled: () => selected !== null,
+          run: () => sessionActionsRef.current?.focusUrl(),
+        },
+      ]),
+    [commands, handleNewSession, selected],
+  )
 
   // Narrow: one pane at a time — the rail or the opened session workspace.
   const stageVisible = !narrow || (drilled && selected !== null)
@@ -215,6 +278,7 @@ export function BrowserPage({
                   size="sm"
                   onClick={() => void handleNewSession()}
                   disabled={starting}
+                  data-autofocus=""
                 >
                   <Plus size={16} aria-hidden />
                   {starting ? 'Starting...' : 'New session'}
@@ -287,6 +351,7 @@ export function BrowserPage({
               enabled
               narrow={narrow}
               tabId={tabId}
+              actionsRef={sessionActionsRef}
               onBack={() => setDrilled(false)}
               onSessionsRefresh={refresh}
               onStopped={() => {

--- a/browser/ui/src/page/palette.tsx
+++ b/browser/ui/src/page/palette.tsx
@@ -1,0 +1,58 @@
+/**
+ * The browser worker in the command palette, before its page is even open.
+ *
+ * A sessions source answers any query with live Chromium sessions read the
+ * same way the rail does (`browser::sessions::list`, `useBrowserSessionsLive`'s
+ * backing function), each row opening that session in the browser page.
+ * Registered from setup, so it exists only while the browser worker is
+ * connected; older consoles without host.palette / host.commands simply get
+ * nothing.
+ */
+
+import type { Host } from '@iii-dev/console-ui'
+import { listBrowserSessions } from '../lib/browser'
+
+const SESSION_ROWS = 30
+
+export function registerBrowserPalette(host: Host): void {
+  host.palette?.registerSource({
+    id: 'sessions',
+    title: 'Browser sessions',
+    kind: 'item',
+    minQuery: 2,
+    async search(query, { signal }) {
+      const sessions = await listBrowserSessions(host.iii)
+      if (signal.aborted) return []
+      const needle = query.toLowerCase()
+      return sessions
+        .filter(
+          (session) =>
+            session.title?.toLowerCase().includes(needle) ||
+            session.url.toLowerCase().includes(needle) ||
+            session.session_id.toLowerCase().includes(needle),
+        )
+        .slice(0, SESSION_ROWS)
+        .map((session) => ({
+          id: session.session_id,
+          title: session.title?.trim() || session.url,
+          detail: session.url,
+          keywords: [session.session_id],
+          run: () =>
+            host.panels?.open({
+              pageId: 'browser',
+              context: { type: 'session', sessionId: session.session_id },
+            }),
+        }))
+    },
+  })
+
+  host.commands?.register('browser', [
+    {
+      id: 'open',
+      title: 'Open the browser',
+      detail: 'Live Chromium sessions you can watch and drive',
+      keywords: ['chromium', 'sessions', 'screencast'],
+      run: () => host.panels?.open({ pageId: 'browser', context: {} }),
+    },
+  ])
+}

--- a/canvas/ui/page.tsx
+++ b/canvas/ui/page.tsx
@@ -18,6 +18,7 @@
 import type { Host } from '@iii-dev/console-ui'
 import { createCanvasTriggerRenderer } from './src/function-trigger-message'
 import { CanvasPage } from './src/page'
+import { listCanvases } from './src/page/data'
 
 export default function setup(host: Host) {
   host.pages.register({
@@ -25,6 +26,46 @@ export default function setup(host: Host) {
     title: 'canvas',
     render: (props) => <CanvasPage host={host} {...props} />,
   })
+
+  host.palette?.registerSource({
+    id: 'canvases',
+    title: 'Canvases',
+    kind: 'item',
+    minQuery: 2,
+    async search(query, { signal }) {
+      const { canvases } = await listCanvases(host)
+      if (signal.aborted) return []
+      const needle = query.toLowerCase()
+      return canvases
+        .filter(
+          (canvas) =>
+            canvas.name.toLowerCase().includes(needle) ||
+            canvas.id.toLowerCase().includes(needle),
+        )
+        .slice(0, 30)
+        .map((canvas) => ({
+          id: canvas.id,
+          title: canvas.name,
+          detail: canvas.family ?? canvas.format,
+          keywords: [canvas.id],
+          run: () =>
+            host.panels?.open({
+              pageId: 'canvas',
+              context: { canvasId: canvas.id },
+            }),
+        }))
+    },
+  })
+
+  host.commands?.register('canvas', [
+    {
+      id: 'open',
+      title: 'Open canvas',
+      detail: 'Diagrams stored as editable source',
+      keywords: ['mermaid', 'freeform', 'diagram', 'whiteboard'],
+      run: () => host.panels?.open({ pageId: 'canvas', context: {} }),
+    },
+  ])
 
   host.functionTriggers.register(createCanvasTriggerRenderer(host))
 }

--- a/canvas/ui/src/page/MermaidPane.tsx
+++ b/canvas/ui/src/page/MermaidPane.tsx
@@ -21,12 +21,18 @@
  * remounted per record (key=id) and rehydrates from the cache.
  */
 
-import { Button, CodeEditor, type Host } from '@iii-dev/console-ui'
+import {
+  Button,
+  CodeEditor,
+  type CodeEditorHandle,
+  type Host,
+} from '@iii-dev/console-ui'
 import type {
   KeyboardEvent as ReactKeyboardEvent,
   PointerEvent as ReactPointerEvent,
 } from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { animateSvgDrawIn } from '../lib/draw'
 import {
   EXPORT_BG,
   initMermaidOnce,
@@ -34,21 +40,20 @@ import {
   loadMermaid,
   mermaidInitConfig,
 } from '../lib/loaders'
-import { animateSvgDrawIn } from '../lib/draw'
 import type { CanvasRecord } from '../lib/types'
 import { updateCanvas } from './data'
+import { ExportMenu, type ExportOptions } from './ExportMenu'
 import {
   downloadSvg,
   downloadSvgAsPng,
   svgDimensions,
   svgWithBackground,
 } from './export'
-import { ExportMenu, type ExportOptions } from './ExportMenu'
 import { errorMessage, exportFilename } from './helpers'
 import { AlertCircle, Maximize } from './icons'
 import {
-  INITIAL_PREVIEW,
   beginRender,
+  INITIAL_PREVIEW,
   renderFailed,
   renderSucceeded,
 } from './preview'
@@ -88,6 +93,10 @@ interface MermaidPaneProps {
   onSaved: (record: CanvasRecord) => void
   /** Dirty-flag transitions — the page shows dots in the sidebar. */
   onDirtyChange: (id: string, dirty: boolean) => void
+  /** Hands the page an imperative save, for the page-level Mod+S command
+      (the page owns the "dirty"/"which format" checks; this pane owns the
+      actual write). Mirrors FreeformPane's `handleRef`. */
+  saveRef?: (save: (() => void) | null) => void
 }
 
 export function MermaidPane({
@@ -96,7 +105,9 @@ export function MermaidPane({
   cache,
   onSaved,
   onDirtyChange,
+  saveRef,
 }: MermaidPaneProps) {
+  const editorRef = useRef<CodeEditorHandle>(null)
   const theme = host.useTheme()
 
   // ── draft + save (cache-hydrated; the page seeds the entry on select) ──
@@ -146,6 +157,12 @@ export function MermaidPane({
       })
       .finally(() => setSaving(false))
   }, [host, cache, record.id, saving, onSaved, onDirtyChange])
+
+  useEffect(() => {
+    if (!saveRef) return
+    saveRef(save)
+    return () => saveRef(null)
+  }, [saveRef, save])
 
   // ── editor|preview split ratio (drag handle between the halves) ──
   const [splitPct, setSplitPct] = useState(() => {
@@ -507,8 +524,15 @@ export function MermaidPane({
         ref={splitRef}
         style={{ '--cv-split': `${splitPct}%` } as React.CSSProperties}
       >
-        <div className="cv-editor">
+        {/* biome-ignore lint/a11y/noStaticElementInteractions: focus relay into the real editor (data-autofocus can only target a DOM node) */}
+        <div
+          className="cv-editor"
+          data-autofocus=""
+          tabIndex={-1}
+          onFocus={() => editorRef.current?.focus()}
+        >
           <CodeEditor
+            ref={editorRef}
             value={draft}
             onChange={setDraft}
             language="plaintext"

--- a/canvas/ui/src/page/index.tsx
+++ b/canvas/ui/src/page/index.tsx
@@ -64,6 +64,8 @@ export function CanvasPage({
   host,
   panelSide,
   onRequestClose,
+  commands,
+  panelContext,
 }: { host: Host } & PageRenderProps) {
   const [canvases, setCanvases] = useState<CanvasRecord[]>([])
   const [listState, setListState] = useState<ListState>({ phase: 'loading' })
@@ -84,6 +86,9 @@ export function CanvasPage({
   // The freeform surface's imperative handle: flush() before switching away
   // so a settling whiteboard edit is persisted, never silently dropped.
   const freeformHandleRef = useRef<FreeformPaneHandle | null>(null)
+  // The open mermaid pane's imperative save, for the page-level Mod+S
+  // command (freeform saves on its own debounce; there's nothing to wrap).
+  const mermaidSaveRef = useRef<(() => void) | null>(null)
   // Bumped when the OPEN record changes under us (an agent edit streaming
   // in) — the pane keys include it, so a remount rehydrates from the
   // refreshed cache. Own saves must NOT bump it: a remount mid-typing
@@ -242,6 +247,19 @@ export function CanvasPage({
     [host],
   )
 
+  // A palette row (or any panels.open caller) names a canvas to open.
+  const appliedContextRef = useRef(0)
+  useEffect(() => {
+    if (!panelContext || panelContext.id === appliedContextRef.current) return
+    appliedContextRef.current = panelContext.id
+    const context = panelContext.context
+    const canvasId =
+      context && typeof context === 'object' && !Array.isArray(context)
+        ? (context as Record<string, unknown>).canvasId
+        : null
+    if (typeof canvasId === 'string' && canvasId) select(canvasId)
+  }, [panelContext, select])
+
   const onDirtyChange = useCallback((id: string, dirty: boolean) => {
     setDirtyIds((prev) => {
       if (prev.has(id) === dirty) return prev
@@ -330,6 +348,53 @@ export function CanvasPage({
     [host, mergeSaved],
   )
 
+  // The page's primary verbs, for the palette and for the keyboard while
+  // this pane has the focus.
+  useEffect(
+    () =>
+      commands?.register([
+        {
+          id: 'new-canvas',
+          title: 'New canvas',
+          detail: 'Create a canvas from the starter flowchart',
+          shortcut: 'N',
+          enabled: () => !creating,
+          run: create,
+        },
+        {
+          id: 'save',
+          title: 'Save',
+          shortcut: 'Mod+S',
+          firesWhileTyping: true,
+          enabled: () =>
+            selectedId !== null &&
+            dirtyIds.has(selectedId) &&
+            record?.format === 'mermaid',
+          run: () => mermaidSaveRef.current?.(),
+        },
+        {
+          id: 'delete-canvas',
+          title: 'Delete canvas',
+          shortcut: 'X',
+          enabled: () => selectedId !== null,
+          run: () => {
+            const rec = canvases.find((c) => c.id === selectedId)
+            if (rec) remove(rec)
+          },
+        },
+      ]),
+    [
+      commands,
+      create,
+      creating,
+      selectedId,
+      dirtyIds,
+      record,
+      canvases,
+      remove,
+    ],
+  )
+
   const nowSecs = Math.floor(Date.now() / 1000)
 
   return (
@@ -364,6 +429,7 @@ export function CanvasPage({
                 onClick={create}
                 disabled={creating}
                 title="new canvas (starter flowchart)"
+                data-autofocus={canvases.length === 0 ? '' : undefined}
               >
                 <Plus size={16} aria-hidden />
                 new
@@ -471,6 +537,9 @@ export function CanvasPage({
               cache={cacheRef.current}
               onSaved={mergeSaved}
               onDirtyChange={onDirtyChange}
+              saveRef={(fn) => {
+                mermaidSaveRef.current = fn
+              }}
             />
           ) : (
             <FreeformPane

--- a/computer/ui/page.tsx
+++ b/computer/ui/page.tsx
@@ -22,6 +22,7 @@
 import type { Host } from '@iii-dev/console-ui'
 import { createComputerRenderer } from './src/function-trigger-message'
 import { ComputerPage } from './src/page'
+import { registerComputerPalette } from './src/page/palette'
 
 export default function setup(host: Host) {
   host.pages.register({
@@ -29,6 +30,8 @@ export default function setup(host: Host) {
     title: 'computer',
     render: (props) => <ComputerPage host={host} {...props} />,
   })
+
+  registerComputerPalette(host)
 
   host.functionTriggers.register(createComputerRenderer(host))
 }

--- a/computer/ui/src/page/SessionRail.tsx
+++ b/computer/ui/src/page/SessionRail.tsx
@@ -8,6 +8,7 @@
  */
 
 import { Badge, Button, StatusDot } from '@iii-dev/console-ui'
+import type { KeyboardEvent } from 'react'
 import { cn } from '../lib/cn'
 import type { ComputerSessionInfo } from '../lib/computer'
 import { formatAge, shortEndpoint } from '../lib/format'
@@ -52,8 +53,23 @@ export function SessionRail({
     )
   }
 
+  // Cheap roving nav: arrow keys step focus between sibling session rows.
+  const onKeyDown = (event: KeyboardEvent<HTMLUListElement>) => {
+    if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return
+    const rows = Array.from(
+      event.currentTarget.querySelectorAll<HTMLButtonElement>(
+        'button.cp-ui-rail-pick',
+      ),
+    )
+    const index = rows.indexOf(document.activeElement as HTMLButtonElement)
+    if (index === -1) return
+    event.preventDefault()
+    const next = index + (event.key === 'ArrowDown' ? 1 : -1)
+    rows[Math.max(0, Math.min(rows.length - 1, next))]?.focus()
+  }
+
   return (
-    <ul className="cp-ui-nav-list">
+    <ul className="cp-ui-nav-list" onKeyDown={onKeyDown}>
       {sessions.map((session) => {
         const selected = session.session_id === selectedId
         return (

--- a/computer/ui/src/page/StartSessionForm.tsx
+++ b/computer/ui/src/page/StartSessionForm.tsx
@@ -1,5 +1,5 @@
 import { Button, Input, Select } from '@iii-dev/console-ui'
-import { useState } from 'react'
+import { forwardRef, useImperativeHandle, useState } from 'react'
 import type { ComputerDisplay, StartSessionInput } from '../lib/computer'
 
 /**
@@ -23,11 +23,16 @@ interface StartSessionFormProps {
   onStart: (input: StartSessionInput) => void
 }
 
-export function StartSessionForm({
-  displays,
-  starting,
-  onStart,
-}: StartSessionFormProps) {
+/** Imperative handle so a page-level command can submit whatever mode and
+ * fields the user currently has set, without lifting that state up. */
+export interface StartSessionFormHandle {
+  submit(): void
+}
+
+export const StartSessionForm = forwardRef<
+  StartSessionFormHandle,
+  StartSessionFormProps
+>(function StartSessionForm({ displays, starting, onStart }, ref) {
   const [mode, setMode] = useState<Mode>('native')
   const [image, setImage] = useState('')
   const [endpoint, setEndpoint] = useState('')
@@ -51,6 +56,8 @@ export function StartSessionForm({
     }
   }
 
+  useImperativeHandle(ref, () => ({ submit }))
+
   return (
     <form
       className="cp-ui-start"
@@ -65,6 +72,7 @@ export function StartSessionForm({
         onChange={setMode}
         aria-label="what to drive"
         className="cp-ui-start-mode"
+        data-autofocus=""
       />
       {mode === 'sandbox' ? (
         <Input
@@ -107,4 +115,4 @@ export function StartSessionForm({
       </Button>
     </form>
   )
-}
+})

--- a/computer/ui/src/page/index.tsx
+++ b/computer/ui/src/page/index.tsx
@@ -38,7 +38,10 @@ import { errorMessage } from '../lib/errors'
 import { formatAge, shortEndpoint } from '../lib/format'
 import { BackButton, LivePill, MonitorIcon } from '../lib/widgets'
 import { SessionRail } from './SessionRail'
-import { StartSessionForm } from './StartSessionForm'
+import {
+  StartSessionForm,
+  type StartSessionFormHandle,
+} from './StartSessionForm'
 import { useLiveFrames } from './useLiveFrames'
 import { useSessionsLive } from './useSessionsLive'
 import { Viewport } from './Viewport'
@@ -81,6 +84,8 @@ export function ComputerPage({
   host,
   panelSide = 'left',
   onRequestClose,
+  panelContext,
+  commands,
 }: { host: Host } & Partial<PageRenderProps>) {
   const { sessions, loading, error, live, refresh } = useSessionsLive(
     host,
@@ -205,6 +210,51 @@ export function ComputerPage({
     }
   }
 
+  // The start form owns its own mode/fields; a page-level command submits
+  // whatever the user currently has configured through this handle.
+  const startFormRef = useRef<StartSessionFormHandle>(null)
+
+  // A palette "computer-sessions" row (or any other host.panels.open caller)
+  // selects a session by id through the standard panelContext channel.
+  const appliedContextRef = useRef(0)
+  useEffect(() => {
+    if (!panelContext || panelContext.id === appliedContextRef.current) return
+    appliedContextRef.current = panelContext.id
+    const context = panelContext.context
+    const sessionId =
+      context && typeof context === 'object' && !Array.isArray(context)
+        ? (context as Record<string, unknown>).sessionId
+        : null
+    if (typeof sessionId === 'string' && sessionId) openSession(sessionId)
+  }, [panelContext, openSession])
+
+  useEffect(
+    () =>
+      commands?.register([
+        {
+          id: 'start-session',
+          title: 'Start session',
+          detail: 'Start a desktop with the current start form settings',
+          keywords: ['new', 'desktop'],
+          shortcut: 'N',
+          enabled: () => !starting,
+          run: () => startFormRef.current?.submit(),
+        },
+        {
+          id: 'stop-session',
+          title: 'Stop session',
+          detail: 'Stop the selected desktop session',
+          keywords: ['close', 'end'],
+          shortcut: 'X',
+          enabled: () => selected !== null,
+          run: () => {
+            if (selected) void handleStop(selected.session_id)
+          },
+        },
+      ]),
+    [commands, starting, selected],
+  )
+
   return (
     <PageShell className="cp-ui-shell">
       <PageHeader
@@ -257,6 +307,7 @@ export function ComputerPage({
             <div className="cp-ui-rail-top">
               <div className="cp-ui-rail-caption">start a session</div>
               <StartSessionForm
+                ref={startFormRef}
                 displays={displays}
                 starting={starting}
                 onStart={(input) => void handleStart(input)}

--- a/computer/ui/src/page/index.tsx
+++ b/computer/ui/src/page/index.tsx
@@ -246,13 +246,14 @@ export function ComputerPage({
           detail: 'Stop the selected desktop session',
           keywords: ['close', 'end'],
           shortcut: 'X',
-          enabled: () => selected !== null,
+          enabled: () => selected !== null && busyId === null,
           run: () => {
-            if (selected) void handleStop(selected.session_id)
+            if (selected && busyId === null)
+              void handleStop(selected.session_id)
           },
         },
       ]),
-    [commands, starting, selected],
+    [commands, starting, selected, busyId],
   )
 
   return (

--- a/computer/ui/src/page/palette.tsx
+++ b/computer/ui/src/page/palette.tsx
@@ -1,0 +1,57 @@
+/**
+ * The computer worker in the command palette, before its page is even open.
+ *
+ * A sessions source answers any query with live desktop sessions read from
+ * `computer::sessions::list` (the same read useSessionsLive bootstraps
+ * from), each row opening that session in the computer page. Registered
+ * from setup, so it exists only while the worker is connected; older
+ * consoles without host.palette / host.commands simply get nothing.
+ */
+
+import type { Host } from '@iii-dev/console-ui'
+import { listSessions } from '../lib/computer'
+
+const SESSION_ROWS = 30
+
+export function registerComputerPalette(host: Host): void {
+  host.palette?.registerSource({
+    id: 'computer-sessions',
+    title: 'Computer sessions',
+    kind: 'item',
+    minQuery: 2,
+    async search(query, { signal }) {
+      const sessions = await listSessions(host.iii)
+      if (signal.aborted) return []
+      const needle = query.toLowerCase()
+      return sessions
+        .filter(
+          (session) =>
+            session.session_id.toLowerCase().includes(needle) ||
+            session.endpoint.toLowerCase().includes(needle) ||
+            session.os.toLowerCase().includes(needle),
+        )
+        .slice(0, SESSION_ROWS)
+        .map((session) => ({
+          id: session.session_id,
+          title: session.session_id,
+          detail: `${session.endpoint} · ${session.os}`,
+          keywords: [session.os],
+          run: () =>
+            host.panels?.open({
+              pageId: 'computer',
+              context: { sessionId: session.session_id },
+            }),
+        }))
+    },
+  })
+
+  host.commands?.register('computer', [
+    {
+      id: 'open',
+      title: 'Open the computer',
+      detail: 'Live desktops you can watch and drive',
+      keywords: ['desktop', 'sessions', 'screencast'],
+      run: () => host.panels?.open({ pageId: 'computer', context: {} }),
+    },
+  ])
+}

--- a/console/DESIGN.md
+++ b/console/DESIGN.md
@@ -1021,7 +1021,21 @@ Workspace tabs behave like this everywhere:
   attached has no rows and no keys. The dispatcher runs the console's keys
   first, then the focused pane's; a page can never shadow a console chord
   (`shortcutClaimReason`). Chat is the first consumer: `I` composer, `J`/`K`
-  walk the transcript, `End` latest, `M` model, `Escape` stop.
+  walk the transcript, `A`/`D` approve or deny the pending call, `O` expand
+  and `Y` copy the focused message, `End` latest, `M` model, `Escape` stop,
+  `N` new chat, `/` search conversations.
+- **Palette sources, prefixes, recents:** a worker registers a live source
+  (`host.palette.registerSource`, `lib/palette/providers.ts`): rows
+  computed per query, asked debounced with an abort signal, shown under the
+  source's own group. `>` and `/` narrow the palette to commands, `#` to
+  files, `@` to chats (`parseQuery`); an empty query opens on the ten most
+  recent choices (`lib/palette/recents.ts`); several words match in any
+  order. `host.palette.open({ query })` lets a row hand over to a mode, the
+  way the shell's "Open file…" lands on `#`.
+- **Shared primitives carry the keyboard:** an interactive `TableRow` joins
+  the tab order and answers Enter, Space and the arrows; a `List` walks its
+  items with the arrows. A page built from them is keyboard-reachable
+  without its own handlers.
 - **Phones** switch workspaces from the bottom sheet; each workspace
   remembers which panel it was showing, per browser tab.
 

--- a/console/DESIGN.md
+++ b/console/DESIGN.md
@@ -1011,7 +1011,17 @@ Workspace tabs behave like this everywhere:
   first: every action and every open workspace is a row in `⌘K`, each
   showing its key, and hovering a control spells the same key
   (`hoverTitle`), so the keys are learned in passing. The full list is a
-  `⌘K` row, not a key of its own.
+  `⌘K` row, not a key of its own. `{` / `}` move the keyboard between
+  panes, and opening a page from `⌘K`, a chord or `panels.open` lands focus
+  inside it (`lib/pane-focus.ts`).
+- **Page commands:** a page contributes rows to `⌘K` and keys to its own
+  pane through `PageRenderProps.commands` (render time, pane-scoped keys)
+  or `host.commands` (setup time, rows only). They live in
+  `lib/page-commands.ts` and die with the worker, so a worker that is not
+  attached has no rows and no keys. The dispatcher runs the console's keys
+  first, then the focused pane's; a page can never shadow a console chord
+  (`shortcutClaimReason`). Chat is the first consumer: `I` composer, `J`/`K`
+  walk the transcript, `End` latest, `M` model, `Escape` stop.
 - **Phones** switch workspaces from the bottom sheet; each workspace
   remembers which panel it was showing, per browser tab.
 

--- a/console/ui/catalog-page.tsx
+++ b/console/ui/catalog-page.tsx
@@ -32,11 +32,12 @@ export default function setup(host: Host) {
   host.pages.register({
     id: 'functions',
     title: 'functions',
-    render: ({ panelSide, onRequestClose }: PageRenderProps) => (
+    render: ({ panelSide, onRequestClose, commands }: PageRenderProps) => (
       <FunctionsPage
         host={host}
         side={panelSide}
         onRequestClose={onRequestClose}
+        commands={commands}
       />
     ),
   })
@@ -44,12 +45,33 @@ export default function setup(host: Host) {
   host.pages.register({
     id: 'triggers',
     title: 'triggers',
-    render: ({ panelSide, onRequestClose }: PageRenderProps) => (
+    render: ({ panelSide, onRequestClose, commands }: PageRenderProps) => (
       <TriggersPage
         host={host}
         side={panelSide}
         onRequestClose={onRequestClose}
+        commands={commands}
       />
     ),
   })
+
+  host.commands?.register('functions', [
+    {
+      id: 'open',
+      title: 'Open functions',
+      detail: 'Every registered function, grouped by worker',
+      keywords: ['catalog', 'invoke', 'trigger'],
+      run: () => host.panels?.open({ pageId: 'functions', context: {} }),
+    },
+  ])
+
+  host.commands?.register('triggers', [
+    {
+      id: 'open',
+      title: 'Open triggers',
+      detail: 'Trigger types and their live bindings',
+      keywords: ['catalog', 'bindings'],
+      run: () => host.panels?.open({ pageId: 'triggers', context: {} }),
+    },
+  ])
 }

--- a/console/ui/src/catalog/FunctionsPage.tsx
+++ b/console/ui/src/catalog/FunctionsPage.tsx
@@ -27,13 +27,21 @@ import {
   EmptyState,
   type Host,
   JsonHighlight,
+  type PageCommandsApi,
   PageHeader,
   Tabs,
   TabsContent,
   TabsList,
   TabsTrigger,
 } from '@iii-dev/console-ui'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  type MutableRefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import { ActivityFeed, formatDuration } from './ActivityFeed'
 import { nextCronRun, untilLabel } from './cron'
 import {
@@ -83,15 +91,21 @@ export function FunctionsPage({
   host,
   side,
   onRequestClose,
+  commands,
 }: {
   host: Host
   side?: 'left' | 'right'
   onRequestClose?: () => void
+  commands?: PageCommandsApi
 }) {
   const [showInternal, setShowInternal] = useState(false)
   const [search, setSearch] = useState('')
   const [selected, setSelected] = useState<string | null>(null)
   const groupState = useGroupToggle(alwaysOpen)
+  const searchInputRef = useRef<HTMLInputElement>(null)
+  // Set by the mounted InvokePanel (invoke tab only) so Mod+Enter can reach
+  // its run() without lifting the whole invoke form up to this page.
+  const invokeRunRef = useRef<(() => void) | null>(null)
 
   // Functions and workers together: the sidebar groups by worker and the
   // document names each worker's runtime, so both loads share one beat.
@@ -178,6 +192,49 @@ export function FunctionsPage({
     }
   }, [catalog.data, selected])
 
+  // The page's primary verbs, for the palette and the keyboard while this
+  // pane has focus.
+  useEffect(
+    () =>
+      commands?.register([
+        {
+          id: 'search',
+          title: 'Search functions',
+          detail: 'Focus the function search field',
+          keywords: ['find', 'filter'],
+          shortcut: '/',
+          run: () => searchInputRef.current?.focus(),
+        },
+        {
+          id: 'toggle-internal',
+          title: 'Toggle internal functions',
+          detail: 'Show or hide console and worker plumbing functions',
+          keywords: ['internal', 'plumbing', 'hidden'],
+          shortcut: 'I',
+          run: () => setShowInternal((v) => !v),
+        },
+        {
+          id: 'refresh',
+          title: 'Refresh functions',
+          detail: 'Reload the function catalog',
+          keywords: ['reload'],
+          shortcut: 'R',
+          run: () => catalog.reload(),
+        },
+        {
+          id: 'run-function',
+          title: 'Run function',
+          detail: 'Trigger the selected function with its current payload',
+          keywords: ['invoke', 'trigger', 'call'],
+          shortcut: 'Mod+Enter',
+          firesWhileTyping: true,
+          enabled: () => invokeRunRef.current !== null,
+          run: () => invokeRunRef.current?.(),
+        },
+      ]),
+    [commands, catalog.reload],
+  )
+
   return (
     <CatalogShell
       side={side}
@@ -215,6 +272,7 @@ export function FunctionsPage({
             value={search}
             onChange={setSearch}
             placeholder="search functions…"
+            inputRef={searchInputRef}
           />
           <Button
             variant="pill"
@@ -312,6 +370,7 @@ export function FunctionsPage({
             runtimeOf={runtimeOf}
             lastCall={activity.lastCall.get(selected)}
             onBack={() => setSelected(null)}
+            invokeRunRef={invokeRunRef}
           />
         ) : (
           <Hero
@@ -347,6 +406,7 @@ function FunctionDocument({
   runtimeOf,
   lastCall,
   onBack,
+  invokeRunRef,
 }: {
   host: Host
   functionId: string
@@ -354,6 +414,7 @@ function FunctionDocument({
   runtimeOf: (worker: string) => string | undefined
   lastCall?: SpanEvent
   onBack: () => void
+  invokeRunRef: MutableRefObject<(() => void) | null>
 }) {
   const load = useCallback(
     () => functionInfo(host, functionId),
@@ -472,6 +533,7 @@ function FunctionDocument({
                 prefill={prefill}
                 label="run function"
                 runningLabel="running…"
+                runRef={invokeRunRef}
               />
             </TabsContent>
             <TabsContent value="input">

--- a/console/ui/src/catalog/InvokePanel.tsx
+++ b/console/ui/src/catalog/InvokePanel.tsx
@@ -21,7 +21,13 @@ import {
   type Host,
   JsonHighlight,
 } from '@iii-dev/console-ui'
-import { type MutableRefObject, useEffect, useMemo, useState } from 'react'
+import {
+  type MutableRefObject,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import { type InvokeOutcome, invoke } from './engine'
 import { schemaFieldNames } from './SchemaTable'
 import { pretty, templateFromSchema } from './schema'
@@ -130,6 +136,7 @@ export function InvokePanel({
     setInvalid(null)
   }
 
+  const inFlightRef = useRef(false)
   const run = async () => {
     let payload: unknown
     try {
@@ -149,10 +156,17 @@ export function InvokePanel({
       )
       return
     }
+    if (inFlightRef.current) return
+    inFlightRef.current = true
     setInvalid(null)
     setRunning(true)
-    const result = await invoke(host, functionId, payload)
-    setRunning(false)
+    let result: Awaited<ReturnType<typeof invoke>>
+    try {
+      result = await invoke(host, functionId, payload)
+    } finally {
+      inFlightRef.current = false
+      setRunning(false)
+    }
     attemptSeq += 1
     setAttempts((prev) => [
       { id: attemptSeq, atMs: Date.now(), body, outcome: result },

--- a/console/ui/src/catalog/InvokePanel.tsx
+++ b/console/ui/src/catalog/InvokePanel.tsx
@@ -21,7 +21,7 @@ import {
   type Host,
   JsonHighlight,
 } from '@iii-dev/console-ui'
-import { useEffect, useMemo, useState } from 'react'
+import { type MutableRefObject, useEffect, useMemo, useState } from 'react'
 import { type InvokeOutcome, invoke } from './engine'
 import { schemaFieldNames } from './SchemaTable'
 import { pretty, templateFromSchema } from './schema'
@@ -79,6 +79,7 @@ export function InvokePanel({
   runningLabel = 'triggering…',
   hint,
   prefill,
+  runRef,
 }: {
   host: Host
   functionId: string
@@ -89,6 +90,9 @@ export function InvokePanel({
   hint?: string
   /** A recorded input pushed in from the activity feed; changes replace the body. */
   prefill?: { value: unknown; nonce: number }
+  /** Kept current with this panel's run() while mounted, so the page's
+      Mod+Enter command can reach it without lifting this form up. */
+  runRef?: MutableRefObject<(() => void) | null>
 }) {
   const [body, setBody] = useState('{}')
   const [running, setRunning] = useState(false)
@@ -155,6 +159,14 @@ export function InvokePanel({
       ...prev.slice(0, 9),
     ])
   }
+
+  if (runRef) runRef.current = run
+  useEffect(() => {
+    return () => {
+      if (runRef) runRef.current = null
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   return (
     <div className="console-catalog-invoke">

--- a/console/ui/src/catalog/TriggersPage.tsx
+++ b/console/ui/src/catalog/TriggersPage.tsx
@@ -26,13 +26,14 @@ import {
   EmptyState,
   type Host,
   JsonHighlight,
+  type PageCommandsApi,
   PageHeader,
   Tabs,
   TabsContent,
   TabsList,
   TabsTrigger,
 } from '@iii-dev/console-ui'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { describeCron, nextCronRun, untilLabel } from './cron'
 import {
   type FunctionSummary,
@@ -115,15 +116,18 @@ export function TriggersPage({
   host,
   side,
   onRequestClose,
+  commands,
 }: {
   host: Host
   side?: 'left' | 'right'
   onRequestClose?: () => void
+  commands?: PageCommandsApi
 }) {
   const [showInternal, setShowInternal] = useState(false)
   const [search, setSearch] = useState('')
   const [family, setFamily] = useState<Family | null>(null)
   const [selected, setSelected] = useState<Selection | null>(null)
+  const searchInputRef = useRef<HTMLInputElement>(null)
 
   // Three independent reads the page needs together, so it pays for one round
   // trip. Functions come along to put each binding's target description on
@@ -282,6 +286,31 @@ export function TriggersPage({
     }
   }, [catalog.data, selected])
 
+  // The page's primary verbs, for the palette and the keyboard while this
+  // pane has focus.
+  useEffect(
+    () =>
+      commands?.register([
+        {
+          id: 'search',
+          title: 'Search triggers',
+          detail: 'Focus the trigger search field',
+          keywords: ['find', 'filter'],
+          shortcut: '/',
+          run: () => searchInputRef.current?.focus(),
+        },
+        {
+          id: 'refresh',
+          title: 'Refresh triggers',
+          detail: 'Reload the trigger catalog',
+          keywords: ['reload'],
+          shortcut: 'R',
+          run: () => catalog.reload(),
+        },
+      ]),
+    [commands, catalog.reload],
+  )
+
   return (
     <CatalogShell
       side={side}
@@ -320,6 +349,7 @@ export function TriggersPage({
               value={search}
               onChange={setSearch}
               placeholder="search triggers…"
+              inputRef={searchInputRef}
             />
             <Button
               variant="pill"

--- a/console/ui/src/catalog/widgets.tsx
+++ b/console/ui/src/catalog/widgets.tsx
@@ -24,7 +24,13 @@ import {
   PageSidebar,
   uiClasses,
 } from '@iii-dev/console-ui'
-import { Fragment, type ReactNode, useCallback, useState } from 'react'
+import {
+  Fragment,
+  type ReactNode,
+  type Ref,
+  useCallback,
+  useState,
+} from 'react'
 import type { Family, Tone } from './trigger-kinds'
 
 /**
@@ -131,15 +137,19 @@ export function SearchField({
   value,
   onChange,
   placeholder,
+  inputRef,
 }: {
   value: string
   onChange: (next: string) => void
   placeholder: string
+  /** Lets the page command palette focus this field on `/`. */
+  inputRef?: Ref<HTMLInputElement>
 }) {
   return (
     <div className="console-catalog-search">
       <SearchGlassIcon />
       <Input
+        ref={inputRef}
         name="catalog-search"
         value={value}
         onChange={onChange}
@@ -147,6 +157,7 @@ export function SearchField({
         placeholder={placeholder}
         aria-label={placeholder}
         className="console-catalog-search-input"
+        data-autofocus=""
         onKeyDown={(e) => {
           if (e.key === 'Escape' && value) {
             e.stopPropagation()

--- a/console/web/DESIGN.md
+++ b/console/web/DESIGN.md
@@ -1021,7 +1021,21 @@ Workspace tabs behave like this everywhere:
   attached has no rows and no keys. The dispatcher runs the console's keys
   first, then the focused pane's; a page can never shadow a console chord
   (`shortcutClaimReason`). Chat is the first consumer: `I` composer, `J`/`K`
-  walk the transcript, `End` latest, `M` model, `Escape` stop.
+  walk the transcript, `A`/`D` approve or deny the pending call, `O` expand
+  and `Y` copy the focused message, `End` latest, `M` model, `Escape` stop,
+  `N` new chat, `/` search conversations.
+- **Palette sources, prefixes, recents:** a worker registers a live source
+  (`host.palette.registerSource`, `lib/palette/providers.ts`): rows
+  computed per query, asked debounced with an abort signal, shown under the
+  source's own group. `>` and `/` narrow the palette to commands, `#` to
+  files, `@` to chats (`parseQuery`); an empty query opens on the ten most
+  recent choices (`lib/palette/recents.ts`); several words match in any
+  order. `host.palette.open({ query })` lets a row hand over to a mode, the
+  way the shell's "Open file…" lands on `#`.
+- **Shared primitives carry the keyboard:** an interactive `TableRow` joins
+  the tab order and answers Enter, Space and the arrows; a `List` walks its
+  items with the arrows. A page built from them is keyboard-reachable
+  without its own handlers.
 - **Phones** switch workspaces from the bottom sheet; each workspace
   remembers which panel it was showing, per browser tab.
 

--- a/console/web/DESIGN.md
+++ b/console/web/DESIGN.md
@@ -1011,7 +1011,17 @@ Workspace tabs behave like this everywhere:
   first: every action and every open workspace is a row in `⌘K`, each
   showing its key, and hovering a control spells the same key
   (`hoverTitle`), so the keys are learned in passing. The full list is a
-  `⌘K` row, not a key of its own.
+  `⌘K` row, not a key of its own. `{` / `}` move the keyboard between
+  panes, and opening a page from `⌘K`, a chord or `panels.open` lands focus
+  inside it (`lib/pane-focus.ts`).
+- **Page commands:** a page contributes rows to `⌘K` and keys to its own
+  pane through `PageRenderProps.commands` (render time, pane-scoped keys)
+  or `host.commands` (setup time, rows only). They live in
+  `lib/page-commands.ts` and die with the worker, so a worker that is not
+  attached has no rows and no keys. The dispatcher runs the console's keys
+  first, then the focused pane's; a page can never shadow a console chord
+  (`shortcutClaimReason`). Chat is the first consumer: `I` composer, `J`/`K`
+  walk the transcript, `End` latest, `M` model, `Escape` stop.
 - **Phones** switch workspaces from the bottom sheet; each workspace
   remembers which panel it was showing, per browser tab.
 

--- a/console/web/e2e/keyboard-first.spec.ts
+++ b/console/web/e2e/keyboard-first.spec.ts
@@ -53,6 +53,26 @@ test('the keyboard reaches the chat, the panes and every page command through âŒ
   await row.click()
   await expect(composer(page)).toBeFocused()
 
+  // A prefix narrows the palette to a mode, and the last choice leads the
+  // next empty query.
+  await settle(page)
+  await page.keyboard.press('Meta+k')
+  await palette.getByRole('textbox').fill('>stop')
+  await expect(
+    palette.getByRole('button', { name: /Chat: Stop the turn/ }),
+  ).toHaveCount(0)
+  await palette.getByRole('textbox').fill('>model')
+  await expect(
+    palette.getByRole('button', { name: /Chat: Switch model/ }),
+  ).toBeVisible()
+  await expect(palette.getByRole('button', { name: /^workers/ })).toHaveCount(0)
+  await palette.getByRole('textbox').fill('')
+  await expect(palette.getByText('Recent', { exact: true })).toBeVisible()
+  await expect(
+    palette.getByRole('button', { name: /Chat: Focus the composer/ }).first(),
+  ).toBeVisible()
+  await page.keyboard.press('Escape')
+
   // A second pane, then the braces move the keyboard between panes, and the
   // palette's "open" lands the keyboard in the page it opened.
   await settle(page)

--- a/console/web/e2e/keyboard-first.spec.ts
+++ b/console/web/e2e/keyboard-first.spec.ts
@@ -81,41 +81,20 @@ test('the keyboard reaches the chat, the panes and every page command through âŒ
   await expect(page.locator('[data-workspace-pane-id]')).toHaveCount(3)
   // The new pane opens with its search focused, where `}` is a character.
   await pane(page, 0).focus()
+  const focusedPane = page.locator('[data-workspace-pane-id]:focus-within')
   await page.keyboard.press('}')
-  await expect
-    .poll(() =>
-      page.evaluate(() => {
-        const panes = Array.from(
-          document.querySelectorAll('[data-workspace-pane-id]'),
-        )
-        return panes.findIndex((root) => root.contains(document.activeElement))
-      }),
-    )
-    .toBe(1)
+  await expect(focusedPane).toHaveAttribute('data-workspace-panel', '1')
   await page.keyboard.press('{')
-  await expect
-    .poll(() =>
-      page.evaluate(() => {
-        const panes = Array.from(
-          document.querySelectorAll('[data-workspace-pane-id]'),
-        )
-        return panes.findIndex((root) => root.contains(document.activeElement))
-      }),
-    )
-    .toBe(0)
+  await expect(focusedPane).toHaveAttribute('data-workspace-panel', '0')
 
   await page.keyboard.press('Meta+k')
   await palette.getByRole('textbox').fill('go to workers')
   await palette.getByRole('button', { name: /^workers/ }).click()
-  await expect
-    .poll(() =>
-      page.evaluate(() => {
-        const active = document.activeElement
-        const root = active?.closest('[data-workspace-pane-id]')
-        return root?.querySelector('[aria-label="workers"]') !== null
-      }),
-    )
-    .toBe(true)
+  await expect(
+    page.locator(
+      '[data-workspace-pane-id]:focus-within [aria-label="workers"]',
+    ),
+  ).toHaveCount(1)
 
   expectPassingResult(await stack.finish())
 })

--- a/console/web/e2e/keyboard-first.spec.ts
+++ b/console/web/e2e/keyboard-first.spec.ts
@@ -44,7 +44,7 @@ test('the keyboard reaches the chat, the panes and every page command through ‚å
   await expect(page.locator('[data-message-row]').first()).toBeFocused()
 
   // The palette lists the chat's commands under its name, with their keys.
-  await page.keyboard.press('Meta+k')
+  await page.keyboard.press('ControlOrMeta+k')
   const palette = page.getByRole('dialog')
   await palette.getByRole('textbox').fill('focus the composer')
   const row = palette.getByRole('button', { name: /Chat: Focus the composer/ })
@@ -56,7 +56,7 @@ test('the keyboard reaches the chat, the panes and every page command through ‚å
   // A prefix narrows the palette to a mode, and the last choice leads the
   // next empty query.
   await settle(page)
-  await page.keyboard.press('Meta+k')
+  await page.keyboard.press('ControlOrMeta+k')
   await palette.getByRole('textbox').fill('>stop')
   await expect(
     palette.getByRole('button', { name: /Chat: Stop the turn/ }),
@@ -87,7 +87,7 @@ test('the keyboard reaches the chat, the panes and every page command through ‚å
   await page.keyboard.press('{')
   await expect(focusedPane).toHaveAttribute('data-workspace-panel', '0')
 
-  await page.keyboard.press('Meta+k')
+  await page.keyboard.press('ControlOrMeta+k')
   await palette.getByRole('textbox').fill('go to workers')
   await palette.getByRole('button', { name: /^workers/ }).click()
   await expect(

--- a/console/web/e2e/keyboard-first.spec.ts
+++ b/console/web/e2e/keyboard-first.spec.ts
@@ -8,7 +8,10 @@ const pane = (page: Page, index: number) =>
 const composer = (page: Page) => page.getByLabel('message composer')
 
 async function settle(page: Page): Promise<void> {
-  await page.locator('body').click({ position: { x: 4, y: 4 } })
+  await page.evaluate(() => {
+    const active = document.activeElement
+    if (active instanceof HTMLElement) active.blur()
+  })
 }
 
 test('the keyboard reaches the chat, the panes and every page command through ⌘K', async ({

--- a/console/web/e2e/keyboard-first.spec.ts
+++ b/console/web/e2e/keyboard-first.spec.ts
@@ -9,8 +9,12 @@ const composer = (page: Page) => page.getByLabel('message composer')
 
 async function settle(page: Page): Promise<void> {
   await page.evaluate(() => {
-    const active = document.activeElement
-    if (active instanceof HTMLElement) active.blur()
+    const doc = (
+      globalThis as {
+        document?: { activeElement?: { blur?: () => void } | null }
+      }
+    ).document
+    doc?.activeElement?.blur?.()
   })
 }
 

--- a/console/web/e2e/keyboard-first.spec.ts
+++ b/console/web/e2e/keyboard-first.spec.ts
@@ -1,0 +1,101 @@
+import type { Page } from '@playwright/test'
+import { expect, expectPassingResult, openSession, test } from './harness-stack'
+
+test.use({ scenario: 'streamed-text' })
+
+const pane = (page: Page, index: number) =>
+  page.locator('[data-workspace-pane-id]').nth(index)
+const composer = (page: Page) => page.getByLabel('message composer')
+
+async function settle(page: Page): Promise<void> {
+  await page.locator('body').click({ position: { x: 4, y: 4 } })
+}
+
+test('the keyboard reaches the chat, the panes and every page command through ⌘K', async ({
+  page,
+  stack,
+}) => {
+  const completed = stack.waitForTurnCompleted()
+  await stack.trigger()
+  expect(await completed).toMatchObject({ status: 'completed' })
+
+  await page.setViewportSize({ width: 1280, height: 800 })
+  await openSession(page, stack)
+  await expect(page.locator('[data-message-row]').first()).toBeVisible()
+
+  // The chat's keys are pane-scoped: they fire while focus is inside the pane.
+  await settle(page)
+  await pane(page, 0).focus()
+  await page.keyboard.press('i')
+  await expect(composer(page)).toBeFocused()
+
+  // Typing never fires a page key; a letter in the composer is a letter.
+  await page.keyboard.press('j')
+  await expect(composer(page)).toHaveText('j')
+  await page.keyboard.press('Backspace')
+
+  // J and K walk the transcript; End jumps to the tail.
+  await pane(page, 0).focus()
+  await page.keyboard.press('j')
+  await expect(page.locator('[data-message-row]').first()).toBeFocused()
+  await page.keyboard.press('j')
+  await expect(page.locator('[data-message-row]').nth(1)).toBeFocused()
+  await page.keyboard.press('k')
+  await expect(page.locator('[data-message-row]').first()).toBeFocused()
+
+  // The palette lists the chat's commands under its name, with their keys.
+  await page.keyboard.press('Meta+k')
+  const palette = page.getByRole('dialog')
+  await palette.getByRole('textbox').fill('focus the composer')
+  const row = palette.getByRole('button', { name: /Chat: Focus the composer/ })
+  await expect(row).toBeVisible()
+  await expect(row.locator('kbd')).toHaveText('I')
+  await row.click()
+  await expect(composer(page)).toBeFocused()
+
+  // A second pane, then the braces move the keyboard between panes, and the
+  // palette's "open" lands the keyboard in the page it opened.
+  await settle(page)
+  await expect(page.locator('[data-workspace-pane-id]')).toHaveCount(2)
+  await page.keyboard.press('\\')
+  await expect(page.locator('[data-workspace-pane-id]')).toHaveCount(3)
+  // The new pane opens with its search focused, where `}` is a character.
+  await pane(page, 0).focus()
+  await page.keyboard.press('}')
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const panes = Array.from(
+          document.querySelectorAll('[data-workspace-pane-id]'),
+        )
+        return panes.findIndex((root) => root.contains(document.activeElement))
+      }),
+    )
+    .toBe(1)
+  await page.keyboard.press('{')
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const panes = Array.from(
+          document.querySelectorAll('[data-workspace-pane-id]'),
+        )
+        return panes.findIndex((root) => root.contains(document.activeElement))
+      }),
+    )
+    .toBe(0)
+
+  await page.keyboard.press('Meta+k')
+  await palette.getByRole('textbox').fill('go to workers')
+  await palette.getByRole('button', { name: /^workers/ }).click()
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const active = document.activeElement
+        const root = active?.closest('[data-workspace-pane-id]')
+        return root?.querySelector('[aria-label="workers"]') !== null
+      }),
+    )
+    .toBe(true)
+
+  expectPassingResult(await stack.finish())
+})

--- a/console/web/src/App.tsx
+++ b/console/web/src/App.tsx
@@ -62,6 +62,7 @@ import {
   resolveBindings,
 } from '@/lib/keybindings/registry'
 import { registerPageCommands } from '@/lib/page-commands'
+import { onPaletteOpenRequest } from '@/lib/palette/open-request'
 import {
   focusPane,
   requestPaneFocus,
@@ -187,6 +188,15 @@ export function App({
   // Held here, not in `PaletteHost`: ⌘K is one way in and the phone header's
   // search affordance is the other, so the state has to sit above both.
   const [paletteOpen, setPaletteOpen] = useState(false)
+  const [paletteQuery, setPaletteQuery] = useState('')
+  useEffect(
+    () =>
+      onPaletteOpenRequest((request) => {
+        setPaletteQuery(request.query ?? '')
+        setPaletteOpen(true)
+      }),
+    [],
+  )
   const workspace = useWorkspaceTabs()
   const { activeTab, activeTabId } = workspace
   const workspaceRef = useRef(workspace)
@@ -453,7 +463,10 @@ export function App({
      Which keys reach here while the caret is in a field, and which stand
      down, is the registry's call — not this component's. */
   useKeybindings({
-    'palette.toggle': () => setPaletteOpen((current) => !current),
+    'palette.toggle': () => {
+      setPaletteQuery('')
+      setPaletteOpen((current) => !current)
+    },
     'app.settings': toggleSettings,
     'page.chat': () => openWorkspaceScreen(CHAT_SCREEN),
     'page.workers': () => openWorkspaceScreen('workers'),
@@ -526,6 +539,7 @@ export function App({
           onOpenShortcuts={() => setShortcutsOpen(true)}
           theme={theme}
           onThemeChange={setTheme}
+          initialQuery={paletteQuery}
         />
       </Sheet>
     </ConversationsProvider>

--- a/console/web/src/App.tsx
+++ b/console/web/src/App.tsx
@@ -61,6 +61,12 @@ import {
   keybindingGroups,
   resolveBindings,
 } from '@/lib/keybindings/registry'
+import { registerPageCommands } from '@/lib/page-commands'
+import {
+  focusPane,
+  requestPaneFocus,
+  takePaneFocusRequest,
+} from '@/lib/pane-focus'
 import { subscribePanelOpen } from '@/lib/panel-context'
 import { loadEdgeAddDiscovered, saveEdgeAddDiscovered } from '@/lib/storage'
 import { cn } from '@/lib/utils'
@@ -92,7 +98,67 @@ import { Configuration } from '@/pages/Configuration'
 import { ExtPage } from '@/pages/Ext'
 import { TracesV2 } from '@/pages/TracesV2'
 import { Workers } from '@/pages/Workers'
-import type { PanelSide } from '@/types/injectable-ui'
+import type { PageCommandsApi, PanelSide } from '@/types/injectable-ui'
+
+function firstPartyPageTitle(screen: TabScreen): string {
+  if (screen === CHAT_SCREEN) return 'Chat'
+  if (screen === 'workers') return 'Workers'
+  if (screen === 'traces') return 'Traces'
+  return screen
+}
+
+/** Focus the pane of the screen the keyboard asked for, if it is open. */
+function focusRequestedPane(tab: WorkspaceTab): void {
+  const screen = takePaneFocusRequest(tab.screens)
+  if (screen === null) return
+  const paneId = tabPaneIds(tab)[tab.screens.indexOf(screen)]
+  if (!paneId) return
+  const root = document.querySelector<HTMLElement>(
+    `[data-workspace-pane-id="${CSS.escape(paneId)}"]`,
+  )
+  if (root) focusPane(root)
+}
+
+/**
+ * The `commands` a pane hands its page: registrations are keyed to this pane
+ * so their keys fire only while focus is inside it, and every one still
+ * registered when the pane unmounts is removed with it.
+ */
+function usePaneCommandsApi(
+  pageId: string,
+  pageTitle: string | undefined,
+  paneId: string,
+): PageCommandsApi {
+  const removersRef = useRef(new Set<() => void>())
+  const api = useMemo<PageCommandsApi>(
+    () => ({
+      register(commands) {
+        const off = registerPageCommands({
+          pageId,
+          pageTitle,
+          source: 'page',
+          paneId,
+          commands,
+        })
+        const remove = () => {
+          removersRef.current.delete(remove)
+          off()
+        }
+        removersRef.current.add(remove)
+        return remove
+      },
+    }),
+    [pageId, pageTitle, paneId],
+  )
+  // biome-ignore lint/correctness/useExhaustiveDependencies: a new api means a new pane identity; what the old one registered goes with it.
+  useEffect(
+    () => () => {
+      for (const remove of [...removersRef.current]) remove()
+    },
+    [api],
+  )
+  return api
+}
 
 function paneIdsByTab(tabs: WorkspaceTab[]): Map<string, Set<string>> {
   return new Map(tabs.map((tab) => [tab.id, new Set(tabPaneIds(tab))]))
@@ -240,9 +306,35 @@ export function App({
   )
   const panelCommandsRef = useRef<WorkspacePanelCommands | null>(null)
   const openWorkspaceScreen = useCallback((screen: TabScreen) => {
+    // The keyboard asked for this screen, so the keyboard lands in it: the
+    // panes consume the request once the screen has a pane.
+    requestPaneFocus(screen)
     const commands = panelCommandsRef.current
     if (commands) commands.openScreen(screen)
     else workspaceRef.current.openScreen(screen)
+    window.requestAnimationFrame(() =>
+      focusRequestedPane(workspaceRef.current.activeTab),
+    )
+  }, [])
+  const stepPaneFocus = useCallback((delta: 1 | -1) => {
+    const roots = tabPaneIds(workspaceRef.current.activeTab)
+      .map((paneId) =>
+        document.querySelector<HTMLElement>(
+          `[data-workspace-pane-id="${CSS.escape(paneId)}"]`,
+        ),
+      )
+      .filter((root): root is HTMLElement => root !== null)
+    if (roots.length === 0) return
+    const current = roots.findIndex((root) =>
+      root.contains(document.activeElement),
+    )
+    const next =
+      current === -1
+        ? delta === 1
+          ? 0
+          : roots.length - 1
+        : (current + delta + roots.length) % roots.length
+    focusPane(roots[next])
   }, [])
   const splitWorkspacePanel = useCallback(() => {
     const commands = panelCommandsRef.current
@@ -346,12 +438,14 @@ export function App({
       close: requestCloseTab,
       step: (delta) => workspaceRef.current.activateAdjacent(delta),
       split: splitWorkspacePanel,
+      focusPane: stepPaneFocus,
     }),
     [
       workspace.tabs,
       workspace.activeTabId,
       requestCloseTab,
       splitWorkspacePanel,
+      stepPaneFocus,
     ],
   )
 
@@ -369,6 +463,8 @@ export function App({
     'workspace.previous': () => workspaceRef.current.activateAdjacent(-1),
     'workspace.close': () => requestCloseTab(workspaceRef.current.activeTabId),
     'panel.split': splitWorkspacePanel,
+    'panel.next': () => stepPaneFocus(1),
+    'panel.previous': () => stepPaneFocus(-1),
     // Out of range is a no-op rather than a wrap: pressing 7 with four
     // workspaces open should do nothing, not land somewhere surprising.
     'workspace.selectByIndex': (index) => {
@@ -491,6 +587,12 @@ function WorkspacePanes({
   const { activeTab } = workspace
   const columns = tabColumns(activeTab)
   const containerRef = useRef<HTMLElement>(null)
+  useEffect(() => {
+    const frame = window.requestAnimationFrame(() =>
+      focusRequestedPane(activeTab),
+    )
+    return () => window.cancelAnimationFrame(frame)
+  }, [activeTab])
   const desktopPanelMotion = useMediaQuery(DESKTOP_PANEL_MOTION_QUERY)
   const reducedMotion = useMediaQuery(REDUCED_MOTION_QUERY)
   const paneIds = useMemo(() => tabPaneIds(activeTab), [activeTab])
@@ -1348,6 +1450,11 @@ function ScreenBody({
     [tabId, paneId],
   )
   const extId = extPageIdForScreen(screen)
+  const commands = usePaneCommandsApi(
+    extId ?? screen,
+    extId === null ? firstPartyPageTitle(screen) : undefined,
+    paneId,
+  )
   if (extId !== null) {
     return (
       <ExtPage
@@ -1356,6 +1463,7 @@ function ScreenBody({
         tabId={tabId}
         onRequestClose={onClose}
         setDirty={setDirty}
+        commands={commands}
         onMissing={onExtMissing}
         workingDir={active?.workingDir ?? null}
         conversationId={active?.id ?? null}
@@ -1371,6 +1479,7 @@ function ScreenBody({
           density="dock"
           panelSide={panelSide}
           onRequestClose={onClose}
+          commands={commands}
         />
       )
     case 'workers':

--- a/console/web/src/App.tsx
+++ b/console/web/src/App.tsx
@@ -497,7 +497,10 @@ export function App({
           onCloseTab={requestCloseTab}
           settingsOpen={view === 'configuration'}
           onToggleSettings={toggleSettings}
-          onOpenPalette={() => setPaletteOpen(true)}
+          onOpenPalette={() => {
+            setPaletteQuery('')
+            setPaletteOpen(true)
+          }}
         />
         <WorkspacePanes
           workspace={workspace}

--- a/console/web/src/App.tsx
+++ b/console/web/src/App.tsx
@@ -1630,7 +1630,7 @@ function Header({
             onClick={onOpenPalette}
             aria-label={hoverTitle('Search and commands', 'palette.toggle')}
             title={hoverTitle('Search and commands', 'palette.toggle')}
-            className="relative flex h-10 items-center justify-center rounded-md border border-transparent bg-transparent px-2 text-ink-faint transition-colors hover:bg-surface-hover hover:text-ink focus-visible:border-accent focus-visible:outline-none active:scale-[0.97]"
+            className="relative flex h-10 items-center justify-center rounded-md border border-transparent bg-transparent px-2 text-ink-faint transition-[transform,color,background-color] [transition-duration:var(--motion-duration-control)] [transition-timing-function:var(--motion-ease-standard)] hover:bg-surface-hover hover:text-ink focus-visible:border-accent focus-visible:outline-none active:scale-[0.97]"
           >
             <KeyCombo
               binding={bindingsFor('palette.toggle')[0] ?? 'Mod+K'}

--- a/console/web/src/App.tsx
+++ b/console/web/src/App.tsx
@@ -108,15 +108,19 @@ function firstPartyPageTitle(screen: TabScreen): string {
   return screen
 }
 
+function paneRoot(paneId: string): HTMLElement | null {
+  return document.querySelector<HTMLElement>(
+    `[data-workspace-pane-id="${CSS.escape(paneId)}"]`,
+  )
+}
+
 /** Focus the pane of the screen the keyboard asked for, if it is open. */
 function focusRequestedPane(tab: WorkspaceTab): void {
   const screen = takePaneFocusRequest(tab.screens)
   if (screen === null) return
   const paneId = tabPaneIds(tab)[tab.screens.indexOf(screen)]
   if (!paneId) return
-  const root = document.querySelector<HTMLElement>(
-    `[data-workspace-pane-id="${CSS.escape(paneId)}"]`,
-  )
+  const root = paneRoot(paneId)
   if (root) focusPane(root)
 }
 
@@ -328,22 +332,15 @@ export function App({
   }, [])
   const stepPaneFocus = useCallback((delta: 1 | -1) => {
     const roots = tabPaneIds(workspaceRef.current.activeTab)
-      .map((paneId) =>
-        document.querySelector<HTMLElement>(
-          `[data-workspace-pane-id="${CSS.escape(paneId)}"]`,
-        ),
-      )
+      .map(paneRoot)
       .filter((root): root is HTMLElement => root !== null)
     if (roots.length === 0) return
     const current = roots.findIndex((root) =>
       root.contains(document.activeElement),
     )
+    const start = delta === 1 ? 0 : roots.length - 1
     const next =
-      current === -1
-        ? delta === 1
-          ? 0
-          : roots.length - 1
-        : (current + delta + roots.length) % roots.length
+      current === -1 ? start : (current + delta + roots.length) % roots.length
     focusPane(roots[next])
   }, [])
   const splitWorkspacePanel = useCallback(() => {

--- a/console/web/src/App.tsx
+++ b/console/web/src/App.tsx
@@ -1497,9 +1497,9 @@ function ScreenBody({
         />
       )
     case 'workers':
-      return <Workers onRequestClose={onClose} />
+      return <Workers onRequestClose={onClose} commands={commands} />
     default:
-      return <TracesV2 onRequestClose={onClose} />
+      return <TracesV2 onRequestClose={onClose} commands={commands} />
   }
 }
 

--- a/console/web/src/components/CommandPalette.tsx
+++ b/console/web/src/components/CommandPalette.tsx
@@ -191,6 +191,8 @@ export interface CommandPaletteProps {
   sources?: readonly RegisteredPaletteSource[]
   /** The active chat's working directory, handed to sources. */
   workingDir?: string | null
+  /** The active chat session, handed to sources. */
+  conversationId?: string | null
   /** Text to open with; `#` lands in file mode. Read once per opening. */
   initialQuery?: string
 }
@@ -204,6 +206,7 @@ export function CommandPalette({
   readInventory = readEngine,
   sources = EMPTY_SOURCES,
   workingDir = null,
+  conversationId = null,
   initialQuery = '',
 }: CommandPaletteProps) {
   const [query, setQuery] = useState('')
@@ -255,6 +258,7 @@ export function CommandPalette({
         prefix: parsed.prefix,
         kinds: parsed.kinds,
         workingDir,
+        conversationId,
         signal: controller.signal,
       }).then((entries) => {
         if (controller.signal.aborted) return
@@ -266,7 +270,7 @@ export function CommandPalette({
       window.clearTimeout(timer)
       controller.abort()
     }
-  }, [open, sources, parsed, workingDir])
+  }, [open, sources, parsed, workingDir, conversationId])
 
   useEffect(() => {
     if (!open) return

--- a/console/web/src/components/CommandPalette.tsx
+++ b/console/web/src/components/CommandPalette.tsx
@@ -19,7 +19,10 @@
 import {
   Boxes,
   Command,
+  File,
   FunctionSquare,
+  History,
+  Layers,
   LayoutGrid,
   MessageSquareText,
   Search,
@@ -44,12 +47,23 @@ import {
   matchesKeybinding,
 } from '@/lib/keybindings/registry'
 import {
+  type RegisteredPaletteSource,
+  searchPaletteSources,
+} from '@/lib/palette/providers'
+import {
+  loadRecents,
+  type RecentEntry,
+  recentOf,
+  recordRecent,
+} from '@/lib/palette/recents'
+import {
   type EngineSnapshot,
   filterEntries,
   groupEntries,
   KIND_LABEL,
   type PaletteEntry,
   type PaletteKind,
+  parseQuery,
   readEngine,
 } from '@/lib/palette/sources'
 
@@ -62,6 +76,7 @@ const FILTERS: Array<{ id: PaletteKind | 'all'; label: string }> = [
   { id: 'workspace', label: 'Workspaces' },
   { id: 'command', label: 'Commands' },
   { id: 'action', label: 'Actions' },
+  { id: 'file', label: 'Files' },
 ]
 
 /** The footer's key hints, in the order they read. The chords come from the
@@ -84,7 +99,12 @@ const KIND_STYLE = {
   workspace: { Icon: LayoutGrid, chip: 'bg-surface-active text-ink-faint' },
   command: { Icon: Command, chip: 'bg-ok-muted text-ok' },
   action: { Icon: Settings, chip: 'bg-accent-muted text-accent' },
+  file: { Icon: File, chip: 'bg-warn-muted text-warn' },
+  item: { Icon: Layers, chip: 'bg-surface-active text-ink-faint' },
 } as const
+
+const SOURCE_DEBOUNCE_MS = 120
+const EMPTY_SOURCES: readonly RegisteredPaletteSource[] = []
 
 /**
  * The slice of the screen a phone keyboard leaves behind.
@@ -167,6 +187,12 @@ export interface CommandPaletteProps {
   /** Seam for the gallery, which has no engine to read. Must be a stable
    *  reference: the palette re-reads whenever it changes. */
   readInventory?: () => Promise<EngineSnapshot>
+  /** Live sources (files and the like) answering the query as it is typed. */
+  sources?: readonly RegisteredPaletteSource[]
+  /** The active chat's working directory, handed to sources. */
+  workingDir?: string | null
+  /** Text to open with; `#` lands in file mode. Read once per opening. */
+  initialQuery?: string
 }
 
 export function CommandPalette({
@@ -176,12 +202,18 @@ export function CommandPalette({
   onOpenWorker,
   onOpenFunction,
   readInventory = readEngine,
+  sources = EMPTY_SOURCES,
+  workingDir = null,
+  initialQuery = '',
 }: CommandPaletteProps) {
   const [query, setQuery] = useState('')
   const [filter, setFilter] = useState<PaletteKind | 'all'>('all')
   const [active, setActive] = useState(0)
   const [engineEntries, setEngineEntries] = useState<PaletteEntry[]>([])
   const [engineError, setEngineError] = useState<string | null>(null)
+  const [sourceEntries, setSourceEntries] = useState<PaletteEntry[]>([])
+  const [searching, setSearching] = useState(false)
+  const [recents, setRecents] = useState<RecentEntry[]>([])
   const inputRef = useRef<HTMLInputElement>(null)
   const listRef = useRef<HTMLDivElement>(null)
   const viewportStyle = useKeyboardInset(open)
@@ -194,14 +226,47 @@ export function CommandPalette({
   useEffect(() => {
     if (!open) return
     const opener = document.activeElement as HTMLElement | null
-    setQuery('')
+    setQuery(initialQuery)
     setFilter('all')
     setActive(0)
+    setRecents(loadRecents())
     inputRef.current?.focus()
     return () => {
       if (opener?.isConnected) opener.focus()
     }
-  }, [open])
+  }, [open, initialQuery])
+
+  const parsed = useMemo(() => parseQuery(query, filter), [query, filter])
+
+  // Sources answer as you type, one query at a time: a new keystroke aborts
+  // the last ask, and a slow answer to an old query is dropped.
+  useEffect(() => {
+    if (!open) return
+    const controller = new AbortController()
+    const timer = window.setTimeout(() => {
+      const eligible = sources.length > 0
+      if (!eligible) {
+        setSourceEntries([])
+        return
+      }
+      setSearching(true)
+      void searchPaletteSources(sources, {
+        text: parsed.text,
+        prefix: parsed.prefix,
+        kinds: parsed.kinds,
+        workingDir,
+        signal: controller.signal,
+      }).then((entries) => {
+        if (controller.signal.aborted) return
+        setSourceEntries(entries)
+        setSearching(false)
+      })
+    }, SOURCE_DEBOUNCE_MS)
+    return () => {
+      window.clearTimeout(timer)
+      controller.abort()
+    }
+  }, [open, sources, parsed, workingDir])
 
   useEffect(() => {
     if (!open) return
@@ -242,10 +307,28 @@ export function CommandPalette({
   }, [open, onOpenWorker, onOpenFunction, readInventory])
 
   const results = useMemo(
-    () => filterEntries([...localEntries, ...engineEntries], query, filter),
-    [localEntries, engineEntries, query, filter],
+    () => [
+      ...filterEntries(
+        [...localEntries, ...engineEntries],
+        parsed.text,
+        parsed.kinds,
+      ),
+      // Source rows are already the source's answer to the query.
+      ...sourceEntries,
+    ],
+    [localEntries, engineEntries, sourceEntries, parsed],
   )
-  const groups = useMemo(() => groupEntries(results), [results])
+  const recentRows = useMemo(
+    () =>
+      parsed.text === '' && parsed.prefix === null && filter === 'all'
+        ? recentOf(results, recents)
+        : [],
+    [results, recents, parsed, filter],
+  )
+  const groups = useMemo(
+    () => groupEntries(results, recentRows),
+    [results, recentRows],
+  )
   const flat = useMemo(() => groups.flatMap(([, entries]) => entries), [groups])
 
   useEffect(() => {
@@ -256,6 +339,8 @@ export function CommandPalette({
 
   const choose = (entry: PaletteEntry | undefined) => {
     if (!entry) return
+    // A source row is one answer to one query; it has no place in recents.
+    if (!entry.id.startsWith('source:')) recordRecent(entry.id)
     onClose()
     entry.run()
   }
@@ -340,7 +425,13 @@ export function CommandPalette({
               setQuery(event.target.value)
               setActive(0)
             }}
-            placeholder="Search actions, workspaces, pages, chats, workers, functions…"
+            placeholder={
+              parsed.prefix === '#'
+                ? 'File name…'
+                : parsed.prefix !== null
+                  ? 'Command…'
+                  : 'Search, or type > for commands, # for files, @ for chats…'
+            }
             aria-label="Search the console"
             // Under 16px iOS Safari zooms the page on focus, which strands a
             // fixed overlay off screen. Worker and function ids are not prose,
@@ -379,7 +470,11 @@ export function CommandPalette({
                 setActive(0)
               }}
               className={`min-h-11 shrink-0 rounded-full border px-3 text-sm transition-colors sm:min-h-0 sm:px-2.5 sm:py-1 sm:text-xs ${
-                filter === option.id
+                (
+                  parsed.prefix !== null
+                    ? option.id !== 'all' && parsed.kinds?.has(option.id)
+                    : filter === option.id
+                )
                   ? 'border-edge bg-surface-selected text-ink'
                   : 'border-transparent text-ink-faint hover:bg-surface-hover hover:text-ink'
               }`}
@@ -399,7 +494,11 @@ export function CommandPalette({
           ) : null}
           {flat.length === 0 ? (
             <p className="px-4 py-6 text-center text-base text-ink-faint sm:text-sm">
-              No matches
+              {searching
+                ? 'Searching…'
+                : parsed.prefix === '#' && sources.length === 0
+                  ? 'No worker is providing files right now.'
+                  : 'No matches'}
             </p>
           ) : (
             groups.map(([kind, entries]) => (
@@ -414,7 +513,10 @@ export function CommandPalette({
                 {entries.map((entry) => {
                   cursor += 1
                   const index = cursor
-                  const { Icon: KindIcon, chip } = KIND_STYLE[entry.kind]
+                  const { Icon: KindIcon, chip } =
+                    kind === 'recent'
+                      ? { Icon: History, chip: KIND_STYLE[entry.kind].chip }
+                      : KIND_STYLE[entry.kind]
                   const Icon = entry.icon ?? KindIcon
                   const selected = index === active
                   return (
@@ -500,6 +602,7 @@ export function CommandPalette({
             ))}
           </div>
           <span className="ml-auto tabular-nums">
+            {searching ? 'searching… ' : ''}
             {flat.length} result{flat.length === 1 ? '' : 's'}
           </span>
         </div>

--- a/console/web/src/components/CommandPalette.tsx
+++ b/console/web/src/components/CommandPalette.tsx
@@ -18,6 +18,7 @@
 
 import {
   Boxes,
+  Command,
   FunctionSquare,
   LayoutGrid,
   MessageSquareText,
@@ -59,6 +60,7 @@ const FILTERS: Array<{ id: PaletteKind | 'all'; label: string }> = [
   { id: 'page', label: 'Pages' },
   { id: 'chat', label: 'Chats' },
   { id: 'workspace', label: 'Workspaces' },
+  { id: 'command', label: 'Commands' },
   { id: 'action', label: 'Actions' },
 ]
 
@@ -80,6 +82,7 @@ const KIND_STYLE = {
   page: { Icon: Zap, chip: 'bg-warn-muted text-warn' },
   chat: { Icon: MessageSquareText, chip: 'bg-surface-active text-ink-faint' },
   workspace: { Icon: LayoutGrid, chip: 'bg-surface-active text-ink-faint' },
+  command: { Icon: Command, chip: 'bg-ok-muted text-ok' },
   action: { Icon: Settings, chip: 'bg-accent-muted text-accent' },
 } as const
 

--- a/console/web/src/components/CommandPalette.tsx
+++ b/console/web/src/components/CommandPalette.tsx
@@ -104,6 +104,7 @@ const KIND_STYLE = {
 } as const
 
 const SOURCE_DEBOUNCE_MS = 120
+const SLOW_ANSWER_MS = 200
 const EMPTY_SOURCES: readonly RegisteredPaletteSource[] = []
 
 function placeholderFor(prefix: string | null): string {
@@ -272,7 +273,12 @@ export function CommandPalette({
         setSourceEntries([])
         return
       }
-      setSearching(true)
+      // The indicator waits for a slow answer: a label that flashes for a
+      // fast one makes the palette feel slower than it is.
+      const slow = window.setTimeout(() => setSearching(true), SLOW_ANSWER_MS)
+      controller.signal.addEventListener('abort', () =>
+        window.clearTimeout(slow),
+      )
       void searchPaletteSources(sources, {
         text: parsed.text,
         prefix: parsed.prefix,
@@ -281,6 +287,7 @@ export function CommandPalette({
         conversationId,
         signal: controller.signal,
       }).then((entries) => {
+        window.clearTimeout(slow)
         if (controller.signal.aborted) return
         setSourceEntries(entries)
         setSearching(false)
@@ -355,9 +362,19 @@ export function CommandPalette({
   )
   const flat = useMemo(() => groups.flatMap(([, entries]) => entries), [groups])
 
+  // Rows arrive on their own schedule (sources answer late, the engine
+  // inventory lands), so the highlight follows the row, not its position:
+  // Enter always runs what was lit a moment ago.
+  const activeIdRef = useRef<string | null>(null)
   useEffect(() => {
-    setActive((current) => (current < flat.length ? current : 0))
-  }, [flat.length])
+    activeIdRef.current = flat[active]?.id ?? null
+  }, [active, flat])
+  useEffect(() => {
+    const at = flat.findIndex((entry) => entry.id === activeIdRef.current)
+    setActive((current) =>
+      at !== -1 ? at : current < flat.length ? current : 0,
+    )
+  }, [flat])
 
   if (!open) return null
 
@@ -534,7 +551,7 @@ export function CommandPalette({
                       data-palette-index={index}
                       onMouseEnter={() => setActive(index)}
                       onClick={() => choose(entry)}
-                      className={`flex min-h-12 w-full items-center gap-3 border-l-2 py-2.5 pr-4 pl-3.5 text-left transition-colors sm:min-h-0 sm:py-2 ${
+                      className={`flex min-h-12 w-full items-center gap-3 border-l-2 py-2.5 pr-4 pl-3.5 text-left sm:min-h-0 sm:py-2 ${
                         selected
                           ? 'border-edge bg-surface-selected'
                           : 'border-transparent hover:bg-surface-hover'

--- a/console/web/src/components/CommandPalette.tsx
+++ b/console/web/src/components/CommandPalette.tsx
@@ -106,6 +106,23 @@ const KIND_STYLE = {
 const SOURCE_DEBOUNCE_MS = 120
 const EMPTY_SOURCES: readonly RegisteredPaletteSource[] = []
 
+function placeholderFor(prefix: string | null): string {
+  if (prefix === '#') return 'File name…'
+  if (prefix !== null) return 'Command…'
+  return 'Search, or type > for commands, # for files, @ for chats…'
+}
+
+function emptyText(
+  searching: boolean,
+  prefix: string | null,
+  sourceCount: number,
+): string {
+  if (searching) return 'Searching…'
+  if (prefix === '#' && sourceCount === 0)
+    return 'No worker is providing files right now.'
+  return 'No matches'
+}
+
 /**
  * The slice of the screen a phone keyboard leaves behind.
  *
@@ -240,6 +257,10 @@ export function CommandPalette({
   }, [open, initialQuery])
 
   const parsed = useMemo(() => parseQuery(query, filter), [query, filter])
+  const filterActive = (id: PaletteKind | 'all'): boolean => {
+    if (parsed.prefix === null) return filter === id
+    return id !== 'all' && parsed.kinds?.has(id) === true
+  }
 
   // Sources answer as you type, one query at a time: a new keystroke aborts
   // the last ask, and a slow answer to an old query is dropped.
@@ -247,8 +268,7 @@ export function CommandPalette({
     if (!open) return
     const controller = new AbortController()
     const timer = window.setTimeout(() => {
-      const eligible = sources.length > 0
-      if (!eligible) {
+      if (sources.length === 0) {
         setSourceEntries([])
         return
       }
@@ -429,13 +449,7 @@ export function CommandPalette({
               setQuery(event.target.value)
               setActive(0)
             }}
-            placeholder={
-              parsed.prefix === '#'
-                ? 'File name…'
-                : parsed.prefix !== null
-                  ? 'Command…'
-                  : 'Search, or type > for commands, # for files, @ for chats…'
-            }
+            placeholder={placeholderFor(parsed.prefix)}
             aria-label="Search the console"
             // Under 16px iOS Safari zooms the page on focus, which strands a
             // fixed overlay off screen. Worker and function ids are not prose,
@@ -474,11 +488,7 @@ export function CommandPalette({
                 setActive(0)
               }}
               className={`min-h-11 shrink-0 rounded-full border px-3 text-sm transition-colors sm:min-h-0 sm:px-2.5 sm:py-1 sm:text-xs ${
-                (
-                  parsed.prefix !== null
-                    ? option.id !== 'all' && parsed.kinds?.has(option.id)
-                    : filter === option.id
-                )
+                filterActive(option.id)
                   ? 'border-edge bg-surface-selected text-ink'
                   : 'border-transparent text-ink-faint hover:bg-surface-hover hover:text-ink'
               }`}
@@ -498,11 +508,7 @@ export function CommandPalette({
           ) : null}
           {flat.length === 0 ? (
             <p className="px-4 py-6 text-center text-base text-ink-faint sm:text-sm">
-              {searching
-                ? 'Searching…'
-                : parsed.prefix === '#' && sources.length === 0
-                  ? 'No worker is providing files right now.'
-                  : 'No matches'}
+              {emptyText(searching, parsed.prefix, sources.length)}
             </p>
           ) : (
             groups.map(([kind, entries]) => (
@@ -517,11 +523,9 @@ export function CommandPalette({
                 {entries.map((entry) => {
                   cursor += 1
                   const index = cursor
-                  const { Icon: KindIcon, chip } =
-                    kind === 'recent'
-                      ? { Icon: History, chip: KIND_STYLE[entry.kind].chip }
-                      : KIND_STYLE[entry.kind]
-                  const Icon = entry.icon ?? KindIcon
+                  const { Icon: KindIcon, chip } = KIND_STYLE[entry.kind]
+                  const Icon =
+                    entry.icon ?? (kind === 'recent' ? History : KindIcon)
                   const selected = index === active
                   return (
                     <button

--- a/console/web/src/components/CommandPalette.tsx
+++ b/console/web/src/components/CommandPalette.tsx
@@ -271,6 +271,7 @@ export function CommandPalette({
     const timer = window.setTimeout(() => {
       if (sources.length === 0) {
         setSourceEntries([])
+        setSearching(false)
         return
       }
       // The indicator waits for a slow answer: a label that flashes for a
@@ -286,16 +287,22 @@ export function CommandPalette({
         workingDir,
         conversationId,
         signal: controller.signal,
-      }).then((entries) => {
-        window.clearTimeout(slow)
-        if (controller.signal.aborted) return
-        setSourceEntries(entries)
-        setSearching(false)
       })
+        .then((entries) => {
+          window.clearTimeout(slow)
+          if (controller.signal.aborted) return
+          setSourceEntries(entries)
+          setSearching(false)
+        })
+        .catch(() => {
+          window.clearTimeout(slow)
+          if (!controller.signal.aborted) setSearching(false)
+        })
     }, SOURCE_DEBOUNCE_MS)
     return () => {
       window.clearTimeout(timer)
       controller.abort()
+      setSearching(false)
     }
   }, [open, sources, parsed, workingDir, conversationId])
 

--- a/console/web/src/components/CommandPalette.tsx
+++ b/console/web/src/components/CommandPalette.tsx
@@ -366,9 +366,10 @@ export function CommandPalette({
   // inventory lands), so the highlight follows the row, not its position:
   // Enter always runs what was lit a moment ago.
   const activeIdRef = useRef<string | null>(null)
-  useEffect(() => {
-    activeIdRef.current = flat[active]?.id ?? null
-  }, [active, flat])
+  const select = (index: number) => {
+    activeIdRef.current = flat[index]?.id ?? null
+    setActive(index)
+  }
   useEffect(() => {
     const at = flat.findIndex((entry) => entry.id === activeIdRef.current)
     setActive((current) =>
@@ -392,7 +393,7 @@ export function CommandPalette({
   const move = (step: number) => {
     if (!flat.length) return
     const next = (active + step + flat.length) % flat.length
-    setActive(next)
+    select(next)
     listRef.current
       ?.querySelector(`[data-palette-index="${next}"]`)
       ?.scrollIntoView({ block: 'nearest' })
@@ -549,7 +550,7 @@ export function CommandPalette({
                       key={entry.id}
                       type="button"
                       data-palette-index={index}
-                      onMouseEnter={() => setActive(index)}
+                      onMouseEnter={() => select(index)}
                       onClick={() => choose(entry)}
                       className={`flex min-h-12 w-full items-center gap-3 border-l-2 py-2.5 pr-4 pl-3.5 text-left sm:min-h-0 sm:py-2 ${
                         selected

--- a/console/web/src/components/PaletteHost.tsx
+++ b/console/web/src/components/PaletteHost.tsx
@@ -18,6 +18,7 @@ import {
   keybinding,
 } from '@/lib/keybindings/registry'
 import { usePageCommands } from '@/lib/page-commands'
+import { usePaletteSources } from '@/lib/palette/providers'
 import type { PaletteEntry } from '@/lib/palette/sources'
 import { useExtPages } from '@/lib/ui-slots'
 import {
@@ -87,6 +88,8 @@ export interface PaletteHostProps {
   onOpenShortcuts: () => void
   theme: 'light' | 'dark'
   onThemeChange: (theme: 'light' | 'dark') => void
+  /** Text the palette opens with this time (`#` for files). */
+  initialQuery?: string
 }
 
 export function PaletteHost({
@@ -98,11 +101,13 @@ export function PaletteHost({
   onOpenShortcuts,
   theme,
   onThemeChange,
+  initialQuery,
 }: PaletteHostProps) {
   const { screenOptions, extPageTitles } = useScreenOptions()
-  const { conversations, select, createNew } = useConversationsCtx()
+  const { conversations, select, createNew, active } = useConversationsCtx()
   const pageCommands = usePageCommands()
   const extPages = useExtPages()
+  const sources = usePaletteSources()
 
   // Both land on the workers page, filtered to what was picked: a worker by
   // its name, a function by the worker that registers it, falling back to the
@@ -306,6 +311,9 @@ export function PaletteHost({
       localEntries={localEntries}
       onOpenWorker={openWorker}
       onOpenFunction={openFunction}
+      sources={sources}
+      workingDir={active?.workingDir ?? null}
+      initialQuery={initialQuery}
     />
   )
 }

--- a/console/web/src/components/PaletteHost.tsx
+++ b/console/web/src/components/PaletteHost.tsx
@@ -66,6 +66,10 @@ const PAGE_ACTIONS: Partial<Record<string, KeybindingActionId>> = {
   traces: 'page.traces',
 }
 
+function capitalised(text: string): string {
+  return text.length === 0 ? text : text[0].toUpperCase() + text.slice(1)
+}
+
 export interface PaletteWorkspace {
   tabs: readonly WorkspaceTab[]
   activeTabId: string
@@ -229,10 +233,11 @@ export function PaletteHost({
         return true
       })
       .map((entry) => {
-        const pageTitle =
+        const pageTitle = capitalised(
           entry.pageTitle ??
-          extPages.find((page) => page.id === entry.pageId)?.title ??
-          entry.pageId
+            extPages.find((page) => page.id === entry.pageId)?.title ??
+            entry.pageId,
+        )
         return {
           id: `command:${entry.key}`,
           kind: 'command' as const,

--- a/console/web/src/components/PaletteHost.tsx
+++ b/console/web/src/components/PaletteHost.tsx
@@ -198,11 +198,13 @@ export function PaletteHost({
       workspace.tabs.find((tab) => tab.id === workspace.activeTabId) ??
         workspace.tabs[0],
     )
+    const offered = (id: WorkspaceActionId): boolean => {
+      if (id === 'workspace.create' || id === 'panel.split') return true
+      if (id === 'panel.next' || id === 'panel.previous') return panes > 1
+      return several
+    }
     const workspaceActions: PaletteEntry[] = WORKSPACE_ACTIONS.filter(
-      ({ id }) =>
-        id === 'workspace.create' ||
-        id === 'panel.split' ||
-        (id === 'panel.next' || id === 'panel.previous' ? panes > 1 : several),
+      ({ id }) => offered(id),
     ).map(({ id, detail }) => {
       const definition = keybinding(id)
       return {
@@ -220,34 +222,26 @@ export function PaletteHost({
     // a page-level one is registered by a mounted page, which is the same
     // thing said twice. The same page in two panes registers twice: one row.
     const seenCommands = new Set<string>()
-    const pageCommandRows: PaletteEntry[] = pageCommands
-      .filter(
-        (entry) =>
-          entry.source === 'page' ||
-          extPages.some((page) => page.id === entry.pageId),
+    const pageCommandRows: PaletteEntry[] = []
+    for (const entry of pageCommands) {
+      const page = extPages.find((candidate) => candidate.id === entry.pageId)
+      if (entry.source !== 'page' && !page) continue
+      if (entry.command.enabled?.() === false) continue
+      if (seenCommands.has(entry.key)) continue
+      seenCommands.add(entry.key)
+      const pageTitle = capitalised(
+        entry.pageTitle ?? page?.title ?? entry.pageId,
       )
-      .filter((entry) => entry.command.enabled?.() !== false)
-      .filter((entry) => {
-        if (seenCommands.has(entry.key)) return false
-        seenCommands.add(entry.key)
-        return true
+      pageCommandRows.push({
+        id: `command:${entry.key}`,
+        kind: 'command',
+        title: `${pageTitle}: ${entry.command.title}`,
+        detail: entry.command.detail,
+        keywords: [...(entry.command.keywords ?? []), entry.pageId],
+        shortcut: entry.bindings[0],
+        run: entry.command.run,
       })
-      .map((entry) => {
-        const pageTitle = capitalised(
-          entry.pageTitle ??
-            extPages.find((page) => page.id === entry.pageId)?.title ??
-            entry.pageId,
-        )
-        return {
-          id: `command:${entry.key}`,
-          kind: 'command' as const,
-          title: `${pageTitle}: ${entry.command.title}`,
-          detail: entry.command.detail,
-          keywords: [...(entry.command.keywords ?? []), entry.pageId],
-          shortcut: entry.bindings[0],
-          run: entry.command.run,
-        }
-      })
+    }
 
     const actions: PaletteEntry[] = [
       ...workspaceActions,

--- a/console/web/src/components/PaletteHost.tsx
+++ b/console/web/src/components/PaletteHost.tsx
@@ -318,6 +318,7 @@ export function PaletteHost({
       onOpenFunction={openFunction}
       sources={sources}
       workingDir={active?.workingDir ?? null}
+      conversationId={active?.id ?? null}
       initialQuery={initialQuery}
     />
   )

--- a/console/web/src/components/PaletteHost.tsx
+++ b/console/web/src/components/PaletteHost.tsx
@@ -17,7 +17,9 @@ import {
   type KeybindingActionId,
   keybinding,
 } from '@/lib/keybindings/registry'
+import { usePageCommands } from '@/lib/page-commands'
 import type { PaletteEntry } from '@/lib/palette/sources'
+import { useExtPages } from '@/lib/ui-slots'
 import {
   type TabScreen,
   tabColumns,
@@ -33,6 +35,8 @@ type WorkspaceActionId = Extract<
   KeybindingActionId,
   | 'workspace.create'
   | 'panel.split'
+  | 'panel.next'
+  | 'panel.previous'
   | 'workspace.next'
   | 'workspace.previous'
   | 'workspace.close'
@@ -44,6 +48,11 @@ const WORKSPACE_ACTIONS: ReadonlyArray<{
 }> = [
   { id: 'workspace.create', detail: 'Open an empty workspace' },
   { id: 'panel.split', detail: 'Add a panel beside the current one' },
+  { id: 'panel.next', detail: 'Move the keyboard to the panel on the right' },
+  {
+    id: 'panel.previous',
+    detail: 'Move the keyboard to the panel on the left',
+  },
   { id: 'workspace.next', detail: 'Switch to the workspace on the right' },
   { id: 'workspace.previous', detail: 'Switch to the workspace on the left' },
   { id: 'workspace.close', detail: 'Close the current workspace' },
@@ -64,6 +73,7 @@ export interface PaletteWorkspace {
   close: (id: string) => void
   step: (delta: 1 | -1) => void
   split: () => void
+  focusPane: (delta: 1 | -1) => void
 }
 
 export interface PaletteHostProps {
@@ -91,6 +101,8 @@ export function PaletteHost({
 }: PaletteHostProps) {
   const { screenOptions, extPageTitles } = useScreenOptions()
   const { conversations, select, createNew } = useConversationsCtx()
+  const pageCommands = usePageCommands()
+  const extPages = useExtPages()
 
   // Both land on the workers page, filtered to what was picked: a worker by
   // its name, a function by the worker that registers it, falling back to the
@@ -110,6 +122,7 @@ export function PaletteHost({
     [openScreen],
   )
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `open` re-asks each command's `enabled` when the palette opens.
   const localEntries = useMemo((): PaletteEntry[] => {
     const platform = shortcutPlatform()
     const pages: PaletteEntry[] = screenOptions.map((option) => {
@@ -165,13 +178,22 @@ export function PaletteHost({
     const workspaceRun: Record<WorkspaceActionId, () => void> = {
       'workspace.create': workspace.create,
       'panel.split': workspace.split,
+      'panel.next': () => workspace.focusPane(1),
+      'panel.previous': () => workspace.focusPane(-1),
       'workspace.next': () => workspace.step(1),
       'workspace.previous': () => workspace.step(-1),
       'workspace.close': () => workspace.close(workspace.activeTabId),
     }
     const several = workspace.tabs.length > 1
+    const panes = tabColumns(
+      workspace.tabs.find((tab) => tab.id === workspace.activeTabId) ??
+        workspace.tabs[0],
+    )
     const workspaceActions: PaletteEntry[] = WORKSPACE_ACTIONS.filter(
-      ({ id }) => several || id === 'workspace.create' || id === 'panel.split',
+      ({ id }) =>
+        id === 'workspace.create' ||
+        id === 'panel.split' ||
+        (id === 'panel.next' || id === 'panel.previous' ? panes > 1 : several),
     ).map(({ id, detail }) => {
       const definition = keybinding(id)
       return {
@@ -184,6 +206,38 @@ export function PaletteHost({
         run: workspaceRun[id],
       }
     })
+
+    // A worker-level command needs its page registered (the worker is here);
+    // a page-level one is registered by a mounted page, which is the same
+    // thing said twice. The same page in two panes registers twice: one row.
+    const seenCommands = new Set<string>()
+    const pageCommandRows: PaletteEntry[] = pageCommands
+      .filter(
+        (entry) =>
+          entry.source === 'page' ||
+          extPages.some((page) => page.id === entry.pageId),
+      )
+      .filter((entry) => entry.command.enabled?.() !== false)
+      .filter((entry) => {
+        if (seenCommands.has(entry.key)) return false
+        seenCommands.add(entry.key)
+        return true
+      })
+      .map((entry) => {
+        const pageTitle =
+          entry.pageTitle ??
+          extPages.find((page) => page.id === entry.pageId)?.title ??
+          entry.pageId
+        return {
+          id: `command:${entry.key}`,
+          kind: 'command' as const,
+          title: `${pageTitle}: ${entry.command.title}`,
+          detail: entry.command.detail,
+          keywords: [...(entry.command.keywords ?? []), entry.pageId],
+          shortcut: entry.bindings[0],
+          run: entry.command.run,
+        }
+      })
 
     const actions: PaletteEntry[] = [
       ...workspaceActions,
@@ -226,11 +280,15 @@ export function PaletteHost({
       },
     ]
 
-    return [...actions, ...workspaces, ...pages, ...chats]
+    return [...actions, ...pageCommandRows, ...workspaces, ...pages, ...chats]
   }, [
     screenOptions,
     extPageTitles,
     workspace,
+    pageCommands,
+    extPages,
+    // `enabled` is re-asked each time the palette opens.
+    open,
     conversations,
     select,
     createNew,

--- a/console/web/src/components/chat/ChatPanel.tsx
+++ b/console/web/src/components/chat/ChatPanel.tsx
@@ -7,7 +7,7 @@ import { PageHeader, PageSidebar } from '@/components/ui/PageChrome'
 import { useContainerNarrow } from '@/hooks/use-container-narrow'
 import { useMediaQuery } from '@/hooks/use-media-query'
 import { useConversationsCtx } from '@/lib/conversations-context'
-import type { PanelSide } from '@/types/injectable-ui'
+import type { PageCommandsApi, PanelSide } from '@/types/injectable-ui'
 import { ChatView } from './ChatView'
 
 export type ChatPanelDensity = 'route' | 'dock'
@@ -18,6 +18,8 @@ interface ChatPanelProps {
   panelSide?: PanelSide
   /** Close the hosting pane — the header's standard ✕ when present. */
   onRequestClose?: () => void
+  /** The pane's command registrar; chat's keys and palette rows go through it. */
+  commands?: PageCommandsApi
 }
 
 /**
@@ -43,6 +45,7 @@ export function ChatPanel({
   density = 'route',
   panelSide = 'left',
   onRequestClose,
+  commands,
 }: ChatPanelProps) {
   const {
     conversations,
@@ -159,6 +162,7 @@ export function ChatPanel({
           catalogLoading={catalogLoading}
           density={density}
           onRequestClose={onRequestClose}
+          commands={commands}
           onBack={narrow ? handleBack : undefined}
           onUpdateModel={setModel}
           onUpdateMode={setMode}

--- a/console/web/src/components/chat/ChatPanel.tsx
+++ b/console/web/src/components/chat/ChatPanel.tsx
@@ -1,5 +1,5 @@
 import { Plus } from 'lucide-react'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { ConversationSidebar } from '@/components/sidebar/ConversationSidebar'
 import { Button } from '@/components/ui/Button'
 import { IconButton } from '@/components/ui/IconButton'
@@ -67,6 +67,7 @@ export function ChatPanel({
   } = useConversationsCtx()
 
   const [rootRef, containerNarrow] = useContainerNarrow(NARROW_BELOW)
+  const surfaceRef = useRef<HTMLDivElement | null>(null)
   const mobileViewport = useMediaQuery(MOBILE_VIEWPORT_QUERY)
   const narrow = containerNarrow || mobileViewport
   // Which page the narrow flow shows. Only consulted while narrow; kept
@@ -87,6 +88,40 @@ export function ChatPanel({
     [select],
   )
 
+  // The sidebar's verbs, beside the chat's own: both live in the same pane.
+  useEffect(
+    () =>
+      commands?.register([
+        {
+          id: 'new-chat',
+          title: 'New chat',
+          detail: 'Start a conversation',
+          keywords: ['conversation', 'session', 'create'],
+          shortcut: 'N',
+          run: () => {
+            createNew()
+            setNarrowView('chat')
+          },
+        },
+        {
+          id: 'search-chats',
+          title: 'Search conversations',
+          detail: 'Put the caret in the sidebar search',
+          keywords: ['find', 'sessions', 'filter'],
+          shortcut: '/',
+          run: () => {
+            setNarrowView('list')
+            window.requestAnimationFrame(() => {
+              surfaceRef.current
+                ?.querySelector<HTMLElement>('[data-conversation-search]')
+                ?.focus()
+            })
+          },
+        },
+      ]),
+    [commands, createNew],
+  )
+
   const handleCreate = useCallback(() => {
     createNew()
     setNarrowView('chat')
@@ -103,7 +138,10 @@ export function ChatPanel({
 
   return (
     <div
-      ref={rootRef}
+      ref={(node) => {
+        surfaceRef.current = node
+        rootRef(node)
+      }}
       className={`chat-surface flex-1 flex min-h-0 min-w-0${
         panelSide === 'right' ? ' flex-row-reverse' : ''
       }`}

--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -1876,8 +1876,12 @@ export function ChatView({
       )
       if (button && !button.disabled) button.click()
     }
-    const pendingApproval = () =>
-      viewRef.current?.querySelector('[data-approval-actions]') !== null
+    const pendingApproval = () => {
+      const view = viewRef.current
+      return (
+        view !== null && view.querySelector('[data-approval-actions]') !== null
+      )
+    }
     const answerApproval = (action: 'approve' | 'deny' | 'always-allow') => {
       const row = focusedRow()
       const waiting = Array.from(
@@ -2006,11 +2010,11 @@ export function ChatView({
         keywords: ['cancel', 'interrupt', 'abort'],
         shortcut: 'Escape',
         firesWhileTyping: true,
-        enabled: () => working,
+        enabled: () => working || streamingIndicator,
         run: handleStop,
       },
     ])
-  }, [commands, handleOpenModelPicker, handleStop, working])
+  }, [commands, handleOpenModelPicker, handleStop, working, streamingIndicator])
 
   return (
     <section

--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -1867,6 +1867,17 @@ export function ChatView({
         viewRef.current?.querySelectorAll<HTMLElement>('[data-message-row]') ??
           [],
       )
+    const focusedRow = () =>
+      messageNodes().find((node) => node.contains(document.activeElement))
+    const actOnFocused = (action: string) => {
+      const row = focusedRow()
+      const button = row?.querySelector<HTMLButtonElement>(
+        `[data-message-action="${action}"]`,
+      )
+      if (button && !button.disabled) button.click()
+    }
+    const pendingApproval = () =>
+      viewRef.current?.querySelector('[data-approval-actions]') !== null
     const focusMessage = (delta: 1 | -1) => {
       const nodes = messageNodes()
       if (nodes.length === 0) return
@@ -1921,6 +1932,58 @@ export function ChatView({
           )
           list?.scrollTo({ top: list.scrollHeight })
         },
+      },
+      {
+        id: 'approve',
+        title: 'Approve the pending call',
+        detail: 'Let the focused (or the only waiting) function call run',
+        keywords: ['allow', 'yes', 'permission'],
+        shortcut: 'A',
+        enabled: pendingApproval,
+        run: () => {
+          const row = focusedRow()
+          const scope = row?.querySelector('[data-approval-actions]')
+            ? row
+            : viewRef.current
+          scope
+            ?.querySelector<HTMLButtonElement>(
+              '[data-message-action="approve"]',
+            )
+            ?.click()
+        },
+      },
+      {
+        id: 'deny',
+        title: 'Deny the pending call',
+        detail: 'Refuse the focused (or the only waiting) function call',
+        keywords: ['reject', 'no', 'permission'],
+        shortcut: 'D',
+        enabled: pendingApproval,
+        run: () => {
+          const row = focusedRow()
+          const scope = row?.querySelector('[data-approval-actions]')
+            ? row
+            : viewRef.current
+          scope
+            ?.querySelector<HTMLButtonElement>('[data-message-action="deny"]')
+            ?.click()
+        },
+      },
+      {
+        id: 'expand',
+        title: 'Expand or collapse the focused message',
+        detail: 'Open a function call card, or fold it',
+        keywords: ['open', 'fold', 'details'],
+        shortcut: 'O',
+        run: () => actOnFocused('toggle'),
+      },
+      {
+        id: 'copy',
+        title: 'Copy the focused message',
+        detail: 'Copy its text to the clipboard',
+        keywords: ['clipboard'],
+        shortcut: 'Y',
+        run: () => actOnFocused('copy'),
       },
       {
         id: 'model',

--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -1878,17 +1878,25 @@ export function ChatView({
     }
     const pendingApproval = () =>
       viewRef.current?.querySelector('[data-approval-actions]') !== null
+    const answerApproval = (action: 'approve' | 'deny') => {
+      const row = focusedRow()
+      const scope = row?.querySelector('[data-approval-actions]')
+        ? row
+        : viewRef.current
+      scope
+        ?.querySelector<HTMLButtonElement>(`[data-message-action="${action}"]`)
+        ?.click()
+    }
     const focusMessage = (delta: 1 | -1) => {
       const nodes = messageNodes()
       if (nodes.length === 0) return
       const current = nodes.findIndex((node) =>
         node.contains(document.activeElement),
       )
+      const start = delta === 1 ? 0 : nodes.length - 1
       const index =
         current === -1
-          ? delta === 1
-            ? 0
-            : nodes.length - 1
+          ? start
           : Math.min(nodes.length - 1, Math.max(0, current + delta))
       const node = nodes[index]
       node.tabIndex = -1
@@ -1940,17 +1948,7 @@ export function ChatView({
         keywords: ['allow', 'yes', 'permission'],
         shortcut: 'A',
         enabled: pendingApproval,
-        run: () => {
-          const row = focusedRow()
-          const scope = row?.querySelector('[data-approval-actions]')
-            ? row
-            : viewRef.current
-          scope
-            ?.querySelector<HTMLButtonElement>(
-              '[data-message-action="approve"]',
-            )
-            ?.click()
-        },
+        run: () => answerApproval('approve'),
       },
       {
         id: 'deny',
@@ -1959,15 +1957,7 @@ export function ChatView({
         keywords: ['reject', 'no', 'permission'],
         shortcut: 'D',
         enabled: pendingApproval,
-        run: () => {
-          const row = focusedRow()
-          const scope = row?.querySelector('[data-approval-actions]')
-            ? row
-            : viewRef.current
-          scope
-            ?.querySelector<HTMLButtonElement>('[data-message-action="deny"]')
-            ?.click()
-        },
+        run: () => answerApproval('deny'),
       },
       {
         id: 'expand',

--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -1878,7 +1878,7 @@ export function ChatView({
     }
     const pendingApproval = () =>
       viewRef.current?.querySelector('[data-approval-actions]') !== null
-    const answerApproval = (action: 'approve' | 'deny') => {
+    const answerApproval = (action: 'approve' | 'deny' | 'always-allow') => {
       const row = focusedRow()
       const waiting = Array.from(
         viewRef.current?.querySelectorAll('[data-approval-actions]') ?? [],
@@ -1965,6 +1965,15 @@ export function ChatView({
         shortcut: 'D',
         enabled: pendingApproval,
         run: () => answerApproval('deny'),
+      },
+      {
+        id: 'always-allow',
+        title: 'Always allow the pending call',
+        detail: 'Approve it and stop asking for this function',
+        keywords: ['allow', 'permission', 'session', 'trust'],
+        shortcut: 'S',
+        enabled: pendingApproval,
+        run: () => answerApproval('always-allow'),
       },
       {
         id: 'expand',

--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -41,6 +41,7 @@ import type {
   CompactResult,
   QueuedMessagePreview,
 } from '@/lib/backend/types'
+import { requestComposerFocus } from '@/lib/composer-insert'
 import { useConversationsCtxOptional } from '@/lib/conversations-context'
 import { syncEditorWorkspace } from '@/lib/editor-sync'
 import { expandFileMentions, parseFileMentions } from '@/lib/file-mentions'
@@ -80,6 +81,7 @@ import {
   type TriggerFiredData,
   type UserMessage,
 } from '@/types/chat'
+import type { PageCommandsApi } from '@/types/injectable-ui'
 import { Composer, type ComposerSubmitPayload } from './Composer'
 import { ContextUsage } from './ContextUsage'
 import { MessageList } from './MessageList'
@@ -154,6 +156,8 @@ interface ChatViewProps {
   density?: 'route' | 'dock'
   /** Close the hosting pane — the header's standard ✕ when present. */
   onRequestClose?: () => void
+  /** The pane's command registrar: chat's keys and palette rows. */
+  commands?: PageCommandsApi
   /**
    * Drill-out affordance for narrow (one-pane-at-a-time) hosts: when
    * set, the header renders a ← back button returning to the session
@@ -175,6 +179,7 @@ export function ChatView({
   catalogLoading,
   density = 'route',
   onRequestClose,
+  commands,
   onBack,
   onUpdateModel,
   onUpdateMode,
@@ -1851,8 +1856,96 @@ export function ChatView({
     [conversation.id, onAppendMessage],
   )
 
+  // Chat's keyboard, through the same contract a worker page uses, so the
+  // palette lists these rows under "Chat" with their keys.
+  const viewRef = useRef<HTMLElement>(null)
+  const working = conversation.status === 'working'
+  useEffect(() => {
+    if (!commands) return
+    const messageNodes = () =>
+      Array.from(
+        viewRef.current?.querySelectorAll<HTMLElement>('[data-message-row]') ??
+          [],
+      )
+    const focusMessage = (delta: 1 | -1) => {
+      const nodes = messageNodes()
+      if (nodes.length === 0) return
+      const current = nodes.findIndex((node) =>
+        node.contains(document.activeElement),
+      )
+      const index =
+        current === -1
+          ? delta === 1
+            ? 0
+            : nodes.length - 1
+          : Math.min(nodes.length - 1, Math.max(0, current + delta))
+      const node = nodes[index]
+      node.tabIndex = -1
+      node.focus({ preventScroll: true })
+      node.scrollIntoView({ block: 'nearest' })
+    }
+    return commands.register([
+      {
+        id: 'focus-composer',
+        title: 'Focus the composer',
+        detail: 'Put the caret in the message box',
+        keywords: ['type', 'write', 'input', 'message'],
+        shortcut: 'I',
+        run: () => requestComposerFocus(),
+      },
+      {
+        id: 'next-message',
+        title: 'Next message',
+        detail: 'Move the focus down the conversation',
+        keywords: ['down', 'read', 'inspect'],
+        shortcut: 'J',
+        run: () => focusMessage(1),
+      },
+      {
+        id: 'previous-message',
+        title: 'Previous message',
+        detail: 'Move the focus up the conversation',
+        keywords: ['up', 'read', 'inspect'],
+        shortcut: 'K',
+        run: () => focusMessage(-1),
+      },
+      {
+        id: 'latest',
+        title: 'Jump to the latest message',
+        detail: 'Scroll to the end of the conversation',
+        keywords: ['bottom', 'end', 'scroll', 'tail'],
+        shortcut: 'End',
+        run: () => {
+          const list = viewRef.current?.querySelector<HTMLElement>(
+            '[data-message-list]',
+          )
+          list?.scrollTo({ top: list.scrollHeight })
+        },
+      },
+      {
+        id: 'model',
+        title: 'Switch model',
+        detail: 'Open the model picker',
+        keywords: ['provider', 'picker', 'llm'],
+        shortcut: 'M',
+        run: handleOpenModelPicker,
+      },
+      {
+        id: 'stop',
+        title: 'Stop the turn',
+        detail: 'Interrupt the running generation',
+        keywords: ['cancel', 'interrupt', 'abort'],
+        shortcut: 'Escape',
+        firesWhileTyping: true,
+        enabled: () => working,
+        run: handleStop,
+      },
+    ])
+  }, [commands, handleOpenModelPicker, handleStop, working])
+
   return (
     <section
+      ref={viewRef}
       data-chat-session-id={conversation.id}
       data-chat-session-hydrated={conversation.hydrated}
       className="flex-1 flex flex-col min-w-0 min-h-0"

--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -1880,9 +1880,16 @@ export function ChatView({
       viewRef.current?.querySelector('[data-approval-actions]') !== null
     const answerApproval = (action: 'approve' | 'deny') => {
       const row = focusedRow()
+      const waiting = Array.from(
+        viewRef.current?.querySelectorAll('[data-approval-actions]') ?? [],
+      )
+      // The focused row if it is waiting; else the only waiting call. Two
+      // waiting calls and no focus is a choice the keyboard must not make.
       const scope = row?.querySelector('[data-approval-actions]')
         ? row
-        : viewRef.current
+        : waiting.length === 1
+          ? waiting[0]
+          : null
       scope
         ?.querySelector<HTMLButtonElement>(`[data-message-action="${action}"]`)
         ?.click()

--- a/console/web/src/components/chat/CopyMessageButton.tsx
+++ b/console/web/src/components/chat/CopyMessageButton.tsx
@@ -32,6 +32,7 @@ export function CopyMessageButton({
   }
   return (
     <button
+      data-message-action="copy"
       type="button"
       onClick={copy}
       className={cn(

--- a/console/web/src/components/chat/MessageList.tsx
+++ b/console/web/src/components/chat/MessageList.tsx
@@ -585,6 +585,7 @@ export function MessageList({
     <div className="relative flex min-h-0 min-w-0 flex-1">
       <section
         ref={containerRef}
+        data-message-list=""
         data-tail-scroll={tailState}
         aria-label="conversation messages"
         tabIndex={-1}
@@ -679,12 +680,14 @@ export function MessageList({
                 }
               />
             )
-            return tight ? (
-              <div key={rowKey} className="-mt-6.5">
+            return (
+              <div
+                key={rowKey}
+                data-message-row={rowKey}
+                className={tight ? '-mt-6.5' : undefined}
+              >
                 {node}
               </div>
-            ) : (
-              node
             )
           })}
           {isThinking ? (

--- a/console/web/src/components/chat/MessageList.tsx
+++ b/console/web/src/components/chat/MessageList.tsx
@@ -608,32 +608,33 @@ export function MessageList({
           {rows.map((row, i) => {
             if (row.kind === 'function-trigger-group') {
               return (
-                <FunctionTriggerGroup
-                  key={row.id}
-                  row={row}
-                  renderers={renderers}
-                  defaultOpenCalls={defaultOpenCalls}
-                  onResolveApproval={onResolveApproval}
-                  onAlwaysAllow={onAlwaysAllow}
-                  onResolveFilesystemAccess={onResolveFilesystemAccess}
-                  onManageFilesystemAccess={onManageFilesystemAccess}
-                  workingDir={workingDir}
-                  summaryCopyText={
-                    row.summary
-                      ? (() => {
-                          const calls = fcallsByAssistant.get(row.summary.id)
-                          return calls?.length
-                            ? () =>
-                                assistantCopyText(
-                                  row.summary?.content ?? '',
-                                  calls,
-                                  redactFor,
-                                )
-                            : row.summary.content
-                        })()
-                      : undefined
-                  }
-                />
+                <div key={row.id} data-message-row={row.id}>
+                  <FunctionTriggerGroup
+                    row={row}
+                    renderers={renderers}
+                    defaultOpenCalls={defaultOpenCalls}
+                    onResolveApproval={onResolveApproval}
+                    onAlwaysAllow={onAlwaysAllow}
+                    onResolveFilesystemAccess={onResolveFilesystemAccess}
+                    onManageFilesystemAccess={onManageFilesystemAccess}
+                    workingDir={workingDir}
+                    summaryCopyText={
+                      row.summary
+                        ? (() => {
+                            const calls = fcallsByAssistant.get(row.summary.id)
+                            return calls?.length
+                              ? () =>
+                                  assistantCopyText(
+                                    row.summary?.content ?? '',
+                                    calls,
+                                    redactFor,
+                                  )
+                              : row.summary.content
+                          })()
+                        : undefined
+                    }
+                  />
+                </div>
               )
             }
 

--- a/console/web/src/components/chat/ModelPicker.tsx
+++ b/console/web/src/components/chat/ModelPicker.tsx
@@ -568,7 +568,7 @@ export function ModelPickerPanel({
                           }
                           aria-pressed={selectedOption}
                           className={cn(
-                            'flex min-h-14 w-full min-w-0 items-center gap-3 px-3 py-2 text-left font-sans text-base text-ink hover:bg-surface-hover focus-visible:ring-2 focus-visible:ring-rule-focus focus-visible:outline-none focus-visible:ring-inset disabled:pointer-events-none disabled:opacity-40',
+                            'flex min-h-14 w-full min-w-0 items-center gap-3 px-3 py-2 text-left font-sans text-base text-ink hover:bg-surface-hover active:bg-surface-selected focus-visible:ring-2 focus-visible:ring-rule-focus focus-visible:outline-none focus-visible:ring-inset disabled:pointer-events-none disabled:opacity-40',
                             selectedOption && 'bg-surface-selected',
                             highlighted &&
                               !selectedOption &&

--- a/console/web/src/components/chat/ModelPicker.tsx
+++ b/console/web/src/components/chat/ModelPicker.tsx
@@ -30,6 +30,8 @@ const DEFAULT_EFFORT: ReasoningEffortOption = {
   description: 'use the model default',
 }
 
+const FILTER_KEYS = ['ArrowDown', 'ArrowUp', 'Home', 'End', 'Enter']
+
 interface ModelPickerProps {
   value: ModelId | null
   options: ModelOption[]
@@ -422,31 +424,24 @@ export function ModelPickerPanel({
   }, [activeId])
 
   const onFilterKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
-      event.preventDefault()
-      event.stopPropagation()
-      if (visibleIds.length === 0) return
-      const step = event.key === 'ArrowDown' ? 1 : -1
-      setActiveIndex(
-        (current) =>
-          (Math.min(current, visibleIds.length - 1) +
-            step +
-            visibleIds.length) %
-          visibleIds.length,
-      )
+    if (!FILTER_KEYS.includes(event.key)) return
+    event.preventDefault()
+    event.stopPropagation()
+    if (event.key === 'Enter') {
+      if (activeId) selectModel(activeId)
       return
     }
     if (event.key === 'Home' || event.key === 'End') {
-      event.preventDefault()
-      event.stopPropagation()
       setActiveIndex(event.key === 'Home' ? 0 : visibleIds.length - 1)
       return
     }
-    if (event.key === 'Enter') {
-      event.preventDefault()
-      event.stopPropagation()
-      if (activeId) selectModel(activeId)
-    }
+    if (visibleIds.length === 0) return
+    const step = event.key === 'ArrowDown' ? 1 : -1
+    setActiveIndex(
+      (current) =>
+        (Math.min(current, visibleIds.length - 1) + step + visibleIds.length) %
+        visibleIds.length,
+    )
   }
 
   function selectModel(next: ModelId) {

--- a/console/web/src/components/chat/ModelPicker.tsx
+++ b/console/web/src/components/chat/ModelPicker.tsx
@@ -289,6 +289,7 @@ export function ModelPicker({
                   disabled={disabled}
                   loading={loading}
                   contentClassName="space-y-4 px-3 pb-3"
+                  autoFocusFilter
                 />
               </div>
             )}
@@ -332,6 +333,9 @@ interface ModelPickerPanelProps {
   loading?: boolean
   className?: string
   contentClassName?: string
+  /** Put the caret in the filter on mount: the dropdown does, a sheet page
+      that opens under a finger does not. */
+  autoFocusFilter?: boolean
 }
 
 /**
@@ -351,9 +355,16 @@ export function ModelPickerPanel({
   loading,
   className,
   contentClassName,
+  autoFocusFilter = false,
 }: ModelPickerPanelProps) {
   const ctx = useConversationsCtxOptional()
   const effortByModel = useRef(new Map<ModelId, ThinkingLevel>())
+  // Type to filter, arrows to move, Enter to pick: the caret stays in the
+  // filter the whole time, the way a command palette behaves, because forty
+  // models across eight providers is a list you search, not one you scroll.
+  const [filter, setFilter] = useState('')
+  const [activeIndex, setActiveIndex] = useState(0)
+  const listRef = useRef<HTMLDivElement>(null)
   const optionsById = useMemo(
     () => new Map(options.map((option) => [option.id, option])),
     [options],
@@ -368,12 +379,30 @@ export function ModelPickerPanel({
   )
   const modelGroups = groupByProvider(options)
   const grouped = new Set(modelGroups.map((group) => group.label))
+  const filterWords = filter.toLowerCase().split(/\s+/).filter(Boolean)
+  const matchesFilter = (option: ModelOption, provider: string) => {
+    if (filterWords.length === 0) return true
+    const hay =
+      `${formatModelLabel(option.label)} ${option.id} ${formatProviderLabel(provider) ?? provider}`.toLowerCase()
+    return filterWords.every((word) => hay.includes(word))
+  }
   const groups = [
-    ...modelGroups,
+    ...modelGroups.map((group) => ({
+      label: group.label,
+      options: group.options.filter((option) =>
+        matchesFilter(option, group.label),
+      ),
+    })),
     ...presentIds
       .filter((id) => !grouped.has(id))
       .map((id) => ({ label: id, options: [] })),
-  ].sort((a, b) => a.label.localeCompare(b.label))
+  ]
+    .filter((group) => filterWords.length === 0 || group.options.length > 0)
+    .sort((a, b) => a.label.localeCompare(b.label))
+  const visibleIds = groups.flatMap((group) =>
+    group.options.map((option) => option.id),
+  )
+  const activeId = visibleIds[Math.min(activeIndex, visibleIds.length - 1)]
 
   useEffect(() => {
     if (!safeValue) return
@@ -384,6 +413,41 @@ export function ModelPickerPanel({
     if (thinkingLevel !== 'default') onThinkingLevelChange('default')
     effortByModel.current.set(safeValue, 'default')
   }, [safeValue, selectedEfforts, thinkingLevel, onThinkingLevelChange])
+
+  useEffect(() => {
+    if (!activeId) return
+    listRef.current
+      ?.querySelector(`[data-model-option="${CSS.escape(activeId)}"]`)
+      ?.scrollIntoView({ block: 'nearest' })
+  }, [activeId])
+
+  const onFilterKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault()
+      event.stopPropagation()
+      if (visibleIds.length === 0) return
+      const step = event.key === 'ArrowDown' ? 1 : -1
+      setActiveIndex(
+        (current) =>
+          (Math.min(current, visibleIds.length - 1) +
+            step +
+            visibleIds.length) %
+          visibleIds.length,
+      )
+      return
+    }
+    if (event.key === 'Home' || event.key === 'End') {
+      event.preventDefault()
+      event.stopPropagation()
+      setActiveIndex(event.key === 'Home' ? 0 : visibleIds.length - 1)
+      return
+    }
+    if (event.key === 'Enter') {
+      event.preventDefault()
+      event.stopPropagation()
+      if (activeId) selectModel(activeId)
+    }
+  }
 
   function selectModel(next: ModelId) {
     if (disabled || loading) return
@@ -399,7 +463,35 @@ export function ModelPickerPanel({
 
   return (
     <div className={cn('flex min-h-0 flex-1 flex-col', className)}>
+      <div className="shrink-0 px-3 pb-3">
+        <input
+          type="search"
+          value={filter}
+          onChange={(event) => {
+            setFilter(event.target.value)
+            setActiveIndex(0)
+          }}
+          onKeyDown={onFilterKeyDown}
+          // biome-ignore lint/a11y/noAutofocus: the dropdown opened to pick a model; typing is the fastest way to one
+          autoFocus={autoFocusFilter}
+          placeholder="Filter models…"
+          aria-label="filter models"
+          aria-activedescendant={
+            activeId ? `model-option-${activeId}` : undefined
+          }
+          role="combobox"
+          aria-expanded="true"
+          aria-controls="model-picker-list"
+          autoCapitalize="none"
+          autoCorrect="off"
+          autoComplete="off"
+          spellCheck={false}
+          className="h-9 w-full rounded-md bg-surface px-3 font-sans text-sm text-ink outline-none ring-1 ring-inset ring-edge placeholder:text-ink-ghost focus-visible:ring-rule-focus"
+        />
+      </div>
       <div
+        id="model-picker-list"
+        ref={listRef}
         className={cn(
           'min-h-0 flex-1 space-y-5 overflow-y-auto px-4 pb-4',
           contentClassName,
@@ -411,7 +503,9 @@ export function ModelPickerPanel({
           </div>
         ) : groups.length === 0 ? (
           <div className="rounded-lg bg-surface px-3 py-4 font-sans text-base text-ink-faint">
-            No models are configured.
+            {filterWords.length > 0
+              ? `No model matches "${filter.trim()}".`
+              : 'No models are configured.'}
           </div>
         ) : (
           groups.map((group) => {
@@ -465,16 +559,26 @@ export function ModelPickerPanel({
                   ) : catalogIsUsable ? (
                     group.options.map((option) => {
                       const selectedOption = option.id === safeValue
+                      const highlighted = option.id === activeId
                       return (
                         <button
                           key={option.id}
+                          id={`model-option-${option.id}`}
+                          data-model-option={option.id}
                           type="button"
                           disabled={disabled || unavailable}
                           onClick={() => selectModel(option.id)}
+                          onMouseEnter={() =>
+                            setActiveIndex(visibleIds.indexOf(option.id))
+                          }
                           aria-pressed={selectedOption}
                           className={cn(
                             'flex min-h-14 w-full min-w-0 items-center gap-3 px-3 py-2 text-left font-sans text-base text-ink hover:bg-surface-hover focus-visible:ring-2 focus-visible:ring-rule-focus focus-visible:outline-none focus-visible:ring-inset disabled:pointer-events-none disabled:opacity-40',
                             selectedOption && 'bg-surface-selected',
+                            highlighted &&
+                              !selectedOption &&
+                              'bg-surface-hover',
+                            highlighted && 'ring-1 ring-inset ring-rule-focus',
                           )}
                         >
                           <span className="min-w-0 flex-1 truncate font-medium">

--- a/console/web/src/components/chat/ModelPicker.tsx
+++ b/console/web/src/components/chat/ModelPicker.tsx
@@ -30,7 +30,7 @@ const DEFAULT_EFFORT: ReasoningEffortOption = {
   description: 'use the model default',
 }
 
-const FILTER_KEYS = ['ArrowDown', 'ArrowUp', 'Home', 'End', 'Enter']
+const FILTER_KEYS = ['ArrowDown', 'ArrowUp', 'Home', 'End', 'Enter', 'Escape']
 
 interface ModelPickerProps {
   value: ModelId | null
@@ -425,6 +425,15 @@ export function ModelPickerPanel({
 
   const onFilterKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (!FILTER_KEYS.includes(event.key)) return
+    // Escape with a filter typed clears it; the menu closes on the next one.
+    if (event.key === 'Escape') {
+      if (filter === '') return
+      event.preventDefault()
+      event.stopPropagation()
+      setFilter('')
+      setActiveIndex(0)
+      return
+    }
     event.preventDefault()
     event.stopPropagation()
     if (event.key === 'Enter') {

--- a/console/web/src/components/function-trigger/FunctionTriggerCard.tsx
+++ b/console/web/src/components/function-trigger/FunctionTriggerCard.tsx
@@ -469,6 +469,7 @@ export function FunctionTriggerCard({
       >
         <button
           type="button"
+          data-message-action="toggle"
           onClick={() => setOpen((v) => !v)}
           aria-expanded={open}
           className={cn(
@@ -698,6 +699,7 @@ export function FunctionTriggerCard({
             <Button
               variant="primary"
               size="sm"
+              data-message-action="approve"
               onClick={() => void runResolve('approve')}
               disabled={!onApprove || !!submitting}
             >
@@ -706,6 +708,7 @@ export function FunctionTriggerCard({
             <Button
               variant="pill"
               size="sm"
+              data-message-action="deny"
               onClick={() => void runResolve('deny')}
               disabled={!onDeny || !!submitting}
             >

--- a/console/web/src/components/permissions/AlwaysAllowButton.tsx
+++ b/console/web/src/components/permissions/AlwaysAllowButton.tsx
@@ -49,6 +49,7 @@ export function AlwaysAllowButton({
       <Button
         variant="pill"
         size="sm"
+        data-message-action="always-allow"
         onClick={handleClick}
         disabled={disabled || submitting}
         title={

--- a/console/web/src/components/sidebar/ConversationSidebar.tsx
+++ b/console/web/src/components/sidebar/ConversationSidebar.tsx
@@ -100,6 +100,7 @@ export function ConversationSidebar({
           onChange={setQuery}
           placeholder="Search conversations"
           aria-label="search conversations"
+          data-conversation-search=""
           className="h-12 font-sans text-base normal-case sm:h-9 sm:text-sm"
           onKeyDown={(e) => {
             if (e.key === 'Escape') setQuery('')

--- a/console/web/src/components/ui/List.tsx
+++ b/console/web/src/components/ui/List.tsx
@@ -2,11 +2,44 @@ import uiClasses from '@iii-dev/console-ui/ui-classes'
 import * as React from 'react'
 import { cn } from '@/lib/utils'
 
+/** The arrows walk the list's items; Home and End jump to the ends. */
+function onListKeyDown(event: React.KeyboardEvent<HTMLDivElement>): void {
+  const keys = ['ArrowDown', 'ArrowUp', 'Home', 'End']
+  if (!keys.includes(event.key)) return
+  const target = event.target as HTMLElement
+  if (!target.matches('[data-list-item]')) return
+  const items = Array.from(
+    event.currentTarget.querySelectorAll<HTMLElement>(
+      '[data-list-item]:not([disabled])',
+    ),
+  )
+  const index = items.indexOf(target)
+  if (index === -1) return
+  const next =
+    event.key === 'Home'
+      ? items[0]
+      : event.key === 'End'
+        ? items[items.length - 1]
+        : items[index + (event.key === 'ArrowDown' ? 1 : -1)]
+  if (!next) return
+  event.preventDefault()
+  next.focus()
+}
+
 export const List = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn(uiClasses.list, className)} {...props} />
+>(({ className, onKeyDown, ...props }, ref) => (
+  // biome-ignore lint/a11y/noStaticElementInteractions: the handler only moves focus between the list's own buttons
+  <div
+    ref={ref}
+    className={cn(uiClasses.list, className)}
+    onKeyDown={(event) => {
+      onKeyDown?.(event)
+      if (!event.defaultPrevented) onListKeyDown(event)
+    }}
+    {...props}
+  />
 ))
 List.displayName = 'List'
 
@@ -61,6 +94,7 @@ export const ListItem = React.forwardRef<HTMLButtonElement, ListItemProps>(
     <button
       ref={ref}
       type={type}
+      data-list-item=""
       data-selected={selected || undefined}
       aria-pressed={props['aria-pressed'] ?? selected}
       className={cn(uiClasses.listItem, className)}

--- a/console/web/src/components/ui/List.tsx
+++ b/console/web/src/components/ui/List.tsx
@@ -2,10 +2,21 @@ import uiClasses from '@iii-dev/console-ui/ui-classes'
 import * as React from 'react'
 import { cn } from '@/lib/utils'
 
+const LIST_KEYS = ['ArrowDown', 'ArrowUp', 'Home', 'End']
+
+function nextListItem(
+  items: HTMLElement[],
+  index: number,
+  key: string,
+): HTMLElement | undefined {
+  if (key === 'Home') return items[0]
+  if (key === 'End') return items[items.length - 1]
+  return items[index + (key === 'ArrowDown' ? 1 : -1)]
+}
+
 /** The arrows walk the list's items; Home and End jump to the ends. */
 function onListKeyDown(event: React.KeyboardEvent<HTMLDivElement>): void {
-  const keys = ['ArrowDown', 'ArrowUp', 'Home', 'End']
-  if (!keys.includes(event.key)) return
+  if (!LIST_KEYS.includes(event.key)) return
   const target = event.target as HTMLElement
   if (!target.matches('[data-list-item]')) return
   const items = Array.from(
@@ -15,12 +26,7 @@ function onListKeyDown(event: React.KeyboardEvent<HTMLDivElement>): void {
   )
   const index = items.indexOf(target)
   if (index === -1) return
-  const next =
-    event.key === 'Home'
-      ? items[0]
-      : event.key === 'End'
-        ? items[items.length - 1]
-        : items[index + (event.key === 'ArrowDown' ? 1 : -1)]
+  const next = nextListItem(items, index, event.key)
   if (!next) return
   event.preventDefault()
   next.focus()

--- a/console/web/src/components/ui/PageChrome.tsx
+++ b/console/web/src/components/ui/PageChrome.tsx
@@ -30,10 +30,7 @@ export { PageSidebar, type PageSidebarProps } from './PageSidebar'
 
 /** The pane's root column. Fills the pane whether the parent is a flex
     column (native screens) or a block scroller (the ext-page host). */
-export function PageShell({
-  className,
-  ...rest
-}: React.HTMLAttributes<HTMLDivElement>) {
+export function PageShell({ className, ...rest }: React.ComponentProps<'div'>) {
   return (
     <div
       className={cn(

--- a/console/web/src/components/ui/Table.tsx
+++ b/console/web/src/components/ui/Table.tsx
@@ -79,13 +79,51 @@ export interface TableRowProps
   selected?: boolean
 }
 
+/** Arrow keys walk interactive rows; Enter and Space activate the row. */
+function onInteractiveRowKeyDown(
+  event: React.KeyboardEvent<HTMLTableRowElement>,
+): void {
+  if (event.target !== event.currentTarget) return
+  const row = event.currentTarget
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault()
+    row.click()
+    return
+  }
+  if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return
+  const rows = Array.from(
+    row
+      .closest('table')
+      ?.querySelectorAll<HTMLTableRowElement>('tr[data-interactive]') ?? [],
+  )
+  const index = rows.indexOf(row)
+  if (index === -1) return
+  const next = rows[index + (event.key === 'ArrowDown' ? 1 : -1)]
+  if (!next) return
+  event.preventDefault()
+  next.focus()
+}
+
 export const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(
-  ({ className, interactive, selected, ...props }, ref) => (
+  ({ className, interactive, selected, onKeyDown, ...props }, ref) => (
     <tr
       ref={ref}
       data-interactive={interactive || undefined}
       data-selected={selected || undefined}
-      className={cn(uiClasses.tableRow, className)}
+      // A row that answers a click answers the keyboard too: it joins the
+      // tab order once, and the arrows move between rows from there.
+      tabIndex={interactive ? (props.tabIndex ?? 0) : props.tabIndex}
+      onKeyDown={(event) => {
+        onKeyDown?.(event)
+        if (interactive && !event.defaultPrevented)
+          onInteractiveRowKeyDown(event)
+      }}
+      className={cn(
+        uiClasses.tableRow,
+        interactive &&
+          'focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-accent',
+        className,
+      )}
       {...props}
     />
   ),

--- a/console/web/src/components/ui/Table.tsx
+++ b/console/web/src/components/ui/Table.tsx
@@ -112,7 +112,7 @@ export const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(
       data-selected={selected || undefined}
       // A row that answers a click answers the keyboard too: it joins the
       // tab order once, and the arrows move between rows from there.
-      tabIndex={interactive ? (props.tabIndex ?? 0) : props.tabIndex}
+      tabIndex={props.tabIndex ?? (interactive ? 0 : undefined)}
       onKeyDown={(event) => {
         onKeyDown?.(event)
         if (interactive && !event.defaultPrevented)

--- a/console/web/src/components/workspace/TabStrip.tsx
+++ b/console/web/src/components/workspace/TabStrip.tsx
@@ -330,6 +330,11 @@ export function TabStrip({
         closeTab(focusedId)
         return
       }
+      if (e.key === 'F2') {
+        e.preventDefault()
+        setRenamingId(focusedId)
+        return
+      }
       const next = tabIndexForKey(e.key, current, tabs.length)
       if (next === null) return
       e.preventDefault()

--- a/console/web/src/hooks/lib/console-config-writer.test.ts
+++ b/console/web/src/hooks/lib/console-config-writer.test.ts
@@ -1,0 +1,43 @@
+import { QueryClient } from '@tanstack/react-query'
+import { describe, expect, it, vi } from 'vitest'
+import * as config from '@/lib/console-config'
+import {
+  CONSOLE_CONFIG_QUERY_KEY,
+  consoleConfigWriter,
+} from './console-config-writer'
+
+describe('consoleConfigWriter', () => {
+  it('hands every hook of one query client the same writer', () => {
+    const qc = new QueryClient()
+    expect(consoleConfigWriter(qc)).toBe(consoleConfigWriter(qc))
+    expect(consoleConfigWriter(new QueryClient())).not.toBe(
+      consoleConfigWriter(qc),
+    )
+  })
+
+  it('serializes two writers that used to race, so neither loses the other', async () => {
+    let remote: Record<string, unknown> = { workspace: { columns: 2 } }
+    const reads: number[] = []
+    vi.spyOn(config, 'fetchConsoleConfigValue').mockImplementation(async () => {
+      reads.push(Date.now())
+      return remote
+    })
+    vi.spyOn(config, 'setConsoleConfigValue').mockImplementation(
+      async (value) => {
+        remote = value as Record<string, unknown>
+      },
+    )
+    const qc = new QueryClient()
+    const writer = consoleConfigWriter(qc)
+    // The workspace splits a pane while the traces page records a view.
+    writer.enqueue((value) => ({ ...value, workspace: { columns: 3 } }))
+    writer.enqueue((value) => ({ ...value, traces: { activeView: 'v1' } }))
+    await writer.whenIdle()
+    expect(remote).toEqual({
+      workspace: { columns: 3 },
+      traces: { activeView: 'v1' },
+    })
+    expect(qc.getQueryData(CONSOLE_CONFIG_QUERY_KEY)).toEqual(remote)
+    vi.restoreAllMocks()
+  })
+})

--- a/console/web/src/hooks/lib/console-config-writer.ts
+++ b/console/web/src/hooks/lib/console-config-writer.ts
@@ -1,0 +1,39 @@
+import type { QueryClient } from '@tanstack/react-query'
+import {
+  type ConsoleConfigValue,
+  fetchConsoleConfigValue,
+  setConsoleConfigValue,
+} from '@/lib/console-config'
+import { SerializedConfigWriter } from './serialized-config-writer'
+
+export const CONSOLE_CONFIG_QUERY_KEY = ['consoleConfig'] as const
+
+const writers = new WeakMap<QueryClient, SerializedConfigWriter>()
+
+/**
+ * The one writer for the `console` configuration entry.
+ *
+ * Every hook that read-modify-writes the entry (workspace tabs, trace views,
+ * follow turns, span filters) must go through the same queue: two writers
+ * racing on one value lose whichever update reads first, and publish the
+ * stale copy into the shared query cache on the way, so a pane that was just
+ * split blinks out for a frame and then is gone from the server.
+ */
+export function consoleConfigWriter(qc: QueryClient): SerializedConfigWriter {
+  const existing = writers.get(qc)
+  if (existing) return existing
+  const writer = new SerializedConfigWriter({
+    readRemote: fetchConsoleConfigValue,
+    writeRemote: setConsoleConfigValue,
+    readCached: () =>
+      qc.getQueryData<ConsoleConfigValue | null>(CONSOLE_CONFIG_QUERY_KEY),
+    publish: (value) => {
+      qc.setQueryData(CONSOLE_CONFIG_QUERY_KEY, value)
+    },
+    cancelReads: () => {
+      void qc.cancelQueries({ queryKey: CONSOLE_CONFIG_QUERY_KEY, exact: true })
+    },
+  })
+  writers.set(qc, writer)
+  return writer
+}

--- a/console/web/src/hooks/use-keybindings.test.ts
+++ b/console/web/src/hooks/use-keybindings.test.ts
@@ -149,4 +149,108 @@ describe('createKeyDispatcher', () => {
     dispatcher.onKeyDown(key('c'))
     expect(seen).toEqual([])
   })
+
+  describe('pane-scoped page commands', () => {
+    const pane = (id: string) => {
+      const root = { dataset: { workspacePaneId: id } }
+      return {
+        tagName: 'DIV',
+        dataset: {},
+        closest: (selector: string) =>
+          selector.includes('workspace-pane-id') ? root : null,
+      } as unknown as EventTarget
+    }
+    const entry = (
+      paneId: string,
+      binding: string,
+      run: () => void,
+      extra: Partial<{
+        enabled: () => boolean
+        firesWhileTyping: boolean
+      }> = {},
+    ) => ({
+      key: `page.${binding}`,
+      pageId: 'page',
+      source: 'page' as const,
+      paneId,
+      bindings: [binding],
+      command: { id: binding, title: binding, run, ...extra },
+    })
+
+    it('fires only while focus is inside the pane that registered it', () => {
+      const seen: string[] = []
+      const dispatcher = createKeyDispatcher(
+        () => ({}),
+        'mac',
+        (paneId) =>
+          paneId === 'pane-1'
+            ? [entry('pane-1', 'P', () => seen.push('open'))]
+            : [],
+      )
+      dispatcher.onKeyDown(key('p', { target: pane('pane-2') }))
+      dispatcher.onKeyDown(key('p'))
+      expect(seen).toEqual([])
+      const inside = key('p', { target: pane('pane-1') })
+      dispatcher.onKeyDown(inside)
+      expect(seen).toEqual(['open'])
+      expect(inside.defaultPrevented).toBe(true)
+    })
+
+    it('never shadows a console key and skips a disabled command', () => {
+      const seen: string[] = []
+      const dispatcher = createKeyDispatcher(
+        () => ({ 'workspace.create': () => seen.push('create') }),
+        'mac',
+        () => [
+          entry('pane-1', 'T', () => seen.push('page-t')),
+          entry('pane-1', 'X', () => seen.push('page-x'), {
+            enabled: () => false,
+          }),
+        ],
+      )
+      dispatcher.onKeyDown(key('t', { target: pane('pane-1') }))
+      dispatcher.onKeyDown(key('x', { target: pane('pane-1') }))
+      expect(seen).toEqual(['create'])
+    })
+
+    it('completes a page chord and stands down in a field unless asked', () => {
+      const seen: string[] = []
+      const dispatcher = createKeyDispatcher(
+        () => ({}),
+        'mac',
+        () => [
+          entry('pane-1', 'Q L', () => seen.push('line')),
+          entry('pane-1', 'Escape', () => seen.push('stop'), {
+            firesWhileTyping: true,
+          }),
+        ],
+      )
+      dispatcher.onKeyDown(key('q', { target: pane('pane-1') }))
+      dispatcher.onKeyDown(key('l', { target: pane('pane-1') }))
+      expect(seen).toEqual(['line'])
+
+      const field = {
+        tagName: 'TEXTAREA',
+        dataset: {},
+        closest: (selector: string) =>
+          selector.includes('workspace-pane-id')
+            ? { dataset: { workspacePaneId: 'pane-1' } }
+            : null,
+      } as unknown as EventTarget
+      dispatcher.onKeyDown(key('q', { target: field }))
+      dispatcher.onKeyDown(key('l', { target: field }))
+      dispatcher.onKeyDown(key('Escape', { target: field }))
+      expect(seen).toEqual(['line', 'stop'])
+    })
+
+    it('leaves a key a component already answered alone', () => {
+      const seen: string[] = []
+      const dispatcher = createKeyDispatcher(
+        () => ({ 'workspace.create': () => seen.push('create') }),
+        'mac',
+      )
+      dispatcher.onKeyDown(key('t', { defaultPrevented: true }))
+      expect(seen).toEqual([])
+    })
+  })
 })

--- a/console/web/src/hooks/use-keybindings.ts
+++ b/console/web/src/hooks/use-keybindings.ts
@@ -18,7 +18,6 @@ import {
 import {
   KEYBINDINGS,
   type KeybindingActionId,
-  type KeybindingDefinition,
   matchDigitIndex,
   matchesKeybinding,
   sequencesFor,
@@ -64,7 +63,7 @@ export function insideDialog(target: EventTarget | null): boolean {
  */
 export function allowsWhileTyping(
   target: EventTarget | null,
-  actionId: KeybindingActionId | string,
+  actionId: string,
 ): boolean {
   const element = target as HTMLElement | null
   const allow = element?.dataset?.keybindingsAllow
@@ -119,15 +118,15 @@ export function createKeyDispatcher(
     }
   }
   const standsDown = (
-    definition: KeybindingDefinition,
+    binding: { id: string; firesWhileTyping?: boolean },
     event: DispatchEvent,
     typing: boolean,
     inDialog: boolean,
   ): boolean =>
-    (inDialog && !definition.firesWhileTyping) ||
+    (inDialog && !binding.firesWhileTyping) ||
     (typing &&
-      !definition.firesWhileTyping &&
-      !allowsWhileTyping(event.target, definition.id))
+      !binding.firesWhileTyping &&
+      !allowsWhileTyping(event.target, binding.id))
 
   const onKeyDown = (event: DispatchEvent): void => {
     // A shortcut must not fire off the keystroke that finishes a character
@@ -186,30 +185,26 @@ export function createKeyDispatcher(
     // page can never shadow a global chord, and only while focus is inside
     // that pane, so two panes of the same page never both answer.
     const paneId = paneRootOf(event.target)?.dataset.workspacePaneId
-    if (paneId) {
-      for (const entry of getPaneCommands(paneId)) {
-        const { command } = entry
-        if (inDialog && !command.firesWhileTyping) continue
-        if (
-          typing &&
-          !command.firesWhileTyping &&
-          !allowsWhileTyping(event.target, entry.key)
-        )
+    for (const entry of paneId ? getPaneCommands(paneId) : []) {
+      const { command } = entry
+      const guard = {
+        id: entry.key,
+        firesWhileTyping: command.firesWhileTyping,
+      }
+      if (standsDown(guard, event, typing, inDialog)) continue
+      if (command.enabled?.() === false) continue
+      for (const binding of entry.bindings) {
+        if (isSequence(binding)) {
+          const chords = splitSequence(binding)
+          if (bindingMatchesEvent(chords[0] ?? '', event, platform)) {
+            prefixed.push({ chords, run: command.run })
+          }
           continue
-        if (command.enabled?.() === false) continue
-        for (const binding of entry.bindings) {
-          if (isSequence(binding)) {
-            const chords = splitSequence(binding)
-            if (bindingMatchesEvent(chords[0] ?? '', event, platform)) {
-              prefixed.push({ chords, run: command.run })
-            }
-            continue
-          }
-          if (bindingMatchesEvent(binding, event, platform)) {
-            event.preventDefault()
-            command.run()
-            return
-          }
+        }
+        if (bindingMatchesEvent(binding, event, platform)) {
+          event.preventDefault()
+          command.run()
+          return
         }
       }
     }

--- a/console/web/src/hooks/use-keybindings.ts
+++ b/console/web/src/hooks/use-keybindings.ts
@@ -80,6 +80,9 @@ export type DispatchEvent = KeyEventLike &
 interface ChordCandidate {
   chords: readonly string[]
   run: () => void
+  /** Re-asked on every later chord: focus may have left the pane, or the
+      command may have been disabled, since the prefix. */
+  stillEligible?: (event: DispatchEvent) => boolean
 }
 
 interface PendingChord {
@@ -138,8 +141,10 @@ export function createKeyDispatcher(
     if (pending) {
       const { candidates, depth } = pending
       cancel()
-      const advanced = candidates.filter((candidate) =>
-        bindingMatchesEvent(candidate.chords[depth] ?? '', event, platform),
+      const advanced = candidates.filter(
+        (candidate) =>
+          bindingMatchesEvent(candidate.chords[depth] ?? '', event, platform) &&
+          (candidate.stillEligible?.(event) ?? true),
       )
       if (advanced.length > 0) {
         event.preventDefault()
@@ -197,7 +202,19 @@ export function createKeyDispatcher(
         if (isSequence(binding)) {
           const chords = splitSequence(binding)
           if (bindingMatchesEvent(chords[0] ?? '', event, platform)) {
-            prefixed.push({ chords, run: command.run })
+            prefixed.push({
+              chords,
+              run: command.run,
+              stillEligible: (next) =>
+                paneRootOf(next.target)?.dataset.workspacePaneId === paneId &&
+                !standsDown(
+                  guard,
+                  next,
+                  isTyping(next.target),
+                  insideDialog(next.target),
+                ) &&
+                command.enabled?.() !== false,
+            })
           }
           continue
         }

--- a/console/web/src/hooks/use-keybindings.ts
+++ b/console/web/src/hooks/use-keybindings.ts
@@ -9,9 +9,11 @@
 import { useEffect, useRef } from 'react'
 import {
   bindingMatchesEvent,
+  isSequence,
   type KeyEventLike,
   type Platform,
   shortcutPlatform,
+  splitSequence,
 } from '@/lib/keybindings/bindings'
 import {
   KEYBINDINGS,
@@ -21,6 +23,8 @@ import {
   matchesKeybinding,
   sequencesFor,
 } from '@/lib/keybindings/registry'
+import { paneCommands, type RegisteredPageCommand } from '@/lib/page-commands'
+import { paneRootOf } from '@/lib/pane-focus'
 
 /** How long a chord prefix waits for its next key before it is forgotten. */
 export const CHORD_TIMEOUT_MS = 1500
@@ -60,7 +64,7 @@ export function insideDialog(target: EventTarget | null): boolean {
  */
 export function allowsWhileTyping(
   target: EventTarget | null,
-  actionId: KeybindingActionId,
+  actionId: KeybindingActionId | string,
 ): boolean {
   const element = target as HTMLElement | null
   const allow = element?.dataset?.keybindingsAllow
@@ -70,14 +74,25 @@ export function allowsWhileTyping(
 
 export type DispatchEvent = KeyEventLike &
   Pick<KeyboardEvent, 'isComposing' | 'repeat' | 'target'> & {
+    defaultPrevented?: boolean
     preventDefault: () => void
   }
 
+interface ChordCandidate {
+  chords: readonly string[]
+  run: () => void
+}
+
 interface PendingChord {
-  candidates: Array<{ id: KeybindingActionId; chords: string[] }>
+  candidates: ChordCandidate[]
   depth: number
   timer: ReturnType<typeof setTimeout>
 }
+
+/** The keyed commands of the pane that holds the focus, if any. */
+export type PaneCommandsSource = (
+  paneId: string,
+) => readonly RegisteredPageCommand[]
 
 /**
  * The keystroke-to-handler logic, separated from the window listener so it
@@ -88,6 +103,7 @@ interface PendingChord {
 export function createKeyDispatcher(
   getHandlers: () => KeybindingHandlers,
   platform: Platform = shortcutPlatform(),
+  getPaneCommands: PaneCommandsSource = paneCommands,
 ) {
   let pending: PendingChord | null = null
   const cancel = () => {
@@ -115,8 +131,8 @@ export function createKeyDispatcher(
 
   const onKeyDown = (event: DispatchEvent): void => {
     // A shortcut must not fire off the keystroke that finishes a character
-    // being composed by an IME.
-    if (event.isComposing || event.repeat) return
+    // being composed by an IME, nor one a component already answered.
+    if (event.isComposing || event.repeat || event.defaultPrevented) return
     const typing = isTyping(event.target)
     const inDialog = insideDialog(event.target)
 
@@ -132,7 +148,7 @@ export function createKeyDispatcher(
           (candidate) => candidate.chords.length === depth + 1,
         )
         if (complete) {
-          getHandlers()[complete.id]?.(0)
+          complete.run()
           return
         }
         arm(advanced, depth + 1)
@@ -141,7 +157,7 @@ export function createKeyDispatcher(
       // Anything else ends the chord and is handled as an ordinary key.
     }
 
-    const prefixed: PendingChord['candidates'] = []
+    const prefixed: ChordCandidate[] = []
     for (const definition of KEYBINDINGS) {
       if (definition.scope !== 'global') continue
       if (standsDown(definition, event, typing, inDialog)) continue
@@ -161,10 +177,43 @@ export function createKeyDispatcher(
       }
       for (const chords of sequencesFor(definition.id, platform)) {
         if (bindingMatchesEvent(chords[0] ?? '', event, platform)) {
-          prefixed.push({ id: definition.id, chords })
+          prefixed.push({ chords, run: () => run(0) })
         }
       }
     }
+
+    // The focused pane's own commands come after the console's keys, so a
+    // page can never shadow a global chord, and only while focus is inside
+    // that pane, so two panes of the same page never both answer.
+    const paneId = paneRootOf(event.target)?.dataset.workspacePaneId
+    if (paneId) {
+      for (const entry of getPaneCommands(paneId)) {
+        const { command } = entry
+        if (inDialog && !command.firesWhileTyping) continue
+        if (
+          typing &&
+          !command.firesWhileTyping &&
+          !allowsWhileTyping(event.target, entry.key)
+        )
+          continue
+        if (command.enabled?.() === false) continue
+        for (const binding of entry.bindings) {
+          if (isSequence(binding)) {
+            const chords = splitSequence(binding)
+            if (bindingMatchesEvent(chords[0] ?? '', event, platform)) {
+              prefixed.push({ chords, run: command.run })
+            }
+            continue
+          }
+          if (bindingMatchesEvent(binding, event, platform)) {
+            event.preventDefault()
+            command.run()
+            return
+          }
+        }
+      }
+    }
+
     if (prefixed.length > 0) {
       event.preventDefault()
       arm(prefixed, 1)

--- a/console/web/src/hooks/use-workspace-tabs.ts
+++ b/console/web/src/hooks/use-workspace-tabs.ts
@@ -18,14 +18,11 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import {
-  type ConfigTransform,
-  SerializedConfigWriter,
-} from '@/hooks/lib/serialized-config-writer'
-import {
-  type ConsoleConfigValue,
-  fetchConsoleConfigValue,
-  setConsoleConfigValue,
-} from '@/lib/console-config'
+  CONSOLE_CONFIG_QUERY_KEY,
+  consoleConfigWriter,
+} from '@/hooks/lib/console-config-writer'
+import type { ConfigTransform } from '@/hooks/lib/serialized-config-writer'
+import type { ConsoleConfigValue } from '@/lib/console-config'
 import { moveItem } from '@/lib/reorder'
 import {
   adjacentTabId,
@@ -55,7 +52,6 @@ import {
   workspaceLayoutSource,
 } from '@/lib/workspace-tabs'
 
-const CONSOLE_CONFIG_QUERY_KEY = ['consoleConfig']
 const LOCAL_KEY = 'iii-workspace-tabs'
 const SESSION_ACTIVE_KEY = 'iii-workspace-active'
 const POINTER_WRITE_DELAY_MS = 150
@@ -206,25 +202,7 @@ export interface UseWorkspaceTabsReturn {
 
 export function useWorkspaceTabs(): UseWorkspaceTabsReturn {
   const qc = useQueryClient()
-  const writerRef = useRef<SerializedConfigWriter | null>(null)
-  const writer =
-    writerRef.current ??
-    new SerializedConfigWriter({
-      readRemote: fetchConsoleConfigValue,
-      writeRemote: setConsoleConfigValue,
-      readCached: () =>
-        qc.getQueryData<ConsoleConfigValue | null>(CONSOLE_CONFIG_QUERY_KEY),
-      publish: (value) => {
-        qc.setQueryData(CONSOLE_CONFIG_QUERY_KEY, value)
-      },
-      cancelReads: () => {
-        void qc.cancelQueries({
-          queryKey: CONSOLE_CONFIG_QUERY_KEY,
-          exact: true,
-        })
-      },
-    })
-  writerRef.current = writer
+  const writer = consoleConfigWriter(qc)
 
   // Shares the traces saved-views cache entry; refetchInterval keeps the
   // strip reactive to writes from other browsers/tabs.

--- a/console/web/src/lib/backend/directory-prompts.ts
+++ b/console/web/src/lib/backend/directory-prompts.ts
@@ -60,7 +60,10 @@ export function skillBodyWithBaseDir(skill: SkillBody): string {
   // `C:\...\SKILL.md`. A missing separator must fall through to body-only —
   // `slice(0, -1)` would otherwise hand the model a path with its last
   // character shaved off, which is worse than saying nothing.
-  const cut = Math.max(skill.path.lastIndexOf('/'), skill.path.lastIndexOf('\\'))
+  const cut = Math.max(
+    skill.path.lastIndexOf('/'),
+    skill.path.lastIndexOf('\\'),
+  )
   if (cut <= 0) return skill.body
   const dir = skill.path.slice(0, cut)
   return `${skill.body}\n\nSkill base directory: ${dir} — resolve the skill's relative paths (scripts/, reference/, …) against it; keep the working directory at the user's project.`

--- a/console/web/src/lib/keybindings/registry.test.ts
+++ b/console/web/src/lib/keybindings/registry.test.ts
@@ -11,6 +11,7 @@ import {
   matchesKeybinding,
   resolveBindings,
   sequencesFor,
+  shortcutClaimReason,
 } from './registry'
 
 const PLATFORMS: Platform[] = ['mac', 'other']
@@ -90,6 +91,26 @@ describe('lookup', () => {
       'Search (ctrl K)',
     )
     expect(hoverTitle('Chat', 'page.chat', 'mac')).toBe('Chat (G then C)')
+  })
+
+  it('says why a page may not take a key, or lets it', () => {
+    expect(shortcutClaimReason('t', 'mac')).toMatch(/New workspace/)
+    expect(shortcutClaimReason('7', 'mac')).toMatch(/Select workspace/)
+    expect(shortcutClaimReason('G', 'mac')).toMatch(/Go to/)
+    expect(shortcutClaimReason('G X', 'mac')).toMatch(/starts like/)
+    expect(shortcutClaimReason('Mod+K', 'other')).toMatch(
+      /command palette|Search|palette/i,
+    )
+    expect(shortcutClaimReason('Mod+W', 'mac')).toBe('the browser owns it')
+    expect(shortcutClaimReason('Hyper+Q', 'mac')).toBe('it does not parse')
+    expect(shortcutClaimReason('P', 'mac')).toBeNull()
+    expect(shortcutClaimReason('Escape', 'mac')).toBeNull()
+    expect(shortcutClaimReason('Q L', 'mac')).toBeNull()
+  })
+
+  it('steps panel focus with the braces', () => {
+    expect(bindingsFor('panel.next', 'mac')).toEqual(['}'])
+    expect(bindingsFor('panel.previous', 'other')).toEqual(['{'])
   })
 
   it('lists the chords of a go-to sequence', () => {

--- a/console/web/src/lib/keybindings/registry.ts
+++ b/console/web/src/lib/keybindings/registry.ts
@@ -17,10 +17,12 @@ import {
   conflictIdentity,
   digitFromEvent,
   formatBinding,
+  isBrowserReserved,
   isSequence,
   type KeyEventLike,
   type Platform,
   parseBinding,
+  parseSequence,
   shortcutPlatform,
   splitSequence,
 } from './bindings'
@@ -41,6 +43,8 @@ export type KeybindingActionId =
   | 'workspace.previous'
   | 'workspace.close'
   | 'panel.split'
+  | 'panel.next'
+  | 'panel.previous'
   | 'palette.next'
   | 'palette.previous'
   | 'palette.cycleFilter'
@@ -179,6 +183,22 @@ export const KEYBINDINGS: readonly KeybindingDefinition[] = [
     keywords: ['traces', 'spans', 'go', 'page'],
   },
   {
+    id: 'panel.next',
+    title: 'Focus the next panel',
+    group: 'Workspace',
+    scope: 'global',
+    bindings: ['}'],
+    keywords: ['panel', 'pane', 'focus', 'split'],
+  },
+  {
+    id: 'panel.previous',
+    title: 'Focus the previous panel',
+    group: 'Workspace',
+    scope: 'global',
+    bindings: ['{'],
+    keywords: ['panel', 'pane', 'focus', 'split'],
+  },
+  {
     id: 'app.settings',
     title: 'Open settings',
     group: 'Console',
@@ -262,6 +282,43 @@ export function hoverTitle(
   return binding
     ? `${text} (${formatBinding(binding, platform).join(' ')})`
     : text
+}
+
+/**
+ * Why a page may not take `binding` for itself, or null when it may: the
+ * console's global keys, every digit, a sequence prefix and the chords the
+ * browser owns stay the console's. Pages bind what is left.
+ */
+export function shortcutClaimReason(
+  binding: string,
+  platform: Platform = shortcutPlatform(),
+): string | null {
+  if (!parseSequence(binding)) return 'it does not parse'
+  if (isBrowserReserved(binding, platform)) return 'the browser owns it'
+  const identity = conflictIdentity(binding, platform)
+  const head = conflictIdentity(splitSequence(binding)[0] ?? binding, platform)
+  for (const definition of KEYBINDINGS) {
+    if (definition.scope !== 'global') continue
+    for (const own of resolveBindings(definition.bindings, platform)) {
+      const variants = definition.digitIndex
+        ? DIGITS.map((digit) => own.replace(/[1-9]$/, digit))
+        : [own]
+      for (const variant of variants) {
+        const ownIdentity = conflictIdentity(variant, platform)
+        if (ownIdentity === identity || ownIdentity === head) {
+          return `the console uses it for "${definition.title}"`
+        }
+        if (
+          isSequence(variant) &&
+          conflictIdentity(splitSequence(variant)[0] ?? variant, platform) ===
+            head
+        ) {
+          return `it starts like "${definition.title}"`
+        }
+      }
+    }
+  }
+  return null
 }
 
 export function matchesKeybinding(

--- a/console/web/src/lib/page-commands.test.ts
+++ b/console/web/src/lib/page-commands.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  getPageCommands,
+  paneCommands,
+  registerPageCommands,
+  resetPageCommands,
+} from './page-commands'
+
+const noop = () => {}
+
+describe('page commands', () => {
+  beforeEach(() => {
+    resetPageCommands()
+    vi.spyOn(console, 'warn').mockImplementation(noop)
+  })
+  afterEach(() => vi.restoreAllMocks())
+
+  it('namespaces ids by page and removes exactly what it registered', () => {
+    const off = registerPageCommands(
+      {
+        pageId: 'shell',
+        source: 'page',
+        paneId: 'pane-1',
+        commands: [
+          { id: 'open', title: 'Open file', shortcut: 'P', run: noop },
+          { id: 'find', title: 'Search', shortcut: 'F', run: noop },
+        ],
+      },
+      'mac',
+    )
+    registerPageCommands(
+      {
+        pageId: 'database',
+        source: 'worker',
+        commands: [{ id: 'query', title: 'Run a query', run: noop }],
+      },
+      'mac',
+    )
+    expect(getPageCommands().map((entry) => entry.key)).toEqual([
+      'shell.open',
+      'shell.find',
+      'database.query',
+    ])
+    off()
+    off()
+    expect(getPageCommands().map((entry) => entry.key)).toEqual([
+      'database.query',
+    ])
+  })
+
+  it('keeps keys for a mounted page only, never for a worker-level row', () => {
+    registerPageCommands(
+      {
+        pageId: 'shell',
+        source: 'worker',
+        commands: [
+          { id: 'open', title: 'Open file', shortcut: 'P', run: noop },
+        ],
+      },
+      'mac',
+    )
+    registerPageCommands(
+      {
+        pageId: 'shell',
+        source: 'page',
+        paneId: 'pane-1',
+        commands: [
+          { id: 'open', title: 'Open file', shortcut: 'P', run: noop },
+        ],
+      },
+      'mac',
+    )
+    const [worker, page] = getPageCommands()
+    expect(worker.bindings).toEqual([])
+    expect(page.bindings).toEqual(['P'])
+    expect(paneCommands('pane-1').map((entry) => entry.key)).toEqual([
+      'shell.open',
+    ])
+    expect(paneCommands('pane-2')).toEqual([])
+  })
+
+  it("refuses the console's own keys, digits and chord prefixes, keeps the row", () => {
+    registerPageCommands(
+      {
+        pageId: 'shell',
+        source: 'page',
+        paneId: 'pane-1',
+        commands: [
+          { id: 'a', title: 'a', shortcut: 't', run: noop },
+          { id: 'b', title: 'b', shortcut: '5', run: noop },
+          { id: 'c', title: 'c', shortcut: 'G L', run: noop },
+          { id: 'd', title: 'd', shortcut: 'Mod+K', run: noop },
+          { id: 'e', title: 'e', shortcut: 'Mod+W', run: noop },
+          {
+            id: 'f',
+            title: 'f',
+            shortcut: { mac: ['P'], other: ['Q'] },
+            run: noop,
+          },
+        ],
+      },
+      'mac',
+    )
+    expect(
+      getPageCommands().map((entry) => [entry.command.id, entry.bindings]),
+    ).toEqual([
+      ['a', []],
+      ['b', []],
+      ['c', []],
+      ['d', []],
+      ['e', []],
+      ['f', ['P']],
+    ])
+    expect(console.warn).toHaveBeenCalledTimes(5)
+  })
+
+  it('lets a re-registration from the same pane replace the older one', () => {
+    registerPageCommands(
+      {
+        pageId: 'chat',
+        source: 'page',
+        paneId: 'pane-1',
+        commands: [
+          { id: 'stop', title: 'Stop', enabled: () => false, run: noop },
+        ],
+      },
+      'mac',
+    )
+    registerPageCommands(
+      {
+        pageId: 'chat',
+        source: 'page',
+        paneId: 'pane-1',
+        commands: [
+          { id: 'stop', title: 'Stop', enabled: () => true, run: noop },
+        ],
+      },
+      'mac',
+    )
+    const entries = getPageCommands()
+    expect(entries).toHaveLength(1)
+    expect(entries[0].command.enabled?.()).toBe(true)
+  })
+})

--- a/console/web/src/lib/page-commands.ts
+++ b/console/web/src/lib/page-commands.ts
@@ -97,7 +97,8 @@ function claimedBindings(
   // Only a mounted page may hold keys: they are scoped to its pane. A
   // worker-level command is a palette row, so the console's global keymap
   // stays the console's.
-  if (registration.source !== 'page') return []
+  if (registration.source !== 'page' || registration.paneId === undefined)
+    return []
   if (command.shortcut === undefined) return []
   const wanted =
     typeof command.shortcut === 'string'

--- a/console/web/src/lib/page-commands.ts
+++ b/console/web/src/lib/page-commands.ts
@@ -89,39 +89,43 @@ export function registerPageCommands(
   }
 }
 
+function claimedBindings(
+  registration: PageCommandRegistration,
+  command: PageCommand,
+  platform: ReturnType<typeof shortcutPlatform>,
+): readonly string[] {
+  // Only a mounted page may hold keys: they are scoped to its pane. A
+  // worker-level command is a palette row, so the console's global keymap
+  // stays the console's.
+  if (registration.source !== 'page') return []
+  if (command.shortcut === undefined) return []
+  const wanted =
+    typeof command.shortcut === 'string'
+      ? [command.shortcut]
+      : resolveBindings(command.shortcut, platform)
+  return wanted.filter((binding) => {
+    const reason = shortcutClaimReason(binding, platform)
+    if (reason) {
+      console.warn(
+        `[iii-ui] page '${registration.pageId}' command '${command.id}' cannot bind '${binding}': ${reason}`,
+      )
+    }
+    return reason === null
+  })
+}
+
 function toEntry(
   registration: PageCommandRegistration,
   command: PageCommand,
   platform: ReturnType<typeof shortcutPlatform>,
 ): RegisteredPageCommand {
-  const wanted =
-    command.shortcut === undefined
-      ? []
-      : typeof command.shortcut === 'string'
-        ? [command.shortcut]
-        : resolveBindings(command.shortcut, platform)
-  // Only a mounted page may hold keys: they are scoped to its pane. A
-  // worker-level command is a palette row, so the console's global keymap
-  // stays the console's.
-  const bindings =
-    registration.source === 'page'
-      ? wanted.filter((binding) => {
-          const reason = shortcutClaimReason(binding, platform)
-          if (reason) {
-            console.warn(
-              `[iii-ui] page '${registration.pageId}' command '${command.id}' cannot bind '${binding}': ${reason}`,
-            )
-          }
-          return reason === null
-        })
-      : []
   return {
     key: `${registration.pageId}.${command.id}`,
     pageId: registration.pageId,
     pageTitle: registration.pageTitle,
     source: registration.source,
     paneId: registration.paneId,
-    bindings,
+    bindings: claimedBindings(registration, command, platform),
     command,
   }
 }

--- a/console/web/src/lib/page-commands.ts
+++ b/console/web/src/lib/page-commands.ts
@@ -1,0 +1,157 @@
+/**
+ * Commands a page contributes to the palette and, while its pane has the
+ * focus, to the keyboard.
+ *
+ * Two registration points land here. A worker's setup script registers
+ * commands for a page it owns (`host.commands.register`): those live exactly
+ * as long as the script, torn down with its other registrations when the
+ * worker's assets are removed on disconnect or hot reload. A mounted page
+ * registers commands through `PageRenderProps.commands`: those live while the
+ * page is mounted in a pane and may carry keys, which fire only while focus is
+ * inside that pane. Either way a worker that is not connected has no rows and
+ * no keys, without any presence plumbing of its own.
+ */
+
+import { useSyncExternalStore } from 'react'
+import { shortcutPlatform } from '@/lib/keybindings/bindings'
+import {
+  resolveBindings,
+  shortcutClaimReason,
+} from '@/lib/keybindings/registry'
+import type { PageCommand } from '@/types/injectable-ui'
+
+export type PageCommandSource = 'worker' | 'page'
+
+export interface RegisteredPageCommand {
+  /** `${pageId}.${command.id}`: unique across pages, stable across renders. */
+  key: string
+  pageId: string
+  /** The page's title when known at registration; the palette falls back to
+   *  the registered page's title, then the id. */
+  pageTitle?: string
+  source: PageCommandSource
+  /** The pane a page-level registration belongs to; keys fire only there. */
+  paneId?: string
+  /** Bindings for this platform, after the ones that collide with the
+   *  console's own keys were refused. */
+  bindings: readonly string[]
+  command: PageCommand
+}
+
+let snapshot: readonly RegisteredPageCommand[] = []
+const listeners = new Set<() => void>()
+
+function emit(): void {
+  for (const listener of [...listeners]) listener()
+}
+
+export interface PageCommandRegistration {
+  pageId: string
+  pageTitle?: string
+  source: PageCommandSource
+  paneId?: string
+  commands: readonly PageCommand[]
+}
+
+/** Register a page's commands; the return value removes exactly those. */
+export function registerPageCommands(
+  registration: PageCommandRegistration,
+  platform = shortcutPlatform(),
+): () => void {
+  const entries = registration.commands.map((command) =>
+    toEntry(registration, command, platform),
+  )
+  const keys = new Set(entries.map((entry) => entry.key))
+  const shadowed = snapshot.filter(
+    (entry) =>
+      keys.has(entry.key) &&
+      entry.source === registration.source &&
+      entry.paneId === registration.paneId,
+  )
+  if (shadowed.length > 0) {
+    console.warn(
+      `[iii-ui] page '${registration.pageId}' re-registered commands ${shadowed
+        .map((entry) => `'${entry.command.id}'`)
+        .join(', ')}; the newer registration wins`,
+    )
+  }
+  snapshot = [
+    ...snapshot.filter((entry) => !shadowed.includes(entry)),
+    ...entries,
+  ]
+  emit()
+  let removed = false
+  return () => {
+    if (removed) return
+    removed = true
+    snapshot = snapshot.filter((entry) => !entries.includes(entry))
+    emit()
+  }
+}
+
+function toEntry(
+  registration: PageCommandRegistration,
+  command: PageCommand,
+  platform: ReturnType<typeof shortcutPlatform>,
+): RegisteredPageCommand {
+  const wanted =
+    command.shortcut === undefined
+      ? []
+      : typeof command.shortcut === 'string'
+        ? [command.shortcut]
+        : resolveBindings(command.shortcut, platform)
+  // Only a mounted page may hold keys: they are scoped to its pane. A
+  // worker-level command is a palette row, so the console's global keymap
+  // stays the console's.
+  const bindings =
+    registration.source === 'page'
+      ? wanted.filter((binding) => {
+          const reason = shortcutClaimReason(binding, platform)
+          if (reason) {
+            console.warn(
+              `[iii-ui] page '${registration.pageId}' command '${command.id}' cannot bind '${binding}': ${reason}`,
+            )
+          }
+          return reason === null
+        })
+      : []
+  return {
+    key: `${registration.pageId}.${command.id}`,
+    pageId: registration.pageId,
+    pageTitle: registration.pageTitle,
+    source: registration.source,
+    paneId: registration.paneId,
+    bindings,
+    command,
+  }
+}
+
+export function getPageCommands(): readonly RegisteredPageCommand[] {
+  return snapshot
+}
+
+/** The keyed commands of one pane, for the dispatcher. */
+export function paneCommands(paneId: string): readonly RegisteredPageCommand[] {
+  return snapshot.filter(
+    (entry) => entry.paneId === paneId && entry.bindings.length > 0,
+  )
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+const EMPTY: readonly RegisteredPageCommand[] = []
+
+export function usePageCommands(): readonly RegisteredPageCommand[] {
+  return useSyncExternalStore(subscribe, getPageCommands, () => EMPTY)
+}
+
+/** Tests only. */
+export function resetPageCommands(): void {
+  snapshot = []
+  emit()
+}

--- a/console/web/src/lib/palette/open-request.ts
+++ b/console/web/src/lib/palette/open-request.ts
@@ -1,0 +1,24 @@
+/**
+ * Anyone may ask for the palette: a worker's "Open file…" row opens it on
+ * `#` so the next keystrokes already search files, the way an editor's
+ * command hands over to its quick open.
+ */
+
+export interface PaletteOpenRequest {
+  query?: string
+}
+
+type Listener = (request: PaletteOpenRequest) => void
+
+const listeners = new Set<Listener>()
+
+export function requestPaletteOpen(request: PaletteOpenRequest = {}): void {
+  for (const listener of [...listeners]) listener(request)
+}
+
+export function onPaletteOpenRequest(listener: Listener): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}

--- a/console/web/src/lib/palette/providers.test.ts
+++ b/console/web/src/lib/palette/providers.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  getPaletteSources,
+  registerPaletteSource,
+  resetPaletteSources,
+  searchPaletteSources,
+} from './providers'
+import { loadRecents, recentOf, recordRecent } from './recents'
+import { groupEntries, parseQuery, scoreEntry } from './sources'
+
+const noop = () => {}
+
+describe('parseQuery', () => {
+  it('reads a prefix as a mode and strips it from the text', () => {
+    expect(parseQuery('#main', 'all')).toEqual({
+      prefix: '#',
+      kinds: new Set(['file']),
+      text: 'main',
+    })
+    expect(parseQuery('> open', 'all')).toEqual({
+      prefix: '>',
+      kinds: new Set(['command', 'action']),
+      text: 'open',
+    })
+    expect(parseQuery('/stop', 'chat').kinds).toEqual(
+      new Set(['command', 'action']),
+    )
+    expect(parseQuery('@standup', 'all').kinds).toEqual(new Set(['chat']))
+  })
+
+  it('otherwise keeps the chip filter', () => {
+    expect(parseQuery(' open file ', 'all')).toEqual({
+      prefix: null,
+      kinds: null,
+      text: 'open file',
+    })
+    expect(parseQuery('x', 'worker').kinds).toEqual(new Set(['worker']))
+  })
+})
+
+describe('scoreEntry with several words', () => {
+  const entry = {
+    id: 'c',
+    kind: 'command' as const,
+    title: 'Shell: Open file…',
+    detail: 'Find a file by name',
+    run: noop,
+  }
+  it('matches words in any order and needs every word', () => {
+    expect(scoreEntry(entry, 'open file')).toBeGreaterThan(0)
+    expect(scoreEntry(entry, 'file open')).toBeGreaterThan(0)
+    expect(scoreEntry(entry, 'file shell')).toBeGreaterThan(0)
+    expect(scoreEntry(entry, 'open nothing')).toBe(0)
+  })
+})
+
+describe('palette sources', () => {
+  beforeEach(() => {
+    resetPaletteSources()
+    vi.spyOn(console, 'warn').mockImplementation(noop)
+  })
+  afterEach(() => vi.restoreAllMocks())
+
+  const files = (rows: string[]) => ({
+    id: 'files',
+    title: 'Files',
+    kind: 'file' as const,
+    prefix: '#',
+    minQuery: 3,
+    search: async (query: string) =>
+      rows
+        .filter((row) => row.includes(query))
+        .map((row) => ({ id: row, title: row, run: noop })),
+  })
+
+  it('exists only while registered and is keyed by scope', () => {
+    const off = registerPaletteSource('shell', files([]))
+    expect(getPaletteSources().map((s) => s.key)).toEqual(['shell.files'])
+    off()
+    expect(getPaletteSources()).toEqual([])
+  })
+
+  it('answers with its prefix at any length, otherwise from minQuery', async () => {
+    registerPaletteSource('shell', files(['src/main.rs', 'README.md']))
+    const sources = getPaletteSources()
+    const ask = (text: string, prefix: string | null) =>
+      searchPaletteSources(sources, {
+        text,
+        prefix,
+        kinds: prefix === '#' ? new Set(['file']) : null,
+        workingDir: null,
+        signal: new AbortController().signal,
+      })
+    expect(await ask('ma', null)).toEqual([])
+    expect((await ask('mai', null)).map((e) => e.title)).toEqual([
+      'src/main.rs',
+    ])
+    expect((await ask('m', '#')).map((e) => e.title)).toEqual([
+      'src/main.rs',
+      'README.md',
+    ])
+  })
+
+  it('skips a source outside the mode and one that throws', async () => {
+    registerPaletteSource('shell', files(['src/main.rs']))
+    registerPaletteSource('other', {
+      id: 'broken',
+      title: 'Broken',
+      kind: 'item',
+      search: async () => {
+        throw new Error('no')
+      },
+    })
+    const rows = await searchPaletteSources(getPaletteSources(), {
+      text: 'main',
+      prefix: '>',
+      kinds: new Set(['command', 'action']),
+      workingDir: null,
+      signal: new AbortController().signal,
+    })
+    expect(rows).toEqual([])
+    const all = await searchPaletteSources(getPaletteSources(), {
+      text: 'main',
+      prefix: null,
+      kinds: null,
+      workingDir: null,
+      signal: new AbortController().signal,
+    })
+    expect(all.map((e) => e.id)).toEqual(['source:shell.files:src/main.rs'])
+  })
+
+  it('drops an answer the palette has moved past', async () => {
+    registerPaletteSource('shell', files(['src/main.rs']))
+    const controller = new AbortController()
+    const pending = searchPaletteSources(getPaletteSources(), {
+      text: 'main',
+      prefix: null,
+      kinds: null,
+      workingDir: null,
+      signal: controller.signal,
+    })
+    controller.abort()
+    expect(await pending).toEqual([])
+  })
+})
+
+describe('recents', () => {
+  beforeEach(() => {
+    const store = new Map<string, string>()
+    vi.stubGlobal('window', {
+      localStorage: {
+        getItem: (key: string) => store.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+          store.set(key, value)
+        },
+      },
+    })
+  })
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('keeps the newest ten, most recent first, and leads the empty query', () => {
+    for (let i = 0; i < 12; i += 1) recordRecent(`id-${i}`, i)
+    const recents = loadRecents()
+    expect(recents).toHaveLength(10)
+    expect(recents[0].id).toBe('id-11')
+    recordRecent('id-3', 99)
+    expect(loadRecents()[0].id).toBe('id-3')
+
+    const entries = [
+      { id: 'id-3', kind: 'action' as const, title: 'three', run: noop },
+      { id: 'id-11', kind: 'page' as const, title: 'eleven', run: noop },
+      { id: 'other', kind: 'page' as const, title: 'other', run: noop },
+    ]
+    const recent = recentOf(entries, loadRecents())
+    expect(recent.map((e) => e.id)).toEqual(['id-3', 'id-11'])
+    const groups = groupEntries(entries, recent)
+    expect(groups.map(([group, rows]) => [group, rows.length])).toEqual([
+      ['recent', 2],
+      ['page', 1],
+    ])
+  })
+})

--- a/console/web/src/lib/palette/providers.test.ts
+++ b/console/web/src/lib/palette/providers.test.ts
@@ -89,6 +89,7 @@ describe('palette sources', () => {
         prefix,
         kinds: prefix === '#' ? new Set(['file']) : null,
         workingDir: null,
+        conversationId: null,
         signal: new AbortController().signal,
       })
     expect(await ask('ma', null)).toEqual([])
@@ -116,6 +117,7 @@ describe('palette sources', () => {
       prefix: '>',
       kinds: new Set(['command', 'action']),
       workingDir: null,
+      conversationId: null,
       signal: new AbortController().signal,
     })
     expect(rows).toEqual([])
@@ -124,6 +126,7 @@ describe('palette sources', () => {
       prefix: null,
       kinds: null,
       workingDir: null,
+      conversationId: null,
       signal: new AbortController().signal,
     })
     expect(all.map((e) => e.id)).toEqual(['source:shell.files:src/main.rs'])
@@ -137,6 +140,7 @@ describe('palette sources', () => {
       prefix: null,
       kinds: null,
       workingDir: null,
+      conversationId: null,
       signal: controller.signal,
     })
     controller.abort()

--- a/console/web/src/lib/palette/providers.ts
+++ b/console/web/src/lib/palette/providers.ts
@@ -94,17 +94,30 @@ export async function searchPaletteSources(
     if (input.prefix !== null && input.prefix === source.prefix) return true
     return input.text.length >= (source.minQuery ?? 1)
   })
-  const settled = await Promise.allSettled(
-    asked.map(async ({ key, source }) => {
-      const rows = await source.search(input.text, {
-        workingDir: input.workingDir,
-        conversationId: input.conversationId,
-        signal: input.signal,
+  // A source that ignores its abort signal must not hold the whole answer
+  // hostage: the race ends the aggregation the moment the query is stale.
+  const settled = await Promise.race([
+    Promise.allSettled(
+      asked.map(async ({ key, source }) => {
+        const rows = await source.search(input.text, {
+          workingDir: input.workingDir,
+          conversationId: input.conversationId,
+          signal: input.signal,
+        })
+        return rows.map((row) => toEntry(key, source, row))
+      }),
+    ),
+    new Promise<null>((resolve) => {
+      if (input.signal.aborted) {
+        resolve(null)
+        return
+      }
+      input.signal.addEventListener('abort', () => resolve(null), {
+        once: true,
       })
-      return rows.map((row) => toEntry(key, source, row))
     }),
-  )
-  if (input.signal.aborted) return []
+  ])
+  if (settled === null || input.signal.aborted) return []
   return settled.flatMap((result) =>
     result.status === 'fulfilled' ? result.value : [],
   )

--- a/console/web/src/lib/palette/providers.ts
+++ b/console/web/src/lib/palette/providers.ts
@@ -1,0 +1,132 @@
+/**
+ * Live palette sources: a worker answers a query with rows, the way an
+ * editor's quick open lists files as you type.
+ *
+ * A source is registered by a worker's setup script through
+ * `host.palette.registerSource`, rides the same teardown as its other
+ * registrations, and therefore exists only while the worker is connected.
+ * The palette asks every source that fits the current mode, debounced,
+ * with an abort signal for the query it has moved past.
+ */
+
+import { useSyncExternalStore } from 'react'
+import type { PaletteSource, PaletteSourceRow } from '@/types/injectable-ui'
+import type { PaletteEntry, PaletteKind } from './sources'
+
+export interface RegisteredPaletteSource {
+  /** `${scope}.${source.id}`. */
+  key: string
+  scope: string
+  source: PaletteSource
+}
+
+let snapshot: readonly RegisteredPaletteSource[] = []
+const listeners = new Set<() => void>()
+
+function emit(): void {
+  for (const listener of [...listeners]) listener()
+}
+
+export function registerPaletteSource(
+  scope: string,
+  source: PaletteSource,
+): () => void {
+  const entry: RegisteredPaletteSource = {
+    key: `${scope}.${source.id}`,
+    scope,
+    source,
+  }
+  const shadowed = snapshot.find((existing) => existing.key === entry.key)
+  if (shadowed) {
+    console.warn(
+      `[iii-ui] palette source '${entry.key}' registered twice; the newer one wins`,
+    )
+  }
+  snapshot = [...snapshot.filter((existing) => existing !== shadowed), entry]
+  emit()
+  let removed = false
+  return () => {
+    if (removed) return
+    removed = true
+    snapshot = snapshot.filter((existing) => existing !== entry)
+    emit()
+  }
+}
+
+export function getPaletteSources(): readonly RegisteredPaletteSource[] {
+  return snapshot
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+const EMPTY: readonly RegisteredPaletteSource[] = []
+
+export function usePaletteSources(): readonly RegisteredPaletteSource[] {
+  return useSyncExternalStore(subscribe, getPaletteSources, () => EMPTY)
+}
+
+export interface SourceSearchInput {
+  text: string
+  /** The prefix the query was typed with, if any: `#`, `>`, `/`, `@`. */
+  prefix: string | null
+  kinds: ReadonlySet<PaletteKind> | null
+  workingDir: string | null
+  signal: AbortSignal
+}
+
+/**
+ * Ask the sources that fit: the kind must be in the mode, and the query
+ * must be long enough unless it was typed with the source's own prefix. A
+ * source that throws contributes nothing; the others still answer.
+ */
+export async function searchPaletteSources(
+  sources: readonly RegisteredPaletteSource[],
+  input: SourceSearchInput,
+): Promise<PaletteEntry[]> {
+  const asked = sources.filter(({ source }) => {
+    if (input.kinds && !input.kinds.has(source.kind)) return false
+    const minQuery = source.minQuery ?? 1
+    if (input.prefix !== null && input.prefix === source.prefix) return true
+    return input.text.length >= minQuery
+  })
+  const settled = await Promise.allSettled(
+    asked.map(async ({ key, source }) => {
+      const rows = await source.search(input.text, {
+        workingDir: input.workingDir,
+        signal: input.signal,
+      })
+      return rows.map((row) => toEntry(key, source, row))
+    }),
+  )
+  if (input.signal.aborted) return []
+  return settled.flatMap((result) =>
+    result.status === 'fulfilled' ? result.value : [],
+  )
+}
+
+function toEntry(
+  key: string,
+  source: PaletteSource,
+  row: PaletteSourceRow,
+): PaletteEntry {
+  return {
+    id: `source:${key}:${row.id}`,
+    kind: source.kind,
+    title: row.title,
+    detail: row.detail,
+    meta: row.meta ?? source.title,
+    keywords: row.keywords ? [...row.keywords] : undefined,
+    run: row.run,
+  }
+}
+
+/** Tests only. */
+export function resetPaletteSources(): void {
+  snapshot = []
+  emit()
+}

--- a/console/web/src/lib/palette/providers.ts
+++ b/console/web/src/lib/palette/providers.ts
@@ -76,6 +76,7 @@ export interface SourceSearchInput {
   prefix: string | null
   kinds: ReadonlySet<PaletteKind> | null
   workingDir: string | null
+  conversationId: string | null
   signal: AbortSignal
 }
 
@@ -98,6 +99,7 @@ export async function searchPaletteSources(
     asked.map(async ({ key, source }) => {
       const rows = await source.search(input.text, {
         workingDir: input.workingDir,
+        conversationId: input.conversationId,
         signal: input.signal,
       })
       return rows.map((row) => toEntry(key, source, row))

--- a/console/web/src/lib/palette/providers.ts
+++ b/console/web/src/lib/palette/providers.ts
@@ -91,9 +91,8 @@ export async function searchPaletteSources(
 ): Promise<PaletteEntry[]> {
   const asked = sources.filter(({ source }) => {
     if (input.kinds && !input.kinds.has(source.kind)) return false
-    const minQuery = source.minQuery ?? 1
     if (input.prefix !== null && input.prefix === source.prefix) return true
-    return input.text.length >= minQuery
+    return input.text.length >= (source.minQuery ?? 1)
   })
   const settled = await Promise.allSettled(
     asked.map(async ({ key, source }) => {

--- a/console/web/src/lib/palette/recents.ts
+++ b/console/web/src/lib/palette/recents.ts
@@ -1,0 +1,59 @@
+/**
+ * What the palette ran last, so an empty query opens on the things you
+ * reach for: kept per browser in localStorage, newest first, ten deep.
+ */
+
+const KEY = 'iii-palette-recents'
+const LIMIT = 10
+
+export interface RecentEntry {
+  id: string
+  at: number
+}
+
+function storage(): Storage | null {
+  return typeof window === 'undefined' ? null : window.localStorage
+}
+
+export function loadRecents(): RecentEntry[] {
+  try {
+    const raw = storage()?.getItem(KEY)
+    if (!raw) return []
+    const parsed: unknown = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter(
+      (item): item is RecentEntry =>
+        typeof item === 'object' &&
+        item !== null &&
+        typeof (item as RecentEntry).id === 'string' &&
+        typeof (item as RecentEntry).at === 'number',
+    )
+  } catch {
+    return []
+  }
+}
+
+export function recordRecent(id: string, now = Date.now()): RecentEntry[] {
+  const next = [
+    { id, at: now },
+    ...loadRecents().filter((entry) => entry.id !== id),
+  ].slice(0, LIMIT)
+  try {
+    storage()?.setItem(KEY, JSON.stringify(next))
+  } catch {
+    // Private mode or a full store: recents are a convenience, not state.
+  }
+  return next
+}
+
+/** Rows the palette already has, in recency order, for an empty query. */
+export function recentOf<T extends { id: string }>(
+  entries: readonly T[],
+  recents: readonly RecentEntry[],
+): T[] {
+  const byId = new Map(entries.map((entry) => [entry.id, entry]))
+  return recents.flatMap((recent) => {
+    const entry = byId.get(recent.id)
+    return entry ? [entry] : []
+  })
+}

--- a/console/web/src/lib/palette/sources.test.ts
+++ b/console/web/src/lib/palette/sources.test.ts
@@ -32,12 +32,16 @@ describe('scoreEntry', () => {
     expect(anywhere).toBeGreaterThan(0)
   })
 
-  it('falls back to a subsequence, below every literal match', () => {
-    const subsequence = scoreEntry(entry('engine::workers::list'), 'ewl')
+  it('falls back to a subsequence for ids and paths, below every literal match', () => {
+    const fn = entry('engine::workers::list', 'function')
+    const subsequence = scoreEntry(fn, 'ewl')
     expect(subsequence).toBeGreaterThan(0)
-    expect(subsequence).toBeLessThan(
-      scoreEntry(entry('engine::workers::list'), 'workers'),
-    )
+    expect(subsequence).toBeLessThan(scoreEntry(fn, 'workers'))
+  })
+
+  it('never fuzzes a prose title', () => {
+    expect(scoreEntry(entry('Open settings'), 'ping')).toBe(0)
+    expect(scoreEntry(entry('Open settings'), 'settings')).toBeGreaterThan(0)
   })
 
   it('rejects an entry it cannot match at all', () => {

--- a/console/web/src/lib/palette/sources.ts
+++ b/console/web/src/lib/palette/sources.ts
@@ -21,6 +21,7 @@ export type PaletteKind =
   | 'page'
   | 'chat'
   | 'workspace'
+  | 'command'
   | 'action'
 
 export interface PaletteEntry {
@@ -203,12 +204,14 @@ export const KIND_LABEL: Record<PaletteKind, string> = {
   page: 'Pages',
   chat: 'Chats',
   workspace: 'Workspaces',
+  command: 'Commands',
   action: 'Actions',
 }
 
 /** Group in a fixed order so the list does not reshuffle as scores change. */
 export const KIND_ORDER: PaletteKind[] = [
   'action',
+  'command',
   'workspace',
   'page',
   'chat',

--- a/console/web/src/lib/palette/sources.ts
+++ b/console/web/src/lib/palette/sources.ts
@@ -23,6 +23,45 @@ export type PaletteKind =
   | 'workspace'
   | 'command'
   | 'action'
+  | 'file'
+  | 'item'
+
+/** A group header: a kind, or the recents the empty query opens on. */
+export type PaletteGroup = PaletteKind | 'recent'
+
+/**
+ * A leading character picks a mode, the way editors and chat apps do: `>`
+ * and `/` commands, `#` files, `@` chats. The rest of the query is the
+ * search text.
+ */
+export const PREFIX_MODES: Record<string, readonly PaletteKind[]> = {
+  '>': ['command', 'action'],
+  '/': ['command', 'action'],
+  '#': ['file'],
+  '@': ['chat'],
+}
+
+export interface ParsedQuery {
+  prefix: string | null
+  kinds: ReadonlySet<PaletteKind> | null
+  text: string
+}
+
+export function parseQuery(
+  raw: string,
+  filter: PaletteKind | 'all',
+): ParsedQuery {
+  const first = raw[0] ?? ''
+  const mode = PREFIX_MODES[first]
+  if (mode) {
+    return { prefix: first, kinds: new Set(mode), text: raw.slice(1).trim() }
+  }
+  return {
+    prefix: null,
+    kinds: filter === 'all' ? null : new Set([filter]),
+    text: raw.trim(),
+  }
+}
 
 export interface PaletteEntry {
   id: string
@@ -148,13 +187,29 @@ export async function readEngine(): Promise<EngineSnapshot> {
  */
 export function scoreEntry(entry: PaletteEntry, query: string): number {
   if (!query) return 1
-  const needle = query.toLowerCase()
   const haystacks = [
     entry.title,
     entry.detail ?? '',
     ...(entry.keywords ?? []),
   ].map((value) => value.toLowerCase())
+  // Several words match in any order ("file open" finds "Open file…"); the
+  // row scores as its weakest word, so every word has to land somewhere.
+  const words = query.toLowerCase().split(/\s+/).filter(Boolean)
+  if (words.length > 1) {
+    let weakest = Number.POSITIVE_INFINITY
+    for (const word of words) {
+      const score = scoreWord(haystacks, word)
+      if (score === 0) return 0
+      weakest = Math.min(weakest, score)
+    }
+    const whole = scoreWord(haystacks, words.join(' '))
+    return Math.max(whole, weakest)
+  }
+  return scoreWord(haystacks, words[0] ?? '')
+}
 
+function scoreWord(haystacks: string[], needle: string): number {
+  if (!needle) return 1
   let best = 0
   for (const hay of haystacks) {
     if (!hay) continue
@@ -186,10 +241,14 @@ export function scoreEntry(entry: PaletteEntry, query: string): number {
 export function filterEntries(
   entries: PaletteEntry[],
   query: string,
-  kind: PaletteKind | 'all',
+  kind: PaletteKind | 'all' | ReadonlySet<PaletteKind> | null,
 ): PaletteEntry[] {
   const scoped =
-    kind === 'all' ? entries : entries.filter((entry) => entry.kind === kind)
+    kind === 'all' || kind === null
+      ? entries
+      : typeof kind === 'string'
+        ? entries.filter((entry) => entry.kind === kind)
+        : entries.filter((entry) => kind.has(entry.kind))
   if (!query.trim()) return scoped
   return scoped
     .map((entry) => ({ entry, score: scoreEntry(entry, query.trim()) }))
@@ -198,7 +257,8 @@ export function filterEntries(
     .map((row) => row.entry)
 }
 
-export const KIND_LABEL: Record<PaletteKind, string> = {
+export const KIND_LABEL: Record<PaletteGroup, string> = {
+  recent: 'Recent',
   worker: 'Workers',
   function: 'Functions',
   page: 'Pages',
@@ -206,30 +266,39 @@ export const KIND_LABEL: Record<PaletteKind, string> = {
   workspace: 'Workspaces',
   command: 'Commands',
   action: 'Actions',
+  file: 'Files',
+  item: 'Results',
 }
 
 /** Group in a fixed order so the list does not reshuffle as scores change. */
 export const KIND_ORDER: PaletteKind[] = [
-  'action',
+  'file',
   'command',
+  'action',
   'workspace',
   'page',
   'chat',
+  'item',
   'worker',
   'function',
 ]
 
+/** Group in a fixed order so the list does not reshuffle as scores change;
+    `recent` rows, when given, lead and are not repeated below. */
 export function groupEntries(
   entries: PaletteEntry[],
-): Array<[PaletteKind, PaletteEntry[]]> {
+  recent: PaletteEntry[] = [],
+): Array<[PaletteGroup, PaletteEntry[]]> {
+  const recentIds = new Set(recent.map((entry) => entry.id))
   const groups = new Map<PaletteKind, PaletteEntry[]>()
   for (const entry of entries) {
+    if (recentIds.has(entry.id)) continue
     const bucket = groups.get(entry.kind)
     if (bucket) bucket.push(entry)
     else groups.set(entry.kind, [entry])
   }
-  return KIND_ORDER.filter((kind) => groups.has(kind)).map((kind) => [
-    kind,
-    groups.get(kind) as PaletteEntry[],
-  ])
+  const ordered: Array<[PaletteGroup, PaletteEntry[]]> = KIND_ORDER.filter(
+    (kind) => groups.has(kind),
+  ).map((kind) => [kind, groups.get(kind) as PaletteEntry[]])
+  return recent.length > 0 ? [['recent', recent], ...ordered] : ordered
 }

--- a/console/web/src/lib/palette/sources.ts
+++ b/console/web/src/lib/palette/sources.ts
@@ -185,6 +185,15 @@ export async function readEngine(): Promise<EngineSnapshot> {
  * `engine::workers::list`) comes last, because it is the loosest and would
  * otherwise bury the obvious answers.
  */
+/** Kinds whose titles are ids or paths, where `ewl` for `engine::workers::list`
+    is a real habit. Prose titles rank by words only, so "ping" never lands
+    on "Open settings". */
+const SUBSEQUENCE_KINDS: ReadonlySet<PaletteKind> = new Set([
+  'worker',
+  'function',
+  'file',
+])
+
 export function scoreEntry(entry: PaletteEntry, query: string): number {
   if (!query) return 1
   const haystacks = [
@@ -195,20 +204,25 @@ export function scoreEntry(entry: PaletteEntry, query: string): number {
   // Several words match in any order ("file open" finds "Open file…"); the
   // row scores as its weakest word, so every word has to land somewhere.
   const words = query.toLowerCase().split(/\s+/).filter(Boolean)
+  const fuzzy = SUBSEQUENCE_KINDS.has(entry.kind)
   if (words.length > 1) {
     let weakest = Number.POSITIVE_INFINITY
     for (const word of words) {
-      const score = scoreWord(haystacks, word)
+      const score = scoreWord(haystacks, word, fuzzy)
       if (score === 0) return 0
       weakest = Math.min(weakest, score)
     }
-    const whole = scoreWord(haystacks, words.join(' '))
+    const whole = scoreWord(haystacks, words.join(' '), fuzzy)
     return Math.max(whole, weakest)
   }
-  return scoreWord(haystacks, words[0] ?? '')
+  return scoreWord(haystacks, words[0] ?? '', fuzzy)
 }
 
-function scoreWord(haystacks: string[], needle: string): number {
+function scoreWord(
+  haystacks: string[],
+  needle: string,
+  fuzzy: boolean,
+): number {
   if (!needle) return 1
   let best = 0
   for (const hay of haystacks) {
@@ -226,6 +240,7 @@ function scoreWord(haystacks: string[], needle: string): number {
     }
   }
   if (best > 0) return best
+  if (!fuzzy) return 0
 
   // Subsequence: every needle character appears in order.
   const title = haystacks[0]

--- a/console/web/src/lib/pane-focus.ts
+++ b/console/web/src/lib/pane-focus.ts
@@ -1,0 +1,42 @@
+/**
+ * Focus handoff for a screen the keyboard asked for.
+ *
+ * Opening a page from the palette, a go-to chord, a deep link or a worker's
+ * `panels.open` records the screen here; the workspace panes consume the
+ * request once that screen has a pane and move focus into it, so the next
+ * keystroke already goes to the page instead of to wherever the pointer was.
+ */
+
+let requested: string | null = null
+
+export function requestPaneFocus(screen: string): void {
+  requested = screen
+}
+
+/** The pending screen, if it is among `screens`; consuming clears it. */
+export function takePaneFocusRequest(
+  screens: readonly (string | null)[],
+): string | null {
+  if (requested === null) return null
+  if (!screens.includes(requested)) return null
+  const screen = requested
+  requested = null
+  return screen
+}
+
+export function clearPaneFocusRequest(): void {
+  requested = null
+}
+
+/** Move focus into a pane: its own autofocus target first, else the root. */
+export function focusPane(root: HTMLElement): void {
+  const target = root.querySelector<HTMLElement>('[data-autofocus]') ?? root
+  target.focus({ preventScroll: true })
+}
+
+/** The pane root that contains `node`, if any. */
+export function paneRootOf(node: EventTarget | null): HTMLElement | null {
+  const element = node as Element | null
+  if (typeof element?.closest !== 'function') return null
+  return element.closest<HTMLElement>('[data-workspace-pane-id]')
+}

--- a/console/web/src/lib/table-conformance.test.ts
+++ b/console/web/src/lib/table-conformance.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync, readdirSync } from 'node:fs'
+import { readdirSync, readFileSync } from 'node:fs'
 import { extname, join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 

--- a/console/web/src/lib/ui-loader.tsx
+++ b/console/web/src/lib/ui-loader.tsx
@@ -12,6 +12,7 @@
 
 import { ErrorBoundary } from '@/components/ui/ErrorBoundary'
 import type { IiiClient } from '@/lib/iii-client'
+import { registerPageCommands } from '@/lib/page-commands'
 import { requestPanelOpen } from '@/lib/panel-context'
 import { ExtensionScopeProvider } from '@/lib/ui-scope'
 import {
@@ -141,6 +142,13 @@ function makeHost(
               </ScopedExtension>
             ),
           }),
+        )
+      },
+    },
+    commands: {
+      register(pageId, commands) {
+        return track(
+          registerPageCommands({ pageId, source: 'worker', commands }),
         )
       },
     },

--- a/console/web/src/lib/ui-loader.tsx
+++ b/console/web/src/lib/ui-loader.tsx
@@ -13,6 +13,8 @@
 import { ErrorBoundary } from '@/components/ui/ErrorBoundary'
 import type { IiiClient } from '@/lib/iii-client'
 import { registerPageCommands } from '@/lib/page-commands'
+import { requestPaletteOpen } from '@/lib/palette/open-request'
+import { registerPaletteSource } from '@/lib/palette/providers'
 import { requestPanelOpen } from '@/lib/panel-context'
 import { ExtensionScopeProvider } from '@/lib/ui-scope'
 import {
@@ -150,6 +152,14 @@ function makeHost(
         return track(
           registerPageCommands({ pageId, source: 'worker', commands }),
         )
+      },
+    },
+    palette: {
+      registerSource(source) {
+        return track(registerPaletteSource(scope, source))
+      },
+      open(options) {
+        requestPaletteOpen(options)
       },
     },
     functionTriggers: {

--- a/console/web/src/pages/Ext/index.tsx
+++ b/console/web/src/pages/Ext/index.tsx
@@ -23,7 +23,7 @@ import { PageHeader, PageShell } from '@/components/ui/PageChrome'
 import { useExtPageRoute } from '@/hooks/use-hash-route'
 import { usePanelContext } from '@/lib/panel-context'
 import { useExtPages } from '@/lib/ui-slots'
-import type { PanelSide } from '@/types/injectable-ui'
+import type { PageCommandsApi, PanelSide } from '@/types/injectable-ui'
 
 interface ExtPageProps {
   onMissing: () => void
@@ -58,6 +58,7 @@ interface ExtPageProps {
   conversationId?: string | null
   /** Report unsaved work so closing the pane or workspace asks first. */
   setDirty?: (dirty: boolean | string) => void
+  commands?: PageCommandsApi
 }
 
 export function ExtPage({
@@ -69,6 +70,7 @@ export function ExtPage({
   workingDir,
   conversationId,
   setDirty,
+  commands,
 }: ExtPageProps) {
   const routePageId = useExtPageRoute()
   const pageId = pageIdProp ?? routePageId
@@ -133,6 +135,7 @@ export function ExtPage({
         panelContext={panelContext}
         conversationId={conversationId}
         setDirty={setDirty}
+        commands={commands}
       />
     </div>
   )

--- a/console/web/src/pages/TracesV2/hooks/useFollowTurns.ts
+++ b/console/web/src/pages/TracesV2/hooks/useFollowTurns.ts
@@ -13,14 +13,10 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useCallback, useState } from 'react'
 import {
-  type ConsoleConfigValue,
-  fetchConsoleConfigValue,
-  setConsoleConfigValue,
-} from '@/lib/console-config'
-
-// Same key as `useTraceViews` / `useSpanFilterSelection` — all three hooks
-// read the one `console` entry, sharing the React Query cache.
-const CONSOLE_CONFIG_QUERY_KEY = ['consoleConfig']
+  CONSOLE_CONFIG_QUERY_KEY,
+  consoleConfigWriter,
+} from '@/hooks/lib/console-config-writer'
+import type { ConsoleConfigValue } from '@/lib/console-config'
 
 /** Parse `traces.followTurns` out of the raw console-config value.
  *  `undefined` = no choice recorded (callers default to ON). */
@@ -53,10 +49,11 @@ export interface UseFollowTurnsReturn {
 
 export function useFollowTurns(): UseFollowTurnsReturn {
   const qc = useQueryClient()
+  const writer = consoleConfigWriter(qc)
 
   const { data } = useQuery<ConsoleConfigValue | null>({
     queryKey: CONSOLE_CONFIG_QUERY_KEY,
-    queryFn: fetchConsoleConfigValue,
+    queryFn: () => writer.readForQuery(),
     staleTime: 30_000,
     retry: 1,
   })
@@ -69,13 +66,12 @@ export function useFollowTurns(): UseFollowTurnsReturn {
 
   const mutation = useMutation({
     mutationFn: async (on: boolean) => {
-      const current = (await fetchConsoleConfigValue()) ?? {}
-      const next = withFollowTurns(current, on)
-      await setConsoleConfigValue(next)
+      const next = writer.enqueue(
+        (value) => withFollowTurns(value, on),
+        data ?? {},
+      )
+      await writer.whenIdle()
       return next
-    },
-    onSuccess: (next) => {
-      qc.setQueryData(CONSOLE_CONFIG_QUERY_KEY, next)
     },
   })
 

--- a/console/web/src/pages/TracesV2/hooks/useSpanFilterSelection.ts
+++ b/console/web/src/pages/TracesV2/hooks/useSpanFilterSelection.ts
@@ -23,10 +23,10 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
-  type ConsoleConfigValue,
-  fetchConsoleConfigValue,
-  setConsoleConfigValue,
-} from '@/lib/console-config'
+  CONSOLE_CONFIG_QUERY_KEY,
+  consoleConfigWriter,
+} from '@/hooks/lib/console-config-writer'
+import type { ConsoleConfigValue } from '@/lib/console-config'
 import {
   EMPTY_HIDDEN_IDS,
   fetchTraceHiddenFunctionIds,
@@ -40,19 +40,16 @@ import {
   withSpanFilters,
 } from '../lib/spanFilters'
 
-// Same key as `useTraceViews` — both hooks read the one `console` entry,
-// sharing the React Query cache.
-const CONSOLE_CONFIG_QUERY_KEY = ['consoleConfig']
-
 const TRACE_HIDDEN_FUNCTIONS_QUERY_KEY = ['traceHiddenFunctions']
 
 const SAVE_DEBOUNCE_MS = 400
 
 export function useSpanFilterSelection(): SpanFilterControls {
   const qc = useQueryClient()
+  const writer = consoleConfigWriter(qc)
   const { data } = useQuery<ConsoleConfigValue | null>({
     queryKey: CONSOLE_CONFIG_QUERY_KEY,
-    queryFn: fetchConsoleConfigValue,
+    queryFn: () => writer.readForQuery(),
     staleTime: 30_000,
     retry: 1,
   })
@@ -82,18 +79,16 @@ export function useSpanFilterSelection(): SpanFilterControls {
 
   const persist = useCallback(
     async (next: SpanFilterPrefs) => {
+      // Configuration worker unavailable — keep the selection in-memory.
+      if (data == null) return
       try {
-        const current = await fetchConsoleConfigValue()
-        // Configuration worker unavailable — keep the selection in-memory.
-        if (current == null) return
-        const value = withSpanFilters(current, next)
-        await setConsoleConfigValue(value)
-        qc.setQueryData(CONSOLE_CONFIG_QUERY_KEY, value)
+        writer.enqueue((value) => withSpanFilters(value, next), data)
+        await writer.whenIdle()
       } catch {
         // Best-effort persistence; the in-memory selection stays live.
       }
     },
-    [qc],
+    [data, writer],
   )
 
   // Debounced save: a burst of toggles collapses into one write. `dirty`

--- a/console/web/src/pages/TracesV2/hooks/useTraceViews.ts
+++ b/console/web/src/pages/TracesV2/hooks/useTraceViews.ts
@@ -14,10 +14,10 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useCallback, useState } from 'react'
 import {
-  type ConsoleConfigValue,
-  fetchConsoleConfigValue,
-  setConsoleConfigValue,
-} from '@/lib/console-config'
+  CONSOLE_CONFIG_QUERY_KEY,
+  consoleConfigWriter,
+} from '@/hooks/lib/console-config-writer'
+import type { ConsoleConfigValue } from '@/lib/console-config'
 import {
   DEFAULT_VIEW_ID,
   newViewId,
@@ -28,8 +28,6 @@ import {
   withActiveViewId,
   withViews,
 } from '../lib/tracesViews'
-
-const CONSOLE_CONFIG_QUERY_KEY = ['consoleConfig']
 
 export interface UseTraceViewsReturn {
   views: TracesView[]
@@ -46,10 +44,11 @@ export interface UseTraceViewsReturn {
 
 export function useTraceViews(): UseTraceViewsReturn {
   const qc = useQueryClient()
+  const writer = consoleConfigWriter(qc)
 
   const { data, isLoading } = useQuery<ConsoleConfigValue | null>({
     queryKey: CONSOLE_CONFIG_QUERY_KEY,
-    queryFn: fetchConsoleConfigValue,
+    queryFn: () => writer.readForQuery(),
     staleTime: 30_000,
     retry: 1,
   })
@@ -72,19 +71,16 @@ export function useTraceViews(): UseTraceViewsReturn {
   const activeViewId =
     chosenViewId === undefined ? (serverViewId ?? null) : chosenViewId
 
-  // One mutation funnel: take the freshest server value, transform the whole
-  // entry value, write it back, then refresh the cache.
+  // One mutation funnel through the shared writer: the transform is applied
+  // optimistically, rebased on the freshest server value when its turn
+  // comes, and published to the cache by the writer, never by this hook.
   const mutation = useMutation({
     mutationFn: async (
       transform: (value: ConsoleConfigValue) => ConsoleConfigValue,
     ) => {
-      const current = (await fetchConsoleConfigValue()) ?? {}
-      const next = transform(current)
-      await setConsoleConfigValue(next)
+      const next = writer.enqueue(transform, data ?? {})
+      await writer.whenIdle()
       return next
-    },
-    onSuccess: (next) => {
-      qc.setQueryData(CONSOLE_CONFIG_QUERY_KEY, next)
     },
   })
 

--- a/console/web/src/pages/TracesV2/index.tsx
+++ b/console/web/src/pages/TracesV2/index.tsx
@@ -43,6 +43,7 @@ import { useConversationsCtxOptional } from '@/lib/conversations-context'
 import { getIiiClient } from '@/lib/iii-client'
 import { startTraceSpansStream } from '@/lib/traces-stream'
 import { cn } from '@/lib/utils'
+import type { PageCommandsApi } from '@/types/injectable-ui'
 import { fetchTraces, type StoredSpan } from './api/traces'
 import { GroupedTraceList } from './components/GroupedTraceList'
 import { SpanPanel } from './components/SpanPanel'
@@ -89,9 +90,15 @@ export interface TracesV2Props {
   initialTraceId?: string
   /** Close the hosting pane — the header's standard ✕ when present. */
   onRequestClose?: () => void
+  /** The pane's command registrar: the page's verbs and keys. */
+  commands?: PageCommandsApi
 }
 
-export function TracesV2({ initialTraceId, onRequestClose }: TracesV2Props) {
+export function TracesV2({
+  initialTraceId,
+  onRequestClose,
+  commands,
+}: TracesV2Props) {
   // The strip's system/pause/refresh controls were removed; both stay at
   // their defaults (streams live, internal spans hidden) until some other
   // surface grows a toggle.
@@ -504,17 +511,70 @@ export function TracesV2({ initialTraceId, onRequestClose }: TracesV2Props) {
     selectTrace(initialTraceId)
   }, [initialTraceId, selectTrace])
 
-  // Esc walks back out: span panel first, then the expanded detail.
+  // Esc walks back out: span panel first, then the expanded detail. A
+  // pane-scoped command when the host offers one, so it only fires while
+  // this pane has the focus; the raw listener stays for older hosts.
+  const back = useCallback(() => {
+    if (selectedSpan) setSelectedSpan(null)
+    else selectTrace(null)
+  }, [selectedSpan, selectTrace])
   useEffect(() => {
-    if (!selectedTraceId) return
+    if (commands || !selectedTraceId) return
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return
-      if (selectedSpan) setSelectedSpan(null)
-      else selectTrace(null)
+      back()
     }
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
-  }, [selectedTraceId, selectedSpan, selectTrace])
+  }, [commands, selectedTraceId, back])
+  useEffect(
+    () =>
+      commands?.register([
+        {
+          id: 'search',
+          title: 'Search traces',
+          detail: 'Put the caret in the trace search',
+          keywords: ['filter', 'find'],
+          shortcut: '/',
+          run: () =>
+            document
+              .querySelector<HTMLElement>('[placeholder="search traces..."]')
+              ?.focus(),
+        },
+        {
+          id: 'follow',
+          title: followTurns ? 'Stop following turns' : 'Follow turns',
+          detail: 'Jump to each new turn as it arrives',
+          keywords: ['live', 'tail', 'auto'],
+          shortcut: 'F',
+          run: toggleFollowTurns,
+        },
+        {
+          id: 'clear-filters',
+          title: 'Clear the trace filters',
+          detail: 'Back to every trace',
+          keywords: ['reset', 'filters'],
+          run: resetFilters,
+        },
+        {
+          id: 'back',
+          title: 'Close the trace detail',
+          detail: 'Span panel first, then the expanded trace',
+          keywords: ['escape', 'close', 'collapse'],
+          shortcut: 'Escape',
+          enabled: () => selectedTraceId !== null,
+          run: back,
+        },
+      ]),
+    [
+      commands,
+      followTurns,
+      toggleFollowTurns,
+      resetFilters,
+      selectedTraceId,
+      back,
+    ],
+  )
 
   // The expanded detail, rendered as an accordion item under the selected
   // row (or pinned at the top of the scroll area when that row isn't in the

--- a/console/web/src/pages/TracesV2/index.tsx
+++ b/console/web/src/pages/TracesV2/index.tsx
@@ -114,6 +114,7 @@ export function TracesV2({
   }, [])
 
   const [selectedTraceId, setSelectedTraceId] = useState<string | null>(null)
+  const rootRef = useRef<HTMLElement>(null)
   const [selectedSpan, setSelectedSpan] = useState<VisualizationSpan | null>(
     null,
   )
@@ -537,8 +538,8 @@ export function TracesV2({
           keywords: ['filter', 'find'],
           shortcut: '/',
           run: () =>
-            document
-              .querySelector<HTMLElement>('[placeholder="search traces..."]')
+            rootRef.current
+              ?.querySelector<HTMLElement>('[placeholder="search traces..."]')
               ?.focus(),
         },
         {
@@ -663,6 +664,7 @@ export function TracesV2({
 
   return (
     <section
+      ref={rootRef}
       aria-label="traces"
       className="flex-1 flex flex-col overflow-hidden"
     >

--- a/console/web/src/pages/Workers/index.tsx
+++ b/console/web/src/pages/Workers/index.tsx
@@ -73,7 +73,7 @@ export function Workers({ onRequestClose, commands }: WorkersProps) {
           onClose={closeConfiguration}
         />
       ) : (
-        <PageShell aria-label="workers">
+        <PageShell ref={rootRef} aria-label="workers">
           <PageHeader
             icon={<Blocks />}
             title="Workers"

--- a/console/web/src/pages/Workers/index.tsx
+++ b/console/web/src/pages/Workers/index.tsx
@@ -1,10 +1,12 @@
 import { AlertCircle, Blocks, RefreshCw } from 'lucide-react'
+import { useEffect, useRef } from 'react'
 import { Button } from '@/components/ui/Button'
 import { PageHeader, PageShell } from '@/components/ui/PageChrome'
 import { StatusPanel } from '@/components/ui/StatusPanel'
 import { TooltipProvider } from '@/components/ui/Tooltip'
 import { useWorkersConfigurationRoute } from '@/hooks/use-hash-route'
 import { cn } from '@/lib/utils'
+import type { PageCommandsApi } from '@/types/injectable-ui'
 import { WorkerConfigurationPanel } from './components/WorkerConfigurationPanel'
 import { WorkersFilters } from './components/WorkersFilters'
 import { WorkersTable } from './components/WorkersTable'
@@ -13,9 +15,11 @@ import { useWorkersLive } from './hooks/useWorkersLive'
 interface WorkersProps {
   /** Close the hosting pane — the header's standard ✕ when present. */
   onRequestClose?: () => void
+  /** The pane's command registrar: the page's verbs and keys. */
+  commands?: PageCommandsApi
 }
 
-export function Workers({ onRequestClose }: WorkersProps) {
+export function Workers({ onRequestClose, commands }: WorkersProps) {
   const [configurationRoute, navigateConfiguration, closeConfiguration] =
     useWorkersConfigurationRoute()
   const {
@@ -31,6 +35,32 @@ export function Workers({ onRequestClose }: WorkersProps) {
     stoppingName,
     stopWorker,
   } = useWorkersLive()
+  const rootRef = useRef<HTMLDivElement>(null)
+  useEffect(
+    () =>
+      commands?.register([
+        {
+          id: 'refresh',
+          title: 'Refresh workers',
+          detail: 'Read the fleet again',
+          keywords: ['reload', 'fleet'],
+          shortcut: 'R',
+          run: () => void refetch(),
+        },
+        {
+          id: 'search',
+          title: 'Search workers',
+          detail: 'Put the caret in the filter',
+          keywords: ['filter', 'find'],
+          shortcut: '/',
+          run: () =>
+            rootRef.current
+              ?.querySelector<HTMLElement>('[aria-label="search workers"]')
+              ?.focus(),
+        },
+      ]),
+    [commands, refetch],
+  )
 
   const countLabel = isLoading ? '…' : String(allRows.length)
 

--- a/console/web/src/types/injectable-ui.ts
+++ b/console/web/src/types/injectable-ui.ts
@@ -176,6 +176,8 @@ export interface PaletteSourceRow {
 }
 
 export interface PaletteSearchContext {
+  /** The active chat session, for data that lives per conversation. */
+  conversationId: string | null
   /** The active chat's working directory, when one is set. */
   workingDir: string | null
   /** Set when the palette has moved past this query; drop the answer. */

--- a/console/web/src/types/injectable-ui.ts
+++ b/console/web/src/types/injectable-ui.ts
@@ -123,6 +123,44 @@ export interface PageRenderProps {
    * asks first. Absent on older consoles; feature-detect before calling.
    */
   setDirty?: (dirty: boolean | string) => void
+  /**
+   * Contribute commands while mounted: rows in the command palette, and keys
+   * that fire only while focus is inside this pane. Register in an effect and
+   * return its remover. Absent on older consoles; feature-detect.
+   */
+  commands?: PageCommandsApi
+}
+
+/** A binding in the console's shortcut syntax: `Mod+S`, `Shift+Enter`, or a
+    sequence of chords separated by a space, `G L`. */
+export type PageShortcut =
+  | string
+  | { mac: readonly string[]; other: readonly string[] }
+
+/**
+ * One thing a page can do for the keyboard. The palette lists it as
+ * `Page: Title` with its key on the right, so the key is learned in passing.
+ */
+export interface PageCommand {
+  /** Unique within the page; the console namespaces it with the page id. */
+  id: string
+  title: string
+  detail?: string
+  keywords?: readonly string[]
+  /** Keys are honoured for commands registered by a mounted page only, and
+      only while focus is inside its pane. A key the console already uses is
+      refused with a warning; the row stays. */
+  shortcut?: PageShortcut
+  /** Fire while the caret is in a field. Default false. */
+  firesWhileTyping?: boolean
+  /** Checked when the palette opens and again before the command runs; false
+      hides the row and ignores the key. */
+  enabled?: () => boolean
+  run: () => void
+}
+
+export interface PageCommandsApi {
+  register(commands: readonly PageCommand[]): () => void
 }
 
 export interface PageRegistration {
@@ -362,6 +400,15 @@ export interface Host {
   path: string
   pages: {
     register(page: PageRegistration): () => void
+  }
+  commands: {
+    /**
+     * Palette rows for a page this script owns, alive exactly as long as the
+     * script: removed with its other registrations when the worker leaves.
+     * For a page that may not be open yet; `run` usually calls
+     * `panels.open`. Keys are not honoured here, only on a mounted page.
+     */
+    register(pageId: string, commands: readonly PageCommand[]): () => void
   }
   functionTriggers: {
     register(renderer: FunctionTriggerRenderer): () => void

--- a/console/web/src/types/injectable-ui.ts
+++ b/console/web/src/types/injectable-ui.ts
@@ -163,6 +163,53 @@ export interface PageCommandsApi {
   register(commands: readonly PageCommand[]): () => void
 }
 
+/** One answer a palette source gives for a query. */
+export interface PaletteSourceRow {
+  /** Unique within the source for this query; the console namespaces it. */
+  id: string
+  title: string
+  detail?: string
+  /** Right-hand tag; defaults to the source's title. */
+  meta?: string
+  keywords?: readonly string[]
+  run: () => void
+}
+
+export interface PaletteSearchContext {
+  /** The active chat's working directory, when one is set. */
+  workingDir: string | null
+  /** Set when the palette has moved past this query; drop the answer. */
+  signal: AbortSignal
+}
+
+/**
+ * A live palette source: rows computed per query by a worker, the way an
+ * editor's quick open lists files as you type. Registered from a script's
+ * setup, so it exists only while the worker is connected.
+ */
+export interface PaletteSource {
+  /** Unique within the script. */
+  id: string
+  /** Group label in the palette: "Files". */
+  title: string
+  /** Which kind its rows are; `file` rows get the file icon and answer the
+      `#` prefix, `item` is anything else. */
+  kind: 'file' | 'item'
+  /** A one-character prefix that selects this source alone: `#`. */
+  prefix?: string
+  /** Fewest characters before the source is asked without its prefix. Default 1. */
+  minQuery?: number
+  search(
+    query: string,
+    context: PaletteSearchContext,
+  ): Promise<readonly PaletteSourceRow[]>
+}
+
+export interface PaletteOpenOptions {
+  /** Text to open with; a prefix (`#`) lands the palette in that mode. */
+  query?: string
+}
+
 export interface PageRegistration {
   /** kebab-case, unique per tab; convention `<worker>-<name>`. Routes at `#/ext/<id>`. */
   id: string
@@ -409,6 +456,12 @@ export interface Host {
      * `panels.open`. Keys are not honoured here, only on a mounted page.
      */
     register(pageId: string, commands: readonly PageCommand[]): () => void
+  }
+  palette: {
+    /** A live source of rows, alive as long as the script. */
+    registerSource(source: PaletteSource): () => void
+    /** Open the palette, optionally on a query or a prefix such as `#`. */
+    open(options?: PaletteOpenOptions): void
   }
   functionTriggers: {
     register(renderer: FunctionTriggerRenderer): () => void

--- a/cron/ui/page.tsx
+++ b/cron/ui/page.tsx
@@ -1,9 +1,11 @@
 import type { Host } from '@iii-dev/console-ui'
 import { CronConfigForm } from './src/configuration'
 import { CronSchedulesPage } from './src/page'
+import { registerCronPalette } from './src/palette'
 import { createCronTriggerActivityRenderer } from './src/trigger-activity'
 
 export default function setup(host: Host) {
+  registerCronPalette(host)
   host.pages.register({
     id: 'cron',
     title: 'cron',

--- a/cron/ui/src/page/index.tsx
+++ b/cron/ui/src/page/index.tsx
@@ -44,11 +44,29 @@ import {
   sendToSession,
 } from '../lib/api'
 import { nextCronRun } from '../lib/cron'
-import { createSchedulePrompt, manualSchedulePrompt, replaceSchedulePrompt } from '../lib/prompts'
+import {
+  createSchedulePrompt,
+  manualSchedulePrompt,
+  replaceSchedulePrompt,
+} from '../lib/prompts'
 import { BindingDetail, TaskDetail } from './detail'
 import { ManualTaskForm, type ManualTaskSpec } from './manual-form'
-import { BindingListRow, BindingRow, cadenceLabel, TaskListRow, TaskRow } from './rows'
-import { byNextRun, countByStatus, type Filter, matchesBindingQuery, matchesFilter, matchesQuery } from './status'
+import { parseCronPanelContext } from './panel-context'
+import {
+  BindingListRow,
+  BindingRow,
+  cadenceLabel,
+  TaskListRow,
+  TaskRow,
+} from './rows'
+import {
+  byNextRun,
+  countByStatus,
+  type Filter,
+  matchesBindingQuery,
+  matchesFilter,
+  matchesQuery,
+} from './status'
 
 type View = 'tasks' | 'bindings'
 type Feedback = { tone: 'success' | 'warn' | 'alert'; message: string }
@@ -87,16 +105,32 @@ function subscribe<T>(
 
 function ClockIcon({ className }: { className?: string }) {
   return (
-    <svg className={className} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+    >
       <circle cx="12" cy="12" r="8.5" stroke="currentColor" strokeWidth="1.7" />
-      <path d="M12 7.5v5l3.3 2" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" />
+      <path
+        d="M12 7.5v5l3.3 2"
+        stroke="currentColor"
+        strokeWidth="1.7"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
     </svg>
   )
 }
 
 function RefreshIcon({ className }: { className?: string }) {
   return (
-    <svg className={className} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+    >
       <path
         d="M19 8a7.5 7.5 0 1 0 .2 7.7M19 4v4h-4"
         stroke="currentColor"
@@ -110,32 +144,74 @@ function RefreshIcon({ className }: { className?: string }) {
 
 function SearchIcon({ className }: { className?: string }) {
   return (
-    <svg className={className} viewBox="0 0 24 24" fill="none" aria-hidden="true">
-      <circle cx="10.8" cy="10.8" r="6.3" stroke="currentColor" strokeWidth="1.7" />
-      <path d="m16 16 4 4" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" />
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+    >
+      <circle
+        cx="10.8"
+        cy="10.8"
+        r="6.3"
+        stroke="currentColor"
+        strokeWidth="1.7"
+      />
+      <path
+        d="m16 16 4 4"
+        stroke="currentColor"
+        strokeWidth="1.7"
+        strokeLinecap="round"
+      />
     </svg>
   )
 }
 
 function PlusIcon({ className }: { className?: string }) {
   return (
-    <svg className={className} viewBox="0 0 24 24" fill="none" aria-hidden="true">
-      <path d="M12 5v14M5 12h14" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+    >
+      <path
+        d="M12 5v14M5 12h14"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+      />
     </svg>
   )
 }
 
 function ChevronIcon({ className }: { className?: string }) {
   return (
-    <svg className={className} viewBox="0 0 24 24" fill="none" aria-hidden="true">
-      <path d="m9 6 6 6-6 6" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" />
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+    >
+      <path
+        d="m9 6 6 6-6 6"
+        stroke="currentColor"
+        strokeWidth="1.7"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
     </svg>
   )
 }
 
 function SparkIcon({ className }: { className?: string }) {
   return (
-    <svg viewBox="0 0 16 16" className={className} aria-hidden="true" fill="currentColor">
+    <svg
+      viewBox="0 0 16 16"
+      className={className}
+      aria-hidden="true"
+      fill="currentColor"
+    >
       <path d="M8 1.5l1.2 3.4 3.3 1.2-3.3 1.2L8 10.7 6.8 7.3 3.5 6.1l3.3-1.2L8 1.5zM12.5 10l.6 1.6 1.6.6-1.6.6-.6 1.6-.6-1.6-1.6-.6 1.6-.6.6-1.6z" />
     </svg>
   )
@@ -143,8 +219,18 @@ function SparkIcon({ className }: { className?: string }) {
 
 function CloseIcon({ className }: { className?: string }) {
   return (
-    <svg className={className} viewBox="0 0 24 24" fill="none" aria-hidden="true">
-      <path d="m7 7 10 10M17 7 7 17" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" />
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+    >
+      <path
+        d="m7 7 10 10M17 7 7 17"
+        stroke="currentColor"
+        strokeWidth="1.7"
+        strokeLinecap="round"
+      />
     </svg>
   )
 }
@@ -154,6 +240,8 @@ export function CronSchedulesPage({
   panelSide = 'left',
   onRequestClose,
   conversationId,
+  panelContext,
+  commands,
 }: { host: Host } & Partial<PageRenderProps>) {
   const [view, setView] = useState<View>('tasks')
   const [tasks, setTasks] = useState<SessionCronTask[]>([])
@@ -168,7 +256,8 @@ export function CronSchedulesPage({
   const [sending, setSending] = useState(false)
   const [feedback, setFeedback] = useState<Feedback | null>(null)
   const [inspector, setInspector] = useState<Inspector>(null)
-  const [replacementTask, setReplacementTask] = useState<SessionCronTask | null>(null)
+  const [replacementTask, setReplacementTask] =
+    useState<SessionCronTask | null>(null)
   const [statusFilter, setStatusFilter] = useState<Filter>('all')
   const [narrow, setNarrow] = useState(false)
   const [now, setNow] = useState(() => new Date())
@@ -188,6 +277,7 @@ export function CronSchedulesPage({
   const inspectorRef = useRef<HTMLElement | null>(null)
   const lastFocus = useRef<HTMLElement | null>(null)
   const composerRef = useRef<HTMLInputElement | null>(null)
+  const searchRef = useRef<HTMLInputElement | null>(null)
   const openConversationRef = useRef<(sessionId: string) => void>(() => {})
 
   /** A schedule runs in a session of its own, and a session that has never
@@ -201,7 +291,8 @@ export function CronSchedulesPage({
     if (!model) {
       setFeedback({
         tone: 'alert',
-        message: 'No model chosen yet. Pick one in a chat composer, then schedule.',
+        message:
+          'No model chosen yet. Pick one in a chat composer, then schedule.',
       })
       setSending(false)
     }
@@ -209,7 +300,10 @@ export function CronSchedulesPage({
   }
 
   const openInspector = useCallback((next: Exclude<Inspector, null>) => {
-    lastFocus.current = document.activeElement instanceof HTMLElement ? document.activeElement : null
+    lastFocus.current =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null
     setInspector(next)
   }, [])
 
@@ -252,7 +346,8 @@ export function CronSchedulesPage({
     } else {
       setBindingsError(errorMessage(bindingsResult.reason))
     }
-    if (functionsResult.status === 'fulfilled') setFunctions(functionsResult.value)
+    if (functionsResult.status === 'fulfilled')
+      setFunctions(functionsResult.value)
     setBindingsLoading(false)
   }, [host])
 
@@ -305,7 +400,9 @@ export function CronSchedulesPage({
     if (!narrow || !inspectorIdentity) return
     const frame = window.requestAnimationFrame(() => {
       inspectorRef.current
-        ?.querySelector<HTMLElement>('button, input, textarea, [tabindex]:not([tabindex="-1"])')
+        ?.querySelector<HTMLElement>(
+          'button, input, textarea, [tabindex]:not([tabindex="-1"])',
+        )
         ?.focus()
     })
     return () => window.cancelAnimationFrame(frame)
@@ -314,13 +411,21 @@ export function CronSchedulesPage({
   useEffect(() => {
     setInspector((current) => {
       if (current?.kind === 'task') {
-        const next = tasks.find((task) => task.subscriptionId === current.task.subscriptionId)
-        if (next) return next === current.task ? current : { kind: 'task', task: next }
+        const next = tasks.find(
+          (task) => task.subscriptionId === current.task.subscriptionId,
+        )
+        if (next)
+          return next === current.task ? current : { kind: 'task', task: next }
         return tasksLoading ? current : null
       }
       if (current?.kind === 'binding') {
-        const next = bindings.find((binding) => binding.id === current.binding.id)
-        if (next) return next === current.binding ? current : { kind: 'binding', binding: next }
+        const next = bindings.find(
+          (binding) => binding.id === current.binding.id,
+        )
+        if (next)
+          return next === current.binding
+            ? current
+            : { kind: 'binding', binding: next }
         return bindingsLoading ? current : null
       }
       return current
@@ -387,7 +492,11 @@ export function CronSchedulesPage({
       } else {
         const title = taskRequest.slice(0, 72)
         awaitedSession.current = { title, since: Date.now() }
-        const sessionId = await createSchedule(host, { title, instruction, model })
+        const sessionId = await createSchedule(host, {
+          title,
+          instruction,
+          model,
+        })
         // Usually the subscription got there first; this covers a console too
         // old to deliver session::created.
         awaitedSession.current = null
@@ -443,7 +552,8 @@ export function CronSchedulesPage({
       closeInspector()
       setFeedback({
         tone: 'success',
-        message: 'Registration request sent. Harness will add the task after the active turn completes the call.',
+        message:
+          'Registration request sent. Harness will add the task after the active turn completes the call.',
       })
     } catch (error) {
       if (request !== sendRequest.current) return
@@ -476,10 +586,16 @@ export function CronSchedulesPage({
 
   const removeTask = async (task: SessionCronTask) => {
     try {
-      const removed = await removeSessionCronTask(host, task.sessionId, task.subscriptionId)
+      const removed = await removeSessionCronTask(
+        host,
+        task.sessionId,
+        task.subscriptionId,
+      )
       setFeedback({
         tone: removed ? 'success' : 'warn',
-        message: removed ? 'Scheduled task removed.' : 'The task was already retired.',
+        message: removed
+          ? 'Scheduled task removed.'
+          : 'The task was already retired.',
       })
       closeInspector()
       await refreshTasks()
@@ -516,7 +632,10 @@ export function CronSchedulesPage({
       ...inspectorRef.current.querySelectorAll<HTMLElement>(
         'button, input, textarea, select, [href], [tabindex]:not([tabindex="-1"])',
       ),
-    ].filter((element) => !element.matches(':disabled') && element.getClientRects().length > 0)
+    ].filter(
+      (element) =>
+        !element.matches(':disabled') && element.getClientRects().length > 0,
+    )
     if (focusable.length === 0) {
       event.preventDefault()
       return
@@ -532,18 +651,51 @@ export function CronSchedulesPage({
     }
   }
 
+  // A context from the palette source (a schedule by subscription id) or the
+  // setup-time "New schedule…" command (`{ action: 'new' }`). A schedule is
+  // left unapplied until it shows up in `tasks` — the page can mount before
+  // the first fetch resolves.
+  const appliedContextRef = useRef(0)
+  useEffect(() => {
+    if (!panelContext || panelContext.id === appliedContextRef.current) return
+    const context = parseCronPanelContext(panelContext.context)
+    if (!context) {
+      appliedContextRef.current = panelContext.id
+      return
+    }
+    if (context.action === 'new') {
+      appliedContextRef.current = panelContext.id
+      setView('tasks')
+      setReplacementTask(null)
+      openInspector({ kind: 'new' })
+      return
+    }
+    const task = tasks.find((t) => t.subscriptionId === context.subscriptionId)
+    if (!task) return // wait for the list to load
+    appliedContextRef.current = panelContext.id
+    setView('tasks')
+    openInspector({ kind: 'task', task })
+  }, [panelContext, tasks, openInspector])
+
   const counts = countByStatus(tasks, now.getTime())
   const orderedTasks = useMemo(() => {
     const runs = new Map(
       tasks.map((task) => [
         task.subscriptionId,
-        nextCronRun(task.expression, now)?.getTime() ?? Number.POSITIVE_INFINITY,
+        nextCronRun(task.expression, now)?.getTime() ??
+          Number.POSITIVE_INFINITY,
       ]),
     )
     return [...tasks]
       .filter((task) => matchesFilter(task, statusFilter, now.getTime()))
-      .filter((task) => matchesQuery(task, cadenceLabel(task.expression), query))
-      .sort(byNextRun((task) => runs.get(task.subscriptionId) ?? Number.POSITIVE_INFINITY))
+      .filter((task) =>
+        matchesQuery(task, cadenceLabel(task.expression), query),
+      )
+      .sort(
+        byNextRun(
+          (task) => runs.get(task.subscriptionId) ?? Number.POSITIVE_INFINITY,
+        ),
+      )
   }, [tasks, statusFilter, query, now])
 
   const orderedBindings = useMemo(
@@ -555,6 +707,51 @@ export function CronSchedulesPage({
   const error = view === 'tasks' ? tasksError : bindingsError
   const showDetail = inspector !== null
   const detailOnly = narrow && showDetail
+
+  // The page's verbs, for the palette and for the keyboard while this pane
+  // has the focus. The keys stay clear of the console's own.
+  useEffect(
+    () =>
+      commands?.register([
+        {
+          id: 'focus-composer',
+          title: 'Focus the schedule composer',
+          detail: 'Describe a routine to schedule in plain language',
+          keywords: ['compose', 'describe'],
+          enabled: () => !detailOnly,
+          run: () => composerRef.current?.focus(),
+        },
+        {
+          id: 'new-schedule',
+          title: 'New schedule',
+          detail: 'Open the manual schedule form',
+          keywords: ['create', 'cron', 'add'],
+          shortcut: 'N',
+          run: () => {
+            setView('tasks')
+            setReplacementTask(null)
+            openInspector({ kind: 'new' })
+          },
+        },
+        {
+          id: 'search',
+          title: 'Search schedules',
+          detail: 'Filter schedules and system bindings by name',
+          keywords: ['filter', 'find'],
+          shortcut: '/',
+          run: () => searchRef.current?.focus(),
+        },
+        {
+          id: 'refresh',
+          title: 'Refresh',
+          detail: 'Reload schedules and system bindings',
+          keywords: ['reload'],
+          shortcut: 'R',
+          run: () => void refreshAll(),
+        },
+      ]),
+    [commands, detailOnly, openInspector, refreshAll],
+  )
 
   const detailBody =
     inspector === null ? null : inspector.kind === 'new' ? (
@@ -601,6 +798,7 @@ export function CronSchedulesPage({
             <div className="cron-ui-search">
               <SearchIcon className={uiClasses.icon} />
               <Input
+                ref={searchRef}
                 type="search"
                 value={query}
                 onChange={setQuery}
@@ -615,7 +813,11 @@ export function CronSchedulesPage({
               onClick={() => void refreshAll()}
               disabled={tasksLoading || bindingsLoading}
             >
-              <RefreshIcon className={loading ? `${uiClasses.icon} cron-ui-spin` : uiClasses.icon} />
+              <RefreshIcon
+                className={
+                  loading ? `${uiClasses.icon} cron-ui-spin` : uiClasses.icon
+                }
+              />
             </IconButton>
             <Button
               variant="primary"
@@ -636,7 +838,10 @@ export function CronSchedulesPage({
       <PageBody side={panelSide}>
         <PageMain className="cron-ui-main">
           {detailOnly ? (
-            <section className="cron-ui-detail-page" aria-label="Schedule details">
+            <section
+              className="cron-ui-detail-page"
+              aria-label="Schedule details"
+            >
               <div className="cron-ui-detail-bar">
                 <Button variant="ghost" size="sm" onClick={closeInspector}>
                   <ChevronIcon className={`${uiClasses.icon} cron-ui-back`} />
@@ -654,9 +859,12 @@ export function CronSchedulesPage({
                   void submitNaturalTask()
                 }}
               >
-                <SparkIcon className={`${uiClasses.icon} cron-ui-composer-icon`} />
+                <SparkIcon
+                  className={`${uiClasses.icon} cron-ui-composer-icon`}
+                />
                 <Input
                   ref={composerRef}
+                  data-autofocus=""
                   value={composer}
                   onChange={setComposer}
                   placeholder={
@@ -677,7 +885,12 @@ export function CronSchedulesPage({
                 </Button>
               </form>
 
-              {feedback ? <StatusPanel variant={feedback.tone} headline={feedback.message} /> : null}
+              {feedback ? (
+                <StatusPanel
+                  variant={feedback.tone}
+                  headline={feedback.message}
+                />
+              ) : null}
 
               {model ? null : (
                 <StatusPanel
@@ -687,7 +900,10 @@ export function CronSchedulesPage({
                 />
               )}
 
-              <Tabs value={view} onValueChange={(value) => setView(value as View)}>
+              <Tabs
+                value={view}
+                onValueChange={(value) => setView(value as View)}
+              >
                 <div className="cron-ui-toolbar">
                   <TabsList>
                     <TabsTrigger value="tasks">
@@ -705,17 +921,39 @@ export function CronSchedulesPage({
                       value={statusFilter}
                       onChange={setStatusFilter}
                       options={[
-                        { value: 'all', label: `All ${counts.all}`, icon: false },
-                        { value: 'active', label: `Active ${counts.active}`, icon: false },
-                        { value: 'ending', label: `Ending soon ${counts.ending}`, icon: false },
-                        { value: 'finished', label: `Finished ${counts.finished}`, icon: false },
+                        {
+                          value: 'all',
+                          label: `All ${counts.all}`,
+                          icon: false,
+                        },
+                        {
+                          value: 'active',
+                          label: `Active ${counts.active}`,
+                          icon: false,
+                        },
+                        {
+                          value: 'ending',
+                          label: `Ending soon ${counts.ending}`,
+                          icon: false,
+                        },
+                        {
+                          value: 'finished',
+                          label: `Finished ${counts.finished}`,
+                          icon: false,
+                        },
                       ]}
                     />
                   ) : null}
                 </div>
 
                 <TabsContent value="tasks" className="cron-ui-tab-content">
-                  {error ? <StatusPanel variant="alert" headline="Could not read schedules" detail={error} /> : null}
+                  {error ? (
+                    <StatusPanel
+                      variant="alert"
+                      headline="Could not read schedules"
+                      detail={error}
+                    />
+                  ) : null}
                   {loading && orderedTasks.length === 0 ? (
                     <div className="cron-ui-skeletons">
                       <Skeleton className="cron-ui-skeleton" />
@@ -725,7 +963,11 @@ export function CronSchedulesPage({
                   ) : orderedTasks.length === 0 ? (
                     <EmptyState
                       icon={ClockIcon}
-                      title={tasks.length === 0 ? 'No schedules yet' : 'Nothing matches'}
+                      title={
+                        tasks.length === 0
+                          ? 'No schedules yet'
+                          : 'Nothing matches'
+                      }
                       description={
                         tasks.length === 0
                           ? 'Describe a routine above, or write the cron expression yourself.'
@@ -750,7 +992,11 @@ export function CronSchedulesPage({
                           key={task.subscriptionId}
                           task={task}
                           now={now}
-                          selected={inspector?.kind === 'task' && inspector.task.subscriptionId === task.subscriptionId}
+                          selected={
+                            inspector?.kind === 'task' &&
+                            inspector.task.subscriptionId ===
+                              task.subscriptionId
+                          }
                           onOpen={() => openInspector({ kind: 'task', task })}
                         />
                       ))}
@@ -766,7 +1012,9 @@ export function CronSchedulesPage({
                               <TableHead>Target</TableHead>
                               <TableHead>Cadence</TableHead>
                               <TableHead>Next run</TableHead>
-                              <TableHead className="cron-ui-cell-numeric">Runs</TableHead>
+                              <TableHead className="cron-ui-cell-numeric">
+                                Runs
+                              </TableHead>
                               <TableHead className="cron-ui-cell-actions">
                                 <span className="cron-ui-sr">Actions</span>
                               </TableHead>
@@ -779,13 +1027,21 @@ export function CronSchedulesPage({
                                 task={task}
                                 now={now}
                                 selected={
-                                  inspector?.kind === 'task' && inspector.task.subscriptionId === task.subscriptionId
+                                  inspector?.kind === 'task' &&
+                                  inspector.task.subscriptionId ===
+                                    task.subscriptionId
                                 }
-                                onOpen={() => openInspector({ kind: 'task', task })}
+                                onOpen={() =>
+                                  openInspector({ kind: 'task', task })
+                                }
                                 onReplace={() => requestTaskChange(task)}
                                 onRemove={() => void removeTask(task)}
-                                onCopyId={() => void copyId(task.subscriptionId)}
-                                onOpenConversation={() => openConversation(task.sessionId)}
+                                onCopyId={() =>
+                                  void copyId(task.subscriptionId)
+                                }
+                                onOpenConversation={() =>
+                                  openConversation(task.sessionId)
+                                }
                               />
                             ))}
                           </TableBody>
@@ -797,7 +1053,11 @@ export function CronSchedulesPage({
 
                 <TabsContent value="bindings" className="cron-ui-tab-content">
                   {bindingsError ? (
-                    <StatusPanel variant="alert" headline="Could not read system bindings" detail={bindingsError} />
+                    <StatusPanel
+                      variant="alert"
+                      headline="Could not read system bindings"
+                      detail={bindingsError}
+                    />
                   ) : null}
                   {orderedBindings.length === 0 ? (
                     <EmptyState
@@ -812,8 +1072,13 @@ export function CronSchedulesPage({
                           key={binding.id}
                           binding={binding}
                           now={now}
-                          selected={inspector?.kind === 'binding' && inspector.binding.id === binding.id}
-                          onOpen={() => openInspector({ kind: 'binding', binding })}
+                          selected={
+                            inspector?.kind === 'binding' &&
+                            inspector.binding.id === binding.id
+                          }
+                          onOpen={() =>
+                            openInspector({ kind: 'binding', binding })
+                          }
                         />
                       ))}
                     </List>
@@ -828,7 +1093,9 @@ export function CronSchedulesPage({
                               <TableHead>Function</TableHead>
                               <TableHead>Cadence</TableHead>
                               <TableHead>Next run</TableHead>
-                              <TableHead className="cron-ui-cell-numeric">Runs</TableHead>
+                              <TableHead className="cron-ui-cell-numeric">
+                                Runs
+                              </TableHead>
                               <TableHead className="cron-ui-cell-actions">
                                 <span className="cron-ui-sr">Actions</span>
                               </TableHead>
@@ -840,8 +1107,13 @@ export function CronSchedulesPage({
                                 key={binding.id}
                                 binding={binding}
                                 now={now}
-                                selected={inspector?.kind === 'binding' && inspector.binding.id === binding.id}
-                                onOpen={() => openInspector({ kind: 'binding', binding })}
+                                selected={
+                                  inspector?.kind === 'binding' &&
+                                  inspector.binding.id === binding.id
+                                }
+                                onOpen={() =>
+                                  openInspector({ kind: 'binding', binding })
+                                }
                               />
                             ))}
                           </TableBody>

--- a/cron/ui/src/page/panel-context.ts
+++ b/cron/ui/src/page/panel-context.ts
@@ -1,0 +1,24 @@
+import type { JsonValue } from '@iii-dev/console-ui'
+
+/** Opens the page on a specific schedule (the palette source) or straight
+    into the new-schedule form (the setup-time command). */
+export type CronPanelContext =
+  | { action: 'new' }
+  | { action: 'schedule'; subscriptionId: string }
+
+function asRecord(value: JsonValue): Record<string, JsonValue> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value
+    : null
+}
+
+export function parseCronPanelContext(
+  value: JsonValue,
+): CronPanelContext | null {
+  const record = asRecord(value)
+  if (!record) return null
+  if (record.action === 'new') return { action: 'new' }
+  if (typeof record.subscriptionId === 'string' && record.subscriptionId !== '')
+    return { action: 'schedule', subscriptionId: record.subscriptionId }
+  return null
+}

--- a/cron/ui/src/page/panel-context.ts
+++ b/cron/ui/src/page/panel-context.ts
@@ -18,7 +18,11 @@ export function parseCronPanelContext(
   const record = asRecord(value)
   if (!record) return null
   if (record.action === 'new') return { action: 'new' }
-  if (typeof record.subscriptionId === 'string' && record.subscriptionId !== '')
+  if (
+    record.action === 'schedule' &&
+    typeof record.subscriptionId === 'string' &&
+    record.subscriptionId !== ''
+  )
     return { action: 'schedule', subscriptionId: record.subscriptionId }
   return null
 }

--- a/cron/ui/src/palette.ts
+++ b/cron/ui/src/palette.ts
@@ -1,0 +1,62 @@
+/**
+ * The cron worker in the command palette, before its page is even open.
+ *
+ * A schedules source answers with every schedule by label, each row opening
+ * the page on that schedule's detail. Registered from setup, so it exists
+ * only while the worker is connected; older consoles without `host.palette`
+ * / `host.commands` simply get nothing.
+ */
+
+import type { Host } from '@iii-dev/console-ui'
+import { listAllSchedules } from './lib/api'
+
+const ROWS = 30
+
+export function registerCronPalette(host: Host): void {
+  host.palette?.registerSource({
+    id: 'cron-schedules',
+    title: 'Schedules',
+    kind: 'item',
+    minQuery: 2,
+    async search(query, { signal }) {
+      const needle = query.trim().toLowerCase()
+      const tasks = await listAllSchedules(host)
+      if (signal.aborted) return []
+      return tasks
+        .filter((task) => (task.label ?? '').toLowerCase().includes(needle))
+        .slice(0, ROWS)
+        .map((task) => ({
+          id: task.subscriptionId,
+          title: task.label ?? 'Untitled schedule',
+          detail: task.expression,
+          keywords: [task.expression],
+          run: () =>
+            host.panels?.open({
+              pageId: 'cron',
+              context: {
+                action: 'schedule',
+                subscriptionId: task.subscriptionId,
+              },
+            }),
+        }))
+    },
+  })
+
+  host.commands?.register('cron', [
+    {
+      id: 'open',
+      title: 'Open schedules',
+      detail: 'Natural-language and manual cron schedules, and system bindings',
+      keywords: ['cron', 'schedule', 'tasks'],
+      run: () => host.panels?.open({ pageId: 'cron', context: {} }),
+    },
+    {
+      id: 'new-schedule',
+      title: 'New schedule…',
+      detail: 'Open the schedule composer',
+      keywords: ['cron', 'create', 'add'],
+      run: () =>
+        host.panels?.open({ pageId: 'cron', context: { action: 'new' } }),
+    },
+  ])
+}

--- a/database/ui/page.tsx
+++ b/database/ui/page.tsx
@@ -24,9 +24,11 @@ import type { Host } from '@iii-dev/console-ui'
 import { DatabaseConfigForm } from './src/configuration'
 import { createDatabaseTriggerRenderer } from './src/function-trigger-message'
 import { DatabasePage } from './src/page'
+import { registerDatabasePalette } from './src/palette'
 
 export default function setup(host: Host) {
   host.functionTriggers.register(createDatabaseTriggerRenderer(host))
+  registerDatabasePalette(host)
 
   host.pages.register({
     id: 'database',

--- a/database/ui/src/page/SchemaTree.tsx
+++ b/database/ui/src/page/SchemaTree.tsx
@@ -40,6 +40,24 @@ interface TableSchema {
   indexes: IndexInfo[]
 }
 
+/** Arrow-key roving across a group's table/view name buttons — the tree has
+    no built-in keyboard nav otherwise, only Tab-per-row. */
+function roveTreeRow(e: React.KeyboardEvent<HTMLUListElement>) {
+  if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return
+  const target = e.target
+  if (!(target instanceof HTMLElement) || !target.matches('.db-tree-name'))
+    return
+  const rows = Array.from(
+    e.currentTarget.querySelectorAll<HTMLButtonElement>('.db-tree-name'),
+  )
+  const i = rows.indexOf(target as HTMLButtonElement)
+  if (i === -1) return
+  e.preventDefault()
+  rows[
+    (i + (e.key === 'ArrowDown' ? 1 : -1) + rows.length) % rows.length
+  ]?.focus()
+}
+
 export function SchemaTree({
   host,
   db,
@@ -121,6 +139,8 @@ export function SchemaTree({
           onChange={setQuery}
           placeholder="Filter tables"
           aria-label="filter tables"
+          data-autofocus=""
+          data-db-tables-filter=""
           onKeyDown={(e) => {
             if (e.key === 'Escape') setQuery('')
           }}
@@ -139,7 +159,7 @@ export function SchemaTree({
             {group.kind === 'view' ? (
               <div className="db-tree-grouphead">Views · {entries.length}</div>
             ) : null}
-            <ul>
+            <ul onKeyDown={roveTreeRow}>
               {entries.map((table) => {
                 const isOpen = expanded.has(table.name)
                 const isSelected = selectedTable === table.name

--- a/database/ui/src/page/SqlPanel.tsx
+++ b/database/ui/src/page/SqlPanel.tsx
@@ -17,7 +17,15 @@ import {
   type Host,
   StatusPanel,
 } from '@iii-dev/console-ui'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import { errText } from '../lib/errors'
 import { type ExplainResult, explain } from '../lib/rpc'
 import {
@@ -57,6 +65,12 @@ interface SqlPanelProps {
    * typed or edited counts.
    */
   onDirtyChange?: (dirty: boolean) => void
+}
+
+/** Imperative handle so the page's `S` command can move focus into the
+    editor once it switches the panel to SQL. */
+export interface SqlPanelHandle {
+  focus(): void
 }
 
 const HISTORY_LIMIT = 20
@@ -129,332 +143,337 @@ function saveHistory(db: string, entries: string[]) {
   }
 }
 
-export function SqlPanel({
-  host,
-  db,
-  seedSql,
-  tables,
-  starterSql,
-  onWrite,
-  onDirtyChange,
-}: SqlPanelProps) {
-  const [sql, setSql] = useState(seedSql ?? '')
-  const completions = useMemo(
-    () => Array.from(new Set([...(tables ?? []), ...SQL_KEYWORDS])),
-    [tables],
-  )
-  const [running, setRunning] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const [outcome, setOutcome] = useState<AdhocResult | null>(null)
-  const [history, setHistory] = useState<string[]>(() => loadHistory(db))
-  const [historyOpen, setHistoryOpen] = useState(false)
-  const [plan, setPlan] = useState<ExplainResult | null>(null)
-  // The statement the current outcome belongs to — once the editor moves on,
-  // the result line dims rather than passing off old numbers as current.
-  const [ranSql, setRanSql] = useState<string | null>(null)
-  const editorRef = useRef<CodeEditorHandle>(null)
-  const actionsRef = useRef<HTMLDivElement>(null)
-  const historyRef = useRef<HTMLDivElement>(null)
-  const historyBtnRef = useRef<HTMLSpanElement>(null)
+export const SqlPanel = forwardRef<SqlPanelHandle, SqlPanelProps>(
+  function SqlPanel(
+    { host, db, seedSql, tables, starterSql, onWrite, onDirtyChange },
+    ref,
+  ) {
+    const [sql, setSql] = useState(seedSql ?? '')
+    const completions = useMemo(
+      () => Array.from(new Set([...(tables ?? []), ...SQL_KEYWORDS])),
+      [tables],
+    )
+    const [running, setRunning] = useState(false)
+    const [error, setError] = useState<string | null>(null)
+    const [outcome, setOutcome] = useState<AdhocResult | null>(null)
+    const [history, setHistory] = useState<string[]>(() => loadHistory(db))
+    const [historyOpen, setHistoryOpen] = useState(false)
+    const [plan, setPlan] = useState<ExplainResult | null>(null)
+    // The statement the current outcome belongs to — once the editor moves on,
+    // the result line dims rather than passing off old numbers as current.
+    const [ranSql, setRanSql] = useState<string | null>(null)
+    const editorRef = useRef<CodeEditorHandle>(null)
+    const actionsRef = useRef<HTMLDivElement>(null)
+    const historyRef = useRef<HTMLDivElement>(null)
+    const historyBtnRef = useRef<HTMLSpanElement>(null)
+    useImperativeHandle(
+      ref,
+      () => ({ focus: () => editorRef.current?.focus() }),
+      [],
+    )
 
-  // Dropdown manners: Escape and clicking elsewhere both dismiss. The
-  // trigger is excluded from "elsewhere" so its own toggle doesn't
-  // close-then-reopen in one click.
-  useEffect(() => {
-    if (!historyOpen) return
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setHistoryOpen(false)
-    }
-    const onDown = (e: MouseEvent) => {
-      const t = e.target
-      if (!(t instanceof Node)) return
-      if (historyRef.current?.contains(t) || historyBtnRef.current?.contains(t))
-        return
-      setHistoryOpen(false)
-    }
-    document.addEventListener('keydown', onKey)
-    document.addEventListener('mousedown', onDown)
-    return () => {
-      document.removeEventListener('keydown', onKey)
-      document.removeEventListener('mousedown', onDown)
-    }
-  }, [historyOpen])
+    // Dropdown manners: Escape and clicking elsewhere both dismiss. The
+    // trigger is excluded from "elsewhere" so its own toggle doesn't
+    // close-then-reopen in one click.
+    useEffect(() => {
+      if (!historyOpen) return
+      const onKey = (e: KeyboardEvent) => {
+        if (e.key === 'Escape') setHistoryOpen(false)
+      }
+      const onDown = (e: MouseEvent) => {
+        const t = e.target
+        if (!(t instanceof Node)) return
+        if (
+          historyRef.current?.contains(t) ||
+          historyBtnRef.current?.contains(t)
+        )
+          return
+        setHistoryOpen(false)
+      }
+      document.addEventListener('keydown', onKey)
+      document.addEventListener('mousedown', onDown)
+      return () => {
+        document.removeEventListener('keydown', onKey)
+        document.removeEventListener('mousedown', onDown)
+      }
+    }, [historyOpen])
 
-  // The last seeded statement, so dirtiness means "the user's own text" —
-  // a seeded prefill must not trip the discard guard.
-  const seededRef = useRef(seedSql ?? '')
-  useEffect(() => {
-    if (seedSql) {
-      setSql(seedSql)
-      seededRef.current = seedSql
-    }
-  }, [seedSql])
+    // The last seeded statement, so dirtiness means "the user's own text" —
+    // a seeded prefill must not trip the discard guard.
+    const seededRef = useRef(seedSql ?? '')
+    useEffect(() => {
+      if (seedSql) {
+        setSql(seedSql)
+        seededRef.current = seedSql
+      }
+    }, [seedSql])
 
-  const onDirtyChangeRef = useRef(onDirtyChange)
-  onDirtyChangeRef.current = onDirtyChange
-  useEffect(() => {
-    onDirtyChangeRef.current?.(sql.trim() !== '' && sql !== seededRef.current)
-  }, [sql])
-  // Unmount (db switch, page close) always releases the guard.
-  useEffect(() => () => onDirtyChangeRef.current?.(false), [])
+    const onDirtyChangeRef = useRef(onDirtyChange)
+    onDirtyChangeRef.current = onDirtyChange
+    useEffect(() => {
+      onDirtyChangeRef.current?.(sql.trim() !== '' && sql !== seededRef.current)
+    }, [sql])
+    // Unmount (db switch, page close) always releases the guard.
+    useEffect(() => () => onDirtyChangeRef.current?.(false), [])
 
-  const run = useCallback(
-    async (statement: string) => {
-      const trimmed = statement.trim()
+    const run = useCallback(
+      async (statement: string) => {
+        const trimmed = statement.trim()
+        if (!trimmed || running) return
+        setRunning(true)
+        setError(null)
+        setPlan(null)
+        try {
+          const next = await runAdhocSql(host, db, trimmed)
+          setOutcome(next)
+          setRanSql(trimmed)
+          if (next.write) onWrite?.()
+          setHistory((cur) => {
+            const updated = [
+              trimmed,
+              ...cur.filter((s) => s !== trimmed),
+            ].slice(0, HISTORY_LIMIT)
+            saveHistory(db, updated)
+            return updated
+          })
+        } catch (err) {
+          setOutcome(null)
+          setError(errText(err))
+        } finally {
+          setRunning(false)
+        }
+      },
+      [host, db, running, onWrite],
+    )
+
+    /**
+     * The worker parses the plan. Prefixing `EXPLAIN` and rendering the result
+     * as a grid of text was the old shape; `database::explain` normalises three
+     * dialects into one tree and computes the warnings, so this only draws.
+     */
+    const explainNow = useCallback(async () => {
+      const trimmed = sql.trim()
       if (!trimmed || running) return
       setRunning(true)
       setError(null)
-      setPlan(null)
+      setOutcome(null)
       try {
-        const next = await runAdhocSql(host, db, trimmed)
-        setOutcome(next)
-        setRanSql(trimmed)
-        if (next.write) onWrite?.()
-        setHistory((cur) => {
-          const updated = [trimmed, ...cur.filter((s) => s !== trimmed)].slice(
-            0,
-            HISTORY_LIMIT,
-          )
-          saveHistory(db, updated)
-          return updated
-        })
+        setPlan(await explain(host, db, trimmed))
       } catch (err) {
-        setOutcome(null)
+        setPlan(null)
         setError(errText(err))
       } finally {
         setRunning(false)
       }
-    },
-    [host, db, running, onWrite],
-  )
+    }, [host, db, sql, running])
 
-  /**
-   * The worker parses the plan. Prefixing `EXPLAIN` and rendering the result
-   * as a grid of text was the old shape; `database::explain` normalises three
-   * dialects into one tree and computes the warnings, so this only draws.
-   */
-  const explainNow = useCallback(async () => {
-    const trimmed = sql.trim()
-    if (!trimmed || running) return
-    setRunning(true)
-    setError(null)
-    setOutcome(null)
-    try {
-      setPlan(await explain(host, db, trimmed))
-    } catch (err) {
-      setPlan(null)
-      setError(errText(err))
-    } finally {
-      setRunning(false)
-    }
-  }, [host, db, sql, running])
+    const isWrite = sql.trim() !== '' && !isReadOnlySql(sql)
+    const ddl = useMemo(() => (isWrite ? ddlInfo(sql) : null), [isWrite, sql])
+    const stale = outcome !== null && ranSql !== null && sql.trim() !== ranSql
 
-  const isWrite = sql.trim() !== '' && !isReadOnlySql(sql)
-  const ddl = useMemo(() => (isWrite ? ddlInfo(sql) : null), [isWrite, sql])
-  const stale = outcome !== null && ranSql !== null && sql.trim() !== ranSql
-
-  return (
-    <div className="db-sql">
-      <div className="db-sql-top">
-        <div className="db-sql-editor-wrap">
-          <CodeEditor
-            value={sql}
-            onChange={setSql}
-            language="sql"
-            className="db-sql-code"
-            placeholder={`select * from … — ${RUN_CHORD} runs against ${db}`}
-            aria-label="sql statement"
-            completions={completions}
-            ref={editorRef}
-            onKeyDown={(e) => {
-              if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
-                e.preventDefault()
-                void run(sql)
-              }
-              // Monaco keeps Tab for indentation, so Escape is the keyboard
-              // exit: land on the first usable action, or just release focus
-              // when they're all disabled. (Monaco consumes Escape while a
-              // widget is open — closing it — so this fires on the second.)
-              if (e.key === 'Escape') {
-                const next =
-                  actionsRef.current?.querySelector<HTMLButtonElement>(
-                    'button:not(:disabled)',
-                  )
-                if (next) next.focus()
-                else if (document.activeElement instanceof HTMLElement)
-                  document.activeElement.blur()
-              }
-            }}
-          />
-        </div>
-        <div className="db-sql-actions" ref={actionsRef}>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => void run(sql)}
-            disabled={running || sql.trim() === ''}
-          >
-            <Play size={16} aria-hidden />
-            {running ? 'Running…' : 'Run'}
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => void explainNow()}
-            disabled={running || sql.trim() === ''}
-          >
-            Explain
-          </Button>
-          <span ref={historyBtnRef} style={{ display: 'contents' }}>
+    return (
+      <div className="db-sql">
+        <div className="db-sql-top">
+          <div className="db-sql-editor-wrap">
+            <CodeEditor
+              value={sql}
+              onChange={setSql}
+              language="sql"
+              className="db-sql-code"
+              placeholder={`select * from … — ${RUN_CHORD} runs against ${db}`}
+              aria-label="sql statement"
+              completions={completions}
+              ref={editorRef}
+              onKeyDown={(e) => {
+                if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+                  e.preventDefault()
+                  void run(sql)
+                }
+                // Monaco keeps Tab for indentation, so Escape is the keyboard
+                // exit: land on the first usable action, or just release focus
+                // when they're all disabled. (Monaco consumes Escape while a
+                // widget is open — closing it — so this fires on the second.)
+                if (e.key === 'Escape') {
+                  const next =
+                    actionsRef.current?.querySelector<HTMLButtonElement>(
+                      'button:not(:disabled)',
+                    )
+                  if (next) next.focus()
+                  else if (document.activeElement instanceof HTMLElement)
+                    document.activeElement.blur()
+                }
+              }}
+            />
+          </div>
+          <div className="db-sql-actions" ref={actionsRef}>
             <Button
               variant="ghost"
               size="sm"
-              onClick={() => setHistoryOpen((v) => !v)}
-              disabled={history.length === 0}
-              aria-expanded={historyOpen}
+              onClick={() => void run(sql)}
+              disabled={running || sql.trim() === ''}
             >
-              <History size={16} aria-hidden />
-              History · {history.length}
+              <Play size={16} aria-hidden />
+              {running ? 'Running…' : 'Run'}
             </Button>
-          </span>
-          {isWrite ? (
-            // A heads-up, not a gate: this statement will mutate and commit.
-            // Schema changes get the louder ink and name what they do.
-            <span className={`db-sql-warn${ddl ? ' ddl' : ''}`}>
-              {ddl
-                ? `${ddl.present} — commits on ${db}`
-                : `write — runs and commits on ${db}`}
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => void explainNow()}
+              disabled={running || sql.trim() === ''}
+            >
+              Explain
+            </Button>
+            <span ref={historyBtnRef} style={{ display: 'contents' }}>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setHistoryOpen((v) => !v)}
+                disabled={history.length === 0}
+                aria-expanded={historyOpen}
+              >
+                <History size={16} aria-hidden />
+                History · {history.length}
+              </Button>
             </span>
-          ) : null}
-          {outcome ? (
-            <span className={`db-sql-meta${stale ? ' stale' : ''}`}>
-              {outcome.write
-                ? (outcome.write.echo ??
-                  `${outcome.write.affectedRows} affected${
-                    outcome.write.lastInsertId !== null
-                      ? ` · id ${outcome.write.lastInsertId}`
-                      : ''
-                  }`)
-                : `${outcome.result.row_count} row${outcome.result.row_count === 1 ? '' : 's'}`}{' '}
-              · {outcome.durationMs}
-              ms
-            </span>
-          ) : null}
-          {/* The audible twin of the visual states: one polite live region
+            {isWrite ? (
+              // A heads-up, not a gate: this statement will mutate and commit.
+              // Schema changes get the louder ink and name what they do.
+              <span className={`db-sql-warn${ddl ? ' ddl' : ''}`}>
+                {ddl
+                  ? `${ddl.present} — commits on ${db}`
+                  : `write — runs and commits on ${db}`}
+              </span>
+            ) : null}
+            {outcome ? (
+              <span className={`db-sql-meta${stale ? ' stale' : ''}`}>
+                {outcome.write
+                  ? (outcome.write.echo ??
+                    `${outcome.write.affectedRows} affected${
+                      outcome.write.lastInsertId !== null
+                        ? ` · id ${outcome.write.lastInsertId}`
+                        : ''
+                    }`)
+                  : `${outcome.result.row_count} row${outcome.result.row_count === 1 ? '' : 's'}`}{' '}
+                · {outcome.durationMs}
+                ms
+              </span>
+            ) : null}
+            {/* The audible twin of the visual states: one polite live region
               voices running/result/failure and the write heads-up. The armed
               message is static on purpose — including the typed table name
               would re-announce on every keystroke. */}
-          <span className="db-sr-only" role="status">
-            {running
-              ? 'running'
-              : error
-                ? `query failed: ${error}`
-                : outcome
-                  ? outcome.write
-                    ? `${outcome.write.echo ?? `${outcome.write.affectedRows} rows affected`} in ${outcome.durationMs}ms`
-                    : `${outcome.result.row_count} rows in ${outcome.durationMs}ms`
-                  : isWrite
-                    ? `write statement — runs and commits on ${db}`
-                    : ''}
-          </span>
-        </div>
-        {historyOpen && history.length > 0 ? (
-          <div className="db-sql-history" ref={historyRef}>
-            {/* Where these live is worth one line: they never leave this
+            <span className="db-sr-only" role="status">
+              {running
+                ? 'running'
+                : error
+                  ? `query failed: ${error}`
+                  : outcome
+                    ? outcome.write
+                      ? `${outcome.write.echo ?? `${outcome.write.affectedRows} rows affected`} in ${outcome.durationMs}ms`
+                      : `${outcome.result.row_count} rows in ${outcome.durationMs}ms`
+                    : isWrite
+                      ? `write statement — runs and commits on ${db}`
+                      : ''}
+            </span>
+          </div>
+          {historyOpen && history.length > 0 ? (
+            <div className="db-sql-history" ref={historyRef}>
+              {/* Where these live is worth one line: they never leave this
                 browser, and eviction is silent at the cap. */}
-            <div className="db-sql-history-note">
-              Recent statements · Saved in this browser · Newest first
-            </div>
-            {history.map((entry) => (
-              <div key={entry} className="db-sql-history-row">
-                <button
-                  type="button"
-                  className="db-sql-history-pick"
-                  onClick={() => {
-                    setSql(entry)
-                    setHistoryOpen(false)
-                    editorRef.current?.focus()
-                  }}
-                  title={entry}
-                >
-                  {entry}
-                </button>
-                <button
-                  type="button"
-                  className="db-icon-btn"
-                  onClick={() =>
-                    setHistory((cur) => {
-                      const updated = cur.filter((s) => s !== entry)
-                      saveHistory(db, updated)
-                      return updated
-                    })
-                  }
-                  aria-label="remove from history"
-                >
-                  <X size={16} />
-                </button>
+              <div className="db-sql-history-note">
+                Recent statements · Saved in this browser · Newest first
               </div>
-            ))}
-          </div>
-        ) : null}
-      </div>
-      <div className={`db-sql-results${running ? ' running' : ''}`}>
-        {error ? (
-          <div className="db-pad">
-            <StatusPanel
-              variant="alert"
-              icon={<AlertCircle size={18} />}
-              headline="Query failed"
-              detail={error}
-            />
-          </div>
-        ) : plan ? (
-          <PlanTree plan={plan} />
-        ) : outcome ? (
-          outcome.write && outcome.result.rows.length === 0 ? (
-            // A write without RETURNING has no grid to draw; an empty one
-            // reads as "nothing happened", which is the opposite of the truth.
-            <p className="db-sql-placeholder">
-              Statement ran —{' '}
-              {outcome.write.echo ??
-                `${outcome.write.affectedRows} row${outcome.write.affectedRows === 1 ? '' : 's'} affected`}
-            </p>
+              {history.map((entry) => (
+                <div key={entry} className="db-sql-history-row">
+                  <button
+                    type="button"
+                    className="db-sql-history-pick"
+                    onClick={() => {
+                      setSql(entry)
+                      setHistoryOpen(false)
+                      editorRef.current?.focus()
+                    }}
+                    title={entry}
+                  >
+                    {entry}
+                  </button>
+                  <button
+                    type="button"
+                    className="db-icon-btn"
+                    onClick={() =>
+                      setHistory((cur) => {
+                        const updated = cur.filter((s) => s !== entry)
+                        saveHistory(db, updated)
+                        return updated
+                      })
+                    }
+                    aria-label="remove from history"
+                  >
+                    <X size={16} />
+                  </button>
+                </div>
+              ))}
+            </div>
+          ) : null}
+        </div>
+        <div className={`db-sql-results${running ? ' running' : ''}`}>
+          {error ? (
+            <div className="db-pad">
+              <StatusPanel
+                variant="alert"
+                icon={<AlertCircle size={18} />}
+                headline="Query failed"
+                detail={error}
+              />
+            </div>
+          ) : plan ? (
+            <PlanTree plan={plan} />
+          ) : outcome ? (
+            outcome.write && outcome.result.rows.length === 0 ? (
+              // A write without RETURNING has no grid to draw; an empty one
+              // reads as "nothing happened", which is the opposite of the truth.
+              <p className="db-sql-placeholder">
+                Statement ran —{' '}
+                {outcome.write.echo ??
+                  `${outcome.write.affectedRows} row${outcome.write.affectedRows === 1 ? '' : 's'} affected`}
+              </p>
+            ) : (
+              <ResultGrid
+                columns={outcome.result.columns}
+                rows={outcome.result.rows}
+                rowCount={outcome.result.row_count}
+                stickyHeader
+              />
+            )
           ) : (
-            <ResultGrid
-              columns={outcome.result.columns}
-              rows={outcome.result.rows}
-              rowCount={outcome.result.row_count}
-              stickyHeader
-            />
-          )
-        ) : (
-          <p className={`db-sql-placeholder${running ? ' db-pulse' : ''}`}>
-            {running ? (
-              'running…'
-            ) : starterSql ? (
-              <>
-                results appear here. try{' '}
-                {/* The old copy suggested `select name from sqlite_master`
+            <p className={`db-sql-placeholder${running ? ' db-pulse' : ''}`}>
+              {running ? (
+                'running…'
+              ) : starterSql ? (
+                <>
+                  results appear here. try{' '}
+                  {/* The old copy suggested `select name from sqlite_master`
                     whatever the driver was — an error on two of the three.
                     A statement from the schema in front of you runs, and one
                     click beats retyping it. */}
-                <button
-                  type="button"
-                  className="db-linkish"
-                  onClick={() => {
-                    setSql(starterSql)
-                    void run(starterSql)
-                  }}
-                >
-                  {starterSql}
-                </button>
-              </>
-            ) : (
-              'results appear here.'
-            )}
-          </p>
-        )}
+                  <button
+                    type="button"
+                    className="db-linkish"
+                    onClick={() => {
+                      setSql(starterSql)
+                      void run(starterSql)
+                    }}
+                  >
+                    {starterSql}
+                  </button>
+                </>
+              ) : (
+                'results appear here.'
+              )}
+            </p>
+          )}
+        </div>
       </div>
-    </div>
-  )
-}
+    )
+  },
+)

--- a/database/ui/src/page/index.tsx
+++ b/database/ui/src/page/index.tsx
@@ -77,8 +77,9 @@ import {
   Settings,
   Table2,
 } from './icons'
+import { parseDatabasePanelContext } from './panel-context'
 import { SchemaTree } from './SchemaTree'
-import { SqlPanel } from './SqlPanel'
+import { SqlPanel, type SqlPanelHandle } from './SqlPanel'
 import { TableDataPanel } from './TableDataPanel'
 import { useDatabaseRead } from './useDatabaseRead'
 
@@ -192,6 +193,8 @@ export function DatabasePage({
   panelSide = 'left',
   tabId = '',
   onRequestClose,
+  panelContext,
+  commands,
 }: { host: Host } & Partial<PageRenderProps>) {
   const [selectedDb, setSelectedDb] = useState<string | undefined>(undefined)
   const [selectedTable, setSelectedTable] = useState<string | null>(null)
@@ -228,6 +231,9 @@ export function DatabasePage({
   const onSqlDirtyChange = useCallback((dirty: boolean) => {
     sqlDirtyRef.current = dirty
   }, [])
+  // Lets the `S` command move focus into the Monaco editor after switching
+  // the panel to SQL — the panel itself owns the editor instance.
+  const sqlPanelRef = useRef<SqlPanelHandle>(null)
 
   const follow = useCallback(
     (table: string, column: string, value: unknown) => {
@@ -361,6 +367,77 @@ export function DatabasePage({
     // means leaving the tree.
     if (narrow) setDrilled(true)
   }
+
+  // A context from the palette source (or another worker's "inspect this
+  // table" affordance) selects a table once its database's list has loaded.
+  // Left unapplied rather than clearing selectedTable while it loads — the
+  // db/table pair only becomes valid once both requests settle.
+  const appliedContextRef = useRef(0)
+  useEffect(() => {
+    if (!panelContext || panelContext.id === appliedContextRef.current) return
+    const context = parseDatabasePanelContext(panelContext.context)
+    if (!context) {
+      appliedContextRef.current = panelContext.id
+      return
+    }
+    const targetDb = context.db ?? activeDb?.name
+    if (!targetDb) return
+    if (targetDb !== activeDb?.name) {
+      if (dbs.some((d) => d.name === targetDb)) setSelectedDb(targetDb)
+      return
+    }
+    if (!tables.some((t) => t.name === context.table)) return
+    appliedContextRef.current = panelContext.id
+    setTrail([])
+    setSelectedTable(context.table)
+    setMode('data')
+    if (narrow) setDrilled(true)
+  }, [panelContext, activeDb, dbs, tables, narrow])
+
+  // The page's verbs, for the palette and for the keyboard while this pane
+  // has the focus. The keys stay clear of the console's own.
+  useEffect(
+    () =>
+      commands?.register([
+        {
+          id: 'focus-sql',
+          title: 'Focus the SQL editor',
+          detail: 'Switch to the SQL panel and start typing a statement',
+          keywords: ['sql', 'query', 'editor'],
+          shortcut: 'S',
+          enabled: () => !!activeDb,
+          run: () => {
+            pickMode('sql')
+            window.requestAnimationFrame(() => sqlPanelRef.current?.focus())
+          },
+        },
+        {
+          id: 'refresh',
+          title: 'Refresh',
+          detail: 'Reload databases, tables and the active panel',
+          keywords: ['reload'],
+          shortcut: 'R',
+          run: refresh,
+        },
+        {
+          id: 'focus-tables',
+          title: 'Focus the table filter',
+          detail: 'Jump to the table list and start typing to filter it',
+          keywords: ['tables', 'filter', 'schema'],
+          shortcut: '/',
+          enabled: () => !!activeDb,
+          run: () => {
+            if (narrow) setDrilled(false)
+            window.requestAnimationFrame(() =>
+              document
+                .querySelector<HTMLElement>('[data-db-tables-filter]')
+                ?.focus(),
+            )
+          },
+        },
+      ]),
+    [commands, activeDb, narrow],
+  )
 
   // A configured database without a `url` (redacted in the worker's config
   // response) still counts as configured — fall back to its name, not to the
@@ -613,6 +690,7 @@ export function DatabasePage({
                         can't disconfirm what just happened. */}
                     <SqlPanel
                       key={activeDb.name}
+                      ref={sqlPanelRef}
                       host={host}
                       db={activeDb.name}
                       seedSql={seedSql}

--- a/database/ui/src/page/index.tsx
+++ b/database/ui/src/page/index.tsx
@@ -373,6 +373,7 @@ export function DatabasePage({
   // Left unapplied rather than clearing selectedTable while it loads — the
   // db/table pair only becomes valid once both requests settle.
   const appliedContextRef = useRef(0)
+  const shellRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
     if (!panelContext || panelContext.id === appliedContextRef.current) return
     const context = parseDatabasePanelContext(panelContext.context)
@@ -429,8 +430,8 @@ export function DatabasePage({
           run: () => {
             if (narrow) setDrilled(false)
             window.requestAnimationFrame(() =>
-              document
-                .querySelector<HTMLElement>('[data-db-tables-filter]')
+              shellRef.current
+                ?.querySelector<HTMLElement>('[data-db-tables-filter]')
                 ?.focus(),
             )
           },
@@ -453,7 +454,7 @@ export function DatabasePage({
   const showMain = !narrow || drilled
 
   return (
-    <PageShell className="db-ui-shell">
+    <PageShell ref={shellRef} className="db-ui-shell">
       <PageHeader
         icon={<Database size={16} />}
         title="Database"

--- a/database/ui/src/page/panel-context.ts
+++ b/database/ui/src/page/panel-context.ts
@@ -1,0 +1,26 @@
+import type { JsonValue } from '@iii-dev/console-ui'
+
+/** Opens the page with a table pre-selected — the palette source, or any
+    other worker's "inspect this table" affordance. */
+export interface DatabasePanelContext {
+  db?: string
+  table: string
+}
+
+function asRecord(value: JsonValue): Record<string, JsonValue> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value
+    : null
+}
+
+export function parseDatabasePanelContext(
+  value: JsonValue,
+): DatabasePanelContext | null {
+  const record = asRecord(value)
+  if (!record || typeof record.table !== 'string' || record.table === '')
+    return null
+  return {
+    table: record.table,
+    db: typeof record.db === 'string' ? record.db : undefined,
+  }
+}

--- a/database/ui/src/palette.ts
+++ b/database/ui/src/palette.ts
@@ -1,0 +1,61 @@
+/**
+ * The database worker in the command palette, before its page is even open.
+ *
+ * A tables source answers with every configured database's tables and views
+ * by name, each row opening the page with that table selected. Registered
+ * from setup, so it exists only while the worker is connected; older
+ * consoles without `host.palette` / `host.commands` simply get nothing.
+ */
+
+import type { Host } from '@iii-dev/console-ui'
+import { listDbs, listTables } from './page/db-data'
+
+const ROWS = 30
+
+export function registerDatabasePalette(host: Host): void {
+  host.palette?.registerSource({
+    id: 'database-tables',
+    title: 'Database tables',
+    kind: 'item',
+    minQuery: 2,
+    async search(query, { signal }) {
+      const needle = query.trim().toLowerCase()
+      const dbs = await listDbs(host)
+      if (signal.aborted) return []
+      const out: { db: string; table: string; kind: 'table' | 'view' }[] = []
+      for (const db of dbs) {
+        if (signal.aborted) return []
+        const tables = await listTables(host, db.name, db.driver).catch(
+          () => [],
+        )
+        for (const table of tables) {
+          if (table.name.toLowerCase().includes(needle)) {
+            out.push({ db: db.name, table: table.name, kind: table.kind })
+          }
+        }
+      }
+      if (signal.aborted) return []
+      return out.slice(0, ROWS).map(({ db, table, kind }) => ({
+        id: `${db}.${table}`,
+        title: table,
+        detail: dbs.length > 1 ? db : kind === 'view' ? 'view' : undefined,
+        keywords: [db, table],
+        run: () =>
+          host.panels?.open({
+            pageId: 'database',
+            context: { db, table },
+          }),
+      }))
+    },
+  })
+
+  host.commands?.register('database', [
+    {
+      id: 'open',
+      title: 'Open the database browser',
+      detail: 'Schema, table rows, and an ad-hoc SQL panel',
+      keywords: ['sql', 'tables', 'schema', 'rows'],
+      run: () => host.panels?.open({ pageId: 'database', context: {} }),
+    },
+  ])
+}

--- a/docs/sops/console-ui-conformance.md
+++ b/docs/sops/console-ui-conformance.md
@@ -86,6 +86,20 @@ selection, tooltip, or selector behavior.
 | Dialogs, menus, selects, selectors, tooltips, sheets | Shared portal scope and motion vocabulary |
 | Streaming context usage | High-frequency width updates are immediate |
 
+## Commands
+
+A page's primary verbs are palette rows (`PageRenderProps.commands`, or
+`host.commands` for a page not yet open), each with a key where one is
+natural, scoped to the page's pane. No page listens for a key the console
+owns; the registry refuses those at registration. See the injectable-UI SOP,
+"Commands: the keyboard reaches every page".
+
+| Page | Commands | Keys |
+|---|---|---|
+| chat (first-party) | focus composer, next / previous message, latest, switch model, stop | `I`, `J` / `K`, `End`, `M`, `Escape` |
+| shell | pending (MOT-4529) | |
+| every other worker page | pending (MOT-4530) | |
+
 ## Deliberate local-control exceptions
 
 - `DirectoryPicker` and model/provider navigation use hierarchical drill-in

--- a/docs/sops/console-ui-conformance.md
+++ b/docs/sops/console-ui-conformance.md
@@ -94,11 +94,31 @@ natural, scoped to the page's pane. No page listens for a key the console
 owns; the registry refuses those at registration. See the injectable-UI SOP,
 "Commands: the keyboard reaches every page".
 
-| Page | Commands | Keys |
-|---|---|---|
-| chat (first-party) | focus composer, next / previous message, latest, switch model, stop | `I`, `J` / `K`, `End`, `M`, `Escape` |
-| shell | pending (MOT-4529) | |
-| every other worker page | pending (MOT-4530) | |
+| Page | Commands (render time unless noted) | Keys | Palette source |
+|---|---|---|---|
+| chat (first-party) | focus composer, next / previous message, approve / deny the pending call, expand, copy, latest, switch model, stop, new chat, search conversations | `I`, `J` / `K`, `A` / `D`, `O`, `Y`, `End`, `M`, `Escape`, `N`, `/` | chats (built in) |
+| workers (first-party) | refresh, search | `R`, `/` | workers, functions (built in) |
+| traces (first-party) | search, follow turns, clear filters, close detail | `/`, `F`, `Escape` | |
+| shell | open file…, search in files, file tree, toggle sidebar, toggle terminal, next / previous tab, close tab, next / previous change; setup: open file…, open | `P`, `F`, `E`, `B`, `` ` ``, `Alt+←` / `Alt+→`, `W`, `J` / `K` | files (`coder::search`, `#`) |
+| database | focus SQL, refresh, focus tables; setup: open | `S`, `R`, `/` | tables (`database::listTables`) |
+| cron | new schedule, search, refresh, focus composer; setup: open, new schedule… | `N`, `/`, `R` | schedules (`listAllSchedules`) |
+| state | save; setup: open | `Mod+S` | keys (`state::list_groups` + `state::list_keys`) |
+| storage | upload, refresh; setup: open | `U`, `R` | objects (`storage::listObjects`) |
+| memory | reload, new bank; setup: open | `R`, `N` | banks (`memory::bank::list`), memories (`memory::list`) |
+| iii-directory | new entry, filter, save; setup: open | `N`, `/`, `Mod+S` | entries (`directory::skills::list`, `prompts::list`, `system-prompts::list`) |
+| canvas | new, save, delete; setup: open | `N`, `Mod+S`, `X` | canvases (`canvas::list`) |
+| a2ui | new from template, undo, pin, export React; setup: open | `N`, `Z`, `P`, `E` | surfaces (`a2ui::surface::list`, per conversation) |
+| browser | new session, stop, inspect, address bar; setup: open | `N`, `X`, `I`, `L` | sessions (`browser::sessions::list`) |
+| sandbox-code-runner | new, run code, refresh; setup: open | `N`, `C`, `R` | sandboxes (`sandbox::list`) |
+| computer | start, stop; setup: open | `N`, `X` | sessions (`computer::sessions::list`) |
+| worktree | refresh, close detail; setup: open | `R`, `Escape` | worktrees (`worktree::list`) |
+| console catalog (functions, triggers) | search, toggle internal, refresh, run function; setup: open | `/`, `I`, `R`, `Mod+Enter` | functions (built in) |
+| eval | new evaluation, refresh history; setup: open, new evaluation… | `N`, `R` | evaluations (`api.list`) |
+| github | toggle live, refresh, close detail; setup: open | `L`, `R`, `Escape` | (PR / issue data not wired in the UI yet) |
+| pdf | choose file; setup: open | `O` | |
+| editor (deprecated) | save; setup: open | `Mod+S` | |
+
+Every page names its `data-autofocus` target. Shared `TableRow interactive` and `List` carry the arrows, Enter and Space for the rows and lists built from them.
 
 ## Deliberate local-control exceptions
 

--- a/docs/sops/injectable-console-ui.md
+++ b/docs/sops/injectable-console-ui.md
@@ -347,6 +347,11 @@ valid and simply ignores them:
   once it is saved or discarded; closing the pane, its workspace, or the
   browser tab then asks first. Absent on older consoles, so call it as
   `setDirty?.(…)`. The host clears the entry when its pane or workspace tab is removed; unmounting a background tab does not clear it.
+- `commands`: contribute commands while mounted — rows in the command
+  palette (`⌘K`) under the page's name, and keys that fire only while focus
+  is inside this pane. Register in an effect and return its remover:
+  `useEffect(() => commands?.register([...]), [commands])`. Absent on older
+  consoles; feature-detect. See [Commands](#commands-the-keyboard-reaches-every-page).
 
 #### The page chrome — MANDATORY layout for pages
 
@@ -412,6 +417,75 @@ for machine-readable ids, paths, values, payloads, source, terminal output,
 and tabular data. Application icons use a 16 px baseline globally;
 icon-only actions use `IconButton`, which retains an accessible label and the
 shared tooltip. Do not author application icons below 16 px.
+
+### Commands: the keyboard reaches every page
+
+The console is keyboard-first: `⌘K` finds and takes any action, every row
+shows its key, and hovering a control spells the same key. A page joins
+that through commands. There are two registration points and one rule:
+**a command exists only while its worker is connected.** Both paths ride
+the same teardown every other registration uses, so nothing extra is needed
+for that rule to hold.
+
+```ts
+interface PageCommand {
+  id: string                 // unique within the page; namespaced `<pageId>.<id>`
+  title: string              // the palette row reads "Shell: Open file…"
+  detail?: string
+  keywords?: string[]
+  shortcut?: string | { mac: string[]; other: string[] }   // 'Mod+S', 'G L'
+  firesWhileTyping?: boolean // default false: the caret in a field wins
+  enabled?: () => boolean    // asked when the palette opens and before run
+  run: () => void
+}
+```
+
+**`host.commands.register(pageId, commands)`** — setup time, worker level.
+Rows for a page that may not be open yet ("Shell: open file…"). Lives
+exactly as long as the script: removed with the page and every other
+registration when the worker's assets go. `run` usually calls
+`host.panels.open({ pageId, context })` so the page opens and acts on the
+context. Keys are **not** honoured here: the console's global keymap stays
+the console's.
+
+**`PageRenderProps.commands.register(commands)`** — render time, page
+level. Lives while the page is mounted in a pane. Keys are honoured and
+scoped to that pane: they fire only while focus is inside it, so two panes
+of the same page never both answer. Register from an effect:
+
+```tsx
+function Page({ commands }: PageRenderProps) {
+  useEffect(
+    () =>
+      commands?.register([
+        { id: 'open', title: 'Open file…', shortcut: 'P', run: openQuickOpen },
+        { id: 'find', title: 'Search in files', shortcut: 'F', run: focusSearch },
+        { id: 'save', title: 'Save', shortcut: 'Mod+S', firesWhileTyping: true,
+          enabled: () => dirty, run: save },
+      ]),
+    [commands, dirty],
+  )
+}
+```
+
+Keys a page may take: anything the console does not already use. The
+console's own keys (`1`–`9`, `t`, `[`, `]`, `Shift+W`, `\`, `,`, `{`, `}`,
+`Mod+K`), the prefix of any go-to chord (`G`) and the chords the browser owns
+(`Mod+W`, `Mod+T`, `Mod+1`…) are refused at registration with a
+`console.warn`; the row stays, without a key. Single letters and chords
+(`Q L`) are fine; the typing guard keeps them out of fields unless the
+command says `firesWhileTyping`, and a field can hand specific commands back
+with `data-keybindings-allow="<pageId>.<id>"`.
+
+Focus follows the keyboard: opening a page from `⌘K`, a go-to chord or
+`host.panels.open` moves focus into its pane — the first `[data-autofocus]`
+element inside it, else the pane root — so the next keystroke is already
+the page's. Mark the element a page wants focused on arrival with
+`data-autofocus`. `{` / `}` step focus across panes.
+
+Definition of done for a page: its primary verbs are commands, each with a
+key where one is natural, and nothing in the page listens for a key the
+console owns.
 
 ### `host.panels.open({ pageId, context })`
 
@@ -849,6 +923,7 @@ them):
 | Named typed component exports on the runtime module | shipped (beyond spec: the spec only had the `components` record) |
 | Manifest `worker` attribution | always `null` |
 | Scope-preserving shared portals | shipped for `Dialog`, `DropdownMenu`, `Select`, `Selector`, `Tooltip`, and `BottomSheet`; stamp only custom domain portals |
+| Page commands and pane-scoped keys | shipped **beyond spec** as `host.commands` + `PageRenderProps.commands`; chat is the first consumer, shell next |
 
 Naming note: function messages use `host.functionTriggers` and the
 `function-trigger` role. Normalized trigger lifecycle activities use the

--- a/docs/sops/injectable-console-ui.md
+++ b/docs/sops/injectable-console-ui.md
@@ -494,7 +494,7 @@ host.palette?.registerSource({
   kind: 'item',               // 'file' for real files (answers `#`), 'item' otherwise
   prefix: '#',                // optional: a one-character mode that selects this source alone
   minQuery: 2,                // asked without its prefix from this many characters
-  async search(query, { workingDir, signal }) {
+  async search(query, { workingDir, conversationId, signal }) {
     const tables = await host.iii.trigger('database::listTables', { query })
     if (signal.aborted) return []
     return tables.slice(0, 30).map((table) => ({

--- a/docs/sops/injectable-console-ui.md
+++ b/docs/sops/injectable-console-ui.md
@@ -483,9 +483,46 @@ element inside it, else the pane root — so the next keystroke is already
 the page's. Mark the element a page wants focused on arrival with
 `data-autofocus`. `{` / `}` step focus across panes.
 
+**`host.palette.registerSource(source)`** — a live source: rows computed per
+query by the worker, the way an editor's quick open lists files as you type.
+Registered at setup, so it exists only while the worker is connected.
+
+```ts
+host.palette?.registerSource({
+  id: 'tables',
+  title: 'Tables',            // the group label
+  kind: 'item',               // 'file' for real files (answers `#`), 'item' otherwise
+  prefix: '#',                // optional: a one-character mode that selects this source alone
+  minQuery: 2,                // asked without its prefix from this many characters
+  async search(query, { workingDir, signal }) {
+    const tables = await host.iii.trigger('database::listTables', { query })
+    if (signal.aborted) return []
+    return tables.slice(0, 30).map((table) => ({
+      id: table.name,
+      title: table.name,
+      detail: table.database,
+      run: () => host.panels.open({ pageId: 'database', context: { table: table.name } }),
+    }))
+  },
+})
+```
+
+The palette asks every source that fits the mode, debounced, and drops an
+answer to a query it has moved past (`signal`). A source that throws
+contributes nothing; the others still answer. Rows open the page with a
+context the page already understands through `panelContext`.
+
+**`host.palette.open({ query })`** opens the palette on a query. A prefix
+lands it in that mode: `>` or `/` commands, `#` files, `@` chats. The shell's
+"Open file…" row calls `host.palette.open({ query: '#' })` and hands over.
+
+An empty query opens on the ten rows used most recently in this browser;
+several words match in any order.
+
 Definition of done for a page: its primary verbs are commands, each with a
-key where one is natural, and nothing in the page listens for a key the
-console owns.
+key where one is natural; the data a user jumps to by name is a source; the
+element the page wants focused on arrival carries `data-autofocus`; and
+nothing in the page listens for a key the console owns.
 
 ### `host.panels.open({ pageId, context })`
 
@@ -923,7 +960,8 @@ them):
 | Named typed component exports on the runtime module | shipped (beyond spec: the spec only had the `components` record) |
 | Manifest `worker` attribution | always `null` |
 | Scope-preserving shared portals | shipped for `Dialog`, `DropdownMenu`, `Select`, `Selector`, `Tooltip`, and `BottomSheet`; stamp only custom domain portals |
-| Page commands and pane-scoped keys | shipped **beyond spec** as `host.commands` + `PageRenderProps.commands`; chat is the first consumer, shell next |
+| Page commands and pane-scoped keys | shipped **beyond spec** as `host.commands` + `PageRenderProps.commands`; chat and shell are the first consumers |
+| Live palette sources | shipped **beyond spec** as `host.palette.registerSource` + `host.palette.open`; the shell's Files source is the reference |
 
 Naming note: function messages use `host.functionTriggers` and the
 `function-trigger` role. Normalized trigger lifecycle activities use the

--- a/editor/ui/page.tsx
+++ b/editor/ui/page.tsx
@@ -26,4 +26,14 @@ export default function setup(host: Host) {
     title: 'editor',
     render: (props) => <EditorPage host={host} {...props} />,
   })
+
+  host.commands?.register('editor', [
+    {
+      id: 'open',
+      title: 'Open editor',
+      detail: 'Changed files, tabs, and the shared Monaco editor',
+      keywords: ['file', 'code', 'diff'],
+      run: () => host.panels?.open({ pageId: 'editor', context: {} }),
+    },
+  ])
 }

--- a/editor/ui/src/page/index.tsx
+++ b/editor/ui/src/page/index.tsx
@@ -178,6 +178,7 @@ interface Delta {
 export function EditorPage({
   host,
   panelSide = 'left',
+  commands,
 }: { host: Host } & Partial<PageRenderProps>) {
   const api = useMemo(() => createApi(host), [host])
   // Follows the console's own light/dark toggle, not the OS preference.
@@ -834,6 +835,22 @@ export function EditorPage({
       setBusy(false)
     }
   }, [activeBuffer, activeDraft, activePath, api, applyWorkspace, refreshGit])
+
+  useEffect(
+    () =>
+      commands?.register([
+        {
+          id: 'save',
+          title: 'Save',
+          detail: 'Write the active file to disk',
+          shortcut: 'Mod+S',
+          firesWhileTyping: true,
+          enabled: () => dirty,
+          run: () => void save(),
+        },
+      ]),
+    [commands, dirty, save],
+  )
 
   const closeTab = useCallback(
     async (path: string) => {

--- a/eval/Cargo.lock
+++ b/eval/Cargo.lock
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "harness"
-version = "1.8.5"
+version = "1.8.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/eval/tests/golden/schemas/eval.assert.exact.json
+++ b/eval/tests/golden/schemas/eval.assert.exact.json
@@ -434,8 +434,15 @@
             "minimum": 0.0,
             "type": "integer"
           },
+          "skills": {
+            "default": 0,
+            "description": "Selected skill bodies contained in the system prompt.",
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
           "system_prompt": {
-            "description": "Final assembled system prompt: mode paragraph, identity, per-step aids, and any compaction summary section.",
+            "description": "Final assembled system prompt excluding tokens attributed to `skills`: mode paragraph, identity, per-step aids, and any compaction summary section.",
             "format": "uint64",
             "minimum": 0.0,
             "type": "integer"

--- a/eval/tests/golden/schemas/eval.assert.normalized_text.json
+++ b/eval/tests/golden/schemas/eval.assert.normalized_text.json
@@ -434,8 +434,15 @@
             "minimum": 0.0,
             "type": "integer"
           },
+          "skills": {
+            "default": 0,
+            "description": "Selected skill bodies contained in the system prompt.",
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
           "system_prompt": {
-            "description": "Final assembled system prompt: mode paragraph, identity, per-step aids, and any compaction summary section.",
+            "description": "Final assembled system prompt excluding tokens attributed to `skills`: mode paragraph, identity, per-step aids, and any compaction summary section.",
             "format": "uint64",
             "minimum": 0.0,
             "type": "integer"

--- a/eval/tests/golden/schemas/eval.compare-sessions.json
+++ b/eval/tests/golden/schemas/eval.compare-sessions.json
@@ -851,8 +851,15 @@
             "minimum": 0.0,
             "type": "integer"
           },
+          "skills": {
+            "default": 0,
+            "description": "Selected skill bodies contained in the system prompt.",
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
           "system_prompt": {
-            "description": "Final assembled system prompt: mode paragraph, identity, per-step aids, and any compaction summary section.",
+            "description": "Final assembled system prompt excluding tokens attributed to `skills`: mode paragraph, identity, per-step aids, and any compaction summary section.",
             "format": "uint64",
             "minimum": 0.0,
             "type": "integer"

--- a/eval/tests/golden/schemas/eval.result.json
+++ b/eval/tests/golden/schemas/eval.result.json
@@ -1480,8 +1480,15 @@
             "minimum": 0.0,
             "type": "integer"
           },
+          "skills": {
+            "default": 0,
+            "description": "Selected skill bodies contained in the system prompt.",
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
           "system_prompt": {
-            "description": "Final assembled system prompt: mode paragraph, identity, per-step aids, and any compaction summary section.",
+            "description": "Final assembled system prompt excluding tokens attributed to `skills`: mode paragraph, identity, per-step aids, and any compaction summary section.",
             "format": "uint64",
             "minimum": 0.0,
             "type": "integer"

--- a/eval/ui/page.tsx
+++ b/eval/ui/page.tsx
@@ -1,10 +1,68 @@
 import type { Host } from '@iii-dev/console-ui'
+import { createEvalApi } from './src/api'
 import { EvalPage } from './src/page'
 
+const PALETTE_ROWS = 30
+
 export default function setup(host: Host) {
+  const api = createEvalApi(host)
+
   host.pages.register({
     id: 'eval-benchmarks',
     title: 'eval',
     render: (props) => <EvalPage host={host} {...props} />,
+  })
+
+  host.commands?.register('eval-benchmarks', [
+    {
+      id: 'open',
+      title: 'Open eval',
+      detail: 'Compare sessions and prompt experiments',
+      keywords: ['evaluation', 'benchmark', 'compare'],
+      run: () => host.panels?.open({ pageId: 'eval-benchmarks', context: {} }),
+    },
+    {
+      id: 'new-evaluation',
+      title: 'New evaluation…',
+      detail: 'Start a prompt comparison',
+      keywords: ['evaluation', 'experiment', 'compare prompts'],
+      run: () =>
+        host.panels?.open({
+          pageId: 'eval-benchmarks',
+          context: { type: 'new' },
+        }),
+    },
+  ])
+
+  host.palette?.registerSource({
+    id: 'evaluations',
+    title: 'Evaluations',
+    kind: 'item',
+    minQuery: 2,
+    async search(query, { signal }) {
+      const evaluations = await api.list()
+      if (signal.aborted) return []
+      const needle = query.trim().toLowerCase()
+      return evaluations
+        .filter((evaluation) =>
+          `${evaluation.control_label ?? ''} ${evaluation.treatment_label ?? ''} ${evaluation.model} ${evaluation.dimension}`
+            .toLowerCase()
+            .includes(needle),
+        )
+        .slice(0, PALETTE_ROWS)
+        .map((evaluation) => ({
+          id: evaluation.evaluation_id,
+          title: `${evaluation.control_label ?? 'control'} vs ${evaluation.treatment_label ?? 'treatment'}`,
+          detail: `${evaluation.model} · ${evaluation.dimension}`,
+          run: () =>
+            host.panels?.open({
+              pageId: 'eval-benchmarks',
+              context: {
+                type: 'evaluation',
+                evaluationId: evaluation.evaluation_id,
+              },
+            }),
+        }))
+    },
   })
 }

--- a/eval/ui/src/page/SessionComparison.tsx
+++ b/eval/ui/src/page/SessionComparison.tsx
@@ -238,7 +238,7 @@ export function SessionComparison({ host }: { host: Host }) {
         <>
           <section className="eval-ui-panel eval-ui-session-picker">
             <div className="eval-ui-panel-title">sessions · {selected.length}/5 selected</div>
-            <input className="eval-ui-input" type="search" value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Search title or session id" />
+            <input className="eval-ui-input" type="search" value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Search title or session id" data-autofocus="" />
             <div className="eval-ui-session-list">
               {filteredSessions.map((session) => {
                 const checked = selected.includes(session.session_id)

--- a/eval/ui/src/page/index.tsx
+++ b/eval/ui/src/page/index.tsx
@@ -1,5 +1,5 @@
 import { EmptyState, type Host, type PageRenderProps, Skeleton, StatusPanel } from '@iii-dev/console-ui'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createEvalApi, errorMessage, isTerminal } from '../api'
 import { useEvalCompleted } from '../events'
 import type { CatalogModel, EvalRequest, EvalResultResponse, EvalStatusResponse, EvalSummary } from '../types'
@@ -8,9 +8,11 @@ import { History } from './History'
 import { NewEvaluationForm } from './NewEvaluationForm'
 import { SessionComparison } from './SessionComparison'
 
-export function EvalPage({ host, panelSide = 'left' }: { host: Host } & Partial<PageRenderProps>) {
+export function EvalPage({ host, panelSide = 'left', panelContext, commands }: { host: Host } & Partial<PageRenderProps>) {
   const api = useMemo(() => createEvalApi(host), [host])
   const [surface, setSurface] = useState<'sessions' | 'experiments'>('sessions')
+  const sessionsTabRef = useRef<HTMLButtonElement>(null)
+  const experimentsTabRef = useRef<HTMLButtonElement>(null)
   const [evaluations, setEvaluations] = useState<EvalSummary[]>([])
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [creating, setCreating] = useState(false)
@@ -186,12 +188,72 @@ export function EvalPage({ host, panelSide = 'left' }: { host: Host } & Partial<
     [api, loadDetail, loadHistory, selectedId],
   )
 
+  // Context from `host.panels.open` — the palette source and the setup-time
+  // "new evaluation" command both open the page this way.
+  const appliedContextRef = useRef(0)
+  useEffect(() => {
+    if (!panelContext || panelContext.id === appliedContextRef.current) return
+    appliedContextRef.current = panelContext.id
+    const context = panelContext.context as
+      | { type?: string; evaluationId?: string }
+      | undefined
+    if (context?.type === 'new') {
+      setSurface('experiments')
+      setCreating(true)
+    } else if (context?.type === 'evaluation' && context.evaluationId) {
+      setSurface('experiments')
+      setCreating(false)
+      setSelectedId(context.evaluationId)
+    }
+  }, [panelContext])
+
+  const switchSurface = useCallback((next: 'sessions' | 'experiments') => {
+    setSurface(next)
+    ;(next === 'sessions' ? sessionsTabRef : experimentsTabRef).current?.focus()
+  }, [])
+
+  useEffect(
+    () =>
+      commands?.register([
+        {
+          id: 'new-evaluation',
+          title: 'New evaluation',
+          detail: 'Start a prompt comparison',
+          keywords: ['experiment', 'compare prompts'],
+          shortcut: 'N',
+          run: () => {
+            setSurface('experiments')
+            setCreating(true)
+          },
+        },
+        {
+          id: 'refresh-history',
+          title: 'Refresh evaluation history',
+          keywords: ['reload'],
+          shortcut: 'R',
+          enabled: () => surface === 'experiments',
+          run: () => void loadHistory(),
+        },
+      ]),
+    [commands, loadHistory, surface],
+  )
+
   const selected = evaluations.find((item) => item.evaluation_id === selectedId) ?? null
 
   return (
     <div className="eval-ui-container">
-      <div className="eval-ui-tabs" role="tablist" aria-label="Eval views">
+      <div
+        className="eval-ui-tabs"
+        role="tablist"
+        aria-label="Eval views"
+        onKeyDown={(event) => {
+          if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return
+          event.preventDefault()
+          switchSurface(surface === 'sessions' ? 'experiments' : 'sessions')
+        }}
+      >
         <button
+          ref={sessionsTabRef}
           className={surface === 'sessions' ? 'active' : ''}
           type="button"
           role="tab"
@@ -201,6 +263,7 @@ export function EvalPage({ host, panelSide = 'left' }: { host: Host } & Partial<
           Sessions
         </button>
         <button
+          ref={experimentsTabRef}
           className={surface === 'experiments' ? 'active' : ''}
           type="button"
           role="tab"

--- a/github/ui/page.tsx
+++ b/github/ui/page.tsx
@@ -29,4 +29,14 @@ export default function setup(host: Host) {
     title: 'github',
     render: (props) => <GithubPage host={host} {...props} />,
   })
+
+  host.commands?.register('github', [
+    {
+      id: 'open',
+      title: 'Open github',
+      detail: 'The working repository commit graph and worker calls, live',
+      keywords: ['git', 'commits', 'activity'],
+      run: () => host.panels?.open({ pageId: 'github', context: {} }),
+    },
+  ])
 }

--- a/github/ui/src/page/GitGraph.tsx
+++ b/github/ui/src/page/GitGraph.tsx
@@ -32,6 +32,7 @@ import {
 } from '@iii-dev/console-ui'
 import {
   type KeyboardEvent,
+  type MutableRefObject,
   memo,
   useCallback,
   useEffect,
@@ -247,7 +248,17 @@ function useGitGraph(host: Host) {
   }
 }
 
-export function GitGraph({ host }: { host: Host }) {
+export function GitGraph({
+  host,
+  liveRef,
+  refreshRef,
+  closeDetailRef,
+}: {
+  host: Host
+  liveRef?: MutableRefObject<(() => void) | null>
+  refreshRef?: MutableRefObject<(() => void) | null>
+  closeDetailRef?: MutableRefObject<(() => void) | null>
+}) {
   const { commits, status, error, live, setLive, refreshing, refresh } =
     useGitGraph(host)
   const [selected, setSelected] = useState<string | null>(null)
@@ -257,6 +268,30 @@ export function GitGraph({ host }: { host: Host }) {
 
   // Narrow: one pane at a time — the graph, or the drilled-in commit detail.
   const showGraph = !narrow || selected === null
+
+  useEffect(() => {
+    if (!liveRef) return
+    liveRef.current = () => setLive((v) => !v)
+    return () => {
+      liveRef.current = null
+    }
+  }, [liveRef, setLive])
+
+  useEffect(() => {
+    if (!refreshRef) return
+    refreshRef.current = () => void refresh()
+    return () => {
+      refreshRef.current = null
+    }
+  }, [refreshRef, refresh])
+
+  useEffect(() => {
+    if (!closeDetailRef) return
+    closeDetailRef.current = selected !== null ? () => setSelected(null) : null
+    return () => {
+      closeDetailRef.current = null
+    }
+  }, [closeDetailRef, selected])
 
   return (
     <div
@@ -277,6 +312,7 @@ export function GitGraph({ host }: { host: Host }) {
           size="sm"
           aria-pressed={live}
           onClick={() => setLive((v) => !v)}
+          data-autofocus=""
         >
           <StatusDot tone={live ? 'accent' : 'warn'} pulse={live} aria-hidden />
           {live ? 'live' : 'paused'}
@@ -465,10 +501,21 @@ const CommitRow = memo(function CommitRow({
   onSelect: (hash: string) => void
 }) {
   const labels = refLabels(commit.refs)
-  const onKeyDown = (e: KeyboardEvent) => {
+  const onKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault()
       onSelect(commit.hash)
+      return
+    }
+    // Rows are flat siblings in `.gh-ui-graph-rows`, so up/down just walks
+    // the DOM — cheaper than tracking an index for up to MAX_COMMITS rows.
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+      e.preventDefault()
+      const sibling =
+        e.key === 'ArrowDown'
+          ? e.currentTarget.nextElementSibling
+          : e.currentTarget.previousElementSibling
+      if (sibling instanceof HTMLElement) sibling.focus()
     }
   }
   return (

--- a/github/ui/src/page/GithubPage.tsx
+++ b/github/ui/src/page/GithubPage.tsx
@@ -24,7 +24,7 @@ import {
   PageShell,
   SegmentedControl,
 } from '@iii-dev/console-ui'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { GitGraph } from './GitGraph'
 import { GithubIcon } from './icons'
 import { ActivityFeed } from './index'
@@ -56,6 +56,7 @@ export function GithubPage({
   host,
   tabId = '',
   onRequestClose,
+  commands,
 }: { host: Host } & Partial<PageRenderProps>) {
   const storageKey = `github-ui:${tabId || 'page'}:view`
   const [view, setViewState] = useState<View>(() =>
@@ -65,6 +66,44 @@ export function GithubPage({
     setViewState(next)
     writeStored(storageKey, next)
   }
+
+  // Set by whichever view is mounted (graph or activity), so one set of page
+  // commands reaches either one without lifting their state up here.
+  const liveRef = useRef<(() => void) | null>(null)
+  const refreshRef = useRef<(() => void) | null>(null)
+  const closeDetailRef = useRef<(() => void) | null>(null)
+
+  useEffect(
+    () =>
+      commands?.register([
+        {
+          id: 'toggle-live',
+          title: 'Toggle live updates',
+          detail: 'Pause or resume this view',
+          keywords: ['pause', 'resume'],
+          shortcut: 'L',
+          enabled: () => liveRef.current !== null,
+          run: () => liveRef.current?.(),
+        },
+        {
+          id: 'refresh',
+          title: 'Refresh the commit graph',
+          keywords: ['reload', 'git log'],
+          shortcut: 'R',
+          enabled: () => refreshRef.current !== null,
+          run: () => refreshRef.current?.(),
+        },
+        {
+          id: 'close-detail',
+          title: 'Close the open detail',
+          keywords: ['back'],
+          shortcut: 'Escape',
+          enabled: () => closeDetailRef.current !== null,
+          run: () => closeDetailRef.current?.(),
+        },
+      ]),
+    [commands],
+  )
 
   return (
     <PageShell className="gh-ui-shell">
@@ -83,9 +122,18 @@ export function GithubPage({
         />
       </PageHeader>
       {view === 'graph' ? (
-        <GitGraph host={host} />
+        <GitGraph
+          host={host}
+          liveRef={liveRef}
+          refreshRef={refreshRef}
+          closeDetailRef={closeDetailRef}
+        />
       ) : (
-        <ActivityFeed host={host} />
+        <ActivityFeed
+          host={host}
+          liveRef={liveRef}
+          closeDetailRef={closeDetailRef}
+        />
       )}
     </PageShell>
   )

--- a/github/ui/src/page/index.tsx
+++ b/github/ui/src/page/index.tsx
@@ -31,6 +31,7 @@ import {
 } from '@iii-dev/console-ui'
 import {
   type KeyboardEvent,
+  type MutableRefObject,
   useCallback,
   useEffect,
   useRef,
@@ -92,7 +93,15 @@ function useCalledFeed(host: Host) {
   return { entries, clear, paused, setPaused }
 }
 
-export function ActivityFeed({ host }: { host: Host }) {
+export function ActivityFeed({
+  host,
+  liveRef,
+  closeDetailRef,
+}: {
+  host: Host
+  liveRef?: MutableRefObject<(() => void) | null>
+  closeDetailRef?: MutableRefObject<(() => void) | null>
+}) {
   const { entries, clear, paused, setPaused } = useCalledFeed(host)
   const [expanded, setExpanded] = useState<string | null>(null)
   const [rootRef, narrow] = useContainerNarrow(NARROW_BELOW)
@@ -104,6 +113,22 @@ export function ActivityFeed({ host }: { host: Host }) {
     return () => window.clearInterval(id)
   }, [])
   const now = Date.now()
+
+  useEffect(() => {
+    if (!liveRef) return
+    liveRef.current = () => setPaused((p) => !p)
+    return () => {
+      liveRef.current = null
+    }
+  }, [liveRef, setPaused])
+
+  useEffect(() => {
+    if (!closeDetailRef) return
+    closeDetailRef.current = expanded !== null ? () => setExpanded(null) : null
+    return () => {
+      closeDetailRef.current = null
+    }
+  }, [closeDetailRef, expanded])
 
   return (
     <div className={`gh-ui-view${narrow ? ' narrow' : ''}`} ref={rootRef}>

--- a/iii-directory/ui/page.tsx
+++ b/iii-directory/ui/page.tsx
@@ -21,6 +21,7 @@ import type { Host } from '@iii-dev/console-ui'
 import { DirectoryConfigForm } from './src/configuration'
 import { createDirectoryTriggerRenderer } from './src/function-trigger'
 import { DirectoryPage } from './src/page'
+import { registerDirectoryPalette } from './src/page/palette'
 import { createSearchTriggerRenderer } from './src/search/search-card'
 import { createSystemPromptChip } from './src/session-chip'
 
@@ -41,6 +42,8 @@ export default function setup(host: Host) {
     title: 'Directory',
     render: (props) => <DirectoryPage host={host} {...props} />,
   })
+
+  registerDirectoryPalette(host)
 
   host.functionTriggers.register(createDirectoryTriggerRenderer())
   host.functionTriggers.register(createSearchTriggerRenderer())

--- a/iii-directory/ui/src/page/browser.tsx
+++ b/iii-directory/ui/src/page/browser.tsx
@@ -30,12 +30,12 @@ import {
   type Host,
   Input,
   MarkdownPreview,
+  type PageCommandsApi,
   PageSidebar,
   SegmentedControl,
 } from '@iii-dev/console-ui'
 import type { ReactNode } from 'react'
 import { useCallback, useEffect, useId, useRef, useState } from 'react'
-import { draftAction, parseStoredDraft } from './draft-storage'
 import {
   BackButton,
   MarkdownFileIcon,
@@ -43,6 +43,7 @@ import {
   SearchIcon,
   XIcon,
 } from '../lib/widgets'
+import { draftAction, parseStoredDraft } from './draft-storage'
 import {
   frontmatterBody,
   readFrontmatterField,
@@ -145,7 +146,6 @@ function removeStored(key: string) {
   }
 }
 
-
 const clampRatio = (n: number) => Math.min(0.75, Math.max(0.25, n))
 
 /** Observe the browser root's own width. Returns a callback ref to put
@@ -209,6 +209,9 @@ export function CollectionBrowser({
   nav,
   panelSide = 'left',
   storageKey,
+  commands,
+  active = true,
+  pendingOpen,
 }: {
   host: Host
   adapter: BrowserAdapter
@@ -217,6 +220,15 @@ export function CollectionBrowser({
   panelSide?: 'left' | 'right'
   /** localStorage namespace for per-tab+collection UI state. */
   storageKey: string
+  /** The page's command surface — shared across every mounted collection. */
+  commands?: PageCommandsApi
+  /** Whether this collection is the one currently shown (all three stay
+      mounted); only the active one registers page-level commands/keys. */
+  active?: boolean
+  /** A palette row picked this collection's entry — open it (see
+      palette.ts + the page's panelContext handler). `id` is monotonic, so
+      a repeated identical selection still re-applies. */
+  pendingOpen?: { id: number; key: string } | null
 }) {
   const [rows, setRows] = useState<BrowserRow[] | null>(null)
   const [listError, setListError] = useState<string | null>(null)
@@ -371,6 +383,13 @@ export function CollectionBrowser({
     },
     [host, adapter, storageKey],
   )
+
+  const appliedOpenRef = useRef(0)
+  useEffect(() => {
+    if (!pendingOpen || pendingOpen.id === appliedOpenRef.current) return
+    appliedOpenRef.current = pendingOpen.id
+    open(pendingOpen.key)
+  }, [pendingOpen, open])
 
   /** Blank editor for a new entry. `loaded.content` is empty rather than the
       template, so the scaffold already counts as unsaved work and ⌘S/save is
@@ -563,6 +582,37 @@ export function CollectionBrowser({
     setStaleOnDisk(false)
   }
 
+  // The collection's primary verbs, for the palette and for the keyboard
+  // while this pane has the focus — only the visible collection registers,
+  // since all three stay mounted at once. The `/` and ⌘S raw handlers above
+  // keep working as-is; these just make the same actions ⌘K-visible.
+  useEffect(() => {
+    if (!active) return
+    return commands?.register([
+      {
+        id: 'new-entry',
+        title: `New ${adapter.noun}`,
+        shortcut: 'N',
+        enabled: () => !!adapter.create,
+        run: startCreate,
+      },
+      {
+        id: 'filter',
+        title: `Filter ${adapter.noun}s`,
+        shortcut: '/',
+        run: () => searchRef.current?.focus(),
+      },
+      {
+        id: 'save',
+        title: 'Save',
+        shortcut: 'Mod+S',
+        firesWhileTyping: true,
+        enabled: () => dirty && !saving && !deleting,
+        run: save,
+      },
+    ])
+  }, [commands, active, adapter, startCreate, save, dirty, saving, deleting])
+
   // ── split divider ───────────────────────────────────────────────────
 
   const draggingRef = useRef(false)
@@ -737,6 +787,7 @@ export function CollectionBrowser({
                 placeholder={`filter ${adapter.noun}s…`}
                 aria-label={`filter ${adapter.noun}s`}
                 className="dir-ui-search-input"
+                data-autofocus={active ? '' : undefined}
                 onKeyDown={(e) => {
                   if (e.key === 'Escape' && search) {
                     e.stopPropagation()

--- a/iii-directory/ui/src/page/index.tsx
+++ b/iii-directory/ui/src/page/index.tsx
@@ -16,7 +16,7 @@ import {
   PageShell,
   SegmentedControl,
 } from '@iii-dev/console-ui'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { formatBytes, formatRelativeTime } from '../lib/format'
 import { MarkdownFileIcon } from '../lib/widgets'
 import { type BrowserAdapter, CollectionBrowser } from './browser'
@@ -46,7 +46,8 @@ const skillsAdapter: BrowserAdapter = {
   defaultNameKey: 'name',
   // Skill ids are slash-separated lowercase segments (ns/skill/…).
   namePattern: /^[a-z0-9_-]+(\/[a-z0-9_-]+)*$/,
-  nameHint: 'enter an id of lowercase slash-separated segments (a–z, 0–9, hyphens or underscores)',
+  nameHint:
+    'enter an id of lowercase slash-separated segments (a–z, 0–9, hyphens or underscores)',
   onChangeType: 'directory::skills::on-change',
   emptyTitle: 'Select a skill',
   emptyBody:
@@ -83,7 +84,10 @@ const skillsAdapter: BrowserAdapter = {
     return out.id ?? id
   },
   async create(host, id, content) {
-    const out = await host.iii.trigger<{ id: string }>('directory::skills::create', { id, content })
+    const out = await host.iii.trigger<{ id: string }>(
+      'directory::skills::create',
+      { id, content },
+    )
     return out.id ?? id
   },
   async remove(host, id) {
@@ -230,8 +234,44 @@ export function DirectoryPage({
   panelSide = 'left',
   tabId = '',
   onRequestClose,
+  panelContext,
+  commands,
 }: { host: Host } & Partial<PageRenderProps>) {
   const [collection, setCollection] = useState<Collection>('skills')
+  const [pendingOpen, setPendingOpen] = useState<{
+    id: number
+    collection: Collection
+    key: string
+  } | null>(null)
+
+  // A palette row (see palette.ts) selects a collection + entry here once
+  // the page is open. `panelContext.id` is monotonic, so a repeated
+  // identical click still re-applies.
+  const appliedContextRef = useRef(0)
+  useEffect(() => {
+    if (!panelContext || panelContext.id === appliedContextRef.current) return
+    appliedContextRef.current = panelContext.id
+    const context = panelContext.context as {
+      collection?: string
+      key?: string
+    } | null
+    const collectionValue = context?.collection
+    if (
+      !context ||
+      typeof collectionValue !== 'string' ||
+      typeof context.key !== 'string' ||
+      !COLLECTIONS.some((c) => c.value === collectionValue)
+    ) {
+      return
+    }
+    const nextCollection = collectionValue as Collection
+    setCollection(nextCollection)
+    setPendingOpen({
+      id: panelContext.id,
+      collection: nextCollection,
+      key: context.key,
+    })
+  }, [panelContext])
 
   const switcher = (
     <SegmentedControl<Collection>
@@ -263,6 +303,13 @@ export function DirectoryPage({
             nav={switcher}
             panelSide={panelSide}
             storageKey={`iii-directory-ui:${tabId || 'page'}:${c.value}`}
+            commands={commands}
+            active={collection === c.value}
+            pendingOpen={
+              pendingOpen && pendingOpen.collection === c.value
+                ? pendingOpen
+                : null
+            }
           />
         </div>
       ))}

--- a/iii-directory/ui/src/page/palette.ts
+++ b/iii-directory/ui/src/page/palette.ts
@@ -1,0 +1,107 @@
+/**
+ * The directory worker in the command palette, before its page is even
+ * open. One combined source answers a query across all three collections
+ * (skills, prompts, system prompts) — the worker has no unified search
+ * function, so this fetches each collection's list and filters
+ * client-side, the same as the in-page filter does. Rows open the page on
+ * that collection with the entry selected (see the page's panelContext
+ * handler). Registered from setup, so it exists only while the
+ * iii-directory worker is connected; older consoles without
+ * `host.palette` / `host.commands` simply get nothing.
+ */
+
+import type { Host, PaletteSourceRow } from '@iii-dev/console-ui'
+
+const ROWS = 30
+
+export type DirectoryCollection = 'skills' | 'prompts' | 'system-prompts'
+
+const COLLECTIONS: {
+  id: DirectoryCollection
+  label: string
+  listFn: string
+}[] = [
+  { id: 'skills', label: 'Skills', listFn: 'directory::skills::list' },
+  { id: 'prompts', label: 'Prompts', listFn: 'directory::prompts::list' },
+  {
+    id: 'system-prompts',
+    label: 'System prompts',
+    listFn: 'directory::system-prompts::list',
+  },
+]
+
+interface Row {
+  key: string
+  title: string
+  description: string
+}
+
+async function listCollection(
+  host: Host,
+  collection: (typeof COLLECTIONS)[number],
+): Promise<Row[]> {
+  const payload =
+    collection.id === 'skills' ? { include_description: true } : {}
+  const out = await host.iii.trigger<Record<string, unknown>>(
+    collection.listFn,
+    payload,
+  )
+  // Skills answer `{ skills }`; prompts and system prompts both answer
+  // `{ prompts }` (same shape, per PromptRow).
+  const items = (out.skills ?? out.prompts ?? []) as Record<string, unknown>[]
+  return items
+    .map((item) => ({
+      key: String(item.id ?? item.name ?? ''),
+      title: String(item.title || item.name || item.id || ''),
+      description: String(item.description ?? ''),
+    }))
+    .filter((row) => row.key !== '')
+}
+
+export function registerDirectoryPalette(host: Host): void {
+  host.palette?.registerSource({
+    id: 'directory-entries',
+    title: 'Directory',
+    kind: 'item',
+    minQuery: 2,
+    async search(query, { signal }) {
+      const needle = query.toLowerCase()
+      const lists = await Promise.all(
+        COLLECTIONS.map((collection) => listCollection(host, collection)),
+      )
+      if (signal.aborted) return []
+      const rows: PaletteSourceRow[] = []
+      for (let i = 0; i < COLLECTIONS.length; i++) {
+        const collection = COLLECTIONS[i]
+        for (const row of lists[i]) {
+          if (rows.length >= ROWS) break
+          const haystack =
+            `${row.title} ${row.key} ${row.description}`.toLowerCase()
+          if (!haystack.includes(needle)) continue
+          rows.push({
+            id: `${collection.id}:${row.key}`,
+            title: row.title || row.key,
+            detail: collection.label,
+            keywords: [row.key],
+            run: () =>
+              host.panels?.open({
+                pageId: 'directory',
+                context: { collection: collection.id, key: row.key },
+              }),
+          })
+        }
+      }
+      return rows
+    },
+  })
+
+  host.commands?.register('directory', [
+    {
+      id: 'open',
+      title: 'Open Directory',
+      detail: 'Filesystem-backed skills, prompts and system prompts',
+      keywords: ['skills', 'prompts', 'system prompts'],
+      run: () => host.panels?.open({ pageId: 'directory', context: {} }),
+    },
+  ])
+}

--- a/memory/ui/page.tsx
+++ b/memory/ui/page.tsx
@@ -25,6 +25,7 @@
 
 import type { Host } from '@iii-dev/console-ui'
 import { MemoryPage } from './src/page'
+import { registerMemoryPalette } from './src/page/palette'
 
 export default function setup(host: Host) {
   host.pages.register({
@@ -32,4 +33,5 @@ export default function setup(host: Host) {
     title: 'memory',
     render: (props) => <MemoryPage host={host} {...props} />,
   })
+  registerMemoryPalette(host)
 }

--- a/memory/ui/src/page/BankRail.tsx
+++ b/memory/ui/src/page/BankRail.tsx
@@ -5,8 +5,8 @@
  * `memory_bank`. In the narrow drill-in flow this list is the first pane.
  */
 
-import { useState } from 'react'
 import { Button, Input } from '@iii-dev/console-ui'
+import { useState } from 'react'
 import { Plus } from './icons'
 import type { MemoryBank } from './memory-data'
 
@@ -18,6 +18,8 @@ interface BankRailProps {
   onSelect: (bank: string) => void
   onCreate: (name: string) => Promise<boolean>
   creating: boolean
+  /** Focus the first bank row when the page opens with no bank selected. */
+  autofocusFirst?: boolean
 }
 
 export function BankRail({
@@ -27,6 +29,7 @@ export function BankRail({
   onSelect,
   onCreate,
   creating,
+  autofocusFirst,
 }: BankRailProps) {
   const [draft, setDraft] = useState('')
   const valid = /^[a-z0-9][a-z0-9_-]{0,63}$/.test(draft)
@@ -58,12 +61,15 @@ export function BankRail({
           </div>
         ) : (
           <ul className="mem-ui-nav-list">
-            {banks.map((bank) => (
+            {banks.map((bank, index) => (
               <li key={bank.name}>
                 <button
                   type="button"
                   className={`mem-ui-nav-row${selected === bank.name ? ' active' : ''}`}
                   aria-current={selected === bank.name ? 'true' : undefined}
+                  data-autofocus={
+                    autofocusFirst && index === 0 ? '' : undefined
+                  }
                   onClick={() => onSelect(bank.name)}
                 >
                   <span className="name">{bank.name}</span>
@@ -93,6 +99,7 @@ export function BankRail({
           placeholder="new bank"
           aria-label="new bank name"
           className="mem-ui-rail-input"
+          data-mem-new-bank-input=""
         />
         <Button
           type="submit"

--- a/memory/ui/src/page/RulesPanel.tsx
+++ b/memory/ui/src/page/RulesPanel.tsx
@@ -126,7 +126,10 @@ function RuleEditor({
           ? {
               'data-autofocus': '',
               tabIndex: -1,
-              onFocus: () => editorRef.current?.focus(),
+              onFocus: (event: React.FocusEvent<HTMLDivElement>) => {
+                if (event.target === event.currentTarget)
+                  editorRef.current?.focus()
+              },
             }
           : {})}
       >

--- a/memory/ui/src/page/RulesPanel.tsx
+++ b/memory/ui/src/page/RulesPanel.tsx
@@ -1,5 +1,11 @@
-import { useEffect, useState } from 'react'
-import { Button, CodeEditor, EmptyState, Input } from '@iii-dev/console-ui'
+import {
+  Button,
+  CodeEditor,
+  type CodeEditorHandle,
+  EmptyState,
+  Input,
+} from '@iii-dev/console-ui'
+import { useEffect, useRef, useState } from 'react'
 import { Plus, X } from './icons'
 import type { MemoryRule } from './memory-data'
 import { useDirtyDelta } from './widgets'
@@ -26,13 +32,17 @@ function RuleEditor({
   onSet,
   busy,
   reportDirty,
+  autofocus,
 }: {
   name: string
   initial: string
   onSet: (name: string, content: string) => Promise<boolean>
   busy: boolean
   reportDirty: (delta: number) => void
+  /** This is the rules panel's default focus target — see its own comment. */
+  autofocus?: boolean
 }) {
+  const editorRef = useRef<CodeEditorHandle>(null)
   const [content, setContent] = useState(initial)
   // Re-seed the editor when a live refresh changes the rule on disk and
   // the user has no local edits in flight. After a successful save,
@@ -107,8 +117,21 @@ function RuleEditor({
           )}
         </div>
       </div>
-      <div className="mem-ui-rule-editor">
+      <div
+        className="mem-ui-rule-editor"
+        // Forwards a page-level `.focus()` (⌘K, a go-to chord, or
+        // `host.panels.open`) into Monaco — data-autofocus can only target a
+        // DOM node, not the editor's own imperative handle.
+        {...(autofocus
+          ? {
+              'data-autofocus': '',
+              tabIndex: -1,
+              onFocus: () => editorRef.current?.focus(),
+            }
+          : {})}
+      >
         <CodeEditor
+          ref={editorRef}
           value={content}
           onChange={(next) => {
             setContent(next)
@@ -170,7 +193,7 @@ export function RulesPanel({
           description="add one named 'style' with a line like 'answer tersely, code first' — then ask anything in chat on this bank and watch every reply follow it. corrections you make in chat will grow a learned.md here on their own."
         />
       ) : (
-        rules.map((rule) => (
+        rules.map((rule, index) => (
           <RuleEditor
             key={rule.name}
             name={rule.name}
@@ -178,6 +201,7 @@ export function RulesPanel({
             onSet={onSet}
             busy={busy}
             reportDirty={reportDirty}
+            autofocus={index === 0}
           />
         ))
       )}

--- a/memory/ui/src/page/index.tsx
+++ b/memory/ui/src/page/index.tsx
@@ -210,6 +210,7 @@ export function MemoryPage({
   // page is open. `panelContext.id` is monotonic, so a repeated identical
   // click still re-applies.
   const appliedContextRef = useRef(0)
+  const shellRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
     if (!panelContext || panelContext.id === appliedContextRef.current) return
     appliedContextRef.current = panelContext.id
@@ -243,8 +244,8 @@ export function MemoryPage({
           run: () => {
             if (narrow && drilled) backToBanks()
             window.requestAnimationFrame(() => {
-              document
-                .querySelector<HTMLElement>('[data-mem-new-bank-input]')
+              shellRef.current
+                ?.querySelector<HTMLElement>('[data-mem-new-bank-input]')
                 ?.focus()
             })
           },
@@ -262,7 +263,7 @@ export function MemoryPage({
   const showDoc = !narrow || (drilled && selected !== null)
 
   return (
-    <PageShell className="mem-ui-shell">
+    <PageShell ref={shellRef} className="mem-ui-shell">
       <PageHeader
         icon={<Brain size={16} />}
         title="Memory"

--- a/memory/ui/src/page/index.tsx
+++ b/memory/ui/src/page/index.tsx
@@ -32,7 +32,7 @@ import {
   SegmentedControl,
   StatusDot,
 } from '@iii-dev/console-ui'
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { BankRail } from './BankRail'
 import { Brain, RefreshCw } from './icons'
 import { MemoriesPanel } from './MemoriesPanel'
@@ -122,6 +122,8 @@ export function MemoryPage({
   panelSide = 'left',
   tabId = '',
   onRequestClose,
+  panelContext,
+  commands,
 }: { host: Host } & Partial<PageRenderProps>) {
   const {
     banks,
@@ -204,6 +206,53 @@ export function MemoryPage({
     setDrilled(false)
   }
 
+  // Palette rows for a bank/memory (see palette.ts) select it here once the
+  // page is open. `panelContext.id` is monotonic, so a repeated identical
+  // click still re-applies.
+  const appliedContextRef = useRef(0)
+  useEffect(() => {
+    if (!panelContext || panelContext.id === appliedContextRef.current) return
+    appliedContextRef.current = panelContext.id
+    const context = panelContext.context as {
+      type?: string
+      bank?: string
+    } | null
+    if (!context || typeof context.bank !== 'string') return
+    openBank(context.bank)
+    if (context.type === 'memory') setPanel('memories')
+  }, [panelContext, openBank, setPanel])
+
+  // The page's primary verbs, for the palette and for the keyboard while
+  // this pane has the focus.
+  useEffect(
+    () =>
+      commands?.register([
+        {
+          id: 'reload',
+          title: 'Reload from disk',
+          detail: 'Re-read every bank — picks up hand-edited files',
+          shortcut: 'R',
+          enabled: () => !loading && !busy,
+          run: () => void act(() => reloadStore(host)),
+        },
+        {
+          id: 'new-bank',
+          title: 'New bank',
+          detail: 'Create a named memory scope',
+          shortcut: 'N',
+          run: () => {
+            if (narrow && drilled) backToBanks()
+            window.requestAnimationFrame(() => {
+              document
+                .querySelector<HTMLElement>('[data-mem-new-bank-input]')
+                ?.focus()
+            })
+          },
+        },
+      ]),
+    [commands, host, act, loading, busy, narrow, drilled, backToBanks],
+  )
+
   const bankInfo = selected
     ? (banks.find((b) => b.name === selected) ?? null)
     : null
@@ -281,6 +330,7 @@ export function MemoryPage({
               onSelect={openBank}
               onCreate={(name) => act(() => createBank(host, name))}
               creating={busy}
+              autofocusFirst={selected === null}
             />
           </PageSidebar>
         ) : null}

--- a/memory/ui/src/page/palette.ts
+++ b/memory/ui/src/page/palette.ts
@@ -1,0 +1,105 @@
+/**
+ * The memory worker in the command palette, before its page is even open.
+ *
+ * Two live sources answer a query: banks by name, and memories by their
+ * text/tags across every bank (there is no cross-bank search function, so
+ * this fetches each bank's page and filters client-side — bounded by
+ * MEMORIES_PER_BANK and the shared row cap). Both open the page selecting
+ * the matched row. Registered from setup, so they exist only while the
+ * memory worker is connected; older consoles without `host.palette` /
+ * `host.commands` simply get nothing.
+ */
+
+import type { Host, PaletteSourceRow } from '@iii-dev/console-ui'
+import { listBanks, listMemories } from './memory-data'
+
+const ROWS = 30
+const MEMORIES_PER_BANK = 100
+
+export function registerMemoryPalette(host: Host): void {
+  host.palette?.registerSource({
+    id: 'memory-banks',
+    title: 'Memory banks',
+    kind: 'item',
+    minQuery: 2,
+    async search(query, { signal }) {
+      const banks = await listBanks(host)
+      if (signal.aborted) return []
+      const needle = query.toLowerCase()
+      return banks
+        .filter(
+          (bank) =>
+            bank.name.toLowerCase().includes(needle) ||
+            bank.description.toLowerCase().includes(needle),
+        )
+        .slice(0, ROWS)
+        .map((bank) => ({
+          id: bank.name,
+          title: bank.name,
+          detail:
+            bank.description ||
+            `${bank.memories} memories · ${bank.rules} rules`,
+          run: () =>
+            host.panels?.open({
+              pageId: 'memory',
+              context: { type: 'bank', bank: bank.name },
+            }),
+        }))
+    },
+  })
+
+  host.palette?.registerSource({
+    id: 'memories',
+    title: 'Memories',
+    kind: 'item',
+    minQuery: 2,
+    async search(query, { signal }) {
+      const banks = await listBanks(host)
+      if (signal.aborted) return []
+      const needle = query.toLowerCase()
+      const rows: PaletteSourceRow[] = []
+      for (const bank of banks) {
+        if (rows.length >= ROWS) break
+        const { memories } = await listMemories(
+          host,
+          bank.name,
+          false,
+          0,
+          MEMORIES_PER_BANK,
+        )
+        if (signal.aborted) return []
+        for (const memory of memories) {
+          if (rows.length >= ROWS) break
+          const haystack =
+            `${memory.text} ${memory.tags.join(' ')}`.toLowerCase()
+          if (!haystack.includes(needle)) continue
+          rows.push({
+            id: `${bank.name}:${memory.id}`,
+            title:
+              memory.text.length > 88
+                ? `${memory.text.slice(0, 88)}…`
+                : memory.text,
+            detail: bank.name,
+            keywords: memory.tags,
+            run: () =>
+              host.panels?.open({
+                pageId: 'memory',
+                context: { type: 'memory', bank: bank.name, id: memory.id },
+              }),
+          })
+        }
+      }
+      return rows
+    },
+  })
+
+  host.commands?.register('memory', [
+    {
+      id: 'open',
+      title: 'Open memory',
+      detail: 'Banks of rules and memories, injected per turn',
+      keywords: ['banks', 'rules', 'recall'],
+      run: () => host.panels?.open({ pageId: 'memory', context: {} }),
+    },
+  ])
+}

--- a/packages/console-ui/index.d.ts
+++ b/packages/console-ui/index.d.ts
@@ -36,8 +36,15 @@ export interface ExtensionIii {
    * Subscribe a browser-local handler. Handlers are namespaced per tab
    * (`<functionId>::<browserId>`) and default `metadata.internal = true`.
    */
-  on<P = unknown>(functionId: string, handler: (payload: P) => void | Promise<void>): () => void
-  registerTrigger(input: { type: string; function_id: string; config: Record<string, unknown> }): () => void
+  on<P = unknown>(
+    functionId: string,
+    handler: (payload: P) => void | Promise<void>,
+  ): () => void
+  registerTrigger(input: {
+    type: string
+    function_id: string
+    config: Record<string, unknown>
+  }): () => void
   addConnectionStateListener(handler: (state: unknown) => void): () => void
 }
 
@@ -277,8 +284,20 @@ export interface TriggerActivityMessage {
   payload?: unknown
   firedAt?: number
   note?: string
-  outcome?: 'delivered' | 'delivery_failed' | 'skipped' | 'expired' | 'unregistered' | 'invalidated'
-  retirementReason?: 'once_consumed' | 'max_fires' | 'expired' | 'unregistered' | 'invalidated' | 'exhausted'
+  outcome?:
+    | 'delivered'
+    | 'delivery_failed'
+    | 'skipped'
+    | 'expired'
+    | 'unregistered'
+    | 'invalidated'
+  retirementReason?:
+    | 'once_consumed'
+    | 'max_fires'
+    | 'expired'
+    | 'unregistered'
+    | 'invalidated'
+    | 'exhausted'
 }
 
 /**
@@ -293,7 +312,13 @@ export interface TriggerActivityRenderer {
   tryRender(activity: TriggerActivityMessage): React.ReactNode | null
 }
 
-export type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue }
+export type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonValue[]
+  | { [key: string]: JsonValue }
 
 /**
  * Props for a configuration-form override (the `configForms` slot). The
@@ -448,7 +473,10 @@ export interface Host {
   }
   /** Optional on consoles that predate provider-specific configuration UI. */
   providerConfigForms?: {
-    register(providerId: string, component: React.ComponentType<ProviderConfigFormProps>): () => void
+    register(
+      providerId: string,
+      component: React.ComponentType<ProviderConfigFormProps>,
+    ): () => void
   }
   /**
    * Optional: absent on consoles that predate session chips. Feature-detect
@@ -470,7 +498,9 @@ export interface Host {
 }
 
 /** The ONLY required export of a script asset. */
-export type SetupFn = (host: Host) => void | (() => void) | Promise<void | (() => void)>
+export type SetupFn = (
+  host: Host,
+) => void | (() => void) | Promise<void | (() => void)>
 
 /* ── module-level api (same objects the Host carries) ───────────────── */
 
@@ -554,20 +584,25 @@ export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
 /** Compact semantic status label shared by the Console and worker UIs. */
 export declare const Badge: React.ComponentType<BadgeProps>
 
-export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: 'primary' | 'ghost' | 'pill' | 'icon' | 'terminal' | 'wiggle'
   size?: 'sm' | 'md' | 'lg' | 'icon'
   /** Render as the child element (Radix Slot) instead of a `<button>`. */
   asChild?: boolean
 }
-export declare const Button: React.ComponentType<ButtonProps & React.RefAttributes<HTMLButtonElement>>
+export declare const Button: React.ComponentType<
+  ButtonProps & React.RefAttributes<HTMLButtonElement>
+>
 
 export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
   /** Neutral selected treatment: surface, edge and ink; never accent. */
   selected?: boolean
   interactive?: boolean
 }
-export declare const Card: React.ComponentType<CardProps & React.RefAttributes<HTMLDivElement>>
+export declare const Card: React.ComponentType<
+  CardProps & React.RefAttributes<HTMLDivElement>
+>
 export declare const CardHeader: React.ComponentType<
   React.HTMLAttributes<HTMLDivElement> & React.RefAttributes<HTMLDivElement>
 >
@@ -579,7 +614,8 @@ export declare const CardHighlight: React.ComponentType<
   React.HTMLAttributes<HTMLDivElement> & React.RefAttributes<HTMLDivElement>
 >
 
-export interface CollapsibleCardProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface CollapsibleCardProps
+  extends React.HTMLAttributes<HTMLDivElement> {
   /** Controlled expanded state. */
   open?: boolean
   /** Initial expanded state when the component is uncontrolled. */
@@ -596,7 +632,8 @@ export interface CollapsibleCardProps extends React.HTMLAttributes<HTMLDivElemen
 export declare const CollapsibleCard: React.ComponentType<
   CollapsibleCardProps & React.RefAttributes<HTMLDivElement>
 >
-export type CollapsibleCardTriggerProps = React.ButtonHTMLAttributes<HTMLButtonElement>
+export type CollapsibleCardTriggerProps =
+  React.ButtonHTMLAttributes<HTMLButtonElement>
 export declare const CollapsibleCardTrigger: React.ComponentType<
   CollapsibleCardTriggerProps & React.RefAttributes<HTMLButtonElement>
 >
@@ -610,10 +647,13 @@ export interface ChipProps extends React.HTMLAttributes<HTMLSpanElement> {
   tone?: ChipTone
   selected?: boolean
 }
-export declare const Chip: React.ComponentType<ChipProps & React.RefAttributes<HTMLSpanElement>>
+export declare const Chip: React.ComponentType<
+  ChipProps & React.RefAttributes<HTMLSpanElement>
+>
 
 export type TableDensity = 'comfortable' | 'compact'
-export interface TableProps extends React.TableHTMLAttributes<HTMLTableElement> {
+export interface TableProps
+  extends React.TableHTMLAttributes<HTMLTableElement> {
   density?: TableDensity
 }
 export declare const TableViewport: React.ComponentType<
@@ -622,29 +662,40 @@ export declare const TableViewport: React.ComponentType<
 export declare const TableFrame: React.ComponentType<
   React.HTMLAttributes<HTMLDivElement> & React.RefAttributes<HTMLDivElement>
 >
-export declare const Table: React.ComponentType<TableProps & React.RefAttributes<HTMLTableElement>>
+export declare const Table: React.ComponentType<
+  TableProps & React.RefAttributes<HTMLTableElement>
+>
 export declare const TableHeader: React.ComponentType<
-  React.HTMLAttributes<HTMLTableSectionElement> & React.RefAttributes<HTMLTableSectionElement>
+  React.HTMLAttributes<HTMLTableSectionElement> &
+    React.RefAttributes<HTMLTableSectionElement>
 >
 export declare const TableBody: React.ComponentType<
-  React.HTMLAttributes<HTMLTableSectionElement> & React.RefAttributes<HTMLTableSectionElement>
+  React.HTMLAttributes<HTMLTableSectionElement> &
+    React.RefAttributes<HTMLTableSectionElement>
 >
 export declare const TableFooter: React.ComponentType<
-  React.HTMLAttributes<HTMLTableSectionElement> & React.RefAttributes<HTMLTableSectionElement>
+  React.HTMLAttributes<HTMLTableSectionElement> &
+    React.RefAttributes<HTMLTableSectionElement>
 >
-export interface TableRowProps extends React.HTMLAttributes<HTMLTableRowElement> {
+export interface TableRowProps
+  extends React.HTMLAttributes<HTMLTableRowElement> {
   interactive?: boolean
   selected?: boolean
 }
-export declare const TableRow: React.ComponentType<TableRowProps & React.RefAttributes<HTMLTableRowElement>>
+export declare const TableRow: React.ComponentType<
+  TableRowProps & React.RefAttributes<HTMLTableRowElement>
+>
 export declare const TableHead: React.ComponentType<
-  React.ThHTMLAttributes<HTMLTableCellElement> & React.RefAttributes<HTMLTableCellElement>
+  React.ThHTMLAttributes<HTMLTableCellElement> &
+    React.RefAttributes<HTMLTableCellElement>
 >
 export declare const TableCell: React.ComponentType<
-  React.TdHTMLAttributes<HTMLTableCellElement> & React.RefAttributes<HTMLTableCellElement>
+  React.TdHTMLAttributes<HTMLTableCellElement> &
+    React.RefAttributes<HTMLTableCellElement>
 >
 export declare const TableCaption: React.ComponentType<
-  React.HTMLAttributes<HTMLTableCaptionElement> & React.RefAttributes<HTMLTableCaptionElement>
+  React.HTMLAttributes<HTMLTableCaptionElement> &
+    React.RefAttributes<HTMLTableCaptionElement>
 >
 
 export interface ImageViewerProps {
@@ -686,7 +737,9 @@ export interface IconButtonProps extends Omit<ButtonProps, 'size'> {
   tooltip?: React.ReactNode | false
   tooltipSide?: 'top' | 'right' | 'bottom' | 'left'
 }
-export declare const IconButton: React.ComponentType<IconButtonProps & React.RefAttributes<HTMLButtonElement>>
+export declare const IconButton: React.ComponentType<
+  IconButtonProps & React.RefAttributes<HTMLButtonElement>
+>
 
 export interface ConfirmDialogProps {
   open: boolean
@@ -715,15 +768,22 @@ export interface DialogProps {
   children?: React.ReactNode
 }
 export declare const Dialog: React.ComponentType<DialogProps>
-export interface DialogTriggerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export interface DialogTriggerProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   asChild?: boolean
 }
 export declare const DialogTrigger: React.ComponentType<DialogTriggerProps>
 export declare const DialogClose: React.ComponentType<DialogTriggerProps>
 /** Portalled, centered, with overlay and close affordance built in. */
-export declare const DialogContent: React.ComponentType<React.HTMLAttributes<HTMLDivElement>>
-export declare const DialogTitle: React.ComponentType<React.HTMLAttributes<HTMLHeadingElement>>
-export declare const DialogDescription: React.ComponentType<React.HTMLAttributes<HTMLParagraphElement>>
+export declare const DialogContent: React.ComponentType<
+  React.HTMLAttributes<HTMLDivElement>
+>
+export declare const DialogTitle: React.ComponentType<
+  React.HTMLAttributes<HTMLHeadingElement>
+>
+export declare const DialogDescription: React.ComponentType<
+  React.HTMLAttributes<HTMLParagraphElement>
+>
 
 export interface DropdownMenuProps {
   open?: boolean
@@ -733,23 +793,30 @@ export interface DropdownMenuProps {
   children?: React.ReactNode
 }
 export declare const DropdownMenu: React.ComponentType<DropdownMenuProps>
-export interface DropdownMenuTriggerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export interface DropdownMenuTriggerProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   asChild?: boolean
 }
 export declare const DropdownMenuTrigger: React.ComponentType<DropdownMenuTriggerProps>
-export interface DropdownMenuContentProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface DropdownMenuContentProps
+  extends React.HTMLAttributes<HTMLDivElement> {
   side?: 'top' | 'right' | 'bottom' | 'left'
   align?: 'start' | 'center' | 'end'
   sideOffset?: number
 }
 export declare const DropdownMenuContent: React.ComponentType<DropdownMenuContentProps>
-export interface DropdownMenuItemProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface DropdownMenuItemProps
+  extends React.HTMLAttributes<HTMLDivElement> {
   disabled?: boolean
   onSelect?(event: Event): void
 }
 export declare const DropdownMenuItem: React.ComponentType<DropdownMenuItemProps>
-export declare const DropdownMenuLabel: React.ComponentType<React.HTMLAttributes<HTMLDivElement>>
-export declare const DropdownMenuSeparator: React.ComponentType<React.HTMLAttributes<HTMLDivElement>>
+export declare const DropdownMenuLabel: React.ComponentType<
+  React.HTMLAttributes<HTMLDivElement>
+>
+export declare const DropdownMenuSeparator: React.ComponentType<
+  React.HTMLAttributes<HTMLDivElement>
+>
 
 export interface EmptyStateProps {
   icon?: React.ComponentType<{ className?: string }>
@@ -804,13 +871,19 @@ export interface FileDiffProps {
 export declare const FileDiff: React.ComponentType<FileDiffProps>
 
 /** Controlled string input (`onChange` receives the value, not the event). */
-export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange' | 'value'> {
+export interface InputProps
+  extends Omit<
+    React.InputHTMLAttributes<HTMLInputElement>,
+    'onChange' | 'value'
+  > {
   value: string
   onChange: (next: string) => void
   /** @deprecated Inputs preserve case by default; retained for compatibility. */
   preserveCase?: boolean
 }
-export declare const Input: React.ComponentType<InputProps & React.RefAttributes<HTMLInputElement>>
+export declare const Input: React.ComponentType<
+  InputProps & React.RefAttributes<HTMLInputElement>
+>
 
 export declare const List: React.ComponentType<
   React.HTMLAttributes<HTMLDivElement> & React.RefAttributes<HTMLDivElement>
@@ -821,14 +894,17 @@ export declare const ListGroup: React.ComponentType<
 export declare const ListGroupLabel: React.ComponentType<
   React.HTMLAttributes<HTMLDivElement> & React.RefAttributes<HTMLDivElement>
 >
-export interface ListItemProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export interface ListItemProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   selected?: boolean
   leading?: React.ReactNode
   label?: React.ReactNode
   description?: React.ReactNode
   trailing?: React.ReactNode
 }
-export declare const ListItem: React.ComponentType<ListItemProps & React.RefAttributes<HTMLButtonElement>>
+export declare const ListItem: React.ComponentType<
+  ListItemProps & React.RefAttributes<HTMLButtonElement>
+>
 
 /* ── page chrome: THE layout design system for injected pages ─────────
    Every worker page composes the same five pieces so panes stay visually
@@ -845,7 +921,7 @@ export declare const ListItem: React.ComponentType<ListItemProps & React.RefAttr
    PageHeader renders the standard ✕ when `onClose` is present — wire it
    to `PageRenderProps.onRequestClose`. */
 
-export interface PageShellProps extends React.HTMLAttributes<HTMLDivElement> {}
+export interface PageShellProps extends React.ComponentProps<'div'> {}
 /** The pane's root column — fills the pane, `--color-panel` background. */
 export declare const PageShell: React.ComponentType<PageShellProps>
 
@@ -908,7 +984,9 @@ export interface PageSidebarProps extends React.HTMLAttributes<HTMLElement> {
 export declare const PageSidebar: React.ComponentType<PageSidebarProps>
 
 /** The primary workspace column: `--color-panel`, takes what's left. */
-export declare const PageMain: React.ComponentType<React.HTMLAttributes<HTMLElement>>
+export declare const PageMain: React.ComponentType<
+  React.HTMLAttributes<HTMLElement>
+>
 
 export declare const Panel: React.ComponentType<
   React.HTMLAttributes<HTMLDivElement> & React.RefAttributes<HTMLDivElement>
@@ -948,7 +1026,9 @@ export interface SelectProps<T extends string = string> {
   onClear?: () => void
   renderGroupHeader?: (group: SelectGroup<T>) => React.ReactNode
 }
-export declare const Select: <T extends string = string>(props: SelectProps<T>) => React.ReactNode
+export declare const Select: <T extends string = string>(
+  props: SelectProps<T>,
+) => React.ReactNode
 
 export interface SegmentedControlOption<T extends string = string> {
   value: T
@@ -967,7 +1047,9 @@ export interface SegmentedControlProps<T extends string = string> {
   variant?: 'tabs' | 'radio'
   'aria-label'?: string
 }
-export declare const SegmentedControl: <T extends string = string>(props: SegmentedControlProps<T>) => React.ReactNode
+export declare const SegmentedControl: <T extends string = string>(
+  props: SegmentedControlProps<T>,
+) => React.ReactNode
 
 export interface SelectorOption<T extends string = string> {
   value: T
@@ -1011,9 +1093,13 @@ export interface SelectorProps<T extends string = string> {
   'aria-label': string
   'aria-describedby'?: string
 }
-export declare const Selector: <T extends string = string>(props: SelectorProps<T>) => React.ReactNode
+export declare const Selector: <T extends string = string>(
+  props: SelectorProps<T>,
+) => React.ReactNode
 
-export declare const Skeleton: React.ComponentType<React.HTMLAttributes<HTMLSpanElement>>
+export declare const Skeleton: React.ComponentType<
+  React.HTMLAttributes<HTMLSpanElement>
+>
 
 export interface StatusDotProps extends React.HTMLAttributes<HTMLSpanElement> {
   tone?: 'accent' | 'alert' | 'warn' | 'ink'
@@ -1030,7 +1116,8 @@ export interface StatusPanelProps {
 }
 export declare const StatusPanel: React.ComponentType<StatusPanelProps>
 
-export interface TabsProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'dir'> {
+export interface TabsProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'dir'> {
   value?: string
   defaultValue?: string
   onValueChange?(value: string): void
@@ -1042,7 +1129,8 @@ export interface TabsListProps extends React.HTMLAttributes<HTMLDivElement> {
   variant?: 'line'
 }
 export declare const TabsList: React.ComponentType<TabsListProps>
-export interface TabsTriggerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export interface TabsTriggerProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   value: string
   /** Defaults to a semantic 16px icon inferred from `value`; `false` hides it. */
   icon?: React.ReactNode | false
@@ -1105,11 +1193,13 @@ export interface TooltipProps {
   children?: React.ReactNode
 }
 export declare const Tooltip: React.ComponentType<TooltipProps>
-export interface TooltipTriggerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export interface TooltipTriggerProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   asChild?: boolean
 }
 export declare const TooltipTrigger: React.ComponentType<TooltipTriggerProps>
-export interface TooltipContentProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface TooltipContentProps
+  extends React.HTMLAttributes<HTMLDivElement> {
   side?: 'top' | 'right' | 'bottom' | 'left'
   align?: 'start' | 'center' | 'end'
   sideOffset?: number
@@ -1153,7 +1243,9 @@ export interface CodeEditorProps {
     both themes. Grows with content — put it inside an `overflow-auto` pane.
     Never bundle `monaco-editor` (or any other editor) into a worker asset;
     import this instead. */
-export declare const CodeEditor: React.ComponentType<CodeEditorProps & React.RefAttributes<CodeEditorHandle>>
+export declare const CodeEditor: React.ComponentType<
+  CodeEditorProps & React.RefAttributes<CodeEditorHandle>
+>
 
 export interface CodeHighlightProps {
   code: string

--- a/packages/console-ui/index.d.ts
+++ b/packages/console-ui/index.d.ts
@@ -101,6 +101,42 @@ export interface PageRenderProps {
    * asks first. Absent on older consoles; feature-detect before calling.
    */
   setDirty?: (dirty: boolean | string) => void
+  /**
+   * Contribute commands while mounted: rows in the command palette, and keys
+   * that fire only while focus is inside this pane. Register in an effect and
+   * return its remover. Absent on older consoles; feature-detect.
+   */
+  commands?: PageCommandsApi
+}
+
+/** A binding in the console's shortcut syntax: `Mod+S`, `Shift+Enter`, or a
+    sequence of chords separated by a space, `G L`. */
+export type PageShortcut =
+  | string
+  | { mac: readonly string[]; other: readonly string[] }
+
+/** One thing a page can do for the keyboard; the palette lists it as
+    `Page: Title` with its key on the right. */
+export interface PageCommand {
+  /** Unique within the page; the console namespaces it with the page id. */
+  id: string
+  title: string
+  detail?: string
+  keywords?: readonly string[]
+  /** Honoured for commands registered by a mounted page only, while focus is
+      inside its pane. A key the console already uses is refused with a
+      warning; the row stays. */
+  shortcut?: PageShortcut
+  /** Fire while the caret is in a field. Default false. */
+  firesWhileTyping?: boolean
+  /** Checked when the palette opens and before the command runs; false hides
+      the row and ignores the key. */
+  enabled?: () => boolean
+  run: () => void
+}
+
+export interface PageCommandsApi {
+  register(commands: readonly PageCommand[]): () => void
 }
 
 export interface PageRegistration {
@@ -335,6 +371,15 @@ export interface Host {
   /** The script's asset path, e.g. `state/page.js`. */
   path: string
   pages: { register(page: PageRegistration): () => void }
+  /**
+   * Palette rows for a page this script owns, alive exactly as long as the
+   * script. For a page that may not be open yet; `run` usually calls
+   * `panels.open`. Keys are honoured only through `PageRenderProps.commands`.
+   * Absent on older consoles; feature-detect.
+   */
+  commands?: {
+    register(pageId: string, commands: readonly PageCommand[]): () => void
+  }
   functionTriggers: {
     register(renderer: FunctionTriggerRenderer): () => void
   }

--- a/packages/console-ui/index.d.ts
+++ b/packages/console-ui/index.d.ts
@@ -150,6 +150,8 @@ export interface PaletteSourceRow {
 }
 
 export interface PaletteSearchContext {
+  /** The active chat session, for data that lives per conversation. */
+  conversationId: string | null
   workingDir: string | null
   signal: AbortSignal
 }

--- a/packages/console-ui/index.d.ts
+++ b/packages/console-ui/index.d.ts
@@ -139,6 +139,39 @@ export interface PageCommandsApi {
   register(commands: readonly PageCommand[]): () => void
 }
 
+/** One answer a palette source gives for a query. */
+export interface PaletteSourceRow {
+  id: string
+  title: string
+  detail?: string
+  meta?: string
+  keywords?: readonly string[]
+  run: () => void
+}
+
+export interface PaletteSearchContext {
+  workingDir: string | null
+  signal: AbortSignal
+}
+
+/** A live palette source: rows computed per query by a worker, registered
+    from setup, alive only while the worker is connected. */
+export interface PaletteSource {
+  id: string
+  title: string
+  kind: 'file' | 'item'
+  prefix?: string
+  minQuery?: number
+  search(
+    query: string,
+    context: PaletteSearchContext,
+  ): Promise<readonly PaletteSourceRow[]>
+}
+
+export interface PaletteOpenOptions {
+  query?: string
+}
+
 export interface PageRegistration {
   /** kebab-case, unique per tab; convention `<worker>-<name>`. Routes at `#/ext/<id>`. */
   id: string
@@ -379,6 +412,12 @@ export interface Host {
    */
   commands?: {
     register(pageId: string, commands: readonly PageCommand[]): () => void
+  }
+  /** Live palette sources and a way to open the palette on a query. Absent
+      on older consoles; feature-detect. */
+  palette?: {
+    registerSource(source: PaletteSource): () => void
+    open(options?: PaletteOpenOptions): void
   }
   functionTriggers: {
     register(renderer: FunctionTriggerRenderer): () => void

--- a/pdf/ui/page.tsx
+++ b/pdf/ui/page.tsx
@@ -21,8 +21,18 @@ export default function setup(host: Host) {
   host.pages.register({
     id: 'pdf-reader',
     title: 'pdf',
-    render: () => <PdfPage host={host} />,
+    render: (props) => <PdfPage host={host} {...props} />,
   })
 
   host.functionTriggers.register(createPdfTriggerRenderer(host))
+
+  host.commands?.register('pdf-reader', [
+    {
+      id: 'open',
+      title: 'Open pdf',
+      detail: 'Classify a document and read its extracted markdown',
+      keywords: ['document', 'ocr', 'markdown'],
+      run: () => host.panels?.open({ pageId: 'pdf-reader', context: {} }),
+    },
+  ])
 }

--- a/pdf/ui/src/page/index.tsx
+++ b/pdf/ui/src/page/index.tsx
@@ -14,6 +14,7 @@ import {
   CodeEditor,
   EmptyState,
   MarkdownPreview,
+  type PageRenderProps,
   StatusPanel,
   Tabs,
   TabsContent,
@@ -24,7 +25,7 @@ import {
   TooltipTrigger,
   type Host,
 } from '@iii-dev/console-ui'
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import {
   documentTypeLabel,
@@ -40,7 +41,11 @@ type State =
   | { status: 'done'; name: string; result: Inspection }
   | { status: 'failed'; name: string; error: string }
 
-export function PdfPage({ host }: { host: Host }) {
+export function PdfPage({
+  host,
+  onRequestClose,
+  commands,
+}: { host: Host } & Partial<PageRenderProps>) {
   const [state, setState] = useState<State>({ status: 'idle' })
   const [dragging, setDragging] = useState(false)
   const input = useRef<HTMLInputElement>(null)
@@ -77,10 +82,38 @@ export function PdfPage({ host }: { host: Host }) {
   const hasResult = state.status === 'done' || state.status === 'failed'
   const loadedName = hasResult ? state.name : null
 
+  useEffect(
+    () =>
+      commands?.register([
+        {
+          id: 'choose-file',
+          title: 'Choose a file',
+          detail: 'Pick a PDF to classify and extract',
+          keywords: ['open', 'upload', 'drop'],
+          shortcut: 'O',
+          enabled: () => state.status !== 'reading',
+          run: () => input.current?.click(),
+        },
+      ]),
+    [commands, state.status],
+  )
+
   return (
     <div className="pdf-ui">
       <header className="pdf-ui__head">
-        <h1 className="pdf-ui__title">pdf</h1>
+        <div className="pdf-ui__head-row">
+          <h1 className="pdf-ui__title">pdf</h1>
+          {onRequestClose ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onRequestClose}
+              aria-label="close pdf"
+            >
+              close
+            </Button>
+          ) : null}
+        </div>
         <p className="pdf-ui__lede">
           Classify a document, see which pages need OCR, and read the markdown
           an agent would get. Parsing runs in the worker on this machine.
@@ -122,6 +155,7 @@ export function PdfPage({ host }: { host: Host }) {
           variant={hasResult ? 'ghost' : 'pill'}
           onClick={() => input.current?.click()}
           disabled={state.status === 'reading'}
+          data-autofocus=""
         >
           {hasResult ? 'Read another' : 'Choose a file'}
         </Button>

--- a/pdf/ui/styles.css
+++ b/pdf/ui/styles.css
@@ -21,6 +21,13 @@
   gap: 0.35rem;
 }
 
+[data-iii-ui="pdf"] .pdf-ui__head-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
 [data-iii-ui="pdf"] .pdf-ui__title {
   font-size: 1.35rem;
   font-weight: 600;

--- a/sandbox-code-runner/ui/page.tsx
+++ b/sandbox-code-runner/ui/page.tsx
@@ -23,10 +23,13 @@
 
 import type { Host } from '@iii-dev/console-ui'
 import { createSandboxCodeRunnerRenderers } from './src/function-trigger-message'
-import { SandboxPage, createSandboxSessionChip } from './src/page'
+import { createSandboxSessionChip, SandboxPage } from './src/page'
+import { registerSandboxPalette } from './src/page/palette'
 import { createSandboxFamilyRenderer } from './src/sandbox-family'
 
 export default function setup(host: Host) {
+  registerSandboxPalette(host)
+
   const removers = [
     ...createSandboxCodeRunnerRenderers(host).map((renderer) =>
       host.functionTriggers.register(renderer),

--- a/sandbox-code-runner/ui/src/page/FleetRail.tsx
+++ b/sandbox-code-runner/ui/src/page/FleetRail.tsx
@@ -10,6 +10,7 @@
  */
 
 import { Badge, EmptyState, type Host, StatusDot } from '@iii-dev/console-ui'
+import type { KeyboardEvent } from 'react'
 import { useState } from 'react'
 import {
   displayAgeSecs,
@@ -19,8 +20,8 @@ import {
   type SandboxState,
   sandboxState,
 } from './format'
-import { BoxIcon, ChevronIcon } from './icons'
 import { InvokeDialog } from './InvokeDialog'
+import { BoxIcon, ChevronIcon } from './icons'
 import type {
   CatalogImage,
   FleetTombstone,
@@ -36,6 +37,21 @@ const STATUS_DOT: Record<
   running: { tone: 'accent', pulse: false },
   busy: { tone: 'warn', pulse: true },
   stopped: { tone: 'ink', pulse: false },
+}
+
+/** Cheap roving nav: arrow keys step focus between sibling sandbox rows. */
+function onRowKeyDown(event: KeyboardEvent<HTMLButtonElement>) {
+  if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return
+  const rows = Array.from(
+    event.currentTarget.parentElement?.querySelectorAll<HTMLButtonElement>(
+      'button.cr-page-fleet-row',
+    ) ?? [],
+  )
+  const index = rows.indexOf(event.currentTarget)
+  if (index === -1) return
+  event.preventDefault()
+  const next = index + (event.key === 'ArrowDown' ? 1 : -1)
+  rows[Math.max(0, Math.min(rows.length - 1, next))]?.focus()
 }
 
 function SandboxRow({
@@ -62,11 +78,14 @@ function SandboxRow({
       type="button"
       className={`cr-page-fleet-row${selected ? ' selected' : ''}${reapSoon ? ' reap-soon' : ''}`}
       onClick={() => onSelect(sandbox.sandbox_id)}
+      onKeyDown={onRowKeyDown}
       title={`${sandbox.sandbox_id} · ${state}${reapSoon ? ' · idle reap imminent' : ''}`}
       aria-current={selected ? 'true' : undefined}
     >
       <StatusDot tone={dot.tone} pulse={dot.pulse} />
-      <span className="cr-page-fleet-id">{sandbox.name || sandbox.sandbox_id}</span>
+      <span className="cr-page-fleet-id">
+        {sandbox.name || sandbox.sandbox_id}
+      </span>
       <span className="cr-page-fleet-meta">
         <span className="cr-page-fleet-image" title={sandbox.image}>
           {sandbox.image}
@@ -110,7 +129,10 @@ function RuntimeRow({
           disabled={count === 0}
           title={count === 0 ? 'no functions registered' : 'show functions'}
         >
-          <ChevronIcon className={expanded ? 'cr-page-chev open' : 'cr-page-chev'} aria-hidden />
+          <ChevronIcon
+            className={expanded ? 'cr-page-chev open' : 'cr-page-chev'}
+            aria-hidden
+          />
           <span className="cr-page-rt-lang">{runtime.lang}</span>
           <span className="cr-page-rt-count">
             {count} fn{count === 1 ? '' : 's'}
@@ -261,7 +283,9 @@ export function FleetRail({
                 {t.sandbox.name || t.sandbox.sandbox_id}
               </span>
               <span className="cr-page-fleet-meta">
-                <span className="cr-page-fleet-gone">gone — reaped or stopped</span>
+                <span className="cr-page-fleet-gone">
+                  gone — reaped or stopped
+                </span>
               </span>
             </div>
           ))}
@@ -295,7 +319,11 @@ export function FleetRail({
           <div className="cr-page-rail-label">catalog</div>
           <ul className="cr-page-catalog">
             {images.map((image) => (
-              <li key={image.name} className="cr-page-catalog-row" title={image.oci_ref}>
+              <li
+                key={image.name}
+                className="cr-page-catalog-row"
+                title={image.oci_ref}
+              >
                 <span className="cr-page-catalog-name">{image.name}</span>
                 <Badge variant={image.kind === 'preset' ? 'default' : 'accent'}>
                   {image.kind}
@@ -306,7 +334,11 @@ export function FleetRail({
         </>
       ) : null}
 
-      <InvokeDialog host={host} functionId={invokeFn} onClose={() => setInvokeFn(null)} />
+      <InvokeDialog
+        host={host}
+        functionId={invokeFn}
+        onClose={() => setInvokeFn(null)}
+      />
     </div>
   )
 }

--- a/sandbox-code-runner/ui/src/page/SandboxPage.tsx
+++ b/sandbox-code-runner/ui/src/page/SandboxPage.tsx
@@ -24,7 +24,7 @@ import {
   TabsList,
   TabsTrigger,
 } from '@iii-dev/console-ui'
-import { type ReactNode, useEffect, useState } from 'react'
+import { type ReactNode, useEffect, useRef, useState } from 'react'
 import { onSandboxSelected, takeSelectedSandbox } from '../lib/selection'
 import { ConsoleTab } from './ConsoleTab'
 import { CreateDialog } from './CreateDialog'
@@ -46,6 +46,8 @@ export function SandboxPage({
   host,
   panelSide = 'left',
   onRequestClose,
+  panelContext,
+  commands,
 }: { host: Host } & PageRenderProps) {
   const { state, refresh, live } = useFleet(host)
   const [selected, setSelected] = useState<string | null>(null)
@@ -68,6 +70,21 @@ export function SandboxPage({
   }, [])
 
   useEffect(() => onSandboxSelected((id) => setPending(id)), [])
+
+  // A palette "sandboxes" row (or any other host.panels.open caller) selects
+  // a sandbox by id through the standard panelContext channel; it rides the
+  // same pending flow a chat cross-link uses.
+  const appliedContextRef = useRef(0)
+  useEffect(() => {
+    if (!panelContext || panelContext.id === appliedContextRef.current) return
+    appliedContextRef.current = panelContext.id
+    const context = panelContext.context
+    const sandboxId =
+      context && typeof context === 'object' && !Array.isArray(context)
+        ? (context as Record<string, unknown>).sandboxId
+        : null
+    if (typeof sandboxId === 'string' && sandboxId) setPending(sandboxId)
+  }, [panelContext])
 
   useEffect(() => {
     if (pending && state.sandboxes.some((s) => s.sandbox_id === pending)) {
@@ -101,6 +118,38 @@ export function SandboxPage({
     setSelected(id)
     setTab('overview')
   }
+
+  useEffect(
+    () =>
+      commands?.register([
+        {
+          id: 'new',
+          title: 'New sandbox',
+          detail: 'Create a sandbox from a catalog image',
+          keywords: ['create', 'microvm'],
+          shortcut: 'N',
+          enabled: () => !state.daemonAbsent,
+          run: () => setCreateOpen(true),
+        },
+        {
+          id: 'run-code',
+          title: 'Run code',
+          detail: 'Run a snippet against a sandbox',
+          keywords: ['exec', 'code'],
+          shortcut: 'C',
+          run: () => setRunOpen(true),
+        },
+        {
+          id: 'refresh',
+          title: 'Refresh the fleet',
+          detail: 'Re-read sandboxes, runtimes and the catalog',
+          keywords: ['reload'],
+          shortcut: 'R',
+          run: refresh,
+        },
+      ]),
+    [commands, state.daemonAbsent, refresh],
+  )
 
   function renderMain(): ReactNode {
     if (state.error && !state.daemonAbsent && state.sandboxes.length === 0) {
@@ -225,6 +274,7 @@ export function SandboxPage({
               size="sm"
               onClick={() => setCreateOpen(true)}
               disabled={state.daemonAbsent}
+              data-autofocus=""
             >
               <PlusIcon aria-hidden /> new sandbox
             </Button>

--- a/sandbox-code-runner/ui/src/page/palette.tsx
+++ b/sandbox-code-runner/ui/src/page/palette.tsx
@@ -1,0 +1,57 @@
+/**
+ * The sandbox worker in the command palette, before its page is even open.
+ *
+ * A sandboxes source answers any query with the live fleet — the same
+ * `sandbox::list` read useFleet's store bootstraps from — each row opening
+ * the sandbox page with that sandbox selected. Registered from setup, so it
+ * exists only while the worker is connected; older consoles without
+ * host.palette / host.commands simply get nothing.
+ */
+
+import type { Host } from '@iii-dev/console-ui'
+import { LIST_FN, parseSandboxList } from './store'
+
+const SANDBOX_ROWS = 30
+
+export function registerSandboxPalette(host: Host): void {
+  host.palette?.registerSource({
+    id: 'sandboxes',
+    title: 'Sandboxes',
+    kind: 'item',
+    minQuery: 2,
+    async search(query, { signal }) {
+      const sandboxes = parseSandboxList(await host.iii.trigger(LIST_FN, {}))
+      if (signal.aborted) return []
+      const needle = query.toLowerCase()
+      return sandboxes
+        .filter(
+          (sandbox) =>
+            (sandbox.name?.toLowerCase().includes(needle) ?? false) ||
+            sandbox.sandbox_id.toLowerCase().includes(needle) ||
+            sandbox.image.toLowerCase().includes(needle),
+        )
+        .slice(0, SANDBOX_ROWS)
+        .map((sandbox) => ({
+          id: sandbox.sandbox_id,
+          title: sandbox.name || sandbox.sandbox_id,
+          detail: sandbox.image,
+          keywords: [sandbox.sandbox_id],
+          run: () =>
+            host.panels?.open({
+              pageId: 'sandbox',
+              context: { sandboxId: sandbox.sandbox_id },
+            }),
+        }))
+    },
+  })
+
+  host.commands?.register('sandbox', [
+    {
+      id: 'open',
+      title: 'Open the sandbox fleet',
+      detail: 'MicroVM fleet, exec console, files',
+      keywords: ['microvm', 'fleet', 'exec'],
+      run: () => host.panels?.open({ pageId: 'sandbox', context: {} }),
+    },
+  ])
+}

--- a/shell/ui/page.tsx
+++ b/shell/ui/page.tsx
@@ -22,6 +22,7 @@ import { createShellTriggerRenderer } from './src/function-trigger'
 import { createAgentRunRenderer } from './src/function-trigger/AgentRunView'
 import { createFileChangesRenderer } from './src/function-trigger/FileChangesView'
 import { ShellExplorerPage } from './src/page'
+import { registerShellPalette } from './src/page/palette'
 import { ShellTurnSummary } from './src/page/ShellTurnSummary'
 import { createTerminalOutputRouter } from './src/page/terminal-output-router'
 
@@ -57,6 +58,10 @@ export default function setup(host: Host) {
     id: 'shell-last-turn',
     render: ShellTurnSummary,
   })
+
+  // The palette reaches the shell before the page is open: files by name
+  // as you type (`#`), and the verbs that open the page and act.
+  registerShellPalette(host)
 
   return () => terminalRouter.dispose()
 }

--- a/shell/ui/src/page/FilesTab.tsx
+++ b/shell/ui/src/page/FilesTab.tsx
@@ -16,7 +16,10 @@ import { FileTree, useFileTree } from '@pierre/trees/react'
 import { Search, X } from 'lucide-react'
 import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import type { FlatTree } from './coder'
-import { reactivateSelectedFile, shouldActivateTreeSelection } from './tree-activation'
+import {
+  reactivateSelectedFile,
+  shouldActivateTreeSelection,
+} from './tree-activation'
 import { TREE_THEME, TREE_UNSAFE_CSS } from './tree-theme'
 
 /** Directory paths live in the model with a trailing slash; callers key
@@ -129,7 +132,10 @@ export function FilesTab({
         const handle = model.getItem(path) ?? model.getItem(`${path}/`)
         // A method call doesn't narrow the handle union — the literal
         // `isDirectory(): true` return type needs the explicit cast.
-        if (handle?.isDirectory() && (handle as FileTreeDirectoryHandle).isExpanded()) {
+        if (
+          handle?.isDirectory() &&
+          (handle as FileTreeDirectoryHandle).isExpanded()
+        ) {
           open.push(path)
         }
       }
@@ -159,7 +165,10 @@ export function FilesTab({
     lastPathsKeyRef.current = pathsKey
     // The model accepts dir ids in either spelling depending on how the
     // row materialized — hand it both.
-    const initialExpandedPaths = expandedRef.current.flatMap((p) => [p, `${p}/`])
+    const initialExpandedPaths = expandedRef.current.flatMap((p) => [
+      p,
+      `${p}/`,
+    ])
     model.resetPaths(tree?.paths ?? [], { initialExpandedPaths })
   }, [model, pathsKey, tree])
 
@@ -191,7 +200,9 @@ export function FilesTab({
   useEffect(() => {
     const query = filter.trim()
     model.setSearch(query === '' ? null : query)
-    setFilterMatchCount(query === '' ? null : model.getSearchMatchingPaths().length)
+    setFilterMatchCount(
+      query === '' ? null : model.getSearchMatchingPaths().length,
+    )
   }, [model, filter, pathsKey])
 
   useEffect(() => {
@@ -232,6 +243,7 @@ export function FilesTab({
             placeholder="Filter files…"
             autoComplete="off"
             spellCheck={false}
+            data-autofocus=""
           />
           {filter !== '' ? (
             <button
@@ -252,7 +264,9 @@ export function FilesTab({
           <div className="shui-side-note">loading tree…</div>
         ) : tree.paths.length === 0 ? (
           <div className="shui-side-note">
-            {hiddenFiltered ? 'nothing visible — hidden entries are filtered' : 'empty folder'}
+            {hiddenFiltered
+              ? 'nothing visible — hidden entries are filtered'
+              : 'empty folder'}
           </div>
         ) : filterMatchCount === 0 ? (
           <div className="shui-side-note">no matching files</div>
@@ -278,8 +292,9 @@ export function FilesTab({
 
       {tree && tree.truncations.length > 0 ? (
         <div className="shui-side-note ghost">
-          partial listing — {tree.truncations.length} {tree.truncations.length === 1 ? 'folder' : 'folders'} truncated
-          by depth/size limits
+          partial listing — {tree.truncations.length}{' '}
+          {tree.truncations.length === 1 ? 'folder' : 'folders'} truncated by
+          depth/size limits
         </div>
       ) : null}
     </div>

--- a/shell/ui/src/page/SearchTab.tsx
+++ b/shell/ui/src/page/SearchTab.tsx
@@ -73,7 +73,6 @@ export function SearchTab({
           preserveCase
           aria-label="search query"
           data-shell-search-input=""
-          data-autofocus=""
         />
         <div className="shui-search-opts">
           <label className="opt">

--- a/shell/ui/src/page/SearchTab.tsx
+++ b/shell/ui/src/page/SearchTab.tsx
@@ -1,9 +1,9 @@
 /* The search tab — content + path search over the browsed root via the
    worker's `coder::search`. Rows open the file in the editor pane. */
 
+import type { Host } from '@iii-dev/console-ui'
 import { Input } from '@iii-dev/console-ui'
 import { useCallback, useRef, useState } from 'react'
-import type { Host } from '@iii-dev/console-ui'
 import { errorMessage } from '../lib/format'
 import { renderWithHighlight } from '../lib/highlight'
 import { coderSearch, relativeTo, type SearchResponse } from './coder'
@@ -72,6 +72,8 @@ export function SearchTab({
           placeholder="search files & folders…"
           preserveCase
           aria-label="search query"
+          data-shell-search-input=""
+          data-autofocus=""
         />
         <div className="shui-search-opts">
           <label className="opt">
@@ -142,9 +144,7 @@ function SearchResults({
   return (
     <div className="shui-search-results">
       {truncated ? (
-        <div className="shui-side-note warn">
-          truncated — refine the query
-        </div>
+        <div className="shui-side-note warn">truncated — refine the query</div>
       ) : null}
 
       {folderMatches.length > 0 ? (

--- a/shell/ui/src/page/coder.ts
+++ b/shell/ui/src/page/coder.ts
@@ -94,7 +94,10 @@ export function workspaceValidate(
   host: Host,
   path: string,
 ): Promise<WorkspaceValidateResponse> {
-  return host.iii.trigger<WorkspaceValidateResponse>('shell::workspace::validate', { path })
+  return host.iii.trigger<WorkspaceValidateResponse>(
+    'shell::workspace::validate',
+    { path },
+  )
 }
 
 export function coderTree(
@@ -205,18 +208,20 @@ export interface SearchParams {
   regex: boolean
   ignoreCase: boolean
   path: string
+  /** Default true; false asks for path matches only (quick open). */
+  searchContent?: boolean
 }
 
 export function coderSearch(
   host: Host,
-  { query, regex, ignoreCase, path }: SearchParams,
+  { query, regex, ignoreCase, path, searchContent = true }: SearchParams,
 ): Promise<SearchResponse> {
   return host.iii.trigger<SearchResponse>('coder::search', {
     query,
     regex,
     ignore_case: ignoreCase,
     path,
-    search_content: true,
+    search_content: searchContent,
     search_paths: true,
   })
 }

--- a/shell/ui/src/page/index.tsx
+++ b/shell/ui/src/page/index.tsx
@@ -142,6 +142,7 @@ import {
   activateTab,
   basename,
   closeTab,
+  cycleTab,
   EMPTY_TABS,
   lastSegments,
   openPinned,
@@ -2451,6 +2452,26 @@ export function ShellExplorerPage({
     closeTerminal()
   }, [closeTerminal, terminalActive, terminalDock, terminalOpen])
 
+  const orderedReviewEntriesRef = useRef(orderedReviewEntries)
+  orderedReviewEntriesRef.current = orderedReviewEntries
+  const stepReviewEntry = useCallback(
+    (delta: 1 | -1) => {
+      const entries = orderedReviewEntriesRef.current
+      if (entries.length === 0) return
+      const current = entries.findIndex(
+        (entry) => entry.path === tabsRef.current.active,
+      )
+      const index =
+        current === -1
+          ? delta === 1
+            ? 0
+            : entries.length - 1
+          : (current + delta + entries.length) % entries.length
+      openReviewEntry(entries[index])
+    },
+    [openReviewEntry],
+  )
+
   // The page's verbs, for the palette and for the keyboard while this pane
   // has the focus. The keys stay clear of the console's own.
   useEffect(
@@ -2507,8 +2528,53 @@ export function ShellExplorerPage({
           shortcut: '`',
           run: toggleTerminal,
         },
+        {
+          id: 'next-tab',
+          title: 'Next editor tab',
+          keywords: ['tab', 'file', 'cycle'],
+          shortcut: 'Alt+ArrowRight',
+          enabled: () => tabsRef.current.tabs.length > 1,
+          run: () => setTabs((state) => cycleTab(state, 1)),
+        },
+        {
+          id: 'previous-tab',
+          title: 'Previous editor tab',
+          keywords: ['tab', 'file', 'cycle'],
+          shortcut: 'Alt+ArrowLeft',
+          enabled: () => tabsRef.current.tabs.length > 1,
+          run: () => setTabs((state) => cycleTab(state, -1)),
+        },
+        {
+          id: 'close-tab',
+          title: 'Close the editor tab',
+          keywords: ['tab', 'file', 'close'],
+          shortcut: 'W',
+          enabled: () => tabsRef.current.active !== null,
+          run: () => {
+            const active = tabsRef.current.active
+            if (active !== null) onCloseTab(active)
+          },
+        },
+        {
+          id: 'next-change',
+          title: 'Next changed file',
+          detail: 'Open the next file in the review',
+          keywords: ['review', 'diff', 'change'],
+          shortcut: 'J',
+          enabled: () => orderedReviewEntriesRef.current.length > 0,
+          run: () => stepReviewEntry(1),
+        },
+        {
+          id: 'previous-change',
+          title: 'Previous changed file',
+          detail: 'Open the previous file in the review',
+          keywords: ['review', 'diff', 'change'],
+          shortcut: 'K',
+          enabled: () => orderedReviewEntriesRef.current.length > 0,
+          run: () => stepReviewEntry(-1),
+        },
       ]),
-    [commands, host, toggleTerminal],
+    [commands, host, toggleTerminal, onCloseTab, stepReviewEntry],
   )
 
   const header = (

--- a/shell/ui/src/page/index.tsx
+++ b/shell/ui/src/page/index.tsx
@@ -104,13 +104,6 @@ import {
   gitRecentCommits,
   gitRefs,
 } from './git'
-import {
-  fetchSessionTurn,
-  fetchSessionTurns,
-  reviewEntriesFromTurn,
-  type SessionTurnSummary,
-  turnLabel,
-} from './turns'
 import { HoverTip } from './HoverTip'
 import { useWorkspaceChanges } from './live'
 import { normalizeLiveReviewEvent } from './live-review'
@@ -131,8 +124,8 @@ import {
 } from './ReviewPane'
 import {
   ReviewScopePicker,
-  reviewScopeLabel,
   type ReviewScopeSelection,
+  reviewScopeLabel,
 } from './ReviewScopePicker'
 import {
   diffForReviewEntry,
@@ -144,7 +137,6 @@ import { useShellReviewSummaryBridge } from './review-summary-store'
 import { changedParentDirs, withReviewChanges } from './review-tree'
 import { SearchTab } from './SearchTab'
 import { ShellLauncher } from './ShellLauncher'
-import { WorkspaceBrowser } from './WorkspaceBrowser'
 import { TerminalPanel } from './TerminalPanel'
 import {
   activateTab,
@@ -170,6 +162,14 @@ import {
   canCaptureHarnessWorkspaceChange,
   type HarnessReviewWindow,
 } from './turn-status'
+import {
+  fetchSessionTurn,
+  fetchSessionTurns,
+  reviewEntriesFromTurn,
+  type SessionTurnSummary,
+  turnLabel,
+} from './turns'
+import { WorkspaceBrowser } from './WorkspaceBrowser'
 import {
   acknowledgeValidatedWorkingDirectory,
   deepLinkRootTarget,
@@ -242,7 +242,12 @@ function ReviewOption({
 
 function SplitDiffIcon() {
   return (
-    <svg className="shui-diff-style-icon" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+    <svg
+      className="shui-diff-style-icon"
+      viewBox="0 0 16 16"
+      aria-hidden="true"
+      focusable="false"
+    >
       <rect x="1.5" y="2.5" width="13" height="11" rx="2.5" className="frame" />
       <rect x="3" y="4" width="4.5" height="8" rx="1.2" className="del" />
       <rect x="8.5" y="4" width="4.5" height="8" rx="1.2" className="add" />
@@ -252,7 +257,12 @@ function SplitDiffIcon() {
 
 function UnifiedDiffIcon() {
   return (
-    <svg className="shui-diff-style-icon" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+    <svg
+      className="shui-diff-style-icon"
+      viewBox="0 0 16 16"
+      aria-hidden="true"
+      focusable="false"
+    >
       <rect x="1.5" y="2.5" width="13" height="11" rx="2.5" className="frame" />
       <rect x="3" y="4" width="10" height="3.5" rx="1.2" className="del" />
       <rect x="3" y="8.5" width="10" height="3.5" rx="1.2" className="add" />
@@ -272,7 +282,11 @@ function ReviewMenuAction({
   onSelect: () => void
 }) {
   return (
-    <DropdownMenuItem className="shui-review-option" disabled={disabled} onSelect={onSelect}>
+    <DropdownMenuItem
+      className="shui-review-option"
+      disabled={disabled}
+      onSelect={onSelect}
+    >
       <span className="menu-icon" aria-hidden>
         {icon}
       </span>
@@ -355,6 +369,7 @@ export function ShellExplorerPage({
   workingDir,
   panelContext,
   conversationId,
+  commands,
 }: { host: Host; terminalRouter: TerminalOutputRouter } & PageRenderProps) {
   const theme = host.useTheme()
   const observedReview = useHarnessTurn(host, conversationId)
@@ -487,7 +502,9 @@ export function ShellExplorerPage({
     setCopyingPatch(true)
     try {
       const patch = await gitPatch(host, root, reviewScope)
-      await navigator.clipboard.writeText(`git apply <<'PATCH'\n${patch}\nPATCH\n`)
+      await navigator.clipboard.writeText(
+        `git apply <<'PATCH'\n${patch}\nPATCH\n`,
+      )
     } catch (error: unknown) {
       setScopeError(errorMessage(error))
     } finally {
@@ -512,7 +529,9 @@ export function ShellExplorerPage({
     [],
   )
   const [scopeRefs, setScopeRefs] = useState<readonly GitRefSummary[]>([])
-  const [sessionTurns, setSessionTurns] = useState<readonly SessionTurnSummary[]>([])
+  const [sessionTurns, setSessionTurns] = useState<
+    readonly SessionTurnSummary[]
+  >([])
   const [turnOutside, setTurnOutside] = useState(0)
   const [scopeMetadataLoading, setScopeMetadataLoading] = useState(false)
   const [scopeMetadataError, setScopeMetadataError] = useState<string | null>(
@@ -2325,11 +2344,16 @@ export function ShellExplorerPage({
   useEffect(() => {
     let cancelled = false
     void host.iii
-      .trigger<{ workers?: Array<{ name?: unknown }> }>('engine::workers::list', {})
+      .trigger<{ workers?: Array<{ name?: unknown }> }>(
+        'engine::workers::list',
+        {},
+      )
       .then((response) => {
         if (cancelled) return
         const workers = Array.isArray(response?.workers) ? response.workers : []
-        setBrowserAvailable(workers.some((worker) => worker?.name === 'browser'))
+        setBrowserAvailable(
+          workers.some((worker) => worker?.name === 'browser'),
+        )
       })
       .catch(() => {
         if (!cancelled) setBrowserAvailable(false)
@@ -2427,6 +2451,66 @@ export function ShellExplorerPage({
     closeTerminal()
   }, [closeTerminal, terminalActive, terminalDock, terminalOpen])
 
+  // The page's verbs, for the palette and for the keyboard while this pane
+  // has the focus. The keys stay clear of the console's own.
+  useEffect(
+    () =>
+      commands?.register([
+        {
+          id: 'open-file',
+          title: 'Open file…',
+          detail: 'Find a file by name',
+          keywords: ['quick open', 'go to file', 'path'],
+          shortcut: 'P',
+          run: () => host.palette?.open({ query: '#' }),
+        },
+        {
+          id: 'search',
+          title: 'Search in files',
+          detail: 'Find text across the working directory',
+          keywords: ['grep', 'find', 'text'],
+          shortcut: 'F',
+          run: () => {
+            setSideTab('search')
+            setCollapsed(false)
+            window.requestAnimationFrame(() => {
+              document
+                .querySelector<HTMLElement>('[data-shell-search-input]')
+                ?.focus()
+            })
+          },
+        },
+        {
+          id: 'files',
+          title: 'Show the file tree',
+          detail: 'The explorer sidebar',
+          keywords: ['explorer', 'tree', 'sidebar'],
+          shortcut: 'E',
+          run: () => {
+            setSideTab('files')
+            setCollapsed(false)
+          },
+        },
+        {
+          id: 'toggle-sidebar',
+          title: 'Toggle the sidebar',
+          detail: 'Hide or show the file sidebar',
+          keywords: ['collapse', 'explorer'],
+          shortcut: 'B',
+          run: () => setCollapsed((current) => !current),
+        },
+        {
+          id: 'toggle-terminal',
+          title: 'Toggle the terminal',
+          detail: 'Open or close the terminal for this directory',
+          keywords: ['pty', 'console', 'command line'],
+          shortcut: '`',
+          run: toggleTerminal,
+        },
+      ]),
+    [commands, host, toggleTerminal],
+  )
+
   const header = (
     <PageHeader
       className="shui-page-header"
@@ -2513,9 +2597,7 @@ export function ShellExplorerPage({
             {narrow ? (
               <HoverTip
                 label={
-                  collapsed
-                    ? 'Show the file sidebar'
-                    : 'Hide the file sidebar'
+                  collapsed ? 'Show the file sidebar' : 'Hide the file sidebar'
                 }
               >
                 <button
@@ -2717,7 +2799,8 @@ export function ShellExplorerPage({
                     +{turnOutside} outside
                   </span>
                 ) : null}
-                {reviewScope.kind === 'last-turn' && baselineCoverage?.capped ? (
+                {reviewScope.kind === 'last-turn' &&
+                baselineCoverage?.capped ? (
                   <span
                     className="shui-review-count"
                     title={`This workspace holds ${baselineCoverage.candidates} reviewable files; the pre-turn snapshot captured the ${baselineCoverage.captured} most recently modified. Rows outside it fall back to the last commit, or say so when there is none. Open a narrower folder for full coverage.`}
@@ -2747,7 +2830,10 @@ export function ShellExplorerPage({
                   </span>
                 ) : null}
                 <span className="spacer" />
-                <DropdownMenu open={reviewMenuOpen} onOpenChange={setReviewMenuOpen}>
+                <DropdownMenu
+                  open={reviewMenuOpen}
+                  onOpenChange={setReviewMenuOpen}
+                >
                   <DropdownMenuTrigger asChild>
                     <IconButton
                       label="Review options"
@@ -2756,7 +2842,10 @@ export function ShellExplorerPage({
                       <MoreHorizontal aria-hidden />
                     </IconButton>
                   </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end" className="shui-review-menu-content">
+                  <DropdownMenuContent
+                    align="end"
+                    className="shui-review-menu-content"
+                  >
                     <ReviewMenuAction
                       label="Refresh"
                       icon={<RefreshCw />}
@@ -2815,7 +2904,8 @@ export function ShellExplorerPage({
                     <DropdownMenuSeparator />
                     <ReviewMenuAction
                       label={
-                        reviewScope.kind === 'last-turn' || reviewScope.kind === 'turn'
+                        reviewScope.kind === 'last-turn' ||
+                        reviewScope.kind === 'turn'
                           ? 'Copy git apply command (git scopes only)'
                           : 'Copy git apply command'
                       }
@@ -2846,7 +2936,8 @@ export function ShellExplorerPage({
                         emptyMessage="no matching file"
                         triggerIcon={<FileSearch aria-hidden />}
                         onChange={(path) => {
-                          const entry = visibleReviewEntriesRef.current.get(path)
+                          const entry =
+                            visibleReviewEntriesRef.current.get(path)
                           if (entry) openReviewEntry(entry)
                         }}
                       />
@@ -2854,7 +2945,11 @@ export function ShellExplorerPage({
                   </HoverTip>
                 ) : null}
                 <IconButton
-                  label={reviewAllCollapsed ? 'Expand all diffs' : 'Collapse all diffs'}
+                  label={
+                    reviewAllCollapsed
+                      ? 'Expand all diffs'
+                      : 'Collapse all diffs'
+                  }
                   onClick={toggleAllDiffs}
                 >
                   {reviewAllCollapsed ? (

--- a/shell/ui/src/page/index.tsx
+++ b/shell/ui/src/page/index.tsx
@@ -2494,8 +2494,8 @@ export function ShellExplorerPage({
             setSideTab('search')
             setCollapsed(false)
             window.requestAnimationFrame(() => {
-              document
-                .querySelector<HTMLElement>('[data-shell-search-input]')
+              frameEl
+                ?.querySelector<HTMLElement>('[data-shell-search-input]')
                 ?.focus()
             })
           },
@@ -2573,7 +2573,7 @@ export function ShellExplorerPage({
           run: () => stepReviewEntry(-1),
         },
       ]),
-    [commands, host, toggleTerminal, onCloseTab, stepReviewEntry],
+    [commands, host, toggleTerminal, onCloseTab, stepReviewEntry, frameEl],
   )
 
   const header = (

--- a/shell/ui/src/page/index.tsx
+++ b/shell/ui/src/page/index.tsx
@@ -2461,11 +2461,10 @@ export function ShellExplorerPage({
       const current = entries.findIndex(
         (entry) => entry.path === tabsRef.current.active,
       )
+      const start = delta === 1 ? 0 : entries.length - 1
       const index =
         current === -1
-          ? delta === 1
-            ? 0
-            : entries.length - 1
+          ? start
           : (current + delta + entries.length) % entries.length
       openReviewEntry(entries[index])
     },

--- a/shell/ui/src/page/palette.tsx
+++ b/shell/ui/src/page/palette.tsx
@@ -1,0 +1,72 @@
+/**
+ * The shell in the command palette, before its page is even open.
+ *
+ * A files source answers `#` (and any query once it is a few characters)
+ * with path matches from the coder worker under the chat's working
+ * directory, each row opening that file in the shell page. Worker-level
+ * commands open the page on a verb. Everything here is registered from
+ * setup, so it exists only while the shell worker is connected; older
+ * consoles without `host.palette` / `host.commands` simply get nothing.
+ */
+
+import type { Host } from '@iii-dev/console-ui'
+import { coderInfo, coderSearch, relativeTo } from './coder'
+
+const FILE_ROWS = 30
+
+export function registerShellPalette(host: Host): void {
+  host.palette?.registerSource({
+    id: 'files',
+    title: 'Files',
+    kind: 'file',
+    prefix: '#',
+    minQuery: 3,
+    async search(query, { workingDir, signal }) {
+      const base = workingDir ?? (await coderInfo(host)).primary_root
+      if (signal.aborted) return []
+      const out = await coderSearch(host, {
+        query,
+        regex: false,
+        ignoreCase: true,
+        path: base,
+        searchContent: false,
+      })
+      if (signal.aborted) return []
+      return out.path_matches
+        .filter((match) => match.kind !== 'dir')
+        .slice(0, FILE_ROWS)
+        .map((match) => {
+          const rel = relativeTo(base, match.path)
+          const slash = rel.lastIndexOf('/')
+          return {
+            id: match.path,
+            title: slash === -1 ? rel : rel.slice(slash + 1),
+            detail: slash === -1 ? base : rel.slice(0, slash),
+            keywords: [rel],
+            run: () =>
+              host.panels?.open({
+                pageId: 'shell',
+                context: { type: 'file', path: match.path },
+              }),
+          }
+        })
+    },
+  })
+
+  host.commands?.register('shell', [
+    {
+      id: 'open-file',
+      title: 'Open file…',
+      detail: 'Find a file by name and open it in the shell',
+      keywords: ['quick open', 'file', 'go to file', 'path'],
+      run: () => host.palette?.open({ query: '#' }),
+    },
+    {
+      id: 'open',
+      title: 'Open the shell',
+      detail: 'Files, search, changes and a terminal for the working directory',
+      keywords: ['terminal', 'explorer', 'files', 'ide'],
+      run: () => host.panels?.open({ pageId: 'shell', context: {} }),
+    },
+  ])
+}

--- a/shell/ui/src/page/tabs.ts
+++ b/shell/ui/src/page/tabs.ts
@@ -79,11 +79,18 @@ export function activateTab(state: TabsState, path: string): TabsState {
   return { ...state, active: path }
 }
 
+/** The neighbour in strip order, wrapping at either end. */
+export function cycleTab(state: TabsState, delta: 1 | -1): TabsState {
+  if (state.tabs.length < 2 || state.active === null) return state
+  const index = state.tabs.findIndex((t) => t.path === state.active)
+  if (index === -1) return state
+  const next =
+    state.tabs[(index + delta + state.tabs.length) % state.tabs.length]
+  return { ...state, active: next.path }
+}
+
 /** Restore from persisted state, dropping malformed entries. */
-export function restoreTabs(
-  open: unknown,
-  active: unknown,
-): TabsState {
+export function restoreTabs(open: unknown, active: unknown): TabsState {
   const tabs: OpenTab[] = []
   if (Array.isArray(open)) {
     for (const entry of open) {

--- a/state/ui/page.tsx
+++ b/state/ui/page.tsx
@@ -22,8 +22,10 @@ import type { Host } from '@iii-dev/console-ui'
 import { StateConfigForm } from './src/configuration'
 import { createStateTriggerRenderer } from './src/function-trigger-message'
 import { StateManagerPage } from './src/page'
+import { registerStatePalette } from './src/palette'
 
 export default function setup(host: Host) {
+  registerStatePalette(host)
   host.pages.register({
     id: 'state-manager',
     title: 'state',

--- a/state/ui/src/page/ValueEditor.tsx
+++ b/state/ui/src/page/ValueEditor.tsx
@@ -14,7 +14,12 @@
  * `onDirtyChange` so column navigation can ask before discarding them.
  */
 
-import { Button, CodeEditor, type Host } from '@iii-dev/console-ui'
+import {
+  Button,
+  CodeEditor,
+  type Host,
+  type PageCommandsApi,
+} from '@iii-dev/console-ui'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { type Subscribe, useStateEvents } from '../lib/events'
 import { BackButton } from '../lib/widgets'
@@ -27,6 +32,7 @@ export function ValueEditor({
   narrow,
   onBack,
   onDirtyChange,
+  commands,
 }: {
   host: Host
   scope: string
@@ -35,6 +41,7 @@ export function ValueEditor({
   narrow: boolean
   onBack: () => void
   onDirtyChange: (dirty: boolean) => void
+  commands?: PageCommandsApi
 }) {
   const [stored, setStored] = useState<{ loaded: boolean; value: unknown }>({
     loaded: false,
@@ -62,11 +69,15 @@ export function ValueEditor({
         setLoadError(null)
         setStored({ loaded: true, value })
       })
-      .catch((err: unknown) => setLoadError(err instanceof Error ? err.message : String(err)))
+      .catch((err: unknown) =>
+        setLoadError(err instanceof Error ? err.message : String(err)),
+      )
   }, [host, scope, itemKey])
   useEffect(load, [load])
 
-  const storedText = stored.loaded ? JSON.stringify(stored.value ?? null, null, 2) : ''
+  const storedText = stored.loaded
+    ? JSON.stringify(stored.value ?? null, null, 2)
+    : ''
   const text = draft ?? storedText
   const dirty = draft !== null && draft !== storedText
 
@@ -95,7 +106,9 @@ export function ValueEditor({
     // typically the echo of our own save): apply in place.
     setServerNotice(null)
     setStored((prev) => {
-      const prevText = prev.loaded ? JSON.stringify(prev.value ?? null, null, 2) : null
+      const prevText = prev.loaded
+        ? JSON.stringify(prev.value ?? null, null, 2)
+        : null
       if (prevText !== nextText) setLiveAt(Date.now())
       return { loaded: true, value: e.new_value ?? null }
     })
@@ -129,7 +142,11 @@ export function ValueEditor({
     }
     setSaving(true)
     try {
-      await host.iii.trigger('state::set', { scope, key: itemKey, value: parsed })
+      await host.iii.trigger('state::set', {
+        scope,
+        key: itemKey,
+        value: parsed,
+      })
       setStored({ loaded: true, value: parsed })
       setDraft(null)
       setServerNotice(null)
@@ -142,6 +159,25 @@ export function ValueEditor({
       setSaving(false)
     }
   }, [host, scope, itemKey, text, saving])
+
+  // Surfaces the existing ⌘S handler in ⌘K too; the raw keydown below stays
+  // so the shortcut still works while the caret is inside Monaco.
+  useEffect(
+    () =>
+      commands?.register([
+        {
+          id: 'save',
+          title: 'Save',
+          detail: 'Write this value back with state::set',
+          keywords: ['state::set', 'write'],
+          shortcut: 'Mod+S',
+          firesWhileTyping: true,
+          enabled: () => dirty && !parseError,
+          run: () => void save(),
+        },
+      ]),
+    [commands, dirty, parseError, save],
+  )
 
   const loadLatest = useCallback(() => {
     if (serverNotice?.kind !== 'changed') return
@@ -160,17 +196,31 @@ export function ValueEditor({
 
   const lines = stored.loaded ? text.split('\n').length : 0
   const bytes = stored.loaded ? new Blob([text]).size : 0
-  const saveStatus = saving ? 'saving…' : savedFlash ? '✓ saved' : dirty ? 'unsaved' : ''
+  const saveStatus = saving
+    ? 'saving…'
+    : savedFlash
+      ? '✓ saved'
+      : dirty
+        ? 'unsaved'
+        : ''
 
   return (
     // biome-ignore lint/a11y/noStaticElementInteractions: shortcut relay (⌘S saves) around real controls
     <div className="state-ui-doc-inner" onKeyDown={onWorkspaceKeyDown}>
       <header className="state-ui-doc-head">
-        {narrow ? <BackButton onClick={onBack} label={`back to ${scope}`} /> : null}
+        {narrow ? (
+          <BackButton onClick={onBack} label={`back to ${scope}`} />
+        ) : null}
         <div className="state-ui-doc-identity">
           <span className="state-ui-doc-name" title={`${scope} / ${itemKey}`}>
             <span className="txt">{itemKey}</span>
-            {dirty ? <span className="state-ui-dirty-dot" title="unsaved changes" aria-hidden /> : null}
+            {dirty ? (
+              <span
+                className="state-ui-dirty-dot"
+                title="unsaved changes"
+                aria-hidden
+              />
+            ) : null}
           </span>
           {!narrow ? (
             <span className="state-ui-doc-crumb">
@@ -194,7 +244,12 @@ export function ValueEditor({
               revert
             </Button>
           ) : null}
-          <Button variant="primary" size="sm" disabled={!dirty || !!parseError || saving} onClick={() => void save()}>
+          <Button
+            variant="primary"
+            size="sm"
+            disabled={!dirty || !!parseError || saving}
+            onClick={() => void save()}
+          >
             {saving ? 'saving…' : 'save'}
           </Button>
         </div>
@@ -209,7 +264,11 @@ export function ValueEditor({
       {serverNotice?.kind === 'changed' ? (
         <div className="state-ui-banner warn" role="status">
           <span>This value changed on the server while you were editing.</span>
-          <button type="button" className="state-ui-linkish" onClick={loadLatest}>
+          <button
+            type="button"
+            className="state-ui-linkish"
+            onClick={loadLatest}
+          >
             load latest (discards your draft)
           </button>
         </div>
@@ -221,10 +280,18 @@ export function ValueEditor({
             state::set failed.
             <span className="detail">{saveError}</span>
           </span>
-          <button type="button" className="state-ui-linkish" onClick={() => void save()}>
+          <button
+            type="button"
+            className="state-ui-linkish"
+            onClick={() => void save()}
+          >
             retry
           </button>
-          <button type="button" className="state-ui-linkish quiet" onClick={() => setSaveError(null)}>
+          <button
+            type="button"
+            className="state-ui-linkish quiet"
+            onClick={() => setSaveError(null)}
+          >
             dismiss
           </button>
         </div>

--- a/state/ui/src/page/browser.tsx
+++ b/state/ui/src/page/browser.tsx
@@ -16,11 +16,23 @@
  * reports dirty up); column navigation asks before discarding one.
  */
 
-import { Button, type Host, PageSidebar } from '@iii-dev/console-ui'
+import {
+  Button,
+  type Host,
+  type PageCommandsApi,
+  PageSidebar,
+  type PanelContextEvent,
+} from '@iii-dev/console-ui'
 import type { ReactNode } from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { type Subscribe, useStateEvents } from '../lib/events'
-import { BackButton, DatabaseIcon, RefreshButton, useFlash } from '../lib/widgets'
+import {
+  BackButton,
+  DatabaseIcon,
+  RefreshButton,
+  useFlash,
+} from '../lib/widgets'
+import { parseStatePanelContext } from './panel-context'
 import { ValueEditor } from './ValueEditor'
 
 /** Container width (px) below which the browser collapses to the
@@ -33,7 +45,9 @@ const NARROW_BELOW = 800
  * gives it. Measures synchronously on mount to avoid a wide-mode flash;
  * zero widths (display:none) are ignored so a hidden browser keeps its
  * last real layout. */
-function useContainerNarrow(threshold: number): [(node: HTMLDivElement | null) => void, boolean] {
+function useContainerNarrow(
+  threshold: number,
+): [(node: HTMLDivElement | null) => void, boolean] {
   const [narrow, setNarrow] = useState(false)
   const observerRef = useRef<ResizeObserver | null>(null)
   const refCb = useCallback(
@@ -119,10 +133,14 @@ export function StateBrowser({
   host,
   subscribe,
   panelSide = 'left',
+  panelContext,
+  commands,
 }: {
   host: Host
   subscribe: Subscribe
   panelSide?: 'left' | 'right'
+  panelContext?: PanelContextEvent
+  commands?: PageCommandsApi
 }) {
   const [scopes, setScopes] = useState<string[] | null>(null)
   const [scopesError, setScopesError] = useState<string | null>(null)
@@ -152,7 +170,8 @@ export function StateBrowser({
   const onDirtyChange = useCallback((dirty: boolean) => {
     dirtyRef.current = dirty
   }, [])
-  const confirmDiscard = () => !dirtyRef.current || window.confirm('Discard unsaved changes?')
+  const confirmDiscard = () =>
+    !dirtyRef.current || window.confirm('Discard unsaved changes?')
 
   const loadScopes = useCallback(() => {
     host.iii
@@ -161,7 +180,9 @@ export function StateBrowser({
         setScopesError(null)
         setScopes(r.groups)
       })
-      .catch((err: unknown) => setScopesError(err instanceof Error ? err.message : String(err)))
+      .catch((err: unknown) =>
+        setScopesError(err instanceof Error ? err.message : String(err)),
+      )
   }, [host])
   useEffect(loadScopes, [loadScopes])
 
@@ -177,7 +198,8 @@ export function StateBrowser({
   }, [loadScopes])
   useEffect(
     () => () => {
-      if (refetchTimer.current !== null) window.clearTimeout(refetchTimer.current)
+      if (refetchTimer.current !== null)
+        window.clearTimeout(refetchTimer.current)
     },
     [],
   )
@@ -204,6 +226,36 @@ export function StateBrowser({
     setKeysError(null)
     if (scope !== null) loadKeys()
   }, [scope, loadKeys])
+
+  // A context from the palette source (or another worker's "inspect this
+  // key" affordance) selects a scope, then its key, as each list loads —
+  // the page can mount before the first fetch resolves.
+  const appliedContextRef = useRef(0)
+  useEffect(() => {
+    if (!panelContext || panelContext.id === appliedContextRef.current) return
+    const context = parseStatePanelContext(panelContext.context)
+    if (!context) {
+      appliedContextRef.current = panelContext.id
+      return
+    }
+    if (scopes === null) return
+    if (!scopes.includes(context.scope)) {
+      appliedContextRef.current = panelContext.id
+      return
+    }
+    if (scope !== context.scope) {
+      setScope(context.scope)
+      setKey(null)
+      return
+    }
+    if (keys === null) return
+    if (!keys.includes(context.key)) {
+      appliedContextRef.current = panelContext.id
+      return
+    }
+    appliedContextRef.current = panelContext.id
+    setKey(context.key)
+  }, [panelContext, scopes, scope, keys])
 
   useStateEvents(subscribe, (e) => {
     if (e.event_type === 'state:deleted') {
@@ -255,7 +307,10 @@ export function StateBrowser({
   const showDoc = !narrow || key !== null
 
   return (
-    <div className={`state-ui-browser${narrow ? ' narrow' : ''}${panelSide === 'right' ? ' right' : ''}`} ref={rootRef}>
+    <div
+      className={`state-ui-browser${narrow ? ' narrow' : ''}${panelSide === 'right' ? ' right' : ''}`}
+      ref={rootRef}
+    >
       {showScopes ? (
         <PageSidebar
           label="scopes"
@@ -265,11 +320,15 @@ export function StateBrowser({
           defaultWidth={208}
           narrow={narrow}
           className="state-ui-col scopes"
+          data-autofocus=""
+          tabIndex={-1}
           header={
             <div className="state-ui-col-head state-ui-primary-head">
               <span className="label">scopes</span>
               <span className="spacer" />
-              {scopes !== null && !scopesError ? <span className="count">{scopes.length}</span> : null}
+              {scopes !== null && !scopesError ? (
+                <span className="count">{scopes.length}</span>
+              ) : null}
               <RefreshButton onClick={loadScopes} label="refresh scopes" />
             </div>
           }
@@ -285,7 +344,9 @@ export function StateBrowser({
             empty={
               <div className="state-ui-col-empty">
                 <p>No scopes yet.</p>
-                <p className="dim">A scope appears here live with its first state::set.</p>
+                <p className="dim">
+                  A scope appears here live with its first state::set.
+                </p>
               </div>
             }
           />
@@ -299,18 +360,27 @@ export function StateBrowser({
               <header className="state-ui-col-head">
                 <span className="label">keys</span>
               </header>
-              <div className="state-ui-col-hint">Select a scope to list its keys.</div>
+              <div className="state-ui-col-hint">
+                Select a scope to list its keys.
+              </div>
             </>
           ) : (
             <>
               <header className="state-ui-col-head">
-                {narrow ? <BackButton onClick={backToScopes} label="back to scopes" /> : null}
+                {narrow ? (
+                  <BackButton onClick={backToScopes} label="back to scopes" />
+                ) : null}
                 <span className="scope-name" title={scope}>
                   {scope}
                 </span>
                 <span className="spacer" />
-                {keys !== null && !keysError ? <span className="count">{keys.length}</span> : null}
-                <RefreshButton onClick={loadKeys} label={`refresh keys of ${scope}`} />
+                {keys !== null && !keysError ? (
+                  <span className="count">{keys.length}</span>
+                ) : null}
+                <RefreshButton
+                  onClick={loadKeys}
+                  label={`refresh keys of ${scope}`}
+                />
               </header>
               <ColumnBody
                 error={keysError}
@@ -324,7 +394,8 @@ export function StateBrowser({
                   <div className="state-ui-col-empty">
                     <p>Scope is empty.</p>
                     <p className="dim">
-                      New writes appear here live; the scope disappears once its last key is deleted.
+                      New writes appear here live; the scope disappears once its
+                      last key is deleted.
                     </p>
                   </div>
                 }
@@ -341,8 +412,8 @@ export function StateBrowser({
               <DatabaseIcon className="state-ui-hero-icon" />
               <h2 className="state-ui-hero-title">Select a key</h2>
               <p className="state-ui-hero-body">
-                Pick a scope, then a key, to view and edit its JSON value. Edits save back with state::set; remote
-                changes stream in live.
+                Pick a scope, then a key, to view and edit its JSON value. Edits
+                save back with state::set; remote changes stream in live.
               </p>
               <p className="state-ui-hero-hint">
                 <kbd>⌘S</kbd> saves
@@ -359,6 +430,7 @@ export function StateBrowser({
               narrow={narrow}
               onBack={backToKeys}
               onDirtyChange={onDirtyChange}
+              commands={commands}
             />
           )}
         </section>

--- a/state/ui/src/page/index.tsx
+++ b/state/ui/src/page/index.tsx
@@ -21,6 +21,8 @@ export function StateManagerPage({
   host,
   panelSide = 'left',
   onRequestClose,
+  panelContext,
+  commands,
 }: { host: Host } & Partial<PageRenderProps>) {
   const subscribe = useStateEventHub(host)
 
@@ -33,7 +35,13 @@ export function StateManagerPage({
         actions={<LiveDot />}
         onClose={onRequestClose}
       />
-      <StateBrowser host={host} subscribe={subscribe} panelSide={panelSide} />
+      <StateBrowser
+        host={host}
+        subscribe={subscribe}
+        panelSide={panelSide}
+        panelContext={panelContext}
+        commands={commands}
+      />
     </PageShell>
   )
 }

--- a/state/ui/src/page/panel-context.ts
+++ b/state/ui/src/page/panel-context.ts
@@ -1,0 +1,24 @@
+import type { JsonValue } from '@iii-dev/console-ui'
+
+/** Opens the page with a scope/key pre-selected — the palette source, or
+    any other worker's "inspect this key" affordance. */
+export interface StatePanelContext {
+  scope: string
+  key: string
+}
+
+function asRecord(value: JsonValue): Record<string, JsonValue> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value
+    : null
+}
+
+export function parseStatePanelContext(
+  value: JsonValue,
+): StatePanelContext | null {
+  const record = asRecord(value)
+  if (!record) return null
+  if (typeof record.scope !== 'string' || record.scope === '') return null
+  if (typeof record.key !== 'string' || record.key === '') return null
+  return { scope: record.scope, key: record.key }
+}

--- a/state/ui/src/palette.ts
+++ b/state/ui/src/palette.ts
@@ -1,0 +1,61 @@
+/**
+ * The state worker in the command palette, before its page is even open.
+ *
+ * A keys source answers with every scope's keys by name, each row opening
+ * the page with that scope/key selected. Registered from setup, so it
+ * exists only while the worker is connected; older consoles without
+ * `host.palette` / `host.commands` simply get nothing.
+ */
+
+import type { Host } from '@iii-dev/console-ui'
+
+const ROWS = 30
+
+export function registerStatePalette(host: Host): void {
+  host.palette?.registerSource({
+    id: 'state-keys',
+    title: 'State keys',
+    kind: 'item',
+    minQuery: 2,
+    async search(query, { signal }) {
+      const needle = query.trim().toLowerCase()
+      const { groups } = await host.iii.trigger<{ groups: string[] }>(
+        'state::list_groups',
+        {},
+      )
+      if (signal.aborted) return []
+      const out: { scope: string; key: string }[] = []
+      for (const scope of groups) {
+        if (signal.aborted) return []
+        const { keys } = await host.iii
+          .trigger<{ keys: string[] }>('state::list_keys', { scope })
+          .catch(() => ({ keys: [] as string[] }))
+        for (const key of keys) {
+          if (key.toLowerCase().includes(needle)) out.push({ scope, key })
+        }
+      }
+      if (signal.aborted) return []
+      return out.slice(0, ROWS).map(({ scope, key }) => ({
+        id: `${scope} ${key}`,
+        title: key,
+        detail: scope,
+        keywords: [scope, key],
+        run: () =>
+          host.panels?.open({
+            pageId: 'state-manager',
+            context: { scope, key },
+          }),
+      }))
+    },
+  })
+
+  host.commands?.register('state-manager', [
+    {
+      id: 'open',
+      title: 'Open state',
+      detail: 'Scoped key–value store, live',
+      keywords: ['kv', 'state', 'store'],
+      run: () => host.panels?.open({ pageId: 'state-manager', context: {} }),
+    },
+  ])
+}

--- a/storage/ui/page.tsx
+++ b/storage/ui/page.tsx
@@ -1,8 +1,10 @@
 import type { Host } from '@iii-dev/console-ui'
 import { StorageConfigForm } from './src/configuration'
 import { StoragePage } from './src/page'
+import { registerStoragePalette } from './src/palette'
 
 export default function setup(host: Host) {
+  registerStoragePalette(host)
   host.pages.register({
     id: 'storage-manager',
     title: 'storage',

--- a/storage/ui/src/page.tsx
+++ b/storage/ui/src/page.tsx
@@ -2,14 +2,17 @@ import {
   Button,
   EmptyState,
   type Host,
+  type PageCommandsApi,
   PageHeader,
   type PageRenderProps,
   PageShell,
   PageSidebar,
+  type PanelContextEvent,
   StatusPanel,
 } from '@iii-dev/console-ui'
 import type { ComponentType } from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { parseStoragePanelContext } from './panel-context'
 import {
   BackIcon,
   BucketIcon,
@@ -81,10 +84,14 @@ function StorageExplorer({
   host,
   panelSide,
   tabId,
+  panelContext,
+  commands,
 }: {
   host: Host
   panelSide: 'left' | 'right'
   tabId: string
+  panelContext?: PanelContextEvent
+  commands?: PageCommandsApi
 }) {
   const persisted = useMemo(() => readPersisted(tabId), [tabId])
   const [rootRef, narrow] = useContainerNarrow(NARROW_BELOW)
@@ -238,6 +245,29 @@ function StorageExplorer({
       })
   }, [host, bucketName, objectKey])
 
+  // A context from the palette source (or another worker's "inspect this
+  // object" affordance) selects a bucket/prefix/object once the bucket list
+  // has loaded — the page can mount before the first fetch resolves.
+  const appliedContextRef = useRef(0)
+  useEffect(() => {
+    if (!panelContext || panelContext.id === appliedContextRef.current) return
+    const context = parseStoragePanelContext(panelContext.context)
+    if (!context) {
+      appliedContextRef.current = panelContext.id
+      return
+    }
+    if (buckets === null) return
+    if (!buckets.some((b) => b.name === context.bucket)) {
+      appliedContextRef.current = panelContext.id
+      return
+    }
+    appliedContextRef.current = panelContext.id
+    setBucketName(context.bucket)
+    setPrefix(context.prefix ?? '')
+    setObjectKey(context.objectKey ?? null)
+    setActionError(null)
+  }, [panelContext, buckets])
+
   const openBucket = (name: string) => {
     setBucketName(name)
     setPrefix('')
@@ -370,6 +400,35 @@ function StorageExplorer({
     }
   }
 
+  // The page's verbs, for the palette and for the keyboard while this pane
+  // has the focus. The keys stay clear of the console's own.
+  useEffect(
+    () =>
+      commands?.register([
+        {
+          id: 'upload',
+          title: 'Upload a file',
+          detail: 'Choose a file to upload into the current folder',
+          keywords: ['file', 'add'],
+          shortcut: 'U',
+          enabled: () => bucketName !== null && transfer === null,
+          run: () => fileInputRef.current?.click(),
+        },
+        {
+          id: 'refresh',
+          title: 'Refresh',
+          detail: 'Reload buckets and the current folder',
+          keywords: ['reload'],
+          shortcut: 'R',
+          run: () => {
+            loadBuckets()
+            if (bucketName) loadListing()
+          },
+        },
+      ]),
+    [commands, bucketName, transfer, loadBuckets, loadListing],
+  )
+
   const showBuckets = !narrow || bucketName === null
   const showContents = !narrow || (bucketName !== null && objectKey === null)
   const showDetail = !narrow || objectKey !== null
@@ -390,6 +449,8 @@ function StorageExplorer({
           defaultWidth={204}
           narrow={narrow}
           className="storage-ui-buckets"
+          data-autofocus=""
+          tabIndex={-1}
           header={
             <div className="storage-ui-column-head storage-ui-primary-head">
               <span className="storage-ui-column-label">buckets</span>
@@ -806,6 +867,8 @@ export function StoragePage({
   panelSide = 'left',
   tabId = '',
   onRequestClose,
+  panelContext,
+  commands,
 }: { host: Host } & Partial<PageRenderProps>) {
   const [configOpen, setConfigOpen] = useState(false)
   const ConfigurationDialog = host.components.WorkerConfigurationDialog as
@@ -831,7 +894,13 @@ export function StoragePage({
         }
         onClose={onRequestClose}
       />
-      <StorageExplorer host={host} panelSide={panelSide} tabId={tabId} />
+      <StorageExplorer
+        host={host}
+        panelSide={panelSide}
+        tabId={tabId}
+        panelContext={panelContext}
+        commands={commands}
+      />
       {ConfigurationDialog ? (
         <ConfigurationDialog
           configurationId={configOpen ? 'storage' : null}

--- a/storage/ui/src/page.tsx
+++ b/storage/ui/src/page.tsx
@@ -256,7 +256,7 @@ function StorageExplorer({
       appliedContextRef.current = panelContext.id
       return
     }
-    if (buckets === null) return
+    if (buckets === null || bucketError) return
     if (!buckets.some((b) => b.name === context.bucket)) {
       appliedContextRef.current = panelContext.id
       return
@@ -266,7 +266,7 @@ function StorageExplorer({
     setPrefix(context.prefix ?? '')
     setObjectKey(context.objectKey ?? null)
     setActionError(null)
-  }, [panelContext, buckets])
+  }, [panelContext, buckets, bucketError])
 
   const openBucket = (name: string) => {
     setBucketName(name)

--- a/storage/ui/src/palette.ts
+++ b/storage/ui/src/palette.ts
@@ -1,0 +1,86 @@
+/**
+ * The storage worker in the command palette, before its page is even open.
+ *
+ * An objects source scans every configured bucket's keys, each row opening
+ * the page at that object's bucket/folder. Registered from setup, so it
+ * exists only while the worker is connected; older consoles without
+ * `host.palette` / `host.commands` simply get nothing.
+ */
+
+import type { Host } from '@iii-dev/console-ui'
+import { leafName, parentPrefix } from './widgets'
+
+const ROWS = 30
+/** Objects scanned per bucket — a flat, undelimited listing, so this is a
+    best-effort search over the first page of each bucket, not every key. */
+const SCAN_LIMIT = 200
+
+interface BucketSummary {
+  name: string
+  provider: string
+}
+
+interface StorageObject {
+  key: string
+}
+
+interface Listing {
+  objects: StorageObject[]
+  common_prefixes: string[]
+  next_cursor?: string | null
+}
+
+export function registerStoragePalette(host: Host): void {
+  host.palette?.registerSource({
+    id: 'storage-objects',
+    title: 'Storage objects',
+    kind: 'item',
+    minQuery: 2,
+    async search(query, { signal }) {
+      const needle = query.trim().toLowerCase()
+      const { buckets } = await host.iii.trigger<{ buckets: BucketSummary[] }>(
+        'storage::listBuckets',
+        {},
+      )
+      if (signal.aborted) return []
+      const out: { bucket: string; key: string }[] = []
+      for (const bucket of buckets) {
+        if (signal.aborted) return []
+        const listing = await host.iii
+          .trigger<Listing>('storage::listObjects', {
+            bucket: bucket.name,
+            prefix: '',
+            limit: SCAN_LIMIT,
+          })
+          .catch((): Listing => ({ objects: [], common_prefixes: [] }))
+        for (const object of listing.objects) {
+          if (object.key.toLowerCase().includes(needle)) {
+            out.push({ bucket: bucket.name, key: object.key })
+          }
+        }
+      }
+      if (signal.aborted) return []
+      return out.slice(0, ROWS).map(({ bucket, key }) => ({
+        id: `${bucket}/${key}`,
+        title: leafName(key),
+        detail: `${bucket} · ${parentPrefix(key) || '/'}`,
+        keywords: [bucket, key],
+        run: () =>
+          host.panels?.open({
+            pageId: 'storage-manager',
+            context: { bucket, prefix: parentPrefix(key), objectKey: key },
+          }),
+      }))
+    },
+  })
+
+  host.commands?.register('storage-manager', [
+    {
+      id: 'open',
+      title: 'Open storage',
+      detail: 'Buckets, folders, and objects',
+      keywords: ['bucket', 'object', 'file', 'upload'],
+      run: () => host.panels?.open({ pageId: 'storage-manager', context: {} }),
+    },
+  ])
+}

--- a/storage/ui/src/panel-context.ts
+++ b/storage/ui/src/panel-context.ts
@@ -1,0 +1,29 @@
+import type { JsonValue } from '@iii-dev/console-ui'
+
+/** Opens the page at a bucket/prefix/object — the palette source, or any
+    other worker's "inspect this object" affordance. */
+export interface StoragePanelContext {
+  bucket: string
+  prefix?: string
+  objectKey?: string
+}
+
+function asRecord(value: JsonValue): Record<string, JsonValue> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value
+    : null
+}
+
+export function parseStoragePanelContext(
+  value: JsonValue,
+): StoragePanelContext | null {
+  const record = asRecord(value)
+  if (!record || typeof record.bucket !== 'string' || record.bucket === '')
+    return null
+  return {
+    bucket: record.bucket,
+    prefix: typeof record.prefix === 'string' ? record.prefix : undefined,
+    objectKey:
+      typeof record.objectKey === 'string' ? record.objectKey : undefined,
+  }
+}

--- a/worktree/ui/page.tsx
+++ b/worktree/ui/page.tsx
@@ -17,6 +17,7 @@
 
 import type { Host } from '@iii-dev/console-ui'
 import { WorktreesPage } from './src/page'
+import { registerWorktreePalette } from './src/page/palette'
 
 export default function setup(host: Host) {
   host.pages.register({
@@ -24,4 +25,6 @@ export default function setup(host: Host) {
     title: 'worktrees',
     render: (props) => <WorktreesPage host={host} {...props} />,
   })
+
+  registerWorktreePalette(host)
 }

--- a/worktree/ui/src/page/index.tsx
+++ b/worktree/ui/src/page/index.tsx
@@ -29,12 +29,12 @@ import {
   StatusDot,
   StatusPanel,
 } from '@iii-dev/console-ui'
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { AlertCircle, GitBranch, type IconProps, RefreshCw } from './icons'
 import { useWorktreesLive } from './useWorktreesLive'
-import { cn } from './worktree-data'
 import { WorktreeDetailPanel } from './WorktreeDetailPanel'
 import { WorktreeGraph } from './WorktreeGraph'
+import { cn } from './worktree-data'
 
 /** Container width (px) below which the page collapses to the drill-in
  * graph ⇄ detail flow: the detail column (300) plus a usable slice of the
@@ -77,6 +77,8 @@ export function WorktreesPage({
   host,
   panelSide = 'left',
   onRequestClose,
+  panelContext,
+  commands,
 }: { host: Host } & Partial<PageRenderProps>) {
   const { worktrees, loading, error, live, refresh } = useWorktreesLive(host)
 
@@ -84,6 +86,44 @@ export function WorktreesPage({
   const selected = useMemo(
     () => worktrees.find((w) => w.worktree_id === selectedId) ?? null,
     [worktrees, selectedId],
+  )
+
+  // A palette "worktrees" row (or any other host.panels.open caller) selects
+  // a worktree by id through the standard panelContext channel.
+  const appliedContextRef = useRef(0)
+  useEffect(() => {
+    if (!panelContext || panelContext.id === appliedContextRef.current) return
+    appliedContextRef.current = panelContext.id
+    const context = panelContext.context
+    const worktreeId =
+      context && typeof context === 'object' && !Array.isArray(context)
+        ? (context as Record<string, unknown>).worktreeId
+        : null
+    if (typeof worktreeId === 'string' && worktreeId) setSelectedId(worktreeId)
+  }, [panelContext])
+
+  useEffect(
+    () =>
+      commands?.register([
+        {
+          id: 'refresh',
+          title: 'Refresh worktrees',
+          detail: 'Re-read the worktree registry',
+          keywords: ['reload'],
+          shortcut: 'R',
+          run: refresh,
+        },
+        {
+          id: 'close-detail',
+          title: 'Close worktree details',
+          detail: 'Back to the topology graph',
+          keywords: ['back', 'deselect'],
+          shortcut: 'Escape',
+          enabled: () => selected !== null,
+          run: () => setSelectedId(null),
+        },
+      ]),
+    [commands, refresh, selected],
   )
 
   const [bodyRef, narrow] = useContainerNarrow(NARROW_BELOW)
@@ -142,7 +182,7 @@ export function WorktreesPage({
         ref={bodyRef}
       >
         {showCanvas ? (
-          <div className="wt-ui-canvas">
+          <div className="wt-ui-canvas" tabIndex={-1} data-autofocus="">
             {error ? (
               <StatusPanel
                 variant="alert"

--- a/worktree/ui/src/page/palette.tsx
+++ b/worktree/ui/src/page/palette.tsx
@@ -1,0 +1,57 @@
+/**
+ * The worktree worker in the command palette, before its page is even open.
+ *
+ * A worktrees source answers any query with the live registry —
+ * `worktree::list`, the same read useWorktreesLive bootstraps from — each
+ * row opening the worktrees page with that worktree selected. Registered
+ * from setup, so it exists only while the worker is connected; older
+ * consoles without host.palette / host.commands simply get nothing.
+ */
+
+import type { Host } from '@iii-dev/console-ui'
+import { listWorktrees, shortWorktreeId } from './worktree-data'
+
+const WORKTREE_ROWS = 30
+
+export function registerWorktreePalette(host: Host): void {
+  host.palette?.registerSource({
+    id: 'worktrees',
+    title: 'Worktrees',
+    kind: 'item',
+    minQuery: 2,
+    async search(query, { signal }) {
+      const worktrees = await listWorktrees(host)
+      if (signal.aborted) return []
+      const needle = query.toLowerCase()
+      return worktrees
+        .filter(
+          (worktree) =>
+            worktree.branch.toLowerCase().includes(needle) ||
+            worktree.worktree_id.toLowerCase().includes(needle) ||
+            worktree.path.toLowerCase().includes(needle),
+        )
+        .slice(0, WORKTREE_ROWS)
+        .map((worktree) => ({
+          id: worktree.worktree_id,
+          title: worktree.branch,
+          detail: worktree.path,
+          keywords: [shortWorktreeId(worktree.worktree_id)],
+          run: () =>
+            host.panels?.open({
+              pageId: 'worktree',
+              context: { worktreeId: worktree.worktree_id },
+            }),
+        }))
+    },
+  })
+
+  host.commands?.register('worktree', [
+    {
+      id: 'open',
+      title: 'Open worktrees',
+      detail: 'Repo → worktree → session topology',
+      keywords: ['repo', 'branch', 'graph'],
+      run: () => host.panels?.open({ pageId: 'worktree', context: {} }),
+    },
+  ])
+}


### PR DESCRIPTION
Fixes MOT-4528, MOT-4529, MOT-4530
Refs MOT-4527, MOT-4480

Builds on #879 (merged).

## What

The keyboard reaches every page. A contract lets any page contribute commands, keys and live search results to ⌘K, gated on its worker being connected; focus follows the keyboard into an opened page; the palette gains prefix modes, live sources and recents; the shared row and list primitives carry the arrows; and every worker page in the repo adopts it (chat, workers, traces, shell and 17 worker UIs). A separate fix for a lost-update race between the console's configuration writers that this work exposed.

## Why

Opening a page from ⌘K handed the keyboard back to the mouse. Pages got `PageRenderProps` (tabId, workingDir, panelContext, setDirty) and a `host` with `panels.open`, renderers and chips, but nothing let a page receive focus, publish commands, claim keys, or answer a query. "open file" in ⌘K found nothing; the model picker's forty entries were plain buttons. The bar is Superhuman / VS Code / Slack: ⌘K finds and takes any action, each row shows its key, typing a name lists the thing, the hands never leave the keyboard.

Research went into MOT-4527 (VS Code `contributes.commands`/`keybindings` + `when`, `Category: Title`; Obsidian `addCommand` + `checkCallback`; Zed key-context tree and space-separated chords; Raycast `commands[]` + keywords; Superhuman `G then X`; Slack's switcher). A three-agent sweep of every console surface and worker UI produced the gap list the adoption commits close; it is summarised in `docs/sops/console-ui-conformance.md`.

## How

**Contract** (`types/injectable-ui.ts`, mirrored in `packages/console-ui/index.d.ts` as optional members):

```ts
PageRenderProps.commands?.register(commands): () => void        // render time, pane-scoped keys
host.commands.register(pageId, commands): () => void            // setup time, rows only
host.palette.registerSource({ id, title, kind, prefix?, minQuery?, search(query, { workingDir, conversationId, signal }) })
host.palette.open({ query })                                    // hand over to a mode, e.g. '#'
```

**Presence** (`lib/page-commands.ts`, `lib/palette/providers.ts`): one store each in the `ui-slots` pattern. Setup-time registrations ride the loader's `track()`, torn down with every other registration when a worker's assets go; page-level registrations die with the page. The palette shows a worker-level row only while its page is registered. A worker that is not attached contributes nothing; no new presence plumbing.

**Keys** (`hooks/use-keybindings.ts`, `lib/keybindings/registry.ts`): the dispatcher runs the console's registry, then the keyed commands of the pane containing `event.target`; global wins. `shortcutClaimReason` refuses a page key that collides with a console binding, a digit, a sequence prefix or a browser-owned chord (warning, row stays). Chords, platform maps, `firesWhileTyping`, `data-keybindings-allow` and `enabled` work as for the console's own keys. A key a component already answered is left alone.

**Focus** (`lib/pane-focus.ts`): opening a page from ⌘K, a chord or `panels.open` focuses its first `[data-autofocus]` or the pane root. `{` / `}` step panes.

**Palette**: live sources answer as you type (debounced, aborted when the query moves on, one failing source never hides the others); `>` / `/` narrow to commands, `#` to files, `@` to chats; an empty query opens on the ten most recent choices; several words match in any order; kinds `command`, `file`, `item`; rows titled `Page: Title` with key caps.

**Shared primitives**: `TableRow interactive` joins the tab order and answers Enter, Space and the arrows; `List` walks its items with the arrows. The model picker gets a filter box that keeps the caret: type to narrow across providers, arrows, Enter.

**Adoption**: chat (`I` composer, `J`/`K` messages, `A`/`D` approve or deny, `O` expand, `Y` copy, `End`, `M` model, `Escape` stop, `N` new chat, `/` search), workers (`R`, `/`), traces (`/`, `F`, clear, `Escape`), `F2` renames a workspace tab, and every worker page with a setup-time Open row, render-time verbs with keys, a palette source over its data and a `data-autofocus` target: shell (Files source on `#`, `P F E B` `` ` `` `W` `Alt+←/→` `J/K`), database, cron, state, storage, memory, iii-directory, canvas, a2ui, browser, sandbox-code-runner, computer, worktree, console catalog, eval, github, pdf, editor. Full table in the conformance doc.

**Configuration writer fix** (`hooks/lib/console-config-writer.ts`): `useTraceViews`, `useFollowTurns` and `useSpanFilterSelection` did their own read-modify-write of the entry the workspace tabs use, around the `SerializedConfigWriter`. A traces write that began before a split landed after it: the pre-split layout was published for a frame (new pane unmounted, typed search lost, autofocus stole the keyboard) and written to the server, losing the split. All four hooks share one writer per query client.

## Tests

- vitest: page commands, palette sources / prefixes / recents / word scoring, dispatcher pane scope and precedence, `shortcutClaimReason`, `panel.next|previous`, writer identity and the two-writer race. 1636 pass.
- Playwright `e2e/keyboard-first.spec.ts`: `I` focuses the composer, a letter in the composer stays a letter, `J`/`K` walk the transcript, ⌘K lists `Chat: Focus the composer` with `I` and runs it, `>` narrows to commands, the last choice leads the next empty query, `\` then `}` / `{` move focus across three panes, opening workers from ⌘K lands focus in its pane. `workspace-tabs.spec.ts` passes.
- Every worker UI: `tsc --noEmit`, its build, its tests; biome on touched files.
- Live on the compose rig: "open file" → `Shell: Open file…` → `#` mode lists files under the working directory and opens one in the shell.
- Docs: SOP "Commands: the keyboard reaches every page" + sources, conformance table per page, both `DESIGN.md`.

## Decisions

- Worker-level commands carry no keys; keys come only with a mounted page, only inside its pane, and never over a console key.
- A source is the worker's own search; the console only asks, debounces and aborts. Per-conversation data gets `conversationId`.
- Not here: customisable keybindings, wire-declared commands without a script, roving focus on 2D graphs (worktree, memory graph), PR/issue sources for github (the UI has no real data for them yet).
