### PR TITLE
(MOT-4525) fix(harness): attribute loaded skills in context usage

### DIFF
--- a/context-manager/src/functions/assemble.rs
+++ b/context-manager/src/functions/assemble.rs
@@ -10,6 +10,8 @@
 //! their own storage; a busy lease or failed summariser falls through
 //! to emergency reduction and the hard budget check.
 
+use std::collections::BTreeMap;
+
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -147,6 +149,11 @@ pub struct AssembleRequest {
     /// Model-facing invocation schemas included in every budget count.
     #[serde(default)]
     pub tools: Option<Vec<AgentFunction>>,
+    /// Named auxiliary texts to count individually with the same
+    /// estimator. Counted in `breakdown.by_part` only; never added to
+    /// the assembled context.
+    #[serde(default)]
+    pub parts: Option<BTreeMap<String, String>>,
     #[serde(default)]
     pub options: Option<AssembleOptions>,
 }
@@ -203,6 +210,10 @@ pub struct AssembleBreakdown {
     pub tools_tokens: u64,
     /// The returned messages' tokens by role.
     pub by_role: ByRoleTokens,
+    /// Per-part estimates for the request's `parts`, keyed by the
+    /// caller's names; present when the request carried `parts`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub by_part: Option<BTreeMap<String, u64>>,
     pub estimator: EstimatorName,
 }
 
@@ -436,6 +447,12 @@ pub async fn handle(deps: &Deps, req: AssembleRequest) -> Result<AssembleRespons
     }
 
     let by_role = by_role_from_sizes(&working, &sizes);
+    let by_part = req.parts.as_ref().map(|parts| {
+        parts
+            .iter()
+            .map(|(name, text)| (name.clone(), estimator.text(text)))
+            .collect()
+    });
 
     Ok(AssembleResponse {
         system_prompt,
@@ -453,6 +470,7 @@ pub async fn handle(deps: &Deps, req: AssembleRequest) -> Result<AssembleRespons
             system_prompt_tokens: prompt_tokens,
             tools_tokens: tool_tokens,
             by_role: by_role.into(),
+            by_part,
             estimator: estimator.kind().into(),
         },
     })

--- a/context-manager/tests/features/assemble.feature
+++ b/context-manager/tests/features/assemble.feature
@@ -428,3 +428,17 @@ Feature: context::assemble — the model-ready context pipeline
     And the response field "breakdown.by_role.user" exceeds 0
     And the response field "breakdown.by_role.assistant" exceeds 0
     And the response field "breakdown.estimator" is "heuristic"
+
+  # Prevents: prompt segments being double-billed or injected into the model
+  # context when callers request a diagnostic count.
+  Scenario: named prompt parts are reported outside the assembled total
+    Given an empty history
+    When I assemble the history with model "any-model" and request fields:
+      """
+      { "parts": { "skills": "xxxxxxxxxxxxxxxx" } }
+      """
+    Then the call succeeds
+    And the response field "breakdown.by_part.skills" is 4
+    And the response field "token_count" is 0
+    And the response field "messages" has 0 items
+    And the response field "applied.compacted" is false

--- a/context-manager/tests/golden/schemas/context.assemble.json
+++ b/context-manager/tests/golden/schemas/context.assemble.json
@@ -649,6 +649,17 @@
           }
         ]
       },
+      "parts": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "default": null,
+        "description": "Named auxiliary texts to count individually with the same estimator. Counted in `breakdown.by_part` only; never added to the assembled context.",
+        "type": [
+          "object",
+          "null"
+        ]
+      },
       "system_prompt": {
         "default": null,
         "description": "Base system prompt to prepend/merge.",
@@ -956,6 +967,18 @@
       "AssembleBreakdown": {
         "description": "Where the returned `token_count` sits, by category — the same sums the pipeline already maintains, exposed so callers can render a context breakdown without re-counting: `token_count` equals the by_role sum plus `system_prompt_tokens`, `tools_tokens`, and the request overhead.",
         "properties": {
+          "by_part": {
+            "additionalProperties": {
+              "format": "uint64",
+              "minimum": 0.0,
+              "type": "integer"
+            },
+            "description": "Per-part estimates for the request's `parts`, keyed by the caller's names; present when the request carried `parts`.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
           "by_role": {
             "allOf": [
               {

--- a/harness/src/clients/context.rs
+++ b/harness/src/clients/context.rs
@@ -1,6 +1,7 @@
 //! Required `context-manager` client: context assembly and final token
 //! preflight both fail closed so the harness never bypasses provider budgets.
 
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use iii_sdk::protocol::TriggerRequest;
@@ -38,6 +39,8 @@ pub struct AssembleBreakdown {
     #[serde(default)]
     pub by_role: ByRoleTokens,
     #[serde(default)]
+    pub by_part: Option<BTreeMap<String, u64>>,
+    #[serde(default)]
     pub estimator: Option<String>,
 }
 
@@ -74,6 +77,7 @@ pub struct AssembleParams {
     pub model_id: String,
     pub provider: Option<String>,
     pub system_prompt: Option<String>,
+    pub parts: Option<BTreeMap<String, String>>,
     pub previous_summary: Option<String>,
     pub lease_key: String,
     pub thinking_level: Option<ThinkingLevel>,
@@ -130,6 +134,9 @@ impl ContextClient {
         });
         if let Some(sp) = &params.system_prompt {
             payload["system_prompt"] = json!(sp);
+        }
+        if let Some(parts) = &params.parts {
+            payload["parts"] = json!(parts);
         }
 
         let resp = self

--- a/harness/src/context_snapshot.rs
+++ b/harness/src/context_snapshot.rs
@@ -89,8 +89,9 @@ impl From<crate::clients::context::ByRoleTokens> for SnapshotMessagesV1 {
 /// unchanged.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct SnapshotCategoriesV1 {
-    /// Final assembled system prompt: mode paragraph, identity, per-step
-    /// aids, and any compaction summary section.
+    /// Final assembled system prompt excluding tokens attributed to `skills`:
+    /// mode paragraph, identity, per-step aids, and any compaction summary
+    /// section.
     pub system_prompt: u64,
     /// Selected skill bodies contained in the system prompt.
     #[serde(default)]

--- a/harness/src/context_snapshot.rs
+++ b/harness/src/context_snapshot.rs
@@ -92,6 +92,9 @@ pub struct SnapshotCategoriesV1 {
     /// Final assembled system prompt: mode paragraph, identity, per-step
     /// aids, and any compaction summary section.
     pub system_prompt: u64,
+    /// Selected skill bodies contained in the system prompt.
+    #[serde(default)]
+    pub skills: u64,
     /// Function schemas exposed to the model.
     pub tools: u64,
     pub messages: SnapshotMessagesV1,
@@ -231,6 +234,7 @@ fn probe_messages() -> Vec<serde_json::Value> {
 /// `count_tokens` field it fills, its cache kind, and its cache content key.
 enum Part<'a> {
     System(&'a str),
+    Skills(&'a str),
     Tools(&'a [AgentFunction]),
 }
 
@@ -238,13 +242,14 @@ impl Part<'_> {
     fn kind(&self) -> &'static str {
         match self {
             Part::System(_) => "system_prompt",
+            Part::Skills(_) => "skills",
             Part::Tools(_) => "tools",
         }
     }
 
     fn content_key(&self) -> String {
         match self {
-            Part::System(prompt) => (*prompt).to_string(),
+            Part::System(prompt) | Part::Skills(prompt) => (*prompt).to_string(),
             Part::Tools(tools) => serde_json::to_string(tools).unwrap_or_default(),
         }
     }
@@ -290,7 +295,7 @@ async fn counted_delta(
         return Some(Counted { tokens, estimator });
     }
     let (system_prompt, tools) = match part {
-        Part::System(prompt) => (Some(prompt), None),
+        Part::System(prompt) | Part::Skills(prompt) => (Some(prompt), None),
         Part::Tools(tools) => (None, Some(tools)),
     };
     let (with_part, estimator) = router
@@ -313,6 +318,7 @@ pub async fn exactify(
     snapshot: &mut ContextSnapshotV1,
     router: &RouterClient,
     system_prompt: Option<&str>,
+    skills_prompt: Option<&str>,
     tools: &[AgentFunction],
 ) {
     let Some(usage) = snapshot.usage.as_ref() else {
@@ -334,11 +340,18 @@ pub async fn exactify(
     };
 
     let system_part = system_prompt.filter(|p| !p.is_empty()).map(Part::System);
+    let skills_part = skills_prompt.filter(|p| !p.is_empty()).map(Part::Skills);
     let tools_part = (!tools.is_empty()).then_some(Part::Tools(tools));
     // Independent round trips: run them together.
-    let (counted_system, counted_tools) = tokio::join!(
+    let (counted_system, counted_skills, counted_tools) = tokio::join!(
         async {
             match system_part {
+                Some(part) => counted_delta(router, &model, provider, base, part).await,
+                None => Some(Counted::default()),
+            }
+        },
+        async {
+            match skills_part {
                 Some(part) => counted_delta(router, &model, provider, base, part).await,
                 None => Some(Counted::default()),
             }
@@ -350,14 +363,36 @@ pub async fn exactify(
             }
         },
     );
-    let (Some(counted_system), Some(counted_tools)) = (counted_system, counted_tools) else {
+    let (Some(counted_system), Some(counted_skills), Some(counted_tools)) =
+        (counted_system, counted_skills, counted_tools)
+    else {
         return;
     };
     let estimator = counted_system
         .estimator
-        .or(counted_tools.estimator)
+        .clone()
+        .or(counted_skills.estimator.clone())
+        .or(counted_tools.estimator.clone())
         .unwrap_or_else(|| "provider".into());
 
+    apply_exact_counts(
+        snapshot,
+        billed,
+        &counted_system,
+        &counted_skills,
+        &counted_tools,
+        estimator,
+    );
+}
+
+fn apply_exact_counts(
+    snapshot: &mut ContextSnapshotV1,
+    billed: u64,
+    counted_system: &Counted,
+    counted_skills: &Counted,
+    counted_tools: &Counted,
+    estimator: String,
+) {
     let remainder = billed
         .saturating_sub(counted_system.tokens)
         .saturating_sub(counted_tools.tokens);
@@ -376,7 +411,9 @@ pub async fn exactify(
         }
     };
 
-    snapshot.categories.system_prompt = counted_system.tokens;
+    let skills = counted_skills.tokens.min(counted_system.tokens);
+    snapshot.categories.system_prompt = counted_system.tokens - skills;
+    snapshot.categories.skills = skills;
     snapshot.categories.tools = counted_tools.tokens;
     snapshot.categories.messages = messages;
     snapshot.categories.overhead = 0;
@@ -389,6 +426,90 @@ pub async fn exactify(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn snapshot_without_skills_category_defaults_to_zero() {
+        let value = serde_json::json!({
+            "session_id": "s_1",
+            "turn_id": "t_1",
+            "step": 1,
+            "model": "m",
+            "usable": 100,
+            "effective_max_output_tokens": 20,
+            "total": 10,
+            "free": 90,
+            "categories": {
+                "system_prompt": 4,
+                "tools": 0,
+                "messages": { "user": 6, "assistant": 0, "function_result": 0, "custom": 0 },
+                "overhead": 0
+            },
+            "compacted": false,
+            "timestamp": 1
+        });
+
+        let snapshot: ContextSnapshotV1 = serde_json::from_value(value).unwrap();
+        assert_eq!(snapshot.categories.skills, 0);
+    }
+
+    #[test]
+    fn exact_counts_split_skills_from_the_full_system_prompt() {
+        let mut snapshot = ContextSnapshotV1 {
+            session_id: "s_1".into(),
+            turn_id: "t_1".into(),
+            step: 1,
+            model: "m".into(),
+            provider: None,
+            estimator: Some("heuristic".into()),
+            usable: 300,
+            effective_max_output_tokens: 50,
+            total: 150,
+            free: 150,
+            categories: SnapshotCategoriesV1 {
+                system_prompt: 40,
+                skills: 20,
+                tools: 10,
+                messages: SnapshotMessagesV1 {
+                    user: 60,
+                    assistant: 40,
+                    ..Default::default()
+                },
+                overhead: 10,
+                hook_guidance: 10,
+            },
+            compacted: false,
+            summarized_head_tokens: None,
+            usage: None,
+            session_cost_usd: None,
+            timestamp: 1,
+        };
+
+        apply_exact_counts(
+            &mut snapshot,
+            200,
+            &Counted {
+                tokens: 80,
+                estimator: Some("provider".into()),
+            },
+            &Counted {
+                tokens: 30,
+                estimator: Some("provider".into()),
+            },
+            &Counted {
+                tokens: 10,
+                estimator: Some("provider".into()),
+            },
+            "provider".into(),
+        );
+
+        assert_eq!(snapshot.categories.system_prompt, 50);
+        assert_eq!(snapshot.categories.skills, 30);
+        assert_eq!(snapshot.categories.tools, 10);
+        assert_eq!(snapshot.categories.messages.user, 66);
+        assert_eq!(snapshot.categories.messages.assistant, 44);
+        assert_eq!(snapshot.total, 200);
+        assert_eq!(snapshot.free, 100);
+    }
 
     #[test]
     fn snapshot_round_trips_and_tolerates_unknown_fields() {
@@ -405,6 +526,7 @@ mod tests {
             free: 38_000,
             categories: SnapshotCategoriesV1 {
                 system_prompt: 2_400,
+                skills: 0,
                 tools: 9_800,
                 messages: SnapshotMessagesV1 {
                     user: 10_000,

--- a/harness/src/functions/send.rs
+++ b/harness/src/functions/send.rs
@@ -259,6 +259,10 @@ pub async fn start(deps: &Deps, req: SendRequest) -> Result<StartOutcome, Harnes
         }
         None => session.create(title.as_deref(), metadata.as_ref()).await?,
     };
+    if options.skills_prompt.is_none() {
+        let metadata = session.metadata_of(&session_id).await;
+        freeze_skill_prompt(&mut options, metadata);
+    }
     crate::budget::prepare_root(deps, &session_id, &mut options, prev.as_ref()).await?;
 
     // Entry id: idempotent when a dedupe key is set.
@@ -589,6 +593,7 @@ fn build_options(
             opts.mode,
             identity,
         ),
+        skills_prompt: None,
         mode: opts.mode,
         max_turns: opts.max_turns.unwrap_or(cfg.default_max_turns),
         max_output_tokens: opts.max_output_tokens,
@@ -647,6 +652,49 @@ fn prompt_fields_omitted(opts: Option<&SendOptions>) -> bool {
     opts.is_none_or(|o| o.system_prompt.is_none() && o.system_prompt_strategy.is_none())
 }
 
+fn selected_skill_prompt(
+    metadata: &serde_json::Map<String, Value>,
+    resolved_prompt: Option<&str>,
+) -> String {
+    let Some(resolved_prompt) = resolved_prompt else {
+        return String::new();
+    };
+    metadata
+        .get("system_prompt")
+        .and_then(|value| value.get("addons"))
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|addon| {
+            let addon = addon.as_object()?;
+            if addon.get("kind").and_then(Value::as_str) != Some("skill") {
+                return None;
+            }
+            let body = addon.get("body").and_then(Value::as_str)?;
+            (!body.trim().is_empty() && resolved_prompt.contains(body)).then_some(body)
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+fn freeze_skill_prompt(
+    options: &mut TurnOptions,
+    metadata: Result<Option<serde_json::Map<String, Value>>, HarnessError>,
+) {
+    if options.skills_prompt.is_some() {
+        return;
+    }
+    let Ok(metadata) = metadata else {
+        return;
+    };
+    options.skills_prompt = Some(
+        metadata
+            .as_ref()
+            .map(|metadata| selected_skill_prompt(metadata, options.system_prompt.as_deref()))
+            .unwrap_or_default(),
+    );
+}
+
 /// A send that names no prompt fields inherits the prior turn's RESOLVED
 /// system prompt, the same way model/provider/functions are inherited. A
 /// prior `disabled` turn's `None` inherits too — disabled stays disabled.
@@ -654,6 +702,7 @@ fn prompt_fields_omitted(opts: Option<&SendOptions>) -> bool {
 /// is the reset-to-default escape hatch.
 fn inherit_prior_system_prompt(options: &mut TurnOptions, prev: &TurnOptions) {
     options.system_prompt = prev.system_prompt.clone();
+    options.skills_prompt = prev.skills_prompt.clone();
 }
 
 /// Default a BRAND-NEW session's working directory (MOT-3897): when the very
@@ -803,6 +852,55 @@ pub(crate) async fn seed_new(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn selected_skill_prompt_keeps_only_ordered_nonblank_bodies_in_resolved_prompt() {
+        let metadata = serde_json::json!({
+            "system_prompt": {
+                "addons": [
+                    { "kind": "skill", "name": "one", "body": "Skill one." },
+                    { "kind": "prompt", "name": "review", "body": "Review prompt." },
+                    { "kind": "skill", "name": "blank", "body": "   " },
+                    { "kind": "skill", "name": "missing", "body": "Not selected." },
+                    { "kind": "skill", "name": "two", "body": "Skill two." }
+                ]
+            }
+        });
+
+        assert_eq!(
+            selected_skill_prompt(
+                metadata.as_object().unwrap(),
+                Some("Built in.\n\nSkill one.\n\nReview prompt.\n\nSkill two."),
+            ),
+            "Skill one.\n\nSkill two."
+        );
+    }
+
+    #[test]
+    fn skill_prompt_freezing_retries_failures_and_keeps_the_first_success() {
+        let mut options = options_with(None, None);
+        options.system_prompt = Some("Skill one.".into());
+
+        freeze_skill_prompt(
+            &mut options,
+            Err(HarnessError::Dependency("session unavailable".into())),
+        );
+        assert_eq!(options.skills_prompt, None);
+
+        freeze_skill_prompt(&mut options, Ok(None));
+        assert_eq!(options.skills_prompt.as_deref(), Some(""));
+
+        let metadata = serde_json::json!({
+            "system_prompt": {
+                "addons": [{ "kind": "skill", "name": "one", "body": "Skill one." }]
+            }
+        });
+        freeze_skill_prompt(
+            &mut options,
+            Ok(Some(metadata.as_object().unwrap().clone())),
+        );
+        assert_eq!(options.skills_prompt.as_deref(), Some(""));
+    }
 
     #[test]
     fn string_message_becomes_user_text() {
@@ -956,6 +1054,7 @@ mod tests {
             model: "m".into(),
             provider: None,
             system_prompt: None,
+            skills_prompt: None,
             mode,
             max_turns: 16,
             max_output_tokens: None,
@@ -1016,10 +1115,15 @@ mod tests {
         let mut options = bare_options();
         let mut prev = options_with(None, None);
         prev.system_prompt = Some("frozen custom prompt".into());
+        prev.skills_prompt = Some("frozen skill prompt".into());
         inherit_prior_system_prompt(&mut options, &prev);
         assert_eq!(
             options.system_prompt.as_deref(),
             Some("frozen custom prompt")
+        );
+        assert_eq!(
+            options.skills_prompt.as_deref(),
+            Some("frozen skill prompt")
         );
 
         // A prior `disabled` turn's None inherits too — disabled stays disabled.

--- a/harness/src/subagent.rs
+++ b/harness/src/subagent.rs
@@ -302,6 +302,7 @@ async fn seed_child(
             req.options.as_ref().and_then(|o| o.mode),
             Some(identity),
         ),
+        skills_prompt: None,
         mode: req.options.as_ref().and_then(|o| o.mode),
         max_turns,
         max_output_tokens: req
@@ -483,6 +484,7 @@ mod tests {
                 model: "m".into(),
                 provider: None,
                 system_prompt: None,
+                skills_prompt: None,
                 mode: None,
                 max_turns: 16,
                 max_output_tokens: None,

--- a/harness/src/turn_loop.rs
+++ b/harness/src/turn_loop.rs
@@ -826,8 +826,14 @@ pub async fn run_step(
                 None
             }
         };
-        crate::context_snapshot::exactify(snapshot, &router, gen_system_prompt.as_deref(), &tools)
-            .await;
+        crate::context_snapshot::exactify(
+            snapshot,
+            &router,
+            gen_system_prompt.as_deref(),
+            record.options.skills_prompt.as_deref(),
+            &tools,
+        )
+        .await;
         if let Err(error) =
             crate::context_snapshot::put(&deps.iii, snapshot, cfg.session_timeout_ms).await
         {
@@ -2408,6 +2414,9 @@ async fn assemble_context(
         model_id: record.options.model.clone(),
         provider: record.options.provider.clone(),
         system_prompt: inputs.system_prompt,
+        parts: record.options.skills_prompt.as_ref().map(|prompt| {
+            std::collections::BTreeMap::from([("skills".to_string(), prompt.clone())])
+        }),
         previous_summary,
         lease_key: record.session_id.clone(),
         thinking_level: record.options.thinking_level,
@@ -2505,6 +2514,7 @@ fn build_context_snapshot(
     // A context-manager that predates the breakdown response reports nothing,
     // which is what the all-zero default says.
     let b = assembled.breakdown.clone().unwrap_or_default();
+    let (system_prompt, skills) = estimated_prompt_categories(&b);
     ContextSnapshotV1 {
         session_id: record.session_id.clone(),
         turn_id: record.turn_id.clone(),
@@ -2518,7 +2528,8 @@ fn build_context_snapshot(
         total: final_request_tokens,
         free: assembled.usable.saturating_sub(final_request_tokens),
         categories: SnapshotCategoriesV1 {
-            system_prompt: b.system_prompt_tokens,
+            system_prompt,
+            skills,
             tools: b.tools_tokens,
             messages: b.by_role.into(),
             overhead: request_overhead_tokens,
@@ -2529,6 +2540,19 @@ fn build_context_snapshot(
         usage: None,
         timestamp: AgentMessage::now_ms(),
     }
+}
+
+fn estimated_prompt_categories(
+    breakdown: &crate::clients::context::AssembleBreakdown,
+) -> (u64, u64) {
+    let skills = breakdown
+        .by_part
+        .as_ref()
+        .and_then(|parts| parts.get("skills"))
+        .copied()
+        .unwrap_or(0)
+        .min(breakdown.system_prompt_tokens);
+    (breakdown.system_prompt_tokens - skills, skills)
 }
 
 /// Append model-facing context aid lines to the system prompt: the session id
@@ -2877,6 +2901,22 @@ mod tests {
     use crate::types::content::ContentBlock;
     use crate::types::event::{ErrorKind, StopReason};
     use crate::types::message::{AgentMessage, CustomMessage, CustomRoleTag};
+
+    #[test]
+    fn estimated_prompt_categories_split_and_clamp_named_skills() {
+        let breakdown = crate::clients::context::AssembleBreakdown {
+            system_prompt_tokens: 10,
+            by_part: Some(std::collections::BTreeMap::from([("skills".into(), 4)])),
+            ..Default::default()
+        };
+        assert_eq!(super::estimated_prompt_categories(&breakdown), (6, 4));
+
+        let oversized = crate::clients::context::AssembleBreakdown {
+            by_part: Some(std::collections::BTreeMap::from([("skills".into(), 14)])),
+            ..breakdown
+        };
+        assert_eq!(super::estimated_prompt_categories(&oversized), (0, 10));
+    }
 
     #[test]
     fn llm_failure_preserves_router_contract_and_runtime_attribution() {

--- a/harness/src/types/turn.rs
+++ b/harness/src/types/turn.rs
@@ -72,6 +72,11 @@ pub struct TurnOptions {
     pub provider: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system_prompt: Option<String>,
+    /// Aggregate selected-skill bodies frozen from session metadata. `None`
+    /// means provenance has not initialized yet; `Some("")` is initialized
+    /// with no selected skills.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skills_prompt: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mode: Option<Mode>,
     pub max_turns: u32,
@@ -321,6 +326,7 @@ mod tests {
                 model: "m".into(),
                 provider: None,
                 system_prompt: None,
+                skills_prompt: None,
                 mode: None,
                 max_turns: 16,
                 max_output_tokens: None,

--- a/harness/tests/golden/schemas/harness.metrics.json
+++ b/harness/tests/golden/schemas/harness.metrics.json
@@ -410,6 +410,13 @@
             "minimum": 0.0,
             "type": "integer"
           },
+          "skills": {
+            "default": 0,
+            "description": "Selected skill bodies contained in the system prompt.",
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
           "system_prompt": {
             "description": "Final assembled system prompt: mode paragraph, identity, per-step aids, and any compaction summary section.",
             "format": "uint64",

--- a/harness/tests/golden/schemas/harness.metrics.json
+++ b/harness/tests/golden/schemas/harness.metrics.json
@@ -418,7 +418,7 @@
             "type": "integer"
           },
           "system_prompt": {
-            "description": "Final assembled system prompt: mode paragraph, identity, per-step aids, and any compaction summary section.",
+            "description": "Final assembled system prompt excluding tokens attributed to `skills`: mode paragraph, identity, per-step aids, and any compaction summary section.",
             "format": "uint64",
             "minimum": 0.0,
             "type": "integer"

--- a/harness/ui/src/context-chip/index.tsx
+++ b/harness/ui/src/context-chip/index.tsx
@@ -47,6 +47,7 @@ const COLOR_FREE = 'var(--color-rule-2)'
 
 type CategoryKey =
   | 'system'
+  | 'skills'
   | 'tools'
   | 'user'
   | 'assistant'
@@ -78,6 +79,12 @@ function categories(snapshot: ContextSnapshot): Category[] {
       label: 'System prompt',
       color: ink(80),
       tokens: cats.system_prompt,
+    },
+    {
+      key: 'skills',
+      label: 'Skills',
+      color: ink(65),
+      tokens: cats.skills ?? 0,
     },
     {
       key: 'tools',
@@ -148,7 +155,7 @@ interface LegendEntry {
 
 /**
  * The legend, derived from the same category array the bar draws: the three
- * conversation entries collapse into one row, an empty hook row is dropped,
+ * conversation entries collapse into one row, empty optional rows are dropped,
  * and the two rows that are not bar segments (the compaction summary, free
  * space) take their place around the overhead row.
  */
@@ -168,7 +175,11 @@ function legendRows(
       continue
     }
     if (CONVERSATION_KEYS.includes(category.key)) continue
-    if (category.key === 'hooks' && category.tokens <= 0) continue
+    if (
+      (category.key === 'hooks' || category.key === 'skills') &&
+      category.tokens <= 0
+    )
+      continue
     if (category.key === 'overhead' && snapshot.compacted) {
       rows.push({
         key: 'summary',

--- a/harness/ui/src/lib/metrics.ts
+++ b/harness/ui/src/lib/metrics.ts
@@ -14,6 +14,8 @@ export interface SnapshotMessages {
 
 export interface SnapshotCategories {
   system_prompt: number
+  /** Optional on the wire: absent in snapshots written before Skills. */
+  skills?: number
   tools: number
   messages: SnapshotMessages
   overhead: number


### PR DESCRIPTION
## Summary

- Preserve loaded skill provenance from session metadata without changing the model-facing prompt.
- Report aggregate skill tokens separately in estimated and provider-exact context accounting.
- Show a backward-compatible Skills row in the context breakdown.

## Testing

- `cargo test --manifest-path context-manager/Cargo.toml`
- `cargo test --manifest-path harness/Cargo.toml`
- `pnpm --dir console/web test -- --reporter=dot src/components/chat/system-prompt-selection.test.ts src/lib/slash-commands.test.ts`
- `pnpm --dir harness/ui build`
- Rust formatting and diff checks

Fixes MOT-4525