### PR TITLE
fix: use stable Shell release for published workers

### DIFF
--- a/.github/scripts/tests/test_worker_dependency_compatibility.py
+++ b/.github/scripts/tests/test_worker_dependency_compatibility.py
@@ -33,9 +33,15 @@ DEPENDENCY_RANGES = {
     "provider-openai-codex": "^0.4.4",
     "queue": "^0.21.5",
     "session-manager": "^1.0.13",
-    "shell": "^0.11.10",
+    "shell": "^0.11.9",
     "skills": "0.x",
     "state": "^0.22.2",
+}
+
+# Harness is installed from its candidate channel while its stable release is
+# pending. Stable workers must resolve only stable dependency releases.
+WORKER_DEPENDENCY_RANGE_OVERRIDES = {
+    "harness": {"shell": "^0.11.10"},
 }
 
 
@@ -85,8 +91,10 @@ def test_non_experimental_workers_use_validated_dependency_ranges() -> None:
         if worker in EXPERIMENTAL_WORKERS:
             continue
         worker_dependencies = dependencies(worker)
+        worker_overrides = WORKER_DEPENDENCY_RANGE_OVERRIDES.get(worker, {})
         for dependency, expected_range in DEPENDENCY_RANGES.items():
             if dependency in worker_dependencies:
+                expected_range = worker_overrides.get(dependency, expected_range)
                 consumers[dependency].append(worker)
                 dependency_range = worker_dependencies[dependency]
                 assert dependency_range == expected_range, (
@@ -97,6 +105,13 @@ def test_non_experimental_workers_use_validated_dependency_ranges() -> None:
 
     for dependency, workers in consumers.items():
         assert workers, f"expected at least one consumer of {dependency}"
+
+
+def test_worker_dependency_range_overrides_are_active() -> None:
+    for worker, overrides in WORKER_DEPENDENCY_RANGE_OVERRIDES.items():
+        worker_dependencies = dependencies(worker)
+        for dependency, expected_range in overrides.items():
+            assert worker_dependencies.get(dependency) == expected_range
 
 
 def test_approval_gate_uses_shared_runtime_dependency_ranges() -> None:

--- a/docs/architecture/iii-worker-yaml.md
+++ b/docs/architecture/iii-worker-yaml.md
@@ -56,12 +56,14 @@ tags:
 Example: [`harness/iii.worker.yaml`](../../harness/iii.worker.yaml).
 
 Engine-owned dependencies such as `configuration`, `iii-stream`, and
-`iii-observability` use npm-style major wildcards such as `0.x`. Published worker
-dependencies use a caret range whose lower bound is the newest release validated
-with the current SDK. For example, `state: "^0.22.2"` accepts compatible patch
-releases without falling back to an older SDK build. Experimental workers may
-retain broad ranges until their dependency stack is promoted. These forms are
-understood directly by iii and the Registry.
+`iii-observability` use npm-style major wildcards such as `0.x`. Published stable
+worker dependencies use a caret range whose lower bound is the newest stable
+release validated with the current SDK. For example, `state: "^0.22.2"` accepts
+compatible patch releases without falling back to an older SDK build. A worker
+installed explicitly from a candidate channel may temporarily use a newer
+candidate lower bound, but stable dependents must wait until that candidate is
+promoted. Experimental workers may retain broad ranges until their dependency
+stack is promoted. These forms are understood directly by iii and the Registry.
 
 ## Example (minimal Rust binary)
 

--- a/editor/iii.worker.yaml
+++ b/editor/iii.worker.yaml
@@ -9,6 +9,6 @@ tags: [editor, diff, git, code, review]
 description: A shared code workspace — open buffers, a file tree, unified diffs, fuzzy find and conflict-safe saves that an agent and a person see the same view of, plus a console editor page.
 
 dependencies:
-  shell: "^0.11.10"
+  shell: "^0.11.9"
   state: "^0.22.2"
   configuration: "0.x"

--- a/worktree/iii.worker.yaml
+++ b/worktree/iii.worker.yaml
@@ -11,4 +11,4 @@ description: Git worktree lifecycle for parallel agents — mint, claim, and tra
 dependencies:
   configuration: "0.x"
   state: "^0.22.2"
-  shell: "^0.11.10"
+  shell: "^0.11.9"


### PR DESCRIPTION
## Summary

- pin Editor and Worktree to Shell ^0.11.9, the newest stable SDK-ready release
- keep the Harness candidate dependency range explicit in compatibility validation
- document that stable workers must depend on stable Registry releases

## Why

Shell 0.11.10 is currently available only as a prerelease. The default Registry dependency resolver serves stable versions, so published Editor and Worktree packages fail with PACKAGE_NOT_RESOLVED even though Shell 0.11.9 already contains iii-sdk 0.23.0-rc.2.

Slack and Telegram Bot remain unchanged because there is no stable SDK-ready Harness 1.8 release yet.

## Testing

- dependency compatibility tests: 6 passed
- .github/scripts test suite: 223 passed, 3 subtests passed
- Editor manifest validation: passed
- Worktree manifest validation: passed
- Registry resolution: Shell ^0.11.9 resolves to 0.11.9