### PR TITLE
chore(workers): pin SDK-ready dependency releases

### DIFF
--- a/.github/scripts/tests/test_worker_dependency_compatibility.py
+++ b/.github/scripts/tests/test_worker_dependency_compatibility.py
@@ -8,18 +8,34 @@ import yaml
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
-SHARED_DEPENDENCY_RANGES = {
+EXPERIMENTAL_WORKERS = {
+    "a2ui",
+    "canvas",
+    "document",
+    "eval",
+    "pdf",
+    "provider-opencode-go",
+    "provider-openrouter",
+}
+DEPENDENCY_RANGES = {
     "configuration": "0.x",
-    "cron": "0.x",
+    "console": "^1.9.12",
+    "context-manager": "^1.1.3",
+    "cron": "^0.21.9",
+    "harness": "^1.8.5",
+    "iii-directory": "^1.2.3",
     "iii-observability": "0.x",
     "iii-stream": "0.x",
     "llm-router": "^1.4.12",
-    "memory": "0.x",
-    "provider-openai-codex": "0.x",
-    "queue": "0.x",
-    "shell": "0.x",
+    "memory": "^0.2.2",
+    "provider-anthropic": "^1.2.8",
+    "provider-openai": "^1.2.7",
+    "provider-openai-codex": "^0.4.4",
+    "queue": "^0.21.5",
+    "session-manager": "^1.0.13",
+    "shell": "^0.11.10",
     "skills": "0.x",
-    "state": "0.x",
+    "state": "^0.22.2",
 }
 
 
@@ -59,21 +75,24 @@ def test_worker_dependency_graph_is_acyclic() -> None:
         visit(worker)
 
 
-def test_shared_dependencies_use_compatible_ranges() -> None:
+def test_non_experimental_workers_use_validated_dependency_ranges() -> None:
     consumers: dict[str, list[str]] = {
-        dependency: [] for dependency in SHARED_DEPENDENCY_RANGES
+        dependency: [] for dependency in DEPENDENCY_RANGES
     }
 
     for manifest in sorted(REPO_ROOT.glob("*/iii.worker.yaml")):
-        worker_dependencies = dependencies(manifest.parent.name)
-        for dependency, expected_range in SHARED_DEPENDENCY_RANGES.items():
+        worker = manifest.parent.name
+        if worker in EXPERIMENTAL_WORKERS:
+            continue
+        worker_dependencies = dependencies(worker)
+        for dependency, expected_range in DEPENDENCY_RANGES.items():
             if dependency in worker_dependencies:
-                consumers[dependency].append(manifest.parent.name)
+                consumers[dependency].append(worker)
                 dependency_range = worker_dependencies[dependency]
                 assert dependency_range == expected_range, (
                     f"{manifest.relative_to(REPO_ROOT)} pins shared dependency "
                     f"{dependency} to {dependency_range!r}; use {expected_range!r} so "
-                    "all consumers resolve the same compatible worker version"
+                    "non-experimental consumers resolve the validated worker release"
                 )
 
     for dependency, workers in consumers.items():
@@ -97,6 +116,7 @@ def test_harness_llm_stack_uses_shared_state_range() -> None:
     providers = sorted(
         manifest.parent.name
         for manifest in REPO_ROOT.glob("provider-*/iii.worker.yaml")
+        if manifest.parent.name not in EXPERIMENTAL_WORKERS
     )
 
     for worker in ("llm-router", *providers):

--- a/approval-gate/iii.worker.yaml
+++ b/approval-gate/iii.worker.yaml
@@ -9,7 +9,7 @@ tags: [approval, human-in-the-loop, permissions, policy, security]
 description: Policy and decision surface for human-held function calls — pre_trigger gate, pending inbox, per-session permission settings, and two notification trigger types.
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.2"
   configuration: "0.x"
-  iii-directory: "^1.0.0"
-  session-manager: "^1.0.0"
+  iii-directory: "^1.2.3"
+  session-manager: "^1.0.13"

--- a/claude-code/iii.worker.yaml
+++ b/claude-code/iii.worker.yaml
@@ -14,5 +14,5 @@ scripts:
   start: node ./index.mjs
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.2"
   iii-stream: "0.x"

--- a/docs/architecture/iii-worker-yaml.md
+++ b/docs/architecture/iii-worker-yaml.md
@@ -55,13 +55,13 @@ tags:
 
 Example: [`harness/iii.worker.yaml`](../../harness/iii.worker.yaml).
 
-Shared dependencies that are still pre-1.0 use npm-style major wildcards.
-Workers declare `0.x` for every zero-major dependency (`state`, `configuration`,
-`queue`, `cron`, `shell`, and the rest), accepting every stable `0.x` release
-while still excluding `1.0.0` and above. Consumers of `llm-router` retain
-`^1.0.0`: once a dependency is on a stable major, the caret accepts compatible
-`1.x` releases and excludes `2.0.0` and above. These forms are understood
-directly by iii and the Registry.
+Engine-owned dependencies such as `configuration`, `iii-stream`, and
+`iii-observability` use npm-style major wildcards such as `0.x`. Published worker
+dependencies use a caret range whose lower bound is the newest release validated
+with the current SDK. For example, `state: "^0.22.2"` accepts compatible patch
+releases without falling back to an older SDK build. Experimental workers may
+retain broad ranges until their dependency stack is promoted. These forms are
+understood directly by iii and the Registry.
 
 ## Example (minimal Rust binary)
 

--- a/editor/iii.worker.yaml
+++ b/editor/iii.worker.yaml
@@ -9,6 +9,6 @@ tags: [editor, diff, git, code, review]
 description: A shared code workspace — open buffers, a file tree, unified diffs, fuzzy find and conflict-safe saves that an agent and a person see the same view of, plus a console editor page.
 
 dependencies:
-  shell: "0.x"
-  state: "0.x"
+  shell: "^0.11.10"
+  state: "^0.22.2"
   configuration: "0.x"

--- a/harness/iii.worker.yaml
+++ b/harness/iii.worker.yaml
@@ -9,9 +9,9 @@ tags: [agent, harness, loop, autonomous]
 description: Thin durable turn loop that wires session-manager, context-manager, and llm-router into an agent loop; spawns sub-agents as child sessions.
 
 dependencies:
-  state: "0.x"
-  queue: "0.x"
-  cron: "0.x"
+  state: "^0.22.2"
+  queue: "^0.21.5"
+  cron: "^0.21.9"
   configuration: "0.x"
   iii-observability: "0.x"
   iii-stream: "0.x"
@@ -19,8 +19,8 @@ dependencies:
   llm-router: "^1.4.12"
   session-manager: "^1.0.13"
   context-manager: "^1.1.3"
-  provider-openai-codex: "0.x"
+  provider-openai-codex: "^0.4.4"
   provider-anthropic: "^1.2.8"
-  provider-openai: "^1.0.0"
-  shell: "0.x"
-  console: "^1.9.11"
+  provider-openai: "^1.2.7"
+  shell: "^0.11.10"
+  console: "^1.9.12"

--- a/harness/tests/manifest.rs
+++ b/harness/tests/manifest.rs
@@ -54,7 +54,7 @@ fn worker_manifest_uses_the_standalone_queue_worker() {
 
     assert_eq!(
         dependencies.get(serde_yaml::Value::String("queue".into())),
-        Some(&serde_yaml::Value::String("0.x".into()))
+        Some(&serde_yaml::Value::String("^0.21.5".into()))
     );
     assert!(!dependencies.contains_key(serde_yaml::Value::String("iii-queue".into())));
 }
@@ -70,7 +70,7 @@ fn worker_manifest_uses_the_standalone_state_worker() {
 
     assert_eq!(
         dependencies.get(serde_yaml::Value::String("state".into())),
-        Some(&serde_yaml::Value::String("0.x".into()))
+        Some(&serde_yaml::Value::String("^0.22.2".into()))
     );
     assert!(!dependencies.contains_key(serde_yaml::Value::String("iii-state".into())));
 }
@@ -86,7 +86,7 @@ fn worker_manifest_uses_the_standalone_cron_worker() {
 
     assert_eq!(
         dependencies.get(serde_yaml::Value::String("cron".into())),
-        Some(&serde_yaml::Value::String("0.x".into()))
+        Some(&serde_yaml::Value::String("^0.21.9".into()))
     );
     assert!(!dependencies.contains_key(serde_yaml::Value::String("iii-cron".into())));
 }
@@ -103,13 +103,13 @@ fn worker_manifest_uses_the_tested_harness_stack() {
     for (worker, version) in [
         ("session-manager", "^1.0.13"),
         ("llm-router", "^1.4.12"),
-        ("provider-openai-codex", "0.x"),
+        ("provider-openai-codex", "^0.4.4"),
         ("context-manager", "^1.1.3"),
         ("iii-directory", "^1.2.3"),
         ("provider-anthropic", "^1.2.8"),
-        ("provider-openai", "^1.0.0"),
-        ("shell", "0.x"),
-        ("console", "^1.9.11"),
+        ("provider-openai", "^1.2.7"),
+        ("shell", "^0.11.10"),
+        ("console", "^1.9.12"),
     ] {
         assert_eq!(
             dependencies.get(serde_yaml::Value::String(worker.into())),

--- a/llm-router/iii.worker.yaml
+++ b/llm-router/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, router, models, providers]
 description: One front door + provider protocol in front of every LLM provider.
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.2"
   configuration: "0.x"

--- a/memory-consolidate/iii.worker.yaml
+++ b/memory-consolidate/iii.worker.yaml
@@ -9,6 +9,6 @@ tags: [memory, deduplication, cleanup, schedule, maintenance]
 description: Scheduled hygiene for the memory worker — deterministic dedup of near-duplicate memories, applied supersede-only through the public memory functions, pinned untouchable, with catch-up-on-boot scheduling. Install, stop, or remove it without touching stored memory.
 
 dependencies:
-  memory: "0.x"
+  memory: "^0.2.2"
   configuration: "0.x"
-  state: "0.x"
+  state: "^0.22.2"

--- a/memory/iii.worker.yaml
+++ b/memory/iii.worker.yaml
@@ -10,7 +10,7 @@ description: Durable cross-session agent memory — named banks of always-inject
 
 dependencies:
   configuration: "0.x"
-  session-manager: "^1.0.0"
+  session-manager: "^1.0.13"
   llm-router: "^1.4.12"
   state: "^0.22.2"
-  queue: "^0.21.2"
+  queue: "^0.21.5"

--- a/opencode/iii.worker.yaml
+++ b/opencode/iii.worker.yaml
@@ -14,5 +14,5 @@ scripts:
   start: node ./index.mjs
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.2"
   iii-stream: "0.x"

--- a/openwiki/iii.worker.yaml
+++ b/openwiki/iii.worker.yaml
@@ -14,6 +14,6 @@ scripts:
   start: node ./index.mjs
 
 dependencies:
-  state: "0.x"
-  cron: "0.x"
+  state: "^0.22.2"
+  cron: "^0.21.9"
   llm-router: "^1.4.12"

--- a/pi/iii.worker.yaml
+++ b/pi/iii.worker.yaml
@@ -14,5 +14,5 @@ scripts:
   start: node ./index.mjs
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.2"
   iii-stream: "0.x"

--- a/provider-anthropic/iii.worker.yaml
+++ b/provider-anthropic/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, anthropic, claude, messages, provider]
 description: Anthropic Messages API provider worker; implements provider::anthropic::stream and provider::anthropic::refresh_models behind llm-router.
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.2"
   llm-router: "^1.4.12"

--- a/provider-claude-code/iii.worker.yaml
+++ b/provider-claude-code/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, anthropic, claude, claude-code, subscription, provider]
 description: Claude Code (Pro/Max subscription) Messages API provider worker; implements provider::claude-code::stream and provider::claude-code::refresh_models behind llm-router, using OAuth credentials from the auth-credentials vault or ~/.claude/.credentials.json.
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.2"
   llm-router: "^1.4.12"

--- a/provider-deepseek/iii.worker.yaml
+++ b/provider-deepseek/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, deepseek, chat-completions, provider]
 description: DeepSeek Chat Completions provider worker; implements provider::deepseek::stream and provider::deepseek::refresh_models behind llm-router.
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.2"
   llm-router: "^1.4.12"

--- a/provider-github-copilot/iii.worker.yaml
+++ b/provider-github-copilot/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, github, copilot, subscription, chat-completions, provider]
 description: GitHub Copilot subscription provider worker; sign in with GitHub once and the models the plan grants appear in the picker. Implements provider::github-copilot::stream, refresh_models, and a device-flow login surface behind llm-router.
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.2"
   llm-router: "^1.4.12"

--- a/provider-kimi/iii.worker.yaml
+++ b/provider-kimi/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, kimi, moonshot, chat-completions, provider]
 description: Moonshot (Kimi) Chat Completions provider worker; implements provider::kimi::stream and provider::kimi::refresh_models behind llm-router.
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.2"
   llm-router: "^1.4.12"

--- a/provider-llamacpp/iii.worker.yaml
+++ b/provider-llamacpp/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, llama.cpp, local, open-source, provider]
 description: llama.cpp server (llama-server) Chat Completions provider worker; implements provider::llamacpp::stream and provider::llamacpp::refresh_models behind llm-router.
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.2"
   llm-router: "^1.4.12"

--- a/provider-openai-codex/iii.worker.yaml
+++ b/provider-openai-codex/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, openai, codex, chatgpt, subscription, provider]
 description: OpenAI Codex (ChatGPT subscription) provider; implements provider::openai-codex::stream and provider::openai-codex::refresh_models behind llm-router, sourcing credentials from the auth-credentials vault.
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.2"
   llm-router: "^1.4.12"

--- a/provider-openai/iii.worker.yaml
+++ b/provider-openai/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, openai, responses, chat-completions, provider]
 description: OpenAI Responses provider worker with Chat Completions compatibility; implements provider::openai::stream and provider::openai::refresh_models behind llm-router.
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.2"
   llm-router: "^1.4.12"

--- a/provider-xai/iii.worker.yaml
+++ b/provider-xai/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, xai, grok, chat-completions, provider]
 description: xAI Chat Completions provider worker; implements provider::xai::stream and provider::xai::refresh_models behind llm-router.
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.2"
   llm-router: "^1.4.12"

--- a/provider-zai/iii.worker.yaml
+++ b/provider-zai/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, zai, glm, chat-completions, provider]
 description: Z.AI Chat Completions provider worker; implements provider::zai::stream and provider::zai::refresh_models behind llm-router.
 
 dependencies:
-  state: "0.x"
+  state: "^0.22.2"
   llm-router: "^1.4.12"

--- a/slack/iii.worker.yaml
+++ b/slack/iii.worker.yaml
@@ -10,6 +10,6 @@ description: Slack as an iii worker — exposes the Slack Web API as slack::* fu
 
 dependencies:
   configuration: "0.x"
-  state: "0.x"
-  harness: "^1.0.0"
-  session-manager: "^1.0.0"
+  state: "^0.22.2"
+  harness: "^1.8.5"
+  session-manager: "^1.0.13"

--- a/telegram-bot/iii.worker.yaml
+++ b/telegram-bot/iii.worker.yaml
@@ -9,8 +9,8 @@ tags: [telegram, bot, messaging, chat, webhook]
 description: Telegram bridge to the harness stack — polling or webhook ingress, live message edits, approvals, and configurable verbosity.
 
 dependencies:
-  state: "0.x"
-  queue: "0.x"
+  state: "^0.22.2"
+  queue: "^0.21.5"
   configuration: "0.x"
-  session-manager: "^1.0.0"
-  harness: "^1.0.0"
+  session-manager: "^1.0.13"
+  harness: "^1.8.5"

--- a/worktree/iii.worker.yaml
+++ b/worktree/iii.worker.yaml
@@ -10,5 +10,5 @@ description: Git worktree lifecycle for parallel agents — mint, claim, and tra
 
 dependencies:
   configuration: "0.x"
-  state: "0.x"
-  shell: "0.x"
+  state: "^0.22.2"
+  shell: "^0.11.10"


### PR DESCRIPTION
## Summary

- pin non-experimental worker dependencies to the newest validated releases that include the SDK migration
- keep engine-owned dependencies and experimental workers on broad ranges
- update compatibility checks, Harness manifest assertions, and dependency policy documentation

## Validation

- dependency compatibility tests: 5 passed
- non-experimental manifest range audit: 0 mismatches
- Python syntax check: passed
- cargo fmt --check for Harness: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated worker dependency ranges to validated, compatible versions across the worker ecosystem.
  * Improved dependency consistency for state, queue, cron, shell, provider, and session-management components.
  * Preserved flexible version ranges for engine-managed and experimental components where appropriate.

* **Documentation**
  * Clarified dependency versioning guidance for worker configurations.

* **Tests**
  * Enhanced compatibility checks to validate non-experimental workers and provider version ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->