### PR TITLE
(MOT-4535) feat(browser): downloads and history panes, clear browsing data

### DIFF
--- a/browser/README.md
+++ b/browser/README.md
@@ -102,9 +102,12 @@ async fn main() -> anyhow::Result<()> {
 The rest of the surface: `browser::act` (click/hover/type/press/scroll by
 ref or coordinates, left/right/middle and double-click), `browser::evaluate`
 (JS expression), `browser::screenshot` (viewable JPEG), `browser::history`
-(back/forward/reload), `browser::find-in-page` (find bar: highlight matches,
-step next/previous), `browser::zoom` (page zoom 50-200 %), `browser::pdf`
-(print the page to a PDF), `browser::network::read` (requests + failures),
+(back/forward/reload), `browser::history::list` (visited pages for a history
+panel), `browser::find-in-page` (find bar: highlight matches, step
+next/previous), `browser::zoom` (page zoom 50-200 %), `browser::pdf` (print
+the page to a PDF), `browser::downloads::list` / `browser::download` /
+`browser::download::remove` (files the session downloaded), `browser::clear-data`
+(cookies, cache, storage), `browser::network::read` (requests + failures),
 `browser::dom::read` (DOM tree with refs), `browser::styles::read` /
 `browser::styles::write` (computed styles + live inline edits, the design
 panel backing), and `browser::sessions::list` / `browser::sessions::stop`.

--- a/browser/src/events.rs
+++ b/browser/src/events.rs
@@ -24,6 +24,7 @@ pub const CONSOLE_EVENT: &str = "browser::console-event";
 pub const NETWORK_EVENT: &str = "browser::network-event";
 pub const PICKED: &str = "browser::picked";
 pub const HANDOFF_REQUESTED: &str = "browser::handoff-requested";
+pub const DOWNLOAD_CHANGED: &str = "browser::download-changed";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum EventKind {
@@ -34,6 +35,7 @@ pub enum EventKind {
     NetworkEvent,
     Picked,
     HandoffRequested,
+    DownloadChanged,
 }
 
 impl EventKind {
@@ -46,10 +48,11 @@ impl EventKind {
             EventKind::NetworkEvent => NETWORK_EVENT,
             EventKind::Picked => PICKED,
             EventKind::HandoffRequested => HANDOFF_REQUESTED,
+            EventKind::DownloadChanged => DOWNLOAD_CHANGED,
         }
     }
 
-    pub fn all() -> [EventKind; 7] {
+    pub fn all() -> [EventKind; 8] {
         [
             EventKind::SessionStarted,
             EventKind::SessionStopped,
@@ -58,6 +61,7 @@ impl EventKind {
             EventKind::NetworkEvent,
             EventKind::Picked,
             EventKind::HandoffRequested,
+            EventKind::DownloadChanged,
         ]
     }
 }
@@ -108,6 +112,15 @@ pub struct SessionStoppedEvent {
 pub struct NavigatedEvent {
     pub session_id: String,
     pub url: String,
+    pub timestamp: i64,
+}
+
+/// `browser::download-changed` — a download in the session started,
+/// progressed, or finished. The durable record is `browser::downloads::list`;
+/// this is the nudge to re-list.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct DownloadChangedEvent {
+    pub session_id: String,
     pub timestamp: i64,
 }
 
@@ -294,7 +307,7 @@ impl TriggerHandler for BrowserTriggerHandler {
 /// `functions::register_all` so handlers can capture the subscriber sets.
 pub fn register_trigger_types(iii: &Arc<IIIClient>) -> TriggerSets {
     let sets = TriggerSets::new();
-    let descriptions: [(EventKind, &str); 7] = [
+    let descriptions: [(EventKind, &str); 8] = [
         (
             EventKind::SessionStarted,
             "A Chromium session is up and ready.",
@@ -318,6 +331,10 @@ pub fn register_trigger_types(iii: &Arc<IIIClient>) -> TriggerSets {
         (
             EventKind::Picked,
             "The human picked an element in inspect mode.",
+        ),
+        (
+            EventKind::DownloadChanged,
+            "A download started, progressed, or finished in a session.",
         ),
         (
             EventKind::HandoffRequested,

--- a/browser/src/functions/clear_data.rs
+++ b/browser/src/functions/clear_data.rs
@@ -1,0 +1,28 @@
+//! `browser::clear-data` — clear the session's browsing data (cookies,
+//! cache, storage), the way the browser's "Clear browsing data" does. Scoped
+//! to the session's own browser context; other sessions are untouched.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ClearDataInput {
+    pub session_id: String,
+    /// Clear cookies. Default true.
+    #[serde(default)]
+    pub cookies: Option<bool>,
+    /// Clear the HTTP cache. Default true.
+    #[serde(default)]
+    pub cache: Option<bool>,
+    /// Clear localStorage / sessionStorage / IndexedDB for the current
+    /// origin. Default true.
+    #[serde(default)]
+    pub storage: Option<bool>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ClearDataOutput {
+    pub ok: bool,
+    /// What was cleared, for the confirmation message.
+    pub cleared: Vec<String>,
+}

--- a/browser/src/functions/downloads.rs
+++ b/browser/src/functions/downloads.rs
@@ -1,0 +1,48 @@
+//! `browser::downloads::list` / `browser::download` / `browser::download::remove`
+//! — the files a session downloaded, the way a browser's downloads panel
+//! shows them. Files land guid-named in the session's download dir; `download`
+//! returns one file's bytes for saving or attaching to the chat.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::session::DownloadRecord;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DownloadsListInput {
+    pub session_id: String,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct DownloadsListOutput {
+    /// Newest first.
+    pub downloads: Vec<DownloadRecord>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DownloadInput {
+    pub session_id: String,
+    /// The download's CDP guid, from `browser::downloads::list`.
+    pub guid: String,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct DownloadOutput {
+    pub ok: bool,
+    /// The file, base64.
+    pub data: String,
+    pub file_name: String,
+    pub size_bytes: u64,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DownloadRemoveInput {
+    pub session_id: String,
+    /// The download to forget, and delete from disk.
+    pub guid: String,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct DownloadRemoveOutput {
+    pub ok: bool,
+}

--- a/browser/src/functions/downloads.rs
+++ b/browser/src/functions/downloads.rs
@@ -19,6 +19,10 @@ pub struct DownloadsListOutput {
     pub downloads: Vec<DownloadRecord>,
 }
 
+/// Upper bound on a download returned inline: the bytes travel base64 over
+/// the bus, so anything larger stays on disk and the caller is told where.
+pub const MAX_DOWNLOAD_BYTES: u64 = 25 * 1024 * 1024;
+
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct DownloadInput {
     pub session_id: String,

--- a/browser/src/functions/history_list.rs
+++ b/browser/src/functions/history_list.rs
@@ -1,0 +1,41 @@
+//! `browser::history::list` — the session's visited pages, newest first, for
+//! the history panel and address-bar suggestions. Distinct from
+//! `browser::history` (back / forward / reload), which moves the page.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::session::HistoryVisit;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct HistoryListInput {
+    pub session_id: String,
+    /// Only entries whose url or title contains this (case-insensitive).
+    #[serde(default)]
+    pub query: Option<String>,
+    /// Cap on returned entries. Default 100.
+    #[serde(default)]
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct HistoryListOutput {
+    pub visits: Vec<HistoryVisit>,
+}
+
+/// Newest first, filtered and capped.
+pub fn select(visits: &[HistoryVisit], query: Option<&str>, limit: usize) -> Vec<HistoryVisit> {
+    let needle = query.map(|q| q.to_lowercase());
+    visits
+        .iter()
+        .rev()
+        .filter(|v| match &needle {
+            Some(n) if !n.is_empty() => {
+                v.url.to_lowercase().contains(n) || v.title.to_lowercase().contains(n)
+            }
+            _ => true,
+        })
+        .take(limit)
+        .cloned()
+        .collect()
+}

--- a/browser/src/functions/mod.rs
+++ b/browser/src/functions/mod.rs
@@ -35,7 +35,6 @@ use std::time::Duration;
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
 use chromiumoxide::cdp::browser_protocol::accessibility as cdp_ax;
-use chromiumoxide::cdp::browser_protocol::browser as cdp_browser;
 use chromiumoxide::cdp::browser_protocol::css as cdp_css;
 use chromiumoxide::cdp::browser_protocol::dom as cdp_dom;
 use chromiumoxide::cdp::browser_protocol::input;
@@ -368,6 +367,15 @@ pub fn register_all(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
 
 fn handler_err(msg: impl Into<String>) -> Error {
     Error::Handler(msg.into())
+}
+
+/// Download guids are used as file names under the session's download dir;
+/// reject anything that could escape it before it reaches the filesystem.
+fn ensure_safe_guid(guid: &str) -> Result<(), Error> {
+    if guid.contains(['/', '\\']) || guid.contains("..") {
+        return Err(handler_err("download guids never contain path parts"));
+    }
+    Ok(())
 }
 
 /// `scheme://host[:port]` of a url, for the storage origin. None for
@@ -1808,6 +1816,7 @@ fn register_download(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
                 let dir = dir.ok_or_else(|| {
                     handler_err("this session does not own downloads (attached session)")
                 })?;
+                ensure_safe_guid(&req.guid)?;
                 let bytes = std::fs::read(dir.join(&req.guid))
                     .map_err(|e| handler_err(format!("read download failed: {e}")))?;
                 Ok::<_, Error>(downloads::DownloadOutput {
@@ -1830,6 +1839,16 @@ fn register_download_remove(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
             let sx = sx.clone();
             async move {
                 let session = get_session(&sx, &req.session_id)?;
+                // Only a guid the session actually recorded names a file the
+                // worker wrote; anything else must not reach the filesystem.
+                let known = {
+                    let downloads = session.downloads.lock().unwrap_or_else(|p| p.into_inner());
+                    downloads.iter().any(|d| d.guid == req.guid)
+                };
+                if !known {
+                    return Err(handler_err(format!("no download '{}'", req.guid)));
+                }
+                ensure_safe_guid(&req.guid)?;
                 if let Some(dir) = &session.downloads_dir {
                     let _ = std::fs::remove_file(dir.join(&req.guid));
                 }

--- a/browser/src/functions/mod.rs
+++ b/browser/src/functions/mod.rs
@@ -4,9 +4,11 @@
 
 pub mod act;
 pub mod attach;
+pub mod clear_data;
 pub mod console;
 pub mod doctor;
 pub mod dom;
+pub mod downloads;
 pub mod evaluate;
 pub mod execute;
 pub mod find_in_page;
@@ -14,6 +16,7 @@ pub mod frame;
 pub mod handoff;
 pub mod hint;
 pub mod history;
+pub mod history_list;
 pub mod navigate;
 pub mod network;
 pub mod overlays;
@@ -32,12 +35,15 @@ use std::time::Duration;
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
 use chromiumoxide::cdp::browser_protocol::accessibility as cdp_ax;
+use chromiumoxide::cdp::browser_protocol::browser as cdp_browser;
 use chromiumoxide::cdp::browser_protocol::css as cdp_css;
 use chromiumoxide::cdp::browser_protocol::dom as cdp_dom;
 use chromiumoxide::cdp::browser_protocol::input;
+use chromiumoxide::cdp::browser_protocol::network as cdp_network;
 use chromiumoxide::cdp::browser_protocol::overlay;
 use chromiumoxide::cdp::browser_protocol::page as cdp_page;
 use chromiumoxide::cdp::browser_protocol::page::CaptureScreenshotFormat;
+use chromiumoxide::cdp::browser_protocol::storage as cdp_storage;
 use chromiumoxide::cdp::js_protocol::runtime as cdp_rt;
 use chromiumoxide::page::ScreenshotParams;
 use iii_sdk::errors::Error;
@@ -188,6 +194,26 @@ pub const PDF_ID: &str = "browser::pdf";
 pub const PDF_DESC: &str =
     "Print the page to a PDF (the browser's Print -> Save as PDF) and return it base64 with \
      a file name from the title.";
+pub const HISTORY_LIST_ID: &str = "browser::history::list";
+pub const HISTORY_LIST_DESC: &str =
+    "The session's visited pages, newest first, for a history panel or address-bar \
+     suggestions. Filter with query. Distinct from browser::history, which moves back / \
+     forward / reloads.";
+pub const CLEAR_DATA_ID: &str = "browser::clear-data";
+pub const CLEAR_DATA_DESC: &str =
+    "Clear the session's browsing data (cookies, cache, storage), like the browser's Clear \
+     browsing data. Scoped to this session's browser context.";
+pub const DOWNLOADS_LIST_ID: &str = "browser::downloads::list";
+pub const DOWNLOADS_LIST_DESC: &str =
+    "The files this session downloaded (name, url, size, state), newest first. Downloads are \
+     allowed and named per session; read one with browser::download.";
+pub const DOWNLOAD_ID: &str = "browser::download";
+pub const DOWNLOAD_DESC: &str =
+    "Read one downloaded file's bytes by guid (from browser::downloads::list), base64, for \
+     saving or attaching to the chat.";
+pub const DOWNLOAD_REMOVE_ID: &str = "browser::download::remove";
+pub const DOWNLOAD_REMOVE_DESC: &str =
+    "Forget a download and delete its file from the session's download dir.";
 
 /// One wire-surface entry: everything the golden schema test pins.
 pub struct FunctionSpec {
@@ -279,6 +305,23 @@ pub fn catalog() -> Vec<FunctionSpec> {
         ),
         spec::<zoom::ZoomInput, zoom::ZoomOutput>(ZOOM_ID, ZOOM_DESC),
         spec::<pdf::PdfInput, pdf::PdfOutput>(PDF_ID, PDF_DESC),
+        spec::<history_list::HistoryListInput, history_list::HistoryListOutput>(
+            HISTORY_LIST_ID,
+            HISTORY_LIST_DESC,
+        ),
+        spec::<clear_data::ClearDataInput, clear_data::ClearDataOutput>(
+            CLEAR_DATA_ID,
+            CLEAR_DATA_DESC,
+        ),
+        spec::<downloads::DownloadsListInput, downloads::DownloadsListOutput>(
+            DOWNLOADS_LIST_ID,
+            DOWNLOADS_LIST_DESC,
+        ),
+        spec::<downloads::DownloadInput, downloads::DownloadOutput>(DOWNLOAD_ID, DOWNLOAD_DESC),
+        spec::<downloads::DownloadRemoveInput, downloads::DownloadRemoveOutput>(
+            DOWNLOAD_REMOVE_ID,
+            DOWNLOAD_REMOVE_DESC,
+        ),
     ]
 }
 
@@ -315,11 +358,31 @@ pub fn register_all(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
     register_find_in_page(iii, sessions);
     register_zoom(iii, sessions);
     register_pdf(iii, sessions);
+    register_history_list(iii, sessions);
+    register_clear_data(iii, sessions);
+    register_downloads_list(iii, sessions);
+    register_download(iii, sessions);
+    register_download_remove(iii, sessions);
     tracing::info!("all functions registered");
 }
 
 fn handler_err(msg: impl Into<String>) -> Error {
     Error::Handler(msg.into())
+}
+
+/// `scheme://host[:port]` of a url, for the storage origin. None for
+/// about:blank and other origin-less pages.
+fn origin_of(url: &str) -> Option<String> {
+    let (scheme, rest) = url.split_once("://")?;
+    if scheme != "http" && scheme != "https" {
+        return None;
+    }
+    let host = rest.split(['/', '?', '#']).next().unwrap_or("");
+    if host.is_empty() {
+        None
+    } else {
+        Some(format!("{scheme}://{host}"))
+    }
 }
 
 fn get_session(sessions: &Sessions, id: &str) -> Result<Arc<Session>, Error> {
@@ -1638,6 +1701,147 @@ fn register_pdf(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
             }
         })
         .description(PDF_DESC),
+    );
+}
+
+fn register_history_list(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
+    let sx = sessions.clone();
+    iii.register_function(
+        HISTORY_LIST_ID,
+        RegisterFunction::new_async(move |req: history_list::HistoryListInput| {
+            let sx = sx.clone();
+            async move {
+                let session = get_session(&sx, &req.session_id)?;
+                let visits = session.history.lock().unwrap_or_else(|p| p.into_inner());
+                let out =
+                    history_list::select(&visits, req.query.as_deref(), req.limit.unwrap_or(100));
+                Ok::<_, Error>(history_list::HistoryListOutput { visits: out })
+            }
+        })
+        .description(HISTORY_LIST_DESC),
+    );
+}
+
+fn register_clear_data(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
+    let sx = sessions.clone();
+    iii.register_function(
+        CLEAR_DATA_ID,
+        RegisterFunction::new_async(move |req: clear_data::ClearDataInput| {
+            let sx = sx.clone();
+            async move {
+                let session = get_session(&sx, &req.session_id)?;
+                session.touch();
+                let mut cleared = Vec::new();
+                if req.cookies.unwrap_or(true) {
+                    session
+                        .page
+                        .execute(cdp_network::ClearBrowserCookiesParams::default())
+                        .await
+                        .map_err(|e| handler_err(format!("clear cookies failed: {e}")))?;
+                    cleared.push("cookies".to_string());
+                }
+                if req.cache.unwrap_or(true) {
+                    session
+                        .page
+                        .execute(cdp_network::ClearBrowserCacheParams::default())
+                        .await
+                        .map_err(|e| handler_err(format!("clear cache failed: {e}")))?;
+                    cleared.push("cache".to_string());
+                }
+                if req.storage.unwrap_or(true) {
+                    let url = session.page.url().await.ok().flatten().unwrap_or_default();
+                    if let Some(origin) = origin_of(&url) {
+                        if let Ok(params) = cdp_storage::ClearDataForOriginParams::builder()
+                            .origin(origin)
+                            .storage_types("all".to_string())
+                            .build()
+                        {
+                            let _ = session.page.execute(params).await;
+                            cleared.push("storage".to_string());
+                        }
+                    }
+                }
+                Ok::<_, Error>(clear_data::ClearDataOutput { ok: true, cleared })
+            }
+        })
+        .description(CLEAR_DATA_DESC),
+    );
+}
+
+fn register_downloads_list(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
+    let sx = sessions.clone();
+    iii.register_function(
+        DOWNLOADS_LIST_ID,
+        RegisterFunction::new_async(move |req: downloads::DownloadsListInput| {
+            let sx = sx.clone();
+            async move {
+                let session = get_session(&sx, &req.session_id)?;
+                let mut list = session
+                    .downloads
+                    .lock()
+                    .unwrap_or_else(|p| p.into_inner())
+                    .clone();
+                list.reverse();
+                Ok::<_, Error>(downloads::DownloadsListOutput { downloads: list })
+            }
+        })
+        .description(DOWNLOADS_LIST_DESC),
+    );
+}
+
+fn register_download(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
+    let sx = sessions.clone();
+    iii.register_function(
+        DOWNLOAD_ID,
+        RegisterFunction::new_async(move |req: downloads::DownloadInput| {
+            let sx = sx.clone();
+            async move {
+                let session = get_session(&sx, &req.session_id)?;
+                let (file_name, dir) = {
+                    let downloads = session.downloads.lock().unwrap_or_else(|p| p.into_inner());
+                    let record = downloads
+                        .iter()
+                        .find(|d| d.guid == req.guid)
+                        .ok_or_else(|| handler_err(format!("no download '{}'", req.guid)))?;
+                    (record.file_name.clone(), session.downloads_dir.clone())
+                };
+                let dir = dir.ok_or_else(|| {
+                    handler_err("this session does not own downloads (attached session)")
+                })?;
+                let bytes = std::fs::read(dir.join(&req.guid))
+                    .map_err(|e| handler_err(format!("read download failed: {e}")))?;
+                Ok::<_, Error>(downloads::DownloadOutput {
+                    ok: true,
+                    size_bytes: bytes.len() as u64,
+                    data: STANDARD.encode(&bytes),
+                    file_name,
+                })
+            }
+        })
+        .description(DOWNLOAD_DESC),
+    );
+}
+
+fn register_download_remove(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
+    let sx = sessions.clone();
+    iii.register_function(
+        DOWNLOAD_REMOVE_ID,
+        RegisterFunction::new_async(move |req: downloads::DownloadRemoveInput| {
+            let sx = sx.clone();
+            async move {
+                let session = get_session(&sx, &req.session_id)?;
+                if let Some(dir) = &session.downloads_dir {
+                    let _ = std::fs::remove_file(dir.join(&req.guid));
+                }
+                session
+                    .downloads
+                    .lock()
+                    .unwrap_or_else(|p| p.into_inner())
+                    .retain(|d| d.guid != req.guid);
+                Ok::<_, Error>(downloads::DownloadRemoveOutput { ok: true })
+            }
+        })
+        .description(DOWNLOAD_REMOVE_DESC),
     );
 }
 

--- a/browser/src/functions/mod.rs
+++ b/browser/src/functions/mod.rs
@@ -1738,6 +1738,7 @@ fn register_clear_data(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
             let sx = sx.clone();
             async move {
                 let session = get_session(&sx, &req.session_id)?;
+                ensure_writable(&session, "browser::clear-data")?;
                 session.touch();
                 let mut cleared = Vec::new();
                 if req.cookies.unwrap_or(true) {
@@ -1764,8 +1765,9 @@ fn register_clear_data(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
                             .storage_types("all".to_string())
                             .build()
                         {
-                            let _ = session.page.execute(params).await;
-                            cleared.push("storage".to_string());
+                            if session.page.execute(params).await.is_ok() {
+                                cleared.push("storage".to_string());
+                            }
                         }
                     }
                 }
@@ -1817,7 +1819,20 @@ fn register_download(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
                     handler_err("this session does not own downloads (attached session)")
                 })?;
                 ensure_safe_guid(&req.guid)?;
-                let bytes = std::fs::read(dir.join(&req.guid))
+                let path = dir.join(&req.guid);
+                let size = std::fs::metadata(&path)
+                    .map_err(|e| handler_err(format!("read download failed: {e}")))?
+                    .len();
+                if size > downloads::MAX_DOWNLOAD_BYTES {
+                    return Err(handler_err(format!(
+                        "download is {size} bytes, over the {} byte cap; it stays on disk at {}",
+                        downloads::MAX_DOWNLOAD_BYTES,
+                        path.display()
+                    )));
+                }
+                let bytes = tokio::task::spawn_blocking(move || std::fs::read(path))
+                    .await
+                    .map_err(|e| handler_err(format!("read download failed: {e}")))?
                     .map_err(|e| handler_err(format!("read download failed: {e}")))?;
                 Ok::<_, Error>(downloads::DownloadOutput {
                     ok: true,

--- a/browser/src/functions/mod.rs
+++ b/browser/src/functions/mod.rs
@@ -437,6 +437,16 @@ fn register_sessions_start(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
                     .ok()
                     .flatten()
                     .unwrap_or_else(|| "about:blank".to_string());
+                let title = tokio::time::timeout(
+                    std::time::Duration::from_secs(2),
+                    session.page.get_title(),
+                )
+                .await
+                .ok()
+                .and_then(|r| r.ok())
+                .flatten()
+                .unwrap_or_default();
+                session.record_visit(&url, &title);
                 sx.emitter
                     .emit(
                         EventKind::SessionStarted,

--- a/browser/src/session.rs
+++ b/browser/src/session.rs
@@ -128,6 +128,10 @@ pub struct HistoryVisit {
 /// How many navigations a session keeps for the history panel.
 const HISTORY_CAP: usize = 200;
 
+/// How many downloads a session keeps; the oldest record and its file are
+/// dropped past this, like the other per-session buffers.
+const DOWNLOADS_CAP: usize = 100;
+
 /// A download Chromium started, tracked by its CDP guid.
 #[derive(Debug, Clone, serde::Serialize, schemars::JsonSchema)]
 pub struct DownloadRecord {
@@ -405,6 +409,15 @@ impl Session {
             total_bytes: 0,
             started_ms: now_ms(),
         });
+        if downloads.len() > DOWNLOADS_CAP {
+            let overflow = downloads.len() - DOWNLOADS_CAP;
+            let evicted: Vec<DownloadRecord> = downloads.drain(0..overflow).collect();
+            if let Some(dir) = &self.downloads_dir {
+                for record in evicted {
+                    let _ = std::fs::remove_file(dir.join(&record.guid));
+                }
+            }
+        }
     }
 
     /// Update a download's progress and state by guid.

--- a/browser/src/session.rs
+++ b/browser/src/session.rs
@@ -695,16 +695,32 @@ impl Sessions {
         // Let the session download files, named by guid into a per-session
         // dir the worker owns, with progress events. Best-effort: a browser
         // that refuses leaves downloads disabled, not the session broken.
-        let downloads_dir =
-            std::env::temp_dir().join(format!("iii-browser-dl-{}-{slot}", std::process::id()));
-        let _ = std::fs::create_dir_all(&downloads_dir);
-        if let Ok(params) = cdp_browser::SetDownloadBehaviorParams::builder()
-            .behavior(cdp_browser::SetDownloadBehaviorBehavior::AllowAndName)
-            .download_path(downloads_dir.to_string_lossy().to_string())
-            .events_enabled(true)
-            .build()
+        // The dir name carries a nonce so it cannot be squatted in advance,
+        // and it is created fresh, owner-only, refusing a pre-existing path.
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.subsec_nanos())
+            .unwrap_or(0);
+        let downloads_dir = std::env::temp_dir().join(format!(
+            "iii-browser-dl-{}-{slot}-{nonce:08x}",
+            std::process::id()
+        ));
+        let mut dir_builder = std::fs::DirBuilder::new();
+        #[cfg(unix)]
         {
-            let _ = page.execute(params).await;
+            use std::os::unix::fs::DirBuilderExt;
+            dir_builder.mode(0o700);
+        }
+        let dir_ok = dir_builder.create(&downloads_dir).is_ok();
+        if dir_ok {
+            if let Ok(params) = cdp_browser::SetDownloadBehaviorParams::builder()
+                .behavior(cdp_browser::SetDownloadBehaviorBehavior::AllowAndName)
+                .download_path(downloads_dir.to_string_lossy().to_string())
+                .events_enabled(true)
+                .build()
+            {
+                let _ = page.execute(params).await;
+            }
         }
 
         let id = format!("b{slot}");
@@ -735,7 +751,7 @@ impl Sessions {
             exec_state: Mutex::new(serde_json::Value::Object(serde_json::Map::new())),
             history: Mutex::new(Vec::new()),
             downloads: Mutex::new(Vec::new()),
-            downloads_dir: Some(downloads_dir.clone()),
+            downloads_dir: dir_ok.then(|| downloads_dir.clone()),
             pick_counter: AtomicU64::new(0),
             tasks: Mutex::new(vec![handler_task]),
         });
@@ -1458,7 +1474,15 @@ async fn spawn_event_pumps(
                     continue; // subframes don't invalidate top-document refs
                 }
                 s.clear_refs();
-                let title = s.page.get_title().await.ok().flatten().unwrap_or_default();
+                // A wedged renderer must not stall the navigation pump on a
+                // title read; after a short wait the visit records untitled.
+                let title =
+                    tokio::time::timeout(std::time::Duration::from_secs(2), s.page.get_title())
+                        .await
+                        .ok()
+                        .and_then(|r| r.ok())
+                        .flatten()
+                        .unwrap_or_default();
                 s.record_visit(&event.frame.url, &title);
                 sx.emitter
                     .emit(
@@ -1555,6 +1579,10 @@ async fn spawn_event_pumps(
             let s = session.clone();
             let sx = sessions.clone();
             tasks.push(tokio::spawn(async move {
+                // Chromium reports progress very often on a fast download;
+                // terminal states always emit, in-flight ones at most every
+                // 250ms so the bus is not flooded.
+                let mut last_emit = std::time::Instant::now() - std::time::Duration::from_secs(1);
                 while let Some(event) = events.next().await {
                     let state = match event.state {
                         cdp_browser::DownloadProgressState::InProgress => "in_progress",
@@ -1567,7 +1595,10 @@ async fn spawn_event_pumps(
                         event.total_bytes as u64,
                         state,
                     );
-                    emit_download_changed(&sx, &s).await;
+                    if state != "in_progress" || last_emit.elapsed().as_millis() >= 250 {
+                        last_emit = std::time::Instant::now();
+                        emit_download_changed(&sx, &s).await;
+                    }
                 }
             }));
         }

--- a/browser/src/session.rs
+++ b/browser/src/session.rs
@@ -1499,6 +1499,44 @@ async fn spawn_event_pumps(
         }));
     }
 
+    // same-document navigations (hash routes, pushState): single-page apps
+    // move this way, so they count as visits and emit the same event
+    if let Ok(mut events) = page
+        .event_listener::<chromiumoxide::cdp::browser_protocol::page::EventNavigatedWithinDocument>(
+        )
+        .await
+    {
+        let s = session.clone();
+        let sx = sessions.clone();
+        tasks.push(tokio::spawn(async move {
+            while let Some(event) = events.next().await {
+                let main_frame = s.page.mainframe().await.ok().flatten();
+                if main_frame.is_some_and(|id| id != event.frame_id) {
+                    continue;
+                }
+                let title =
+                    tokio::time::timeout(std::time::Duration::from_secs(2), s.page.get_title())
+                        .await
+                        .ok()
+                        .and_then(|r| r.ok())
+                        .flatten()
+                        .unwrap_or_default();
+                s.record_visit(&event.url, &title);
+                sx.emitter
+                    .emit(
+                        EventKind::Navigated,
+                        &s.id,
+                        &NavigatedEvent {
+                            session_id: s.id.clone(),
+                            url: event.url.clone(),
+                            timestamp: now_ms(),
+                        },
+                    )
+                    .await;
+            }
+        }));
+    }
+
     // screencast frames: keep only the newest, ack every frame so Chromium
     // keeps pushing
     if let Ok(mut events) = page

--- a/browser/src/session.rs
+++ b/browser/src/session.rs
@@ -12,6 +12,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
 use chromiumoxide::browser::{Browser, BrowserConfig};
+use chromiumoxide::cdp::browser_protocol::browser as cdp_browser;
 use chromiumoxide::cdp::browser_protocol::dom;
 use chromiumoxide::cdp::browser_protocol::log as cdp_log;
 use chromiumoxide::cdp::browser_protocol::network as cdp_network;
@@ -23,8 +24,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::config::{SharedConfig, WorkerConfig};
 use crate::events::{
-    Bounds, ConsoleEventPayload, Emitter, EventKind, NavigatedEvent, PickedElement, PickedEvent,
-    SessionStoppedEvent,
+    Bounds, ConsoleEventPayload, DownloadChangedEvent, Emitter, EventKind, NavigatedEvent,
+    PickedElement, PickedEvent, SessionStoppedEvent,
 };
 
 /// Truncation caps for values that end up in ring buffers and event
@@ -114,6 +115,30 @@ pub struct NetworkEntry {
     pub failed: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+}
+
+/// One entry in a session's navigation history.
+#[derive(Debug, Clone, serde::Serialize, schemars::JsonSchema)]
+pub struct HistoryVisit {
+    pub url: String,
+    pub title: String,
+    pub timestamp: i64,
+}
+
+/// How many navigations a session keeps for the history panel.
+const HISTORY_CAP: usize = 200;
+
+/// A download Chromium started, tracked by its CDP guid.
+#[derive(Debug, Clone, serde::Serialize, schemars::JsonSchema)]
+pub struct DownloadRecord {
+    pub guid: String,
+    pub file_name: String,
+    pub url: String,
+    /// `in_progress`, `completed`, or `canceled`.
+    pub state: String,
+    pub received_bytes: u64,
+    pub total_bytes: u64,
+    pub started_ms: i64,
 }
 
 pub struct RingBuffer<T> {
@@ -317,6 +342,14 @@ pub struct Session {
     /// Cross-call state for `browser::execute`; lives until the session
     /// stops.
     pub exec_state: Mutex<serde_json::Value>,
+    /// Committed top-document navigations, newest last, for the history
+    /// panel and address-bar suggestions. Capped like the other buffers.
+    pub history: Mutex<Vec<HistoryVisit>>,
+    /// Downloads Chromium started in this session, by CDP guid. None for
+    /// attached sessions, where the worker does not own the download policy.
+    pub downloads: Mutex<Vec<DownloadRecord>>,
+    /// Where `allowAndName` writes files (named by guid); removed on stop.
+    pub downloads_dir: Option<std::path::PathBuf>,
     pick_counter: AtomicU64,
     tasks: Mutex<Vec<tokio::task::JoinHandle<()>>>,
 }
@@ -328,6 +361,60 @@ impl Session {
 
     pub fn last_used_ms(&self) -> i64 {
         self.last_used_ms.load(Ordering::Relaxed) as i64
+    }
+
+    /// Record a committed navigation. Consecutive visits to the same URL
+    /// collapse (a reload is not a new entry); the buffer is capped.
+    pub fn record_visit(&self, url: &str, title: &str) {
+        if url.is_empty() || url == "about:blank" {
+            return;
+        }
+        let mut history = self.history.lock().unwrap_or_else(|p| p.into_inner());
+        if history.last().is_some_and(|last| last.url == url) {
+            if let Some(last) = history.last_mut() {
+                if !title.is_empty() {
+                    last.title = title.to_string();
+                }
+                last.timestamp = now_ms();
+            }
+            return;
+        }
+        history.push(HistoryVisit {
+            url: url.to_string(),
+            title: title.to_string(),
+            timestamp: now_ms(),
+        });
+        let len = history.len();
+        if len > HISTORY_CAP {
+            history.drain(0..len - HISTORY_CAP);
+        }
+    }
+
+    /// Note a download beginning; later progress updates it by guid.
+    pub fn download_begin(&self, guid: &str, file_name: &str, url: &str) {
+        let mut downloads = self.downloads.lock().unwrap_or_else(|p| p.into_inner());
+        if downloads.iter().any(|d| d.guid == guid) {
+            return;
+        }
+        downloads.push(DownloadRecord {
+            guid: guid.to_string(),
+            file_name: file_name.to_string(),
+            url: url.to_string(),
+            state: "in_progress".to_string(),
+            received_bytes: 0,
+            total_bytes: 0,
+            started_ms: now_ms(),
+        });
+    }
+
+    /// Update a download's progress and state by guid.
+    pub fn download_progress(&self, guid: &str, received: u64, total: u64, state: &str) {
+        let mut downloads = self.downloads.lock().unwrap_or_else(|p| p.into_inner());
+        if let Some(record) = downloads.iter_mut().find(|d| d.guid == guid) {
+            record.received_bytes = received;
+            record.total_bytes = total.max(received);
+            record.state = state.to_string();
+        }
     }
 
     pub fn next_seq(&self) -> u64 {
@@ -462,6 +549,9 @@ impl Session {
                 if let Some(dir) = &self.ephemeral_profile {
                     let _ = std::fs::remove_dir_all(dir);
                 }
+                if let Some(dir) = &self.downloads_dir {
+                    let _ = std::fs::remove_dir_all(dir);
+                }
             }
             SessionKind::Attached { owns_page } => {
                 if owns_page {
@@ -589,6 +679,21 @@ impl Sessions {
         let _ = page.execute(cdp_log::EnableParams::default()).await;
         let _ = page.execute(cdp_network::EnableParams::default()).await;
 
+        // Let the session download files, named by guid into a per-session
+        // dir the worker owns, with progress events. Best-effort: a browser
+        // that refuses leaves downloads disabled, not the session broken.
+        let downloads_dir =
+            std::env::temp_dir().join(format!("iii-browser-dl-{}-{slot}", std::process::id()));
+        let _ = std::fs::create_dir_all(&downloads_dir);
+        if let Ok(params) = cdp_browser::SetDownloadBehaviorParams::builder()
+            .behavior(cdp_browser::SetDownloadBehaviorBehavior::AllowAndName)
+            .download_path(downloads_dir.to_string_lossy().to_string())
+            .events_enabled(true)
+            .build()
+        {
+            let _ = page.execute(params).await;
+        }
+
         let id = format!("b{slot}");
         let now = now_ms();
         let session = Arc::new(Session {
@@ -615,6 +720,9 @@ impl Sessions {
             generation: AtomicU64::new(1),
             snapshot_keys: Mutex::new(None),
             exec_state: Mutex::new(serde_json::Value::Object(serde_json::Map::new())),
+            history: Mutex::new(Vec::new()),
+            downloads: Mutex::new(Vec::new()),
+            downloads_dir: Some(downloads_dir.clone()),
             pick_counter: AtomicU64::new(0),
             tasks: Mutex::new(vec![handler_task]),
         });
@@ -710,6 +818,9 @@ impl Sessions {
             generation: AtomicU64::new(1),
             snapshot_keys: Mutex::new(None),
             exec_state: Mutex::new(serde_json::Value::Object(serde_json::Map::new())),
+            history: Mutex::new(Vec::new()),
+            downloads: Mutex::new(Vec::new()),
+            downloads_dir: None,
             pick_counter: AtomicU64::new(0),
             tasks: Mutex::new(vec![handler_task]),
         });
@@ -1334,6 +1445,8 @@ async fn spawn_event_pumps(
                     continue; // subframes don't invalidate top-document refs
                 }
                 s.clear_refs();
+                let title = s.page.get_title().await.ok().flatten().unwrap_or_default();
+                s.record_visit(&event.frame.url, &title);
                 sx.emitter
                     .emit(
                         EventKind::Navigated,
@@ -1405,7 +1518,63 @@ async fn spawn_event_pumps(
         }));
     }
 
+    // downloads: guid-named files land in the session's download dir; the
+    // begin/progress events feed the downloads panel. Only armed when the
+    // worker owns the download policy.
+    if session.downloads_dir.is_some() {
+        if let Ok(mut events) = page
+            .event_listener::<cdp_browser::EventDownloadWillBegin>()
+            .await
+        {
+            let s = session.clone();
+            let sx = sessions.clone();
+            tasks.push(tokio::spawn(async move {
+                while let Some(event) = events.next().await {
+                    s.download_begin(&event.guid, &event.suggested_filename, &event.url);
+                    emit_download_changed(&sx, &s).await;
+                }
+            }));
+        }
+        if let Ok(mut events) = page
+            .event_listener::<cdp_browser::EventDownloadProgress>()
+            .await
+        {
+            let s = session.clone();
+            let sx = sessions.clone();
+            tasks.push(tokio::spawn(async move {
+                while let Some(event) = events.next().await {
+                    let state = match event.state {
+                        cdp_browser::DownloadProgressState::InProgress => "in_progress",
+                        cdp_browser::DownloadProgressState::Completed => "completed",
+                        cdp_browser::DownloadProgressState::Canceled => "canceled",
+                    };
+                    s.download_progress(
+                        &event.guid,
+                        event.received_bytes as u64,
+                        event.total_bytes as u64,
+                        state,
+                    );
+                    emit_download_changed(&sx, &s).await;
+                }
+            }));
+        }
+    }
+
     tasks
+}
+
+async fn emit_download_changed(sessions: &Arc<Sessions>, session: &Arc<Session>) {
+    sessions
+        .emitter
+        .emit(
+            EventKind::DownloadChanged,
+            &session.id,
+            &DownloadChangedEvent {
+                session_id: session.id.clone(),
+                timestamp: now_ms(),
+            },
+        )
+        .await;
 }
 
 async fn push_and_emit(sessions: &Arc<Sessions>, session: &Arc<Session>, entry: ConsoleEntry) {

--- a/browser/tests/golden/schemas/browser.clear-data.json
+++ b/browser/tests/golden/schemas/browser.clear-data.json
@@ -1,0 +1,62 @@
+{
+  "function_id": "browser::clear-data",
+  "description": "Clear the session's browsing data (cookies, cache, storage), like the browser's Clear browsing data. Scoped to this session's browser context.",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ClearDataInput",
+    "type": "object",
+    "required": [
+      "session_id"
+    ],
+    "properties": {
+      "cache": {
+        "description": "Clear the HTTP cache. Default true.",
+        "default": null,
+        "type": [
+          "boolean",
+          "null"
+        ]
+      },
+      "cookies": {
+        "description": "Clear cookies. Default true.",
+        "default": null,
+        "type": [
+          "boolean",
+          "null"
+        ]
+      },
+      "session_id": {
+        "type": "string"
+      },
+      "storage": {
+        "description": "Clear localStorage / sessionStorage / IndexedDB for the current origin. Default true.",
+        "default": null,
+        "type": [
+          "boolean",
+          "null"
+        ]
+      }
+    }
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ClearDataOutput",
+    "type": "object",
+    "required": [
+      "cleared",
+      "ok"
+    ],
+    "properties": {
+      "cleared": {
+        "description": "What was cleared, for the confirmation message.",
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "ok": {
+        "type": "boolean"
+      }
+    }
+  }
+}

--- a/browser/tests/golden/schemas/browser.download.json
+++ b/browser/tests/golden/schemas/browser.download.json
@@ -1,0 +1,50 @@
+{
+  "function_id": "browser::download",
+  "description": "Read one downloaded file's bytes by guid (from browser::downloads::list), base64, for saving or attaching to the chat.",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "DownloadInput",
+    "type": "object",
+    "required": [
+      "guid",
+      "session_id"
+    ],
+    "properties": {
+      "guid": {
+        "description": "The download's CDP guid, from `browser::downloads::list`.",
+        "type": "string"
+      },
+      "session_id": {
+        "type": "string"
+      }
+    }
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "DownloadOutput",
+    "type": "object",
+    "required": [
+      "data",
+      "file_name",
+      "ok",
+      "size_bytes"
+    ],
+    "properties": {
+      "data": {
+        "description": "The file, base64.",
+        "type": "string"
+      },
+      "file_name": {
+        "type": "string"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "size_bytes": {
+        "type": "integer",
+        "format": "uint64",
+        "minimum": 0.0
+      }
+    }
+  }
+}

--- a/browser/tests/golden/schemas/browser.download.remove.json
+++ b/browser/tests/golden/schemas/browser.download.remove.json
@@ -1,0 +1,35 @@
+{
+  "function_id": "browser::download::remove",
+  "description": "Forget a download and delete its file from the session's download dir.",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "DownloadRemoveInput",
+    "type": "object",
+    "required": [
+      "guid",
+      "session_id"
+    ],
+    "properties": {
+      "guid": {
+        "description": "The download to forget, and delete from disk.",
+        "type": "string"
+      },
+      "session_id": {
+        "type": "string"
+      }
+    }
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "DownloadRemoveOutput",
+    "type": "object",
+    "required": [
+      "ok"
+    ],
+    "properties": {
+      "ok": {
+        "type": "boolean"
+      }
+    }
+  }
+}

--- a/browser/tests/golden/schemas/browser.downloads.list.json
+++ b/browser/tests/golden/schemas/browser.downloads.list.json
@@ -1,0 +1,78 @@
+{
+  "function_id": "browser::downloads::list",
+  "description": "The files this session downloaded (name, url, size, state), newest first. Downloads are allowed and named per session; read one with browser::download.",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "DownloadsListInput",
+    "type": "object",
+    "required": [
+      "session_id"
+    ],
+    "properties": {
+      "session_id": {
+        "type": "string"
+      }
+    }
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "DownloadsListOutput",
+    "type": "object",
+    "required": [
+      "downloads"
+    ],
+    "properties": {
+      "downloads": {
+        "description": "Newest first.",
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/DownloadRecord"
+        }
+      }
+    },
+    "definitions": {
+      "DownloadRecord": {
+        "description": "A download Chromium started, tracked by its CDP guid.",
+        "type": "object",
+        "required": [
+          "file_name",
+          "guid",
+          "received_bytes",
+          "started_ms",
+          "state",
+          "total_bytes",
+          "url"
+        ],
+        "properties": {
+          "file_name": {
+            "type": "string"
+          },
+          "guid": {
+            "type": "string"
+          },
+          "received_bytes": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "started_ms": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "state": {
+            "description": "`in_progress`, `completed`, or `canceled`.",
+            "type": "string"
+          },
+          "total_bytes": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "url": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/browser/tests/golden/schemas/browser.history.list.json
+++ b/browser/tests/golden/schemas/browser.history.list.json
@@ -1,0 +1,74 @@
+{
+  "function_id": "browser::history::list",
+  "description": "The session's visited pages, newest first, for a history panel or address-bar suggestions. Filter with query. Distinct from browser::history, which moves back / forward / reloads.",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "HistoryListInput",
+    "type": "object",
+    "required": [
+      "session_id"
+    ],
+    "properties": {
+      "limit": {
+        "description": "Cap on returned entries. Default 100.",
+        "default": null,
+        "type": [
+          "integer",
+          "null"
+        ],
+        "format": "uint",
+        "minimum": 0.0
+      },
+      "query": {
+        "description": "Only entries whose url or title contains this (case-insensitive).",
+        "default": null,
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "session_id": {
+        "type": "string"
+      }
+    }
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "HistoryListOutput",
+    "type": "object",
+    "required": [
+      "visits"
+    ],
+    "properties": {
+      "visits": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/HistoryVisit"
+        }
+      }
+    },
+    "definitions": {
+      "HistoryVisit": {
+        "description": "One entry in a session's navigation history.",
+        "type": "object",
+        "required": [
+          "timestamp",
+          "title",
+          "url"
+        ],
+        "properties": {
+          "timestamp": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/browser/tests/schemas.rs
+++ b/browser/tests/schemas.rs
@@ -1,4 +1,4 @@
-//! Wire-schema snapshots for the thirty-two `browser::*` functions.
+//! Wire-schema snapshots for the thirty-seven `browser::*` functions.
 //!
 //! `browser::functions::catalog()` is the single source of truth for each
 //! function's id, registration description, and schemars-derived
@@ -32,7 +32,7 @@ fn spec_to_pretty_json(spec: &FunctionSpec) -> String {
     pretty
 }
 
-/// The catalog must cover exactly the thirty-two registered functions, in
+/// The catalog must cover exactly the thirty-seven registered functions, in
 /// registration order (kept in lockstep with `register_all`).
 #[test]
 fn catalog_lists_all_functions_in_registration_order() {
@@ -72,6 +72,11 @@ fn catalog_lists_all_functions_in_registration_order() {
             "browser::find-in-page",
             "browser::zoom",
             "browser::pdf",
+            "browser::history::list",
+            "browser::clear-data",
+            "browser::downloads::list",
+            "browser::download",
+            "browser::download::remove",
         ]
     );
 }

--- a/browser/ui/src/lib/browser.ts
+++ b/browser/ui/src/lib/browser.ts
@@ -898,12 +898,16 @@ export async function readBrowserDownload(
   })
   const parsed = downloadSchema.safeParse(res)
   if (!parsed.success) return null
-  return {
-    file: fileFromBase64(
-      parsed.data.data,
-      parsed.data.file_name,
-      'application/octet-stream',
-    ),
+  try {
+    return {
+      file: fileFromBase64(
+        parsed.data.data,
+        parsed.data.file_name,
+        'application/octet-stream',
+      ),
+    }
+  } catch {
+    return null
   }
 }
 

--- a/browser/ui/src/lib/browser.ts
+++ b/browser/ui/src/lib/browser.ts
@@ -807,3 +807,113 @@ export function screenshotFileName(url: string, at = new Date()): string {
   const stamp = at.toISOString().replace(/[:.]/g, '-')
   return `screenshot-${host || 'page'}-${stamp}.jpg`
 }
+
+export const BROWSER_HISTORY_LIST_FUNCTION_ID = 'browser::history::list'
+export const BROWSER_CLEAR_DATA_FUNCTION_ID = 'browser::clear-data'
+export const BROWSER_DOWNLOADS_LIST_FUNCTION_ID = 'browser::downloads::list'
+export const BROWSER_DOWNLOAD_FUNCTION_ID = 'browser::download'
+export const BROWSER_DOWNLOAD_REMOVE_FUNCTION_ID = 'browser::download::remove'
+export const BROWSER_DOWNLOAD_CHANGED_TRIGGER = 'browser::download-changed'
+
+const historyVisitSchema = z.object({
+  url: z.string(),
+  title: z.string(),
+  timestamp: z.number(),
+})
+export type BrowserHistoryVisit = z.infer<typeof historyVisitSchema>
+const historyListSchema = z.object({ visits: z.array(historyVisitSchema) })
+
+export async function listBrowserHistory(
+  iii: ExtensionIii,
+  sessionId: string,
+  query?: string,
+): Promise<BrowserHistoryVisit[]> {
+  const res = await iii.trigger<unknown>(BROWSER_HISTORY_LIST_FUNCTION_ID, {
+    session_id: sessionId,
+    ...(query ? { query } : {}),
+  })
+  return historyListSchema.safeParse(res).success
+    ? historyListSchema.parse(res).visits
+    : []
+}
+
+const clearDataSchema = z.object({
+  ok: z.boolean(),
+  cleared: z.array(z.string()),
+})
+
+export async function clearBrowserData(
+  iii: ExtensionIii,
+  sessionId: string,
+): Promise<string[]> {
+  const res = await iii.trigger<unknown>(BROWSER_CLEAR_DATA_FUNCTION_ID, {
+    session_id: sessionId,
+  })
+  return clearDataSchema.safeParse(res).success
+    ? clearDataSchema.parse(res).cleared
+    : []
+}
+
+const downloadRecordSchema = z.object({
+  guid: z.string(),
+  file_name: z.string(),
+  url: z.string(),
+  state: z.enum(['in_progress', 'completed', 'canceled']),
+  received_bytes: z.number(),
+  total_bytes: z.number(),
+  started_ms: z.number(),
+})
+export type BrowserDownload = z.infer<typeof downloadRecordSchema>
+const downloadsListSchema = z.object({
+  downloads: z.array(downloadRecordSchema),
+})
+
+export async function listBrowserDownloads(
+  iii: ExtensionIii,
+  sessionId: string,
+): Promise<BrowserDownload[]> {
+  const res = await iii.trigger<unknown>(BROWSER_DOWNLOADS_LIST_FUNCTION_ID, {
+    session_id: sessionId,
+  })
+  return downloadsListSchema.safeParse(res).success
+    ? downloadsListSchema.parse(res).downloads
+    : []
+}
+
+const downloadSchema = z.object({
+  ok: z.boolean(),
+  data: z.string(),
+  file_name: z.string(),
+  size_bytes: z.number(),
+})
+
+export async function readBrowserDownload(
+  iii: ExtensionIii,
+  sessionId: string,
+  guid: string,
+): Promise<{ file: File } | null> {
+  const res = await iii.trigger<unknown>(BROWSER_DOWNLOAD_FUNCTION_ID, {
+    session_id: sessionId,
+    guid,
+  })
+  const parsed = downloadSchema.safeParse(res)
+  if (!parsed.success) return null
+  return {
+    file: fileFromBase64(
+      parsed.data.data,
+      parsed.data.file_name,
+      'application/octet-stream',
+    ),
+  }
+}
+
+export async function removeBrowserDownload(
+  iii: ExtensionIii,
+  sessionId: string,
+  guid: string,
+): Promise<void> {
+  await iii.trigger(BROWSER_DOWNLOAD_REMOVE_FUNCTION_ID, {
+    session_id: sessionId,
+    guid,
+  })
+}

--- a/browser/ui/src/lib/format.ts
+++ b/browser/ui/src/lib/format.ts
@@ -18,3 +18,10 @@ export function formatMtime(unixSecs: number, now = Date.now()): string {
   if (months < 12) return `${months}mo ago`
   return `${Math.floor(months / 12)}y ago`
 }
+
+/** Bytes to a short human size ("64kb", "1.2mb"). */
+export function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes}b`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)}kb`
+  return `${(bytes / (1024 * 1024)).toFixed(1)}mb`
+}

--- a/browser/ui/src/lib/icons.tsx
+++ b/browser/ui/src/lib/icons.tsx
@@ -177,3 +177,13 @@ export function Minus(props: IconProps) {
     </Svg>
   )
 }
+
+export function Download(props: IconProps) {
+  return (
+    <Svg {...props}>
+      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+      <path d="M7 10l5 5 5-5" />
+      <path d="M12 15V3" />
+    </Svg>
+  )
+}

--- a/browser/ui/src/page/DownloadsPanel.tsx
+++ b/browser/ui/src/page/DownloadsPanel.tsx
@@ -1,0 +1,177 @@
+/**
+ * Downloads for the selected session: what a browser's downloads panel
+ * shows. Seeded from `browser::downloads::list`, refreshed on the
+ * session-filtered `browser::download-changed` event. Each row can go to the
+ * chat, save to disk, or be removed.
+ */
+
+import { type Host, IconButton } from '@iii-dev/console-ui'
+import { useCallback, useEffect, useState } from 'react'
+import {
+  BROWSER_DOWNLOAD_CHANGED_TRIGGER,
+  type BrowserDownload,
+  downloadFile,
+  errorMessage,
+  formatTime,
+  listBrowserDownloads,
+  readBrowserDownload,
+  removeBrowserDownload,
+} from '../lib/browser'
+import { useBrowserSessionEvent } from '../lib/events'
+import { formatSize } from '../lib/format'
+import { Download, MessageSquarePlus, X } from '../lib/icons'
+
+const DOWNLOADS_FEED_FN = 'iii::browser-ui::downloads-feed'
+
+interface DownloadsPanelProps {
+  host: Host
+  sessionId: string
+  enabled: boolean
+}
+
+export function DownloadsPanel({
+  host,
+  sessionId,
+  enabled,
+}: DownloadsPanelProps) {
+  const [downloads, setDownloads] = useState<BrowserDownload[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const refresh = useCallback(() => {
+    void listBrowserDownloads(host.iii, sessionId)
+      .then(setDownloads)
+      .catch((e: unknown) => setError(errorMessage(e)))
+  }, [host, sessionId])
+  useEffect(() => {
+    setError(null)
+    refresh()
+  }, [refresh])
+  useBrowserSessionEvent({
+    host,
+    enabled,
+    triggerType: BROWSER_DOWNLOAD_CHANGED_TRIGGER,
+    sessionId,
+    fnId: DOWNLOADS_FEED_FN,
+    onEvent: () => refresh(),
+  })
+
+  const canSendToChat = typeof host.chat?.compose === 'function'
+  const sendToChat = useCallback(
+    (guid: string) => {
+      void readBrowserDownload(host.iii, sessionId, guid).then((result) => {
+        if (result) host.chat?.compose?.({ files: [result.file] })
+      })
+    },
+    [host, sessionId],
+  )
+  const save = useCallback(
+    (guid: string) => {
+      void readBrowserDownload(host.iii, sessionId, guid).then((result) => {
+        if (result) downloadFile(result.file)
+      })
+    },
+    [host, sessionId],
+  )
+  const remove = useCallback(
+    (guid: string) => {
+      void removeBrowserDownload(host.iii, sessionId, guid).then(refresh)
+    },
+    [host, sessionId, refresh],
+  )
+
+  if (error) {
+    return <p className="br-ui-downloads-empty">downloads failed: {error}</p>
+  }
+  if (downloads.length === 0) {
+    return (
+      <p className="br-ui-downloads-empty">
+        Nothing downloaded in this session yet.
+      </p>
+    )
+  }
+  return (
+    <ul className="br-ui-downloads" aria-label="downloads">
+      {downloads.map((d) => {
+        const done = d.state === 'completed'
+        const pct =
+          d.total_bytes > 0
+            ? Math.round((d.received_bytes / d.total_bytes) * 100)
+            : 0
+        return (
+          <li key={d.guid} className="br-ui-download-row">
+            <Download size={16} aria-hidden className="br-ui-download-icon" />
+            <div className="br-ui-download-main">
+              <span className="br-ui-download-name" title={d.file_name}>
+                {d.file_name}
+              </span>
+              <span className="br-ui-download-meta">
+                {d.state === 'in_progress'
+                  ? `Downloading… ${pct}%`
+                  : d.state === 'canceled'
+                    ? 'Canceled'
+                    : formatSize(d.received_bytes)}
+                <span aria-hidden> · </span>
+                {formatTime(Math.floor(d.started_ms / 1000))}
+              </span>
+              {d.state === 'in_progress' ? (
+                <span className="br-ui-download-bar" aria-hidden>
+                  <span
+                    className="br-ui-download-bar-fill"
+                    style={{ width: `${pct}%` }}
+                  />
+                </span>
+              ) : null}
+            </div>
+            <span className="br-ui-download-actions">
+              <IconButton
+                label={`send ${d.file_name} to chat`}
+                onClick={() => sendToChat(d.guid)}
+                disabled={!done || !canSendToChat}
+              >
+                <MessageSquarePlus size={15} aria-hidden />
+              </IconButton>
+              <IconButton
+                label={`save ${d.file_name}`}
+                onClick={() => save(d.guid)}
+                disabled={!done}
+              >
+                <Download size={15} aria-hidden />
+              </IconButton>
+              <IconButton
+                label={`remove ${d.file_name}`}
+                onClick={() => remove(d.guid)}
+              >
+                <X size={15} aria-hidden />
+              </IconButton>
+            </span>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+
+export function useDownloadCount(
+  host: Host,
+  sessionId: string,
+  enabled: boolean,
+): number {
+  const [count, setCount] = useState(0)
+  const refresh = useCallback(() => {
+    void listBrowserDownloads(host.iii, sessionId)
+      .then((list) => setCount(list.length))
+      .catch(() => {})
+  }, [host, sessionId])
+  useEffect(() => {
+    setCount(0)
+    refresh()
+  }, [refresh])
+  useBrowserSessionEvent({
+    host,
+    enabled,
+    triggerType: BROWSER_DOWNLOAD_CHANGED_TRIGGER,
+    sessionId,
+    fnId: `${DOWNLOADS_FEED_FN}-count`,
+    onEvent: () => refresh(),
+  })
+  return count
+}

--- a/browser/ui/src/page/DownloadsPanel.tsx
+++ b/browser/ui/src/page/DownloadsPanel.tsx
@@ -23,6 +23,12 @@ import { Download, MessageSquarePlus, X } from '../lib/icons'
 
 const DOWNLOADS_FEED_FN = 'iii::browser-ui::downloads-feed'
 
+function downloadStatusText(d: BrowserDownload, pct: number): string {
+  if (d.state === 'in_progress') return `Downloading… ${pct}%`
+  if (d.state === 'canceled') return 'Canceled'
+  return formatSize(d.received_bytes)
+}
+
 interface DownloadsPanelProps {
   host: Host
   sessionId: string
@@ -104,11 +110,7 @@ export function DownloadsPanel({
                 {d.file_name}
               </span>
               <span className="br-ui-download-meta">
-                {d.state === 'in_progress'
-                  ? `Downloading… ${pct}%`
-                  : d.state === 'canceled'
-                    ? 'Canceled'
-                    : formatSize(d.received_bytes)}
+                {downloadStatusText(d, pct)}
                 <span aria-hidden> · </span>
                 {formatTime(Math.floor(d.started_ms / 1000))}
               </span>

--- a/browser/ui/src/page/DownloadsPanel.tsx
+++ b/browser/ui/src/page/DownloadsPanel.tsx
@@ -127,20 +127,20 @@ export function DownloadsPanel({
                 onClick={() => sendToChat(d.guid)}
                 disabled={!done || !canSendToChat}
               >
-                <MessageSquarePlus size={15} aria-hidden />
+                <MessageSquarePlus size={16} aria-hidden />
               </IconButton>
               <IconButton
                 label={`save ${d.file_name}`}
                 onClick={() => save(d.guid)}
                 disabled={!done}
               >
-                <Download size={15} aria-hidden />
+                <Download size={16} aria-hidden />
               </IconButton>
               <IconButton
                 label={`remove ${d.file_name}`}
                 onClick={() => remove(d.guid)}
               >
-                <X size={15} aria-hidden />
+                <X size={16} aria-hidden />
               </IconButton>
             </span>
           </li>

--- a/browser/ui/src/page/DownloadsPanel.tsx
+++ b/browser/ui/src/page/DownloadsPanel.tsx
@@ -6,7 +6,7 @@
  */
 
 import { type Host, IconButton } from '@iii-dev/console-ui'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import {
   BROWSER_DOWNLOAD_CHANGED_TRIGGER,
   type BrowserDownload,
@@ -42,14 +42,28 @@ export function DownloadsPanel({
 }: DownloadsPanelProps) {
   const [downloads, setDownloads] = useState<BrowserDownload[]>([])
   const [error, setError] = useState<string | null>(null)
+  // Stale guard: a response for the previous session must not land in the
+  // next one's list after a quick session switch.
+  const refreshRevRef = useRef(0)
   const refresh = useCallback(() => {
+    const revision = ++refreshRevRef.current
     void listBrowserDownloads(host.iii, sessionId)
-      .then(setDownloads)
-      .catch((e: unknown) => setError(errorMessage(e)))
+      .then((list) => {
+        if (revision !== refreshRevRef.current) return
+        setDownloads(list)
+        setError(null)
+      })
+      .catch((e: unknown) => {
+        if (revision === refreshRevRef.current) setError(errorMessage(e))
+      })
   }, [host, sessionId])
   useEffect(() => {
     setError(null)
+    setDownloads([])
     refresh()
+    return () => {
+      refreshRevRef.current += 1
+    }
   }, [refresh])
   useBrowserSessionEvent({
     host,
@@ -63,23 +77,29 @@ export function DownloadsPanel({
   const canSendToChat = typeof host.chat?.compose === 'function'
   const sendToChat = useCallback(
     (guid: string) => {
-      void readBrowserDownload(host.iii, sessionId, guid).then((result) => {
-        if (result) host.chat?.compose?.({ files: [result.file] })
-      })
+      void readBrowserDownload(host.iii, sessionId, guid)
+        .then((result) => {
+          if (result) host.chat?.compose?.({ files: [result.file] })
+        })
+        .catch((e: unknown) => setError(errorMessage(e)))
     },
     [host, sessionId],
   )
   const save = useCallback(
     (guid: string) => {
-      void readBrowserDownload(host.iii, sessionId, guid).then((result) => {
-        if (result) downloadFile(result.file)
-      })
+      void readBrowserDownload(host.iii, sessionId, guid)
+        .then((result) => {
+          if (result) downloadFile(result.file)
+        })
+        .catch((e: unknown) => setError(errorMessage(e)))
     },
     [host, sessionId],
   )
   const remove = useCallback(
     (guid: string) => {
-      void removeBrowserDownload(host.iii, sessionId, guid).then(refresh)
+      void removeBrowserDownload(host.iii, sessionId, guid)
+        .then(refresh)
+        .catch((e: unknown) => setError(errorMessage(e)))
     },
     [host, sessionId, refresh],
   )

--- a/browser/ui/src/page/HistoryPanel.tsx
+++ b/browser/ui/src/page/HistoryPanel.tsx
@@ -58,7 +58,7 @@ export function HistoryPanel({ host, sessionId, enabled }: HistoryPanelProps) {
   return (
     <div className="br-ui-history">
       <div className="br-ui-history-search">
-        <Search size={14} aria-hidden className="br-ui-history-search-icon" />
+        <Search size={16} aria-hidden className="br-ui-history-search-icon" />
         <Input
           value={query}
           onChange={setQuery}
@@ -84,7 +84,7 @@ export function HistoryPanel({ host, sessionId, enabled }: HistoryPanelProps) {
                 onClick={() => go(v.url)}
                 title={v.url}
               >
-                <Globe size={15} aria-hidden className="br-ui-history-icon" />
+                <Globe size={16} aria-hidden className="br-ui-history-icon" />
                 <span className="br-ui-history-text">
                   <span className="br-ui-history-title">
                     {v.title || v.url}

--- a/browser/ui/src/page/HistoryPanel.tsx
+++ b/browser/ui/src/page/HistoryPanel.tsx
@@ -1,0 +1,104 @@
+/**
+ * The session's visited pages, newest first: what a browser's history page
+ * shows. Seeded from `browser::history::list`, re-seeded on navigation and
+ * on the filter. Clicking a row navigates the session there.
+ */
+
+import { type Host, Input } from '@iii-dev/console-ui'
+import { useCallback, useEffect, useState } from 'react'
+import {
+  BROWSER_NAVIGATED_TRIGGER,
+  type BrowserHistoryVisit,
+  errorMessage,
+  listBrowserHistory,
+  navigateBrowser,
+} from '../lib/browser'
+import { useBrowserSessionEvent } from '../lib/events'
+import { formatMtime } from '../lib/format'
+import { Globe, Search } from '../lib/icons'
+
+const HISTORY_FEED_FN = 'iii::browser-ui::history-feed'
+
+interface HistoryPanelProps {
+  host: Host
+  sessionId: string
+  enabled: boolean
+}
+
+export function HistoryPanel({ host, sessionId, enabled }: HistoryPanelProps) {
+  const [visits, setVisits] = useState<BrowserHistoryVisit[]>([])
+  const [query, setQuery] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const refresh = useCallback(
+    (q: string) => {
+      void listBrowserHistory(host.iii, sessionId, q || undefined)
+        .then(setVisits)
+        .catch((e: unknown) => setError(errorMessage(e)))
+    },
+    [host, sessionId],
+  )
+  useEffect(() => {
+    setError(null)
+    refresh(query)
+  }, [refresh, query])
+  useBrowserSessionEvent({
+    host,
+    enabled,
+    triggerType: BROWSER_NAVIGATED_TRIGGER,
+    sessionId,
+    fnId: HISTORY_FEED_FN,
+    onEvent: () => refresh(query),
+  })
+  const go = useCallback(
+    (url: string) => {
+      void navigateBrowser(host.iii, sessionId, url).catch(() => {})
+    },
+    [host, sessionId],
+  )
+  return (
+    <div className="br-ui-history">
+      <div className="br-ui-history-search">
+        <Search size={14} aria-hidden className="br-ui-history-search-icon" />
+        <Input
+          value={query}
+          onChange={setQuery}
+          placeholder="Search history"
+          aria-label="search history"
+          preserveCase
+          className="br-ui-history-search-input"
+        />
+      </div>
+      {error ? (
+        <p className="br-ui-history-empty">history failed: {error}</p>
+      ) : visits.length === 0 ? (
+        <p className="br-ui-history-empty">
+          {query ? 'No pages match.' : 'No pages visited yet.'}
+        </p>
+      ) : (
+        <ul className="br-ui-history-list" aria-label="history">
+          {visits.map((v) => (
+            <li key={`${v.timestamp}-${v.url}`}>
+              <button
+                type="button"
+                className="br-ui-history-row"
+                onClick={() => go(v.url)}
+                title={v.url}
+              >
+                <Globe size={15} aria-hidden className="br-ui-history-icon" />
+                <span className="br-ui-history-text">
+                  <span className="br-ui-history-title">
+                    {v.title || v.url}
+                  </span>
+                  <span className="br-ui-history-url">{v.url}</span>
+                </span>
+                <span className="br-ui-history-time">
+                  {formatMtime(Math.floor(v.timestamp / 1000))}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/browser/ui/src/page/HistoryPanel.tsx
+++ b/browser/ui/src/page/HistoryPanel.tsx
@@ -5,7 +5,7 @@
  */
 
 import { type Host, Input } from '@iii-dev/console-ui'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import {
   BROWSER_NAVIGATED_TRIGGER,
   type BrowserHistoryVisit,
@@ -29,11 +29,19 @@ export function HistoryPanel({ host, sessionId, enabled }: HistoryPanelProps) {
   const [visits, setVisits] = useState<BrowserHistoryVisit[]>([])
   const [query, setQuery] = useState('')
   const [error, setError] = useState<string | null>(null)
+  // Only the newest search may touch the list; a slow earlier response
+  // must not overwrite what a faster later keystroke already showed.
+  const searchRevRef = useRef(0)
   const refresh = useCallback(
     (q: string) => {
+      const revision = ++searchRevRef.current
       void listBrowserHistory(host.iii, sessionId, q || undefined)
-        .then(setVisits)
-        .catch((e: unknown) => setError(errorMessage(e)))
+        .then((list) => {
+          if (revision === searchRevRef.current) setVisits(list)
+        })
+        .catch((e: unknown) => {
+          if (revision === searchRevRef.current) setError(errorMessage(e))
+        })
     },
     [host, sessionId],
   )

--- a/browser/ui/src/page/PageMenu.tsx
+++ b/browser/ui/src/page/PageMenu.tsx
@@ -22,6 +22,7 @@ export interface PageMenuActions {
   zoomIn: () => void
   zoomOut: () => void
   zoomReset: () => void
+  clearData: () => void
 }
 
 interface PageMenuProps {
@@ -106,6 +107,8 @@ export function PageMenu({ actions, zoom, canSendToChat }: PageMenuProps) {
         {row('Screenshot to chat', 'screenshotToChat', {
           disabled: !canSendToChat,
         })}
+        <DropdownMenuSeparator />
+        {row('Clear browsing data', 'clearData')}
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/browser/ui/src/page/SessionView.tsx
+++ b/browser/ui/src/page/SessionView.tsx
@@ -18,7 +18,13 @@
  * here — url draft, pick mode, type buffer, pane choices — is session-local.
  */
 
-import { Button, type Host, Input, SegmentedControl } from '@iii-dev/console-ui'
+import {
+  Button,
+  ConfirmDialog,
+  type Host,
+  Input,
+  SegmentedControl,
+} from '@iii-dev/console-ui'
 import type { RefObject } from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import {
@@ -27,6 +33,7 @@ import {
   type BrowserClickOptions,
   type BrowserFindAction,
   type BrowserSessionInfo,
+  clearBrowserData,
   clickBrowserAt,
   controlBrowserHistory,
   downloadFile,
@@ -73,7 +80,9 @@ import {
   renderAnnotationCrop,
 } from './annotations'
 import { ConsolePanel } from './ConsolePanel'
+import { DownloadsPanel, useDownloadCount } from './DownloadsPanel'
 import { FindBar, type FindState } from './FindBar'
+import { HistoryPanel } from './HistoryPanel'
 import { NetworkPanel } from './NetworkPanel'
 import { PageMenu } from './PageMenu'
 import { type LiveFrame, useLiveFrames } from './useLiveFrames'
@@ -84,7 +93,7 @@ const NAVIGATED_FN = 'iii::browser-ui::navigated'
 const FIND_DEBOUNCE_MS = 150
 const TYPE_FLUSH_MS = 200
 
-type FeedPane = 'console' | 'network'
+type FeedPane = 'console' | 'network' | 'downloads' | 'history'
 type NarrowPane = 'viewport' | FeedPane
 
 /** Verbs the page's commands reach through a ref, since they close over
@@ -103,14 +112,28 @@ export interface SessionActions {
   takeScreenshot: () => void
   screenshotToChat: () => void
   printToPdf: () => void
+  clearData: () => void
 }
 
-const FEED_PANES: readonly FeedPane[] = ['console', 'network']
-const NARROW_PANES: readonly NarrowPane[] = ['viewport', 'console', 'network']
+const FEED_PANES: readonly FeedPane[] = [
+  'console',
+  'network',
+  'downloads',
+  'history',
+]
+const NARROW_PANES: readonly NarrowPane[] = [
+  'viewport',
+  'console',
+  'network',
+  'downloads',
+  'history',
+]
 const PANE_LABELS: Record<NarrowPane, string> = {
   viewport: 'Viewport',
   console: 'Console',
   network: 'Network',
+  downloads: 'Downloads',
+  history: 'History',
 }
 
 function readStored(key: string): string | null {
@@ -176,7 +199,11 @@ export function SessionView({
   const dockStoreKey = `browser-ui:${tabId || 'page'}:dock`
   const [dockPane, setDockPaneState] = useState<FeedPane>(() => {
     const stored = readStored(dockStoreKey)
-    return stored === 'network' ? stored : 'console'
+    return stored === 'network' ||
+      stored === 'downloads' ||
+      stored === 'history'
+      ? (stored as FeedPane)
+      : 'console'
   })
   const dockCollapsedStoreKey = `browser-ui:${tabId || 'page'}:dock-collapsed`
   const [dockCollapsed, setDockCollapsedState] = useState(
@@ -626,6 +653,24 @@ export function SessionView({
     })
   }, [host, sessionId, runAction])
 
+  const downloadCount = useDownloadCount(host, sessionId, enabled)
+  const [confirmingClear, setConfirmingClear] = useState(false)
+  const clearData = useCallback(() => {
+    void runAction(async () => {
+      await clearBrowserData(host.iii, sessionId)
+    })
+  }, [host, sessionId, runAction])
+  const paneBody = (pane: FeedPane) =>
+    pane === 'console' ? (
+      <ConsolePanel host={host} sessionId={sessionId} enabled={enabled} />
+    ) : pane === 'network' ? (
+      <NetworkPanel host={host} sessionId={sessionId} enabled={enabled} />
+    ) : pane === 'downloads' ? (
+      <DownloadsPanel host={host} sessionId={sessionId} enabled={enabled} />
+    ) : (
+      <HistoryPanel host={host} sessionId={sessionId} enabled={enabled} />
+    )
+
   const handleStop = useCallback(() => {
     void runAction(async () => {
       await stopBrowserSession(host.iii, sessionId)
@@ -652,6 +697,7 @@ export function SessionView({
       takeScreenshot,
       screenshotToChat,
       printToPdf,
+      clearData: () => setConfirmingClear(true),
     }
     return () => {
       actionsRef.current = null
@@ -678,11 +724,8 @@ export function SessionView({
 
   const displayName =
     session.title?.trim() || hostOf(session.url) || 'about:blank'
-  const feedPane: FeedPane = narrow
-    ? narrowPane === 'network'
-      ? 'network'
-      : 'console'
-    : dockPane
+  const feedPane: FeedPane =
+    narrow && narrowPane !== 'viewport' ? narrowPane : dockPane
   const browserMajor = chromiumVersion?.match(/\d+/)?.[0]
   const browserLabel = browserMajor ? `Chromium ${browserMajor}` : null
 
@@ -891,6 +934,7 @@ export function SessionView({
                   zoomIn: () => applyZoom('in'),
                   zoomOut: () => applyZoom('out'),
                   zoomReset: () => applyZoom('reset'),
+                  clearData: () => setConfirmingClear(true),
                 }}
               />
               <button
@@ -910,6 +954,14 @@ export function SessionView({
                 onClose={closeFind}
               />
             ) : null}
+            <ConfirmDialog
+              open={confirmingClear}
+              onOpenChange={setConfirmingClear}
+              title="Clear browsing data?"
+              description="Cookies, cache and storage for this session are cleared. Other sessions are untouched."
+              confirmLabel="Clear"
+              onConfirm={clearData}
+            />
             <Viewport
               frame={annotating && frozen ? frozen : live.frame}
               loading={live.loading}
@@ -924,13 +976,7 @@ export function SessionView({
           </div>
         </div>
       ) : (
-        <div className="br-ui-pane-fill">
-          {feedPane === 'console' ? (
-            <ConsolePanel host={host} sessionId={sessionId} enabled={enabled} />
-          ) : (
-            <NetworkPanel host={host} sessionId={sessionId} enabled={enabled} />
-          )}
-        </div>
+        <div className="br-ui-pane-fill">{paneBody(feedPane)}</div>
       )}
 
       {!narrow ? (
@@ -941,7 +987,10 @@ export function SessionView({
               onChange={setDockPane}
               options={FEED_PANES.map((pane) => ({
                 value: pane,
-                label: PANE_LABELS[pane],
+                label:
+                  pane === 'downloads' && downloadCount > 0
+                    ? `Downloads ${downloadCount}`
+                    : PANE_LABELS[pane],
               }))}
               className="br-ui-tabs"
               aria-label="Session feeds"
@@ -969,21 +1018,7 @@ export function SessionView({
             </button>
           </div>
           {!dockCollapsed ? (
-            <div className="br-ui-dock-body">
-              {dockPane === 'console' ? (
-                <ConsolePanel
-                  host={host}
-                  sessionId={sessionId}
-                  enabled={enabled}
-                />
-              ) : (
-                <NetworkPanel
-                  host={host}
-                  sessionId={sessionId}
-                  enabled={enabled}
-                />
-              )}
-            </div>
+            <div className="br-ui-dock-body">{paneBody(dockPane)}</div>
           ) : null}
         </div>
       ) : null}

--- a/browser/ui/src/page/index.tsx
+++ b/browser/ui/src/page/index.tsx
@@ -297,7 +297,7 @@ export function BrowserPage({
           title: 'Clear browsing data',
           detail: 'Cookies, cache and storage for this session',
           keywords: ['clear', 'cookies', 'cache', 'storage', 'reset'],
-          enabled: () => selected !== null,
+          enabled: () => selected !== null && sessionActionsRef.current !== null,
           run: () => sessionActionsRef.current?.clearData(),
         },
         {

--- a/browser/ui/src/page/index.tsx
+++ b/browser/ui/src/page/index.tsx
@@ -293,6 +293,14 @@ export function BrowserPage({
           run: () => sessionActionsRef.current?.printToPdf(),
         },
         {
+          id: 'clear-browsing-data',
+          title: 'Clear browsing data',
+          detail: 'Cookies, cache and storage for this session',
+          keywords: ['clear', 'cookies', 'cache', 'storage', 'reset'],
+          enabled: () => selected !== null,
+          run: () => sessionActionsRef.current?.clearData(),
+        },
+        {
           id: 'clear-annotations',
           title: 'Clear the annotations',
           keywords: ['annotations', 'remove', 'reset'],

--- a/browser/ui/styles.css
+++ b/browser/ui/styles.css
@@ -2549,3 +2549,161 @@
 [data-iii-ui="browser"] .br-ui-menu-zoom-level.is-set {
   color: var(--color-ink);
 }
+
+/* downloads panel */
+[data-iii-ui="browser"] .br-ui-downloads-empty {
+  margin: 0;
+  padding: 16px;
+  font-family: var(--font-sans, system-ui, sans-serif);
+  font-size: 13px;
+  color: var(--color-ink-faint);
+}
+[data-iii-ui="browser"] .br-ui-downloads {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  overflow: auto;
+  flex: 1;
+  min-height: 0;
+}
+[data-iii-ui="browser"] .br-ui-download-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--color-edge);
+}
+[data-iii-ui="browser"] .br-ui-download-icon {
+  flex-shrink: 0;
+  color: var(--color-ink-faint);
+}
+[data-iii-ui="browser"] .br-ui-download-main {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
+}
+[data-iii-ui="browser"] .br-ui-download-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-sans, system-ui, sans-serif);
+  font-size: 13px;
+  color: var(--color-ink);
+}
+[data-iii-ui="browser"] .br-ui-download-meta {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11px;
+  color: var(--color-ink-faint);
+}
+[data-iii-ui="browser"] .br-ui-download-bar {
+  display: block;
+  height: 3px;
+  margin-top: 3px;
+  border-radius: 2px;
+  background: var(--color-edge);
+  overflow: hidden;
+}
+[data-iii-ui="browser"] .br-ui-download-bar-fill {
+  display: block;
+  height: 100%;
+  background: var(--color-accent);
+  transition: width var(--motion-duration-control, 150ms) ease-out;
+}
+[data-iii-ui="browser"] .br-ui-download-actions {
+  display: inline-flex;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+/* history panel */
+[data-iii-ui="browser"] .br-ui-history {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  flex: 1;
+}
+[data-iii-ui="browser"] .br-ui-history-search {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--color-edge);
+  flex-shrink: 0;
+}
+[data-iii-ui="browser"] .br-ui-history-search-icon {
+  flex-shrink: 0;
+  color: var(--color-ink-faint);
+}
+[data-iii-ui="browser"] .br-ui-history-search-input {
+  flex: 1;
+  height: 32px;
+}
+[data-iii-ui="browser"] .br-ui-history-empty {
+  margin: 0;
+  padding: 16px;
+  font-family: var(--font-sans, system-ui, sans-serif);
+  font-size: 13px;
+  color: var(--color-ink-faint);
+}
+[data-iii-ui="browser"] .br-ui-history-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  overflow: auto;
+  flex: 1;
+  min-height: 0;
+}
+[data-iii-ui="browser"] .br-ui-history-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 7px 12px;
+  border: 0;
+  border-bottom: 1px solid var(--color-edge);
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  color: var(--color-ink);
+}
+[data-iii-ui="browser"] .br-ui-history-row:hover {
+  background: var(--color-surface-hover);
+}
+[data-iii-ui="browser"] .br-ui-history-row:focus-visible {
+  outline: 2px solid var(--color-rule-focus);
+  outline-offset: -2px;
+}
+[data-iii-ui="browser"] .br-ui-history-icon {
+  flex-shrink: 0;
+  color: var(--color-ink-faint);
+}
+[data-iii-ui="browser"] .br-ui-history-text {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+  flex: 1;
+}
+[data-iii-ui="browser"] .br-ui-history-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-sans, system-ui, sans-serif);
+  font-size: 13px;
+}
+[data-iii-ui="browser"] .br-ui-history-url {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11px;
+  color: var(--color-ink-faint);
+}
+[data-iii-ui="browser"] .br-ui-history-time {
+  flex-shrink: 0;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11px;
+  color: var(--color-ink-ghost);
+}

--- a/docs/sops/console-ui-conformance.md
+++ b/docs/sops/console-ui-conformance.md
@@ -108,7 +108,7 @@ owns; the registry refuses those at registration. See the injectable-UI SOP,
 | iii-directory | new entry, filter, save; setup: open | `N`, `/`, `Mod+S` | entries (`directory::skills::list`, `prompts::list`, `system-prompts::list`) |
 | canvas | new, save, delete; setup: open | `N`, `Mod+S`, `X` | canvases (`canvas::list`) |
 | a2ui | new from template, undo, pin, export React; setup: open | `N`, `Z`, `P`, `E` | surfaces (`a2ui::surface::list`, per conversation) |
-| browser | new session, stop, address bar, ⋮ menu (find in page, zoom, screenshot, print to PDF), annotate (pins carry the element under them), send / download / clear annotations; setup: open | `N`, `X`, `L`, `Mod+F`, `Mod+=`/`Mod+-`/`Mod+0`, `C`, `Mod+Enter` | sessions (`browser::sessions::list`) |
+| browser | new session, stop, address bar, ⋮ menu (find in page, zoom, screenshot, print to PDF, clear browsing data), Console / Network / Downloads / History panes, annotate (pins carry the element under them), send / download / clear annotations; setup: open | `N`, `X`, `L`, `Mod+F`, `Mod+=`/`Mod+-`/`Mod+0`, `C`, `Mod+Enter` | sessions, downloads (`browser::downloads::list`), history (`browser::history::list`) |
 | sandbox-code-runner | new, run code, refresh; setup: open | `N`, `C`, `R` | sandboxes (`sandbox::list`) |
 | computer | start, stop; setup: open | `N`, `X` | sessions (`computer::sessions::list`) |
 | worktree | refresh, close detail; setup: open | `R`, `Escape` | worktrees (`worktree::list`) |


### PR DESCRIPTION
Refs MOT-4535 (child of MOT-4533)

Stacked on #889 (`feat/browser-page-menu`); merge that first. Second chunk of the in-app-browser parity epic (MOT-4533).

## What

Two panes and a menu item, so a session keeps what a browser keeps:

- **Downloads** pane (Console / Network / Downloads / History segmented control): the files the session downloaded, like the browser's downloads panel — name, size, time, a progress bar while in flight; each row goes to the chat, saves to disk, or is removed. The tab shows a count.
- **History** pane: the session's visited pages, newest first, searchable; a row navigates the session there.
- **Clear browsing data** in the ⋮ menu, behind a confirm: cookies, cache and storage for this session's context.

## Why

MOT-4533. Downloads, history and clear-data are the next of what the ⋮ menu of a real browser gives a reader.

## How

**Worker** (catalog now 37, golden-schema pinned):
- Downloads are enabled per session with `Browser.setDownloadBehavior(allowAndName, <per-session dir>, events_enabled)`; `Browser.downloadWillBegin` / `downloadProgress` pumps track each by guid and emit a new `browser::download-changed` event. `browser::downloads::list`, `browser::download` (one file's bytes by guid), `browser::download::remove` (forget + delete). The dir is removed on stop; attached sessions don't own the policy and list nothing.
- `browser::history::list` reads a per-session buffer filled from committed top-document navigations (recorded in the existing `FrameNavigated` listener, title fetched, consecutive same-URL collapsed, capped at 200). Distinct from `browser::history` (back/forward/reload).
- `browser::clear-data` runs `Network.clearBrowserCookies` / `clearBrowserCache` and `Storage.clearDataForOrigin` for the current origin.

**UI**: `DownloadsPanel` (subscribes to `browser::download-changed`, re-lists) and `HistoryPanel` (re-lists on `browser::navigated` and on the filter) as two more feed panes; `useDownloadCount` for the tab badge; Clear browsing data via `ConfirmDialog`; helpers in `lib/browser.ts`; new `Download` icon and a `formatSize`. Two page commands (Clear browsing data; the panes are reached from the segmented control).

## Tests

- Rust: golden schemas for the five functions; `cargo fmt`/`clippy`/`test` (209 lib).
- Browser UI: `tsc`, build, 27 tests.
- Live on the compose rig against the console itself: history lists a real document load ("iii console"), the Downloads pane renders (empty, correct copy), `browser::clear-data` returns `cookies, cache, storage`, `browser::downloads::list` returns `[]`. SPA hash routes correctly do not record history (only document navigations do).
- README function list + conformance row updated.

## Note

A worker restart under an open console tab drops the frame subscription (the tab shows "waiting for the first frame" until reload) — pre-existing, tracked in MOT-4532; unrelated to this change.
