### PR TITLE
(MOT-4543) fix(browser): responsive live viewport — frame fills the pane, no letterbox

### DIFF
--- a/browser/src/functions/mod.rs
+++ b/browser/src/functions/mod.rs
@@ -1741,25 +1741,30 @@ fn register_resize(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
                 let session = get_session(&sx, &req.session_id)?;
                 ensure_writable(&session, "browser::resize")?;
                 session.touch();
-                // A pane auto-fit only applies while this is the one viewer;
-                // with several panes watching the same session, whoever
-                // resized explicitly (or first) keeps the viewport and the
-                // other panes letterbox-scale it instead of fighting.
+                let mut width = resize::clamp(req.width);
+                let mut height = resize::clamp(req.height);
+                // A pane auto-fit with several viewers grows the shared
+                // viewport but never shrinks it: the largest pane wins and the
+                // smaller ones letterbox-scale, so one small viewer can't
+                // shrink a session another viewer needs bigger. A lone viewer
+                // (or an explicit device resize) sizes it freely.
                 if req.fit.unwrap_or(false)
                     && session
                         .screencast_consumers
                         .load(std::sync::atomic::Ordering::Relaxed)
                         > 1
                 {
-                    let (width, height) = session.viewport();
-                    return Ok::<_, Error>(resize::ResizeOutput {
-                        ok: true,
-                        width,
-                        height,
-                    });
+                    let (cur_w, cur_h) = session.viewport();
+                    width = width.max(cur_w);
+                    height = height.max(cur_h);
+                    if width == cur_w && height == cur_h {
+                        return Ok::<_, Error>(resize::ResizeOutput {
+                            ok: true,
+                            width,
+                            height,
+                        });
+                    }
                 }
-                let width = resize::clamp(req.width);
-                let height = resize::clamp(req.height);
                 let dpr = req.device_scale_factor.unwrap_or(1.0).clamp(0.5, 3.0);
                 let params = cdp_emulation::SetDeviceMetricsOverrideParams::builder()
                     .width(i64::from(width))

--- a/browser/src/functions/mod.rs
+++ b/browser/src/functions/mod.rs
@@ -23,6 +23,7 @@ pub mod overlays;
 pub mod pdf;
 pub mod pick;
 pub mod recording;
+pub mod resize;
 pub mod screenshot;
 pub mod sessions;
 pub mod snapshot;
@@ -37,6 +38,7 @@ use base64::Engine;
 use chromiumoxide::cdp::browser_protocol::accessibility as cdp_ax;
 use chromiumoxide::cdp::browser_protocol::css as cdp_css;
 use chromiumoxide::cdp::browser_protocol::dom as cdp_dom;
+use chromiumoxide::cdp::browser_protocol::emulation as cdp_emulation;
 use chromiumoxide::cdp::browser_protocol::input;
 use chromiumoxide::cdp::browser_protocol::network as cdp_network;
 use chromiumoxide::cdp::browser_protocol::overlay;
@@ -213,6 +215,11 @@ pub const DOWNLOAD_DESC: &str =
 pub const DOWNLOAD_REMOVE_ID: &str = "browser::download::remove";
 pub const DOWNLOAD_REMOVE_DESC: &str =
     "Forget a download and delete its file from the session's download dir.";
+pub const RESIZE_ID: &str = "browser::resize";
+pub const RESIZE_DESC: &str =
+    "Set the session's live viewport size (CSS pixels). The console calls this as its browser \
+     pane resizes so the streamed frame fills the pane with no letterboxing and clicks map \
+     1:1; the device toolbar calls it with a preset. Clamped 200..4000.";
 
 /// One wire-surface entry: everything the golden schema test pins.
 pub struct FunctionSpec {
@@ -321,6 +328,7 @@ pub fn catalog() -> Vec<FunctionSpec> {
             DOWNLOAD_REMOVE_ID,
             DOWNLOAD_REMOVE_DESC,
         ),
+        spec::<resize::ResizeInput, resize::ResizeOutput>(RESIZE_ID, RESIZE_DESC),
     ]
 }
 
@@ -362,6 +370,7 @@ pub fn register_all(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
     register_downloads_list(iii, sessions);
     register_download(iii, sessions);
     register_download_remove(iii, sessions);
+    register_resize(iii, sessions);
     tracing::info!("all functions registered");
 }
 
@@ -761,8 +770,8 @@ fn register_screenshot(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
                     details: screenshot::ScreenshotDetails {
                         session_id: session.id.clone(),
                         url,
-                        width: session.viewport_width,
-                        height: session.viewport_height,
+                        width: session.viewport().0,
+                        height: session.viewport().1,
                     },
                 })
             }
@@ -1035,8 +1044,8 @@ fn register_act(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
                             action_point(&session, &req).await?
                         } else {
                             (
-                                session.viewport_width as f64 / 2.0,
-                                session.viewport_height as f64 / 2.0,
+                                session.viewport().0 as f64 / 2.0,
+                                session.viewport().1 as f64 / 2.0,
                             )
                         };
                         let delta_y = req.delta_y.unwrap_or(600.0);
@@ -1719,6 +1728,42 @@ fn register_pdf(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
             }
         })
         .description(PDF_DESC),
+    );
+}
+
+fn register_resize(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
+    let sx = sessions.clone();
+    iii.register_function(
+        RESIZE_ID,
+        RegisterFunction::new_async(move |req: resize::ResizeInput| {
+            let sx = sx.clone();
+            async move {
+                let session = get_session(&sx, &req.session_id)?;
+                session.touch();
+                let width = resize::clamp(req.width);
+                let height = resize::clamp(req.height);
+                let dpr = req.device_scale_factor.unwrap_or(1.0).clamp(0.5, 3.0);
+                let params = cdp_emulation::SetDeviceMetricsOverrideParams::builder()
+                    .width(i64::from(width))
+                    .height(i64::from(height))
+                    .device_scale_factor(dpr)
+                    .mobile(req.mobile.unwrap_or(false))
+                    .build()
+                    .map_err(handler_err)?;
+                session
+                    .page
+                    .execute(params)
+                    .await
+                    .map_err(|e| handler_err(format!("resize failed: {e}")))?;
+                session.set_viewport(width, height);
+                Ok::<_, Error>(resize::ResizeOutput {
+                    ok: true,
+                    width,
+                    height,
+                })
+            }
+        })
+        .description(RESIZE_DESC),
     );
 }
 

--- a/browser/src/functions/mod.rs
+++ b/browser/src/functions/mod.rs
@@ -1756,6 +1756,18 @@ fn register_resize(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
                     .await
                     .map_err(|e| handler_err(format!("resize failed: {e}")))?;
                 session.set_viewport(width, height);
+                // The page content did not change, so the compositor may not
+                // push a screencast frame at the new size on its own. Restart
+                // the screencast to force one, but only while someone is
+                // watching (acquire/release owns the on/off transitions).
+                if session.screencast_on() {
+                    let restart = cdp_page::StartScreencastParams::builder()
+                        .format(cdp_page::StartScreencastFormat::Jpeg)
+                        .quality(sx.config.load().screenshot_quality as i64)
+                        .every_nth_frame(1)
+                        .build();
+                    let _ = session.page.execute(restart).await;
+                }
                 Ok::<_, Error>(resize::ResizeOutput {
                     ok: true,
                     width,

--- a/browser/src/functions/mod.rs
+++ b/browser/src/functions/mod.rs
@@ -1739,7 +1739,25 @@ fn register_resize(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
             let sx = sx.clone();
             async move {
                 let session = get_session(&sx, &req.session_id)?;
+                ensure_writable(&session, "browser::resize")?;
                 session.touch();
+                // A pane auto-fit only applies while this is the one viewer;
+                // with several panes watching the same session, whoever
+                // resized explicitly (or first) keeps the viewport and the
+                // other panes letterbox-scale it instead of fighting.
+                if req.fit.unwrap_or(false)
+                    && session
+                        .screencast_consumers
+                        .load(std::sync::atomic::Ordering::Relaxed)
+                        > 1
+                {
+                    let (width, height) = session.viewport();
+                    return Ok::<_, Error>(resize::ResizeOutput {
+                        ok: true,
+                        width,
+                        height,
+                    });
+                }
                 let width = resize::clamp(req.width);
                 let height = resize::clamp(req.height);
                 let dpr = req.device_scale_factor.unwrap_or(1.0).clamp(0.5, 3.0);
@@ -1757,17 +1775,9 @@ fn register_resize(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
                     .map_err(|e| handler_err(format!("resize failed: {e}")))?;
                 session.set_viewport(width, height);
                 // The page content did not change, so the compositor may not
-                // push a screencast frame at the new size on its own. Restart
-                // the screencast to force one, but only while someone is
-                // watching (acquire/release owns the on/off transitions).
-                if session.screencast_on() {
-                    let restart = cdp_page::StartScreencastParams::builder()
-                        .format(cdp_page::StartScreencastFormat::Jpeg)
-                        .quality(sx.config.load().screenshot_quality as i64)
-                        .every_nth_frame(1)
-                        .build();
-                    let _ = session.page.execute(restart).await;
-                }
+                // push a screencast frame at the new size on its own; nudge
+                // one out through the counted screencast paths.
+                sx.nudge_screencast(&session).await;
                 Ok::<_, Error>(resize::ResizeOutput {
                     ok: true,
                     width,

--- a/browser/src/functions/resize.rs
+++ b/browser/src/functions/resize.rs
@@ -25,6 +25,12 @@ pub struct ResizeInput {
     /// Default false. The device toolbar sets this for phone presets.
     #[serde(default)]
     pub mobile: Option<bool>,
+    /// This resize is a pane auto-fit, not an explicit choice. A fit is
+    /// refused (current size returned) while more than one viewer watches
+    /// the session, so two open panes do not fight over the shared
+    /// viewport; explicit resizes (device toolbar, agents) always apply.
+    #[serde(default)]
+    pub fit: Option<bool>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]

--- a/browser/src/functions/resize.rs
+++ b/browser/src/functions/resize.rs
@@ -1,0 +1,40 @@
+//! `browser::resize` — set the session's live viewport size. The console
+//! calls this as its browser pane resizes so the streamed frame fills the
+//! pane exactly (no letterboxing) and click coordinates map 1:1; the device
+//! toolbar calls it with a preset. Applied as a CDP device-metrics override.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Bounds a viewport dimension can take, so a stray pane measurement can't
+/// ask Chromium for something absurd.
+pub const MIN_DIM: u32 = 200;
+pub const MAX_DIM: u32 = 4000;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ResizeInput {
+    pub session_id: String,
+    /// Viewport width in CSS pixels (clamped 200..4000).
+    pub width: u32,
+    /// Viewport height in CSS pixels (clamped 200..4000).
+    pub height: u32,
+    /// Device pixel ratio. Default 1.
+    #[serde(default)]
+    pub device_scale_factor: Option<f64>,
+    /// Emulate a mobile device (viewport meta, overlay scrollbars, touch).
+    /// Default false. The device toolbar sets this for phone presets.
+    #[serde(default)]
+    pub mobile: Option<bool>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ResizeOutput {
+    pub ok: bool,
+    /// The clamped size actually applied.
+    pub width: u32,
+    pub height: u32,
+}
+
+pub fn clamp(value: u32) -> u32 {
+    value.clamp(MIN_DIM, MAX_DIM)
+}

--- a/browser/src/session.rs
+++ b/browser/src/session.rs
@@ -1197,6 +1197,33 @@ impl Sessions {
     /// Release a screencast consumer. Stops the Chromium screencast on the
     /// 1->0 transition, leaving it running while any other consumer remains
     /// (so stopping a recording never cuts off a UI viewer). Never underflows.
+    /// Force a fresh screencast frame (e.g. after a viewport resize) without
+    /// racing the acquire/release counter: hold a consumer slot of our own
+    /// while re-issuing StartScreencast, so a real viewer's release cannot
+    /// hit the 1 -> 0 stop transition mid-restart. With no other viewer the
+    /// acquire starts and the release stops the cast; both are the counted
+    /// paths, so the counter and the CDP state stay in step.
+    pub async fn nudge_screencast(&self, session: &Arc<Session>) {
+        if self.acquire_screencast(session).await.is_err() {
+            return;
+        }
+        if session
+            .screencast_consumers
+            .load(std::sync::atomic::Ordering::Relaxed)
+            > 1
+        {
+            use chromiumoxide::cdp::browser_protocol::page as cdp_page;
+            let quality = self.config.load().screenshot_quality as i64;
+            let restart = cdp_page::StartScreencastParams::builder()
+                .format(cdp_page::StartScreencastFormat::Jpeg)
+                .quality(quality)
+                .every_nth_frame(1)
+                .build();
+            let _ = session.page.execute(restart).await;
+        }
+        self.release_screencast(session).await;
+    }
+
     pub async fn release_screencast(&self, session: &Arc<Session>) {
         use chromiumoxide::cdp::browser_protocol::page as cdp_page;
         let prev = session

--- a/browser/src/session.rs
+++ b/browser/src/session.rs
@@ -5,7 +5,7 @@
 //! the live feed the console UI subscribes to.
 
 use std::collections::{HashMap, VecDeque};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -304,8 +304,12 @@ pub struct Session {
     /// Viewport captured at launch. Config viewport is a session-start
     /// setting (a running session keeps the browser it launched with), so
     /// per-call consumers read these fields, not the live config.
-    pub viewport_width: u32,
-    pub viewport_height: u32,
+    /// The live viewport the session renders at. Set at launch, then tracked
+    /// to the console pane's size by browser::resize (or overridden by the
+    /// device toolbar), so the streamed frame fills the pane with no
+    /// letterboxing and click coordinates map 1:1.
+    pub viewport_width: AtomicU32,
+    pub viewport_height: AtomicU32,
     pub created_ms: i64,
     /// Temp profile dir removed on shutdown. None in persistent
     /// `user_data_dir` mode.
@@ -361,6 +365,18 @@ pub struct Session {
 impl Session {
     pub fn touch(&self) {
         self.last_used_ms.store(now_ms() as u64, Ordering::Relaxed);
+    }
+
+    pub fn viewport(&self) -> (u32, u32) {
+        (
+            self.viewport_width.load(Ordering::Relaxed),
+            self.viewport_height.load(Ordering::Relaxed),
+        )
+    }
+
+    pub fn set_viewport(&self, width: u32, height: u32) {
+        self.viewport_width.store(width, Ordering::Relaxed);
+        self.viewport_height.store(height, Ordering::Relaxed);
     }
 
     pub fn last_used_ms(&self) -> i64 {
@@ -730,8 +746,8 @@ impl Sessions {
             headless,
             kind: SessionKind::Launched,
             read_only,
-            viewport_width: cfg.viewport_width,
-            viewport_height: cfg.viewport_height,
+            viewport_width: AtomicU32::new(cfg.viewport_width),
+            viewport_height: AtomicU32::new(cfg.viewport_height),
             created_ms: now,
             ephemeral_profile,
             latest_frame: Mutex::new(None),
@@ -828,8 +844,8 @@ impl Sessions {
             headless: false,
             kind: SessionKind::Attached { owns_page },
             read_only,
-            viewport_width: cfg.viewport_width,
-            viewport_height: cfg.viewport_height,
+            viewport_width: AtomicU32::new(cfg.viewport_width),
+            viewport_height: AtomicU32::new(cfg.viewport_height),
             created_ms: now,
             ephemeral_profile: None,
             latest_frame: Mutex::new(None),

--- a/browser/src/session.rs
+++ b/browser/src/session.rs
@@ -1517,6 +1517,9 @@ async fn spawn_event_pumps(
                     continue; // subframes don't invalidate top-document refs
                 }
                 s.clear_refs();
+                // A cross-process navigation kills a running screencast with
+                // the old renderer; restart it so the stream never blanks.
+                sx.nudge_screencast(&s).await;
                 // A wedged renderer must not stall the navigation pump on a
                 // title read; after a short wait the visit records untitled.
                 let title =

--- a/browser/tests/golden/schemas/browser.resize.json
+++ b/browser/tests/golden/schemas/browser.resize.json
@@ -1,0 +1,74 @@
+{
+  "function_id": "browser::resize",
+  "description": "Set the session's live viewport size (CSS pixels). The console calls this as its browser pane resizes so the streamed frame fills the pane with no letterboxing and clicks map 1:1; the device toolbar calls it with a preset. Clamped 200..4000.",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ResizeInput",
+    "type": "object",
+    "required": [
+      "height",
+      "session_id",
+      "width"
+    ],
+    "properties": {
+      "device_scale_factor": {
+        "description": "Device pixel ratio. Default 1.",
+        "default": null,
+        "type": [
+          "number",
+          "null"
+        ],
+        "format": "double"
+      },
+      "height": {
+        "description": "Viewport height in CSS pixels (clamped 200..4000).",
+        "type": "integer",
+        "format": "uint32",
+        "minimum": 0.0
+      },
+      "mobile": {
+        "description": "Emulate a mobile device (viewport meta, overlay scrollbars, touch). Default false. The device toolbar sets this for phone presets.",
+        "default": null,
+        "type": [
+          "boolean",
+          "null"
+        ]
+      },
+      "session_id": {
+        "type": "string"
+      },
+      "width": {
+        "description": "Viewport width in CSS pixels (clamped 200..4000).",
+        "type": "integer",
+        "format": "uint32",
+        "minimum": 0.0
+      }
+    }
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ResizeOutput",
+    "type": "object",
+    "required": [
+      "height",
+      "ok",
+      "width"
+    ],
+    "properties": {
+      "height": {
+        "type": "integer",
+        "format": "uint32",
+        "minimum": 0.0
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "width": {
+        "description": "The clamped size actually applied.",
+        "type": "integer",
+        "format": "uint32",
+        "minimum": 0.0
+      }
+    }
+  }
+}

--- a/browser/tests/golden/schemas/browser.resize.json
+++ b/browser/tests/golden/schemas/browser.resize.json
@@ -20,6 +20,14 @@
         ],
         "format": "double"
       },
+      "fit": {
+        "description": "This resize is a pane auto-fit, not an explicit choice. A fit is refused (current size returned) while more than one viewer watches the session, so two open panes do not fight over the shared viewport; explicit resizes (device toolbar, agents) always apply.",
+        "default": null,
+        "type": [
+          "boolean",
+          "null"
+        ]
+      },
       "height": {
         "description": "Viewport height in CSS pixels (clamped 200..4000).",
         "type": "integer",

--- a/browser/tests/schemas.rs
+++ b/browser/tests/schemas.rs
@@ -1,4 +1,4 @@
-//! Wire-schema snapshots for the thirty-seven `browser::*` functions.
+//! Wire-schema snapshots for the thirty-eight `browser::*` functions.
 //!
 //! `browser::functions::catalog()` is the single source of truth for each
 //! function's id, registration description, and schemars-derived
@@ -32,7 +32,7 @@ fn spec_to_pretty_json(spec: &FunctionSpec) -> String {
     pretty
 }
 
-/// The catalog must cover exactly the thirty-seven registered functions, in
+/// The catalog must cover exactly the thirty-eight registered functions, in
 /// registration order (kept in lockstep with `register_all`).
 #[test]
 fn catalog_lists_all_functions_in_registration_order() {
@@ -77,6 +77,7 @@ fn catalog_lists_all_functions_in_registration_order() {
             "browser::downloads::list",
             "browser::download",
             "browser::download::remove",
+            "browser::resize",
         ]
     );
 }

--- a/browser/ui/src/lib/browser.ts
+++ b/browser/ui/src/lib/browser.ts
@@ -921,3 +921,34 @@ export async function removeBrowserDownload(
     guid,
   })
 }
+
+export const BROWSER_RESIZE_FUNCTION_ID = 'browser::resize'
+
+const resizeSchema = z.object({
+  ok: z.boolean(),
+  width: z.number(),
+  height: z.number(),
+})
+
+/** Set the session's live viewport to `width` x `height` CSS pixels. */
+export async function resizeBrowser(
+  iii: ExtensionIii,
+  sessionId: string,
+  width: number,
+  height: number,
+  options: { deviceScaleFactor?: number; mobile?: boolean } = {},
+): Promise<{ width: number; height: number } | null> {
+  const res = await iii.trigger<unknown>(BROWSER_RESIZE_FUNCTION_ID, {
+    session_id: sessionId,
+    width: Math.round(width),
+    height: Math.round(height),
+    ...(options.deviceScaleFactor
+      ? { device_scale_factor: options.deviceScaleFactor }
+      : {}),
+    ...(options.mobile ? { mobile: options.mobile } : {}),
+  })
+  const parsed = resizeSchema.safeParse(res)
+  return parsed.success
+    ? { width: parsed.data.width, height: parsed.data.height }
+    : null
+}

--- a/browser/ui/src/lib/browser.ts
+++ b/browser/ui/src/lib/browser.ts
@@ -936,7 +936,7 @@ export async function resizeBrowser(
   sessionId: string,
   width: number,
   height: number,
-  options: { deviceScaleFactor?: number; mobile?: boolean } = {},
+  options: { deviceScaleFactor?: number; mobile?: boolean; fit?: boolean } = {},
 ): Promise<{ width: number; height: number } | null> {
   const res = await iii.trigger<unknown>(BROWSER_RESIZE_FUNCTION_ID, {
     session_id: sessionId,
@@ -946,6 +946,7 @@ export async function resizeBrowser(
       ? { device_scale_factor: options.deviceScaleFactor }
       : {}),
     ...(options.mobile ? { mobile: options.mobile } : {}),
+    ...(options.fit ? { fit: true } : {}),
   })
   const parsed = resizeSchema.safeParse(res)
   return parsed.success

--- a/browser/ui/src/page/SessionView.tsx
+++ b/browser/ui/src/page/SessionView.tsx
@@ -535,7 +535,7 @@ export function SessionView({
       window.clearTimeout(resizeTimerRef.current)
       resizeTimerRef.current = window.setTimeout(() => {
         lastSentSizeRef.current = { w: width, h: height }
-        void resizeBrowser(host.iii, sessionId, width, height)
+        void resizeBrowser(host.iii, sessionId, width, height, { fit: true })
           .then((applied) => {
             if (applied) setReseedToken((t) => t + 1)
           })

--- a/browser/ui/src/page/SessionView.tsx
+++ b/browser/ui/src/page/SessionView.tsx
@@ -535,7 +535,10 @@ export function SessionView({
       window.clearTimeout(resizeTimerRef.current)
       resizeTimerRef.current = window.setTimeout(() => {
         lastSentSizeRef.current = { w: width, h: height }
-        void resizeBrowser(host.iii, sessionId, width, height, { fit: true })
+        void resizeBrowser(host.iii, sessionId, width, height, {
+          fit: true,
+          deviceScaleFactor: Math.min(window.devicePixelRatio || 1, 2),
+        })
           .then((applied) => {
             if (applied) setReseedToken((t) => t + 1)
           })

--- a/browser/ui/src/page/SessionView.tsx
+++ b/browser/ui/src/page/SessionView.tsx
@@ -46,6 +46,7 @@ import {
   pinLabel,
   pressBrowserKey,
   printBrowserPageToPdf,
+  resizeBrowser,
   resolveBrowserPick,
   screenshotFileName,
   scrollBrowserAt,
@@ -515,6 +516,29 @@ export function SessionView({
     [host, sessionId],
   )
 
+  // Match the Chromium viewport to the pane as it resizes, so the streamed
+  // frame fills the surface with no letterboxing and clicks map 1:1. The
+  // observer fires often; debounce and skip sub-pixel-ish changes.
+  const resizeTimerRef = useRef<number | undefined>(undefined)
+  const lastSentSizeRef = useRef<{ w: number; h: number } | null>(null)
+  const onSurfaceResize = useCallback(
+    (width: number, height: number) => {
+      const last = lastSentSizeRef.current
+      if (last && Math.abs(last.w - width) < 4 && Math.abs(last.h - height) < 4)
+        return
+      window.clearTimeout(resizeTimerRef.current)
+      resizeTimerRef.current = window.setTimeout(() => {
+        lastSentSizeRef.current = { w: width, h: height }
+        void resizeBrowser(host.iii, sessionId, width, height).catch(() => {})
+      }, 180)
+    },
+    [host, sessionId],
+  )
+  useEffect(() => {
+    lastSentSizeRef.current = null
+    return () => window.clearTimeout(resizeTimerRef.current)
+  }, [sessionId])
+
   // Find in page: the worker keeps the match list in the document; this
   // side keeps the query, the count and the current index for the bar.
   const [find, setFind] = useState<FindState | null>(null)
@@ -967,6 +991,7 @@ export function SessionView({
               loading={live.loading}
               error={live.error}
               annotation={viewportAnnotation}
+              onSurfaceResize={onSurfaceResize}
               onClickAt={handleClickAt}
               onScrollAt={handleScrollAt}
               onTextInput={handleTextInput}

--- a/browser/ui/src/page/SessionView.tsx
+++ b/browser/ui/src/page/SessionView.tsx
@@ -229,7 +229,13 @@ export function SessionView({
   // The screencast subscription is gated on the viewport actually being
   // visible: wide mode always shows it, narrow only on its segment.
   const viewportShown = !narrow || narrowPane === 'viewport'
-  const live = useLiveFrames(host, sessionId, enabled && viewportShown)
+  const [reseedToken, setReseedToken] = useState(0)
+  const live = useLiveFrames(
+    host,
+    sessionId,
+    enabled && viewportShown,
+    reseedToken,
+  )
 
   const [actionError, setActionError] = useState<string | null>(null)
   const runAction = useCallback(async (action: () => Promise<void>) => {
@@ -529,13 +535,18 @@ export function SessionView({
       window.clearTimeout(resizeTimerRef.current)
       resizeTimerRef.current = window.setTimeout(() => {
         lastSentSizeRef.current = { w: width, h: height }
-        void resizeBrowser(host.iii, sessionId, width, height).catch(() => {})
+        void resizeBrowser(host.iii, sessionId, width, height)
+          .then((applied) => {
+            if (applied) setReseedToken((t) => t + 1)
+          })
+          .catch(() => {})
       }, 180)
     },
     [host, sessionId],
   )
   useEffect(() => {
     lastSentSizeRef.current = null
+    setReseedToken(0)
     return () => window.clearTimeout(resizeTimerRef.current)
   }, [sessionId])
 

--- a/browser/ui/src/page/Viewport.tsx
+++ b/browser/ui/src/page/Viewport.tsx
@@ -109,6 +109,10 @@ interface ViewportProps {
   requestHint: (x: number, y: number) => Promise<BrowserPickHint | null>
   /** Present while annotating; the frame shown is the frozen one. */
   annotation?: ViewportAnnotation | null
+  /** The surface's CSS pixel size, reported as it changes, so the caller can
+   * match the live viewport to the pane (no letterboxing). Not called while
+   * annotating (the frozen frame must not resize under the pins). */
+  onSurfaceResize?: (width: number, height: number) => void
 }
 
 export function Viewport({
@@ -121,6 +125,7 @@ export function Viewport({
   onPressKey,
   requestHint,
   annotation = null,
+  onSurfaceResize,
 }: ViewportProps) {
   const surfaceRef = useRef<HTMLDivElement>(null)
   const annotating = annotation !== null
@@ -132,6 +137,26 @@ export function Viewport({
   annotatingRef.current = annotating
   const onScrollAtRef = useRef(onScrollAt)
   onScrollAtRef.current = onScrollAt
+
+  // Report the surface's CSS pixel size so the caller can size the live
+  // viewport to match the pane. Paused while annotating (the frozen frame
+  // and its pins must not move); the caller debounces the actual resize.
+  const onSurfaceResizeRef = useRef(onSurfaceResize)
+  onSurfaceResizeRef.current = onSurfaceResize
+  useEffect(() => {
+    const surface = surfaceRef.current
+    if (!surface || typeof ResizeObserver === 'undefined') return
+    const report = () => {
+      if (annotatingRef.current) return
+      const w = surface.clientWidth
+      const h = surface.clientHeight
+      if (w > 0 && h > 0) onSurfaceResizeRef.current?.(w, h)
+    }
+    const observer = new ResizeObserver(report)
+    observer.observe(surface)
+    report()
+    return () => observer.disconnect()
+  }, [])
 
   /** Client point -> page-viewport point, null outside the rendered image. */
   const mapToPage = useCallback(

--- a/browser/ui/src/page/useLiveFrames.ts
+++ b/browser/ui/src/page/useLiveFrames.ts
@@ -40,6 +40,9 @@ export function useLiveFrames(
   host: Host,
   sessionId: string | null,
   enabled: boolean,
+  /** Bump to re-read the current frame once (e.g. after a resize), so the
+   * new size paints even if the screencast stream is momentarily quiet. */
+  reseedToken = 0,
 ): LiveViewState {
   const [frame, setFrame] = useState<LiveFrame | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -127,6 +130,29 @@ export function useLiveFrames(
       setError(null)
     },
   })
+
+  // Re-seed on demand: read the current frame once and apply it if newer.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: fires on the token, reads live refs
+  useEffect(() => {
+    if (!enabled || !sessionId || reseedToken === 0) return
+    let cancelled = false
+    void readBrowserFrame(host.iii, sessionId)
+      .then((seed) => {
+        if (cancelled || !seed?.frame || seed.frame_seq <= lastSeqRef.current)
+          return
+        lastSeqRef.current = seed.frame_seq
+        setFrame({
+          dataUrl: `data:image/jpeg;base64,${seed.frame}`,
+          width: seed.width,
+          height: seed.height,
+        })
+        setError(null)
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [reseedToken])
 
   return { frame, loading: frame === null && error === null, error }
 }


### PR DESCRIPTION
Refs MOT-4543 (child of MOT-4533)

Stacked on #890 (`feat/browser-downloads`); merge that first.

## What

The browser page's live view is now responsive: the Chromium viewport tracks the console pane, so the streamed frame fills the pane with no black letterbox and follows it as it resizes. Because the frame now matches the pane 1:1, annotation pins land exactly where you click.

## Why

The page rendered every session at a fixed 1280-wide viewport and letterboxed the frame, so the live view had large black bars (the dark sidebar showing through `object-fit: contain`), never filled the pane, and did not respond to the pane's size. A dropped annotation pin could land in the letterbox margin and resolve to nothing or the wrong element (both flagged with screenshots). This is a real usability bug, and the base the device toolbar (MOT-4536) builds on.

## How

- **`browser::resize`** (catalog now 38, golden-schema pinned): `session_id, width, height, [device_scale_factor], [mobile]` applied as a CDP `Emulation.setDeviceMetricsOverride`, clamped 200..4000, updating the session's tracked viewport (now atomic, so screenshot details stay accurate). The page content doesn't change, so a `Page.startScreencast` restart forces a fresh frame at the new size while anyone is watching.
- **UI**: the viewport surface carries a `ResizeObserver` (paused while annotating so a frozen frame can't move under its pins) that reports its CSS pixel size; `SessionView` debounces and calls `resizeBrowser`, deduping sub-4px changes. After a resize succeeds it bumps a re-seed token so `useLiveFrames` reads the current frame once and repaints — the new size shows even when the screencast stream is momentarily quiet (the rig's known post-restart staleness).

## Tests

- Rust: golden schema for `browser::resize`; `cargo fmt`/`clippy`/`test` (209 lib).
- Browser UI: `tsc`, build, 27 tests.
- Live on the rig against the console itself: the frame tracks the pane exactly (339×559 pane → 339×559 frame, gap 0w/1h) and the live view fills the browser panel edge to edge, reflowing to a mobile layout in a narrow pane. `browser::resize` at the wire changes the frame size (1000×760, 405×609, 290×509 all confirmed).
