### PR TITLE
fix(harness): configure managed local compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ Node/Python workers follow the standard `npm install` / `pip install -e .`
 flow — see each module's README for specifics. `harness` is a pnpm
 monorepo (`pnpm install && pnpm build`).
 
+## Harness local development
+
+See [`harness/DEVELOPMENT.md`](harness/DEVELOPMENT.md) to start the iii engine
+and the local Harness stack with `worker-compose.yaml`.
+
 ## Binary releases
 
 Rust workers ship as standalone binaries — see the modules table above —

--- a/harness/DEVELOPMENT.md
+++ b/harness/DEVELOPMENT.md
@@ -1,0 +1,68 @@
+# Harness local development
+
+This guide explains how to run the Harness stack from the local source tree.
+
+## Requirements
+
+Install these tools before you start:
+
+- Rust. The repository selects the version in [`rust-toolchain.toml`](../rust-toolchain.toml).
+- The `iii` CLI version `0.23.0-rc.4` or a compatible build with managed
+  Compose engine support.
+
+Check the required commands:
+
+```bash
+iii --version
+cargo --version
+```
+
+## Start the Harness stack
+
+The Harness [`worker-compose.yaml`](worker-compose.yaml) file runs the Harness
+and its required workers from their directories in this repository. It also
+starts and configures the iii engine. From the repository root, run:
+
+```bash
+cd harness
+iii compose up
+```
+
+The managed engine listens on `ws://127.0.0.1:49134`. Do not start a separate
+engine or pass `--engine` with this Compose file.
+
+Set `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` in the Compose terminal when you
+need the related provider. Keep these values in your local shell or secret
+manager. Do not add them to the repository.
+
+Compose starts each Rust worker with `cargo run`. The local startup flow is:
+
+```text
+iii compose up
+      |
+      +--> managed iii engine
+      |
+      +--> cargo run for each worker
+                    |
+                    v
+          worker connects to the engine
+```
+
+The first run can take several minutes because Cargo must download and compile
+each worker. Compose allows up to 15 minutes for each worker to register. Later
+runs normally reuse the Cargo cache.
+
+Restart Compose after a source change to rebuild and restart the workers.
+
+Press `Ctrl-C` in the Compose terminal to stop the workers and the managed
+engine.
+
+## Run checks
+
+Run the checks from the worker directory that you changed:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features
+```

--- a/harness/README.md
+++ b/harness/README.md
@@ -83,6 +83,11 @@ contract in
 [`architecture/integration.md`](architecture/integration.md): the functions to
 trigger, the triggers to bind, and the canonical consumer patterns.
 
+## Local development
+
+See [`DEVELOPMENT.md`](DEVELOPMENT.md) to run the Harness and its required
+workers from the local source tree with `iii compose`.
+
 ## Working with iii
 
 iii is a WebSocket-routed worker mesh. One engine holds a live registry of every

--- a/harness/worker-compose.yaml
+++ b/harness/worker-compose.yaml
@@ -1,6 +1,18 @@
 namespace: my-harness-ns
-startup_timeout: 5m
+startup_timeout: 15m
 stop_timeout: 10s
+
+engine:
+  url: ws://127.0.0.1:49134
+  workers:
+    configuration:
+      adapter:
+        name: fs
+        config:
+          directory: ./config
+    iii-worker-manager:
+      host: 127.0.0.1
+      port: 49134
 
 containers:
   queue:
@@ -30,6 +42,8 @@ containers:
       - state
     environment:
       RUST_LOG: info
+      ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
+      OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
     scripts:
       run: cargo run --locked --bin llm-router
 


### PR DESCRIPTION
## Summary

- configure the local Harness Compose file to own and configure the iii engine
- forward optional Anthropic and OpenAI credentials to llm-router
- allow enough startup time for cold concurrent Cargo builds
- add a Harness-specific local development guide

## Validation

- built iii 0.23.0-rc.4 with cargo build -p iii
- ran iii compose up from the harness directory
- confirmed all 13 containers became ready
- confirmed Harness became ready and Compose reported 13 of 13 containers changed
- stopped Compose with Ctrl-C and confirmed all containers and the managed engine stopped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for starting and managing the local Harness development environment.
  * Documented required tools, provider API key configuration, worker startup timing, shutdown, restarts, and validation commands.
  * Updated project documentation with links to the local development guide.

* **Configuration**
  * Extended worker startup timeout to support slower local launches.
  * Added engine connectivity settings and optional OpenAI and Anthropic provider configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->