### PR TITLE
fix(opengantry): default to local engine URL

### DIFF
--- a/opengantry/scripts/verify-sandbox-boot.mjs
+++ b/opengantry/scripts/verify-sandbox-boot.mjs
@@ -15,13 +15,13 @@ const ALLOWED_BOOT_FAILURE =
   /ECONNREFUSED|connect ECONNREFUSED|WebSocket|failed to connect|connection refused/i;
 
 const bundleUrl = pathToFileURL(bundle).href;
+const { III_URL: _iiiUrl, III_ENGINE_URL: _iiiEngineUrl, ...sandboxEnv } = process.env;
 const result = spawnSync(
   process.execPath,
   [
     '--input-type=module',
     '-e',
     `const url = ${JSON.stringify(bundleUrl)};
-process.env.III_URL = 'ws://127.0.0.1:1';
 try {
   await import(url);
 } catch (e) {
@@ -35,7 +35,7 @@ try {
 process.exit(0);`,
   ],
   {
-    env: { ...process.env, III_URL: 'ws://127.0.0.1:1' },
+    env: sandboxEnv,
     timeout: 15_000,
     stdio: 'inherit',
   },

--- a/opengantry/src/index.js
+++ b/opengantry/src/index.js
@@ -32,10 +32,7 @@ function opengantryWorkerOptions() {
 }
 
 async function startWorker() {
-  const url = process.env.III_URL ?? process.env.III_ENGINE_URL;
-  if (!url) {
-    throw new Error('opengantry worker: III_URL or III_ENGINE_URL is required');
-  }
+  const url = process.env.III_URL ?? process.env.III_ENGINE_URL ?? 'ws://127.0.0.1:49134';
 
   const worker = registerWorker(url, opengantryWorkerOptions());
   const verdictEmitter = createVerdictEmitter({


### PR DESCRIPTION
## Summary

- default OpenGantry to the local iii engine endpoint when III_URL and III_ENGINE_URL are absent
- verify the bundled worker boots with both engine URL variables removed
- preserve explicit III_URL and III_ENGINE_URL overrides

## Why

The registry release starts the bundle directly for interface collection. OpenGantry exited before registration when the release environment did not define an engine URL. The fallback matches the local engine endpoint used for interface collection.

## Testing

- pnpm test
- pnpm lint
- pnpm build:bundle
- pnpm verify:sandbox
- git diff --check