### PR TITLE
fix(memory): align runtime dependency ranges

### DIFF
--- a/memory/iii.worker.yaml
+++ b/memory/iii.worker.yaml
@@ -12,5 +12,5 @@ dependencies:
   configuration: "0.x"
   session-manager: "^1.0.0"
   llm-router: "^1.4.12"
-  state: "0.x"
-  queue: "0.x"
+  state: "^0.22.2"
+  queue: "^0.21.2"


### PR DESCRIPTION
# Original failure

Installing the published worker failed:
`iii worker add memory`
because the registry produced incompatible constraints:
```
state ^0.22.2
state ^0.21.2
```
The original manifest used broad 0.x ranges:
```
dependencies:
  configuration: "0.x"
  session-manager: "^1.0.0"
  llm-router: "^1.4.12"
  state: "0.x"
  queue: "0.x"
  ```
  # Proposed fix

Replace the ambiguous ranges with explicitly compatible release lines:
```
dependencies:
  configuration: "^0.22.1"
  session-manager: "^1.0.0"
  llm-router: "^1.4.12"
  state: "^0.22.2"
  queue: "^0.21.2"
```
# Local-test complications

These were unrelated to the registry dependency fix:

bin and license are publishing fields unsupported by local installation.
The source worker needed explicit local runtime and scripts.
iii-console-ui is a monorepo path dependency and had to be copied into the isolated test directory.
Its nested [workspace] declaration had to be removed from the temporary copy.
The UI requires Node.js >=22.13; the Rust Bookworm image provided Node 18.
The temporary local manifest therefore needed node:22-bookworm plus Rust installation.

These changes belong only in /tmp/memory-local. They should not be included in the PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency version constraints for improved compatibility and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->