### PR TITLE
(MOT-4479) feat(console): link traces and chat in both directions

### DIFF
--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -47,6 +47,8 @@ import { expandFileMentions, parseFileMentions } from '@/lib/file-mentions'
 import { formatStopReason } from '@/lib/format-stop-reason'
 import { newMessageId } from '@/lib/session-id'
 import { expandSlashInvocation, slashChip } from '@/lib/slash-commands'
+import { clearChatMessageFocus, useChatMessageFocus } from '@/lib/trace-links'
+import { turnAnchorMessageId } from '@/lib/turn-anchor'
 import { useExtSessionChips, useExtSessionTurnSummaries } from '@/lib/ui-slots'
 import { cn } from '@/lib/utils'
 import { fetchDefaultWorkingDir, validateWorkspaceDir } from '@/lib/working-dir'
@@ -1730,6 +1732,37 @@ export function ChatView({
     }
   })()
 
+  /* Trace → message landing: a pending turn-focus for THIS session resolves
+     to the transcript row to center (see lib/turn-anchor), recomputed as the
+     transcript hydrates. Consumed when MessageList lands on it; dropped once
+     a hydrated transcript provably lacks the turn, so a stale request can't
+     fire on a later visit. */
+  const chatFocusEvent = useChatMessageFocus()
+  const chatFocus =
+    chatFocusEvent && chatFocusEvent.sessionId === conversation.id
+      ? chatFocusEvent
+      : undefined
+  const focusMessageId = useMemo(
+    () =>
+      chatFocus
+        ? turnAnchorMessageId(conversation.messages, chatFocus.turnId)
+        : null,
+    [chatFocus, conversation.messages],
+  )
+  useEffect(() => {
+    if (!chatFocus) return
+    if (conversation.hydrated !== false && focusMessageId === null) {
+      clearChatMessageFocus(chatFocus.id)
+    }
+  }, [chatFocus, conversation.hydrated, focusMessageId])
+  const chatFocusIdRef = useRef<number | null>(null)
+  chatFocusIdRef.current = chatFocus?.id ?? null
+  const handleFocusMessageHandled = useCallback(() => {
+    if (chatFocusIdRef.current !== null) {
+      clearChatMessageFocus(chatFocusIdRef.current)
+    }
+  }, [])
+
   const isDock = density === 'dock'
   const compact = isDock || onBack !== undefined
   const headerPad = compact ? 'px-3 sm:px-4' : 'px-3 sm:px-6 lg:px-9'
@@ -1960,6 +1993,8 @@ export function ChatView({
         onConfigureProvider={handleOpenModelPicker}
         workingDir={conversation.workingDir ?? null}
         triggersById={triggersById}
+        focusMessageId={focusMessageId}
+        onFocusMessageHandled={handleFocusMessageHandled}
       />
       <LiveRegion announcement={announcer.announcement} />
 

--- a/console/web/src/components/chat/MessageList.tsx
+++ b/console/web/src/components/chat/MessageList.tsx
@@ -109,6 +109,13 @@ interface MessageListProps {
   defaultOpenCalls?: boolean
   /** Registration rows by subscription id, for trigger-fired card detail. */
   triggersById?: ReadonlyMap<string, SessionTriggerInfo>
+  /**
+   * External landing request (trace → "go to message"): once this row's node
+   * exists, the list centers it, flashes it, and calls
+   * `onFocusMessageHandled` so the owner can consume the request.
+   */
+  focusMessageId?: string | null
+  onFocusMessageHandled?: () => void
 }
 
 /**
@@ -284,6 +291,8 @@ export function MessageList({
   workingDir,
   defaultOpenCalls,
   triggersById,
+  focusMessageId,
+  onFocusMessageHandled,
 }: MessageListProps) {
   const containerRef = useRef<HTMLElement>(null)
   const contentRef = useRef<HTMLDivElement>(null)
@@ -570,6 +579,67 @@ export function MessageList({
     writeScrollTop,
   ])
 
+  /* External landing (trace → "go to message"): center the requested row
+     once it exists, then hand the request back to the owner. Tail following
+     is paused first so a live tail can't yank the view back down; the flash
+     gives the jump a visible landmark. Gated on hydration so it never
+     centers against a partial history. */
+  const focusAppliedRef = useRef<string | null>(null)
+  // biome-ignore lint/correctness/useExhaustiveDependencies: message arrival is the retry trigger while the target row hasn't rendered yet.
+  useEffect(() => {
+    if (!focusMessageId) {
+      focusAppliedRef.current = null
+      return
+    }
+    if (!transcriptHydrated || focusAppliedRef.current === focusMessageId) {
+      return
+    }
+    const container = containerRef.current
+    const content = contentRef.current
+    if (!container || !content) return
+    const node = Array.from(
+      content.querySelectorAll<HTMLElement>('[data-message-id]'),
+    ).find((el) => el.dataset.messageId === focusMessageId)
+    if (!node) return
+    focusAppliedRef.current = focusMessageId
+    cancelTailAnimation()
+    didInitialScrollRef.current = true
+    transitionTailState('paused')
+    const containerRect = container.getBoundingClientRect()
+    const nodeRect = node.getBoundingClientRect()
+    const centeredTop =
+      container.scrollTop +
+      nodeRect.top -
+      containerRect.top -
+      (container.clientHeight - nodeRect.height) / 2
+    const target = Math.max(
+      0,
+      Math.min(tailScrollTarget(container), centeredTop),
+    )
+    if (reducedMotionRef.current) writeScrollTop(container, target)
+    else container.scrollTo({ top: target, behavior: 'smooth' })
+    if (typeof node.animate === 'function') {
+      node.animate(
+        [
+          {
+            backgroundColor: 'color-mix(in srgb, currentColor 5%, transparent)',
+          },
+          { backgroundColor: 'transparent' },
+        ],
+        { duration: 900, easing: 'ease-out' },
+      )
+    }
+    onFocusMessageHandled?.()
+  }, [
+    focusMessageId,
+    transcriptHydrated,
+    messages,
+    onFocusMessageHandled,
+    cancelTailAnimation,
+    transitionTailState,
+    writeScrollTop,
+  ])
+
   if (messages.length === 0 && !header) {
     return (
       <EmptyState {...resolveEmptyState(ctx, density, onConfigureProvider)} />
@@ -659,7 +729,6 @@ export function MessageList({
               row.kind === 'trigger-activity' ? row.id : row.message.id
             const node = (
               <Message
-                key={rowKey}
                 message={m}
                 triggerNotification={
                   row.kind === 'trigger-activity' ? row.notification : undefined
@@ -679,12 +748,16 @@ export function MessageList({
                 }
               />
             )
-            return tight ? (
-              <div key={rowKey} className="-mt-6.5">
+            // Every row carries its message id so external landings
+            // (trace → "go to message") can find the DOM node to center.
+            return (
+              <div
+                key={rowKey}
+                data-message-id={m.id}
+                className={tight ? '-mt-6.5' : undefined}
+              >
                 {node}
               </div>
-            ) : (
-              node
             )
           })}
           {isThinking ? (
@@ -802,7 +875,11 @@ function FunctionTriggerGroup({
           data-function-trigger-group-calls=""
         >
           {visibleCalls.map((call, index) => (
-            <div key={call.id} className={cn(index > 0 && '-mt-6.5')}>
+            <div
+              key={call.id}
+              data-message-id={call.id}
+              className={cn(index > 0 && '-mt-6.5')}
+            >
               <Message
                 message={call}
                 defaultOpenCalls={defaultOpenCalls}
@@ -817,7 +894,9 @@ function FunctionTriggerGroup({
         </div>
       </div>
       {row.summary ? (
-        <Message message={row.summary} copyText={summaryCopyText} />
+        <div data-message-id={row.summary.id}>
+          <Message message={row.summary} copyText={summaryCopyText} />
+        </div>
       ) : null}
     </section>
   )

--- a/console/web/src/lib/conversations-context.tsx
+++ b/console/web/src/lib/conversations-context.tsx
@@ -42,6 +42,13 @@ const backend = getDefaultBackend()
 
 interface ConversationsContextValue extends ConversationsApi {
   backend: ChatBackend
+  /**
+   * Select a conversation AND ask the host to place the chat pane — the
+   * programmatic "open this session" other screens use (e.g. a trace's
+   * open-session button). Same behavior as an injected page's
+   * `ConversationAdapter.selectConversation`.
+   */
+  openConversation: (sessionId: string) => void
   modelOptions: ModelOption[]
   catalogLoading: boolean
   /** Providers present as harness workers (configured or not). */
@@ -211,9 +218,14 @@ export function ConversationsProvider({
     }
   }, [injectableUiRuntime])
 
+  const openConversation = useCallback((sessionId: string) => {
+    conversationAdapterRef.current?.selectConversation(sessionId)
+  }, [])
+
   const value: ConversationsContextValue = {
     ...api,
     backend,
+    openConversation,
     modelOptions,
     catalogLoading,
     presentProviders,

--- a/console/web/src/lib/session-id.ts
+++ b/console/web/src/lib/session-id.ts
@@ -1,12 +1,15 @@
 /**
  * Message / session ID helpers.
  *
- * One fresh `msg-<uuid>` per send. It flows into the engine via baggage so
- * the traces UI can "Group by message", and rides `harness::send` as the
+ * One fresh `msg-<uuid>` per send. It rides `harness::send` as the
  * `idempotency_key`, from which the harness derives the user message's
  * session-manager entry id (`e_idem_<message_id>`) — which is also how the
  * console's optimistic user row reconciles in place (see
- * `predictedUserEntryId` in lib/backend/harness-send.ts).
+ * `predictedUserEntryId` in lib/backend/harness-send.ts) — and travels in
+ * `options.metadata.message_id`. It does NOT reach the trace baggage: the
+ * `iii.message.id` span attribute the traces UI groups by is the harness
+ * TURN id (`t_<uuid>`, see harness/src/functions/turn.rs), correlated back
+ * to transcript rows via the `e_<turn_id>_…` entry ids (lib/turn-anchor.ts).
  *
  * (Conversation ids are minted with the `console-` prefix via
  * [`newSessionId`] and double as the engine session_id, so there is no
@@ -33,9 +36,9 @@ function mintId(prefix: string): string {
 }
 
 /**
- * Mint a fresh message_id for a single turn. Called once per `send()`
- * so every user turn lands under its own `iii.message.id` bucket in
- * the traces UI's "Group by message" view.
+ * Mint a fresh message_id for a single turn. Called once per `send()` so
+ * every user turn gets its own idempotency key (and thus its own
+ * `e_idem_<message_id>` transcript entry).
  */
 export function newMessageId(): string {
   return mintId(MESSAGE_PREFIX)

--- a/console/web/src/lib/trace-links.test.ts
+++ b/console/web/src/lib/trace-links.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  clearChatMessageFocus,
+  getChatMessageFocus,
+  requestChatMessageFocus,
+  resetTraceLinksForTests,
+} from './trace-links'
+
+beforeEach(resetTraceLinksForTests)
+
+describe('chat message focus (traces → chat)', () => {
+  it('carries the session and the harness turn id', () => {
+    const event = requestChatMessageFocus({
+      sessionId: 'console-1',
+      turnId: 't_abc',
+    })
+    expect(getChatMessageFocus()).toBe(event)
+    expect(event.sessionId).toBe('console-1')
+    expect(event.turnId).toBe('t_abc')
+  })
+
+  it('a newer request replaces the pending one', () => {
+    const first = requestChatMessageFocus({
+      sessionId: 'console-1',
+      turnId: 't_a',
+    })
+    const second = requestChatMessageFocus({
+      sessionId: 'console-1',
+      turnId: 't_b',
+    })
+    expect(second.id).toBe(first.id + 1)
+    expect(getChatMessageFocus()).toBe(second)
+  })
+
+  it('clear is id-guarded and idempotent', () => {
+    const first = requestChatMessageFocus({
+      sessionId: 'console-1',
+      turnId: 't_a',
+    })
+    const second = requestChatMessageFocus({
+      sessionId: 'console-1',
+      turnId: 't_b',
+    })
+    clearChatMessageFocus(first.id)
+    expect(getChatMessageFocus()).toBe(second)
+    clearChatMessageFocus(second.id)
+    expect(getChatMessageFocus()).toBeUndefined()
+    clearChatMessageFocus(second.id)
+  })
+})

--- a/console/web/src/lib/trace-links.ts
+++ b/console/web/src/lib/trace-links.ts
@@ -1,0 +1,83 @@
+/**
+ * Ephemeral link from the traces screen to the chat: "go to message".
+ *
+ * A tiny latest-event store modeled on `panel-context.ts`: the request is
+ * stored BEFORE listeners run, so a ChatView mounted in response to it reads
+ * the event on first render. The consumer clears the event after acting on
+ * it — a later remount of the same conversation must never re-apply a stale
+ * request.
+ *
+ * The identity this direction relies on is stamped as baggage on every span
+ * of a harness turn (`harness/src/functions/turn.rs`): `iii.session.id` is
+ * the engine session_id (= `Conversation.id`) and `iii.message.id` is the
+ * harness turn id (`t_<uuid>`) — NOT the console's `msg-<uuid>` message id.
+ *
+ * (The chat → traces direction needs no store: the traces screen follows the
+ * active conversation automatically — see the session scope in
+ * `pages/TracesV2/index.tsx`.)
+ */
+
+import { useSyncExternalStore } from 'react'
+
+/** Traces → chat: land the transcript on one turn's messages. */
+export interface ChatMessageFocusEvent {
+  id: number
+  /** engine session_id (= `Conversation.id`) */
+  sessionId: string
+  /** harness turn id (`t_<uuid>`) — the spans' `iii.message.id` */
+  turnId: string
+}
+
+let nextEventId = 1
+let chatMessageFocus: ChatMessageFocusEvent | undefined
+const chatMessageFocusListeners = new Set<() => void>()
+
+function emit(): void {
+  for (const listener of [...chatMessageFocusListeners]) listener()
+}
+
+function subscribeChatMessageFocus(listener: () => void): () => void {
+  chatMessageFocusListeners.add(listener)
+  return () => chatMessageFocusListeners.delete(listener)
+}
+
+/** Ask the chat to land on one turn's messages once its session is open. */
+export function requestChatMessageFocus(request: {
+  sessionId: string
+  turnId: string
+}): ChatMessageFocusEvent {
+  chatMessageFocus = {
+    id: nextEventId++,
+    sessionId: request.sessionId,
+    turnId: request.turnId,
+  }
+  emit()
+  return chatMessageFocus
+}
+
+export function getChatMessageFocus(): ChatMessageFocusEvent | undefined {
+  return chatMessageFocus
+}
+
+/** Reactive pending turn focus for the mounted chat view. */
+export function useChatMessageFocus(): ChatMessageFocusEvent | undefined {
+  return useSyncExternalStore(
+    subscribeChatMessageFocus,
+    () => chatMessageFocus,
+    () => undefined,
+  )
+}
+
+/** Consume a handled turn focus (id-guarded against a newer event). */
+export function clearChatMessageFocus(id: number): void {
+  if (chatMessageFocus?.id !== id) return
+  chatMessageFocus = undefined
+  emit()
+}
+
+/** Test-only reset; exported to keep the store deterministic in unit tests. */
+export function resetTraceLinksForTests(): void {
+  nextEventId = 1
+  chatMessageFocus = undefined
+  chatMessageFocusListeners.clear()
+}

--- a/console/web/src/lib/turn-anchor.test.ts
+++ b/console/web/src/lib/turn-anchor.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import type { Message } from '@/types/chat'
+import { turnAnchorMessageId } from './turn-anchor'
+
+function user(id: string): Message {
+  return { id, role: 'user', content: 'hi', createdAt: 1 }
+}
+
+function assistant(id: string): Message {
+  return { id, role: 'assistant', content: 'ok', createdAt: 2 }
+}
+
+function notice(id: string): Message {
+  return { id, role: 'system', content: 'note', createdAt: 2 }
+}
+
+describe('turnAnchorMessageId', () => {
+  it('lands on the user row that started the turn', () => {
+    const messages = [
+      user('e_idem_msg-1'),
+      assistant('e_t_aaa_0_assistant'),
+      user('e_idem_msg-2'),
+      assistant('e_t_bbb_0_assistant'),
+    ]
+    expect(turnAnchorMessageId(messages, 't_bbb')).toBe('e_idem_msg-2')
+    expect(turnAnchorMessageId(messages, 't_aaa')).toBe('e_idem_msg-1')
+  })
+
+  it('skips local-only notices between the user row and the turn', () => {
+    const messages = [
+      user('e_idem_msg-1'),
+      notice('local-uid-notice'),
+      assistant('e_t_aaa_0_assistant'),
+    ]
+    expect(turnAnchorMessageId(messages, 't_aaa')).toBe('e_idem_msg-1')
+  })
+
+  it('stops the backward walk at another durable entry', () => {
+    const messages = [
+      user('e_idem_msg-1'),
+      notice('e_t_aaa_stopped'),
+      assistant('e_t_bbb_0_assistant'),
+    ]
+    // msg-1 belongs to turn aaa's exchange — land on turn bbb itself.
+    expect(turnAnchorMessageId(messages, 't_bbb')).toBe('e_t_bbb_0_assistant')
+  })
+
+  it('falls back to the turn entry when no user row precedes it', () => {
+    const messages = [assistant('e_t_aaa_0_assistant')]
+    expect(turnAnchorMessageId(messages, 't_aaa')).toBe('e_t_aaa_0_assistant')
+  })
+
+  it('returns null for an unknown turn or empty turn id', () => {
+    const messages = [user('e_idem_msg-1'), assistant('e_t_aaa_0_assistant')]
+    expect(turnAnchorMessageId(messages, 't_zzz')).toBeNull()
+    expect(turnAnchorMessageId(messages, '')).toBeNull()
+  })
+
+  it('matches the turn id exactly, never a longer id sharing the prefix', () => {
+    const messages = [assistant('e_t_aaab_0_assistant')]
+    expect(turnAnchorMessageId(messages, 't_aaa')).toBeNull()
+  })
+})

--- a/console/web/src/lib/turn-anchor.ts
+++ b/console/web/src/lib/turn-anchor.ts
@@ -1,0 +1,34 @@
+import type { Message } from '@/types/chat'
+
+/**
+ * The transcript row a trace's "go to message" should land on, for one
+ * harness turn.
+ *
+ * Harness-derived entry ids embed the turn id — `e_<turn_id>_<step>_assistant`,
+ * `e_<turn_id>_<function_call_id>`, `e_<turn_id>_stopped` (harness/src/ids.rs)
+ * — so the turn's rows are found by prefix. The USER row that started the
+ * turn (`e_idem_<message_id>` / `e_q_<id>`) does not carry the turn id; it is
+ * recovered positionally as the nearest user row directly above the turn's
+ * first entry, which reads better as a landing point than an arbitrary tool
+ * call. The backward walk skips local-only rows (uid-based system notices)
+ * but stops at any other durable entry — a user row beyond one belongs to a
+ * different exchange.
+ *
+ * Returns null when the transcript holds no entry of that turn (e.g. a turn
+ * still streaming on optimistic local ids, or a pruned history).
+ */
+export function turnAnchorMessageId(
+  messages: ReadonlyArray<Message>,
+  turnId: string,
+): string | null {
+  if (!turnId) return null
+  const prefix = `e_${turnId}_`
+  const first = messages.findIndex((m) => m.id.startsWith(prefix))
+  if (first === -1) return null
+  for (let i = first - 1; i >= 0; i--) {
+    const m = messages[i]
+    if (m.role === 'user') return m.id
+    if (m.id.startsWith('e_')) break
+  }
+  return messages[first].id
+}

--- a/console/web/src/pages/TracesV2/components/TraceDetailSkeleton.tsx
+++ b/console/web/src/pages/TracesV2/components/TraceDetailSkeleton.tsx
@@ -1,6 +1,7 @@
-import { ChevronRight, Clock, Layers, X } from 'lucide-react'
+import { ChevronRight, Clock, Layers, LocateFixed, X } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import { Skeleton } from '@/components/ui/Skeleton'
+import type { TraceChatLink } from '../lib/traceChatLink'
 
 /**
  * Loading placeholder for the trace detail — mirrors the real composition
@@ -26,9 +27,17 @@ const TIMELINE_BARS: ReadonlyArray<readonly [number, number]> = [
 interface TraceDetailSkeletonProps {
   /** wired to the real close affordance so a slow load can be backed out of */
   onClose: () => void
+  /** chat linkage already resolved from the row's trace tags — live like the
+   *  close button, so the jump to the conversation never waits on the spans */
+  chatLink?: TraceChatLink | null
+  onOpenMessage?: (link: TraceChatLink) => void
 }
 
-export function TraceDetailSkeleton({ onClose }: TraceDetailSkeletonProps) {
+export function TraceDetailSkeleton({
+  onClose,
+  chatLink,
+  onOpenMessage,
+}: TraceDetailSkeletonProps) {
   return (
     <div className="flex flex-col overflow-hidden">
       {/* ── TraceHeader ── */}
@@ -67,6 +76,21 @@ export function TraceDetailSkeleton({ onClose }: TraceDetailSkeletonProps) {
           <span className="flex items-center gap-1 px-2 py-0.5 rounded-xs bg-surface">
             <Skeleton className="h-3 w-16" />
           </span>
+
+          {chatLink?.turnId && onOpenMessage ? (
+            <>
+              <span aria-hidden className="w-px h-3 bg-edge" />
+              <button
+                type="button"
+                onClick={() => onOpenMessage(chatLink)}
+                aria-label="go to message"
+                title="open the chat at this trace's message"
+                className="flex items-center px-1.5 py-0.5 rounded-xs bg-surface text-ink-faint hover:text-ink hover:bg-surface-hover transition-colors"
+              >
+                <LocateFixed className="size-4" />
+              </button>
+            </>
+          ) : null}
         </div>
 
         {/* worker share bar + names */}

--- a/console/web/src/pages/TracesV2/components/TraceHeader.tsx
+++ b/console/web/src/pages/TracesV2/components/TraceHeader.tsx
@@ -1,7 +1,16 @@
-import { AlertCircle, ChevronRight, Clock, Copy, Layers, X } from 'lucide-react'
+import {
+  AlertCircle,
+  ChevronRight,
+  Clock,
+  Copy,
+  Layers,
+  LocateFixed,
+  X,
+} from 'lucide-react'
 import { Fragment, useMemo } from 'react'
 import { Button } from '@/components/ui/Button'
 import { cn } from '@/lib/utils'
+import type { TraceChatLink } from '../lib/traceChatLink'
 import { getWorkerColor } from '../lib/traceColors'
 import type { VisualizationSpan, WaterfallData } from '../lib/traceTransform'
 import {
@@ -15,6 +24,10 @@ interface TraceHeaderProps {
   traceId: string
   onClose: () => void
   onSpanClick?: (span: VisualizationSpan) => void
+  /** The chat session/turn behind this trace, when its spans carry it. */
+  chatLink?: TraceChatLink | null
+  /** Open the linked conversation AND land on this trace's turn. */
+  onOpenMessage?: (link: TraceChatLink) => void
 }
 
 export function TraceHeader({
@@ -22,6 +35,8 @@ export function TraceHeader({
   traceId,
   onClose,
   onSpanClick,
+  chatLink,
+  onOpenMessage,
 }: TraceHeaderProps) {
   const { copiedKey, copy } = useCopyToClipboard()
   const copied = copiedKey === 'traceId'
@@ -146,6 +161,21 @@ export function TraceHeader({
             </span>
           </span>
         )}
+
+        {chatLink?.turnId && onOpenMessage ? (
+          <>
+            <span aria-hidden className="w-px h-3 bg-edge" />
+            <button
+              type="button"
+              onClick={() => onOpenMessage(chatLink)}
+              aria-label="go to message"
+              title="open the chat at this trace's message"
+              className="flex items-center px-1.5 py-0.5 rounded-xs bg-surface text-ink-faint hover:text-ink hover:bg-surface-hover transition-colors"
+            >
+              <LocateFixed className="size-4" />
+            </button>
+          </>
+        ) : null}
       </div>
 
       {workerList.length > 1 && (

--- a/console/web/src/pages/TracesV2/index.tsx
+++ b/console/web/src/pages/TracesV2/index.tsx
@@ -22,7 +22,13 @@
  * seed read from fixtures.
  */
 
-import { AlertCircle, GitBranch, RefreshCw } from 'lucide-react'
+import {
+  AlertCircle,
+  GitBranch,
+  MessageSquare,
+  RefreshCw,
+  X,
+} from 'lucide-react'
 import {
   useCallback,
   useEffect,
@@ -41,6 +47,7 @@ import { Skeleton } from '@/components/ui/Skeleton'
 import { StatusPanel } from '@/components/ui/StatusPanel'
 import { useConversationsCtxOptional } from '@/lib/conversations-context'
 import { getIiiClient } from '@/lib/iii-client'
+import { requestChatMessageFocus } from '@/lib/trace-links'
 import { startTraceSpansStream } from '@/lib/traces-stream'
 import { cn } from '@/lib/utils'
 import { fetchTraces, type StoredSpan } from './api/traces'
@@ -67,6 +74,8 @@ import { useTraceData } from './hooks/useTraceData'
 import { useTraceFilters } from './hooks/useTraceFilters'
 import { useTraceViews } from './hooks/useTraceViews'
 import { isTraceLive } from './lib/timelineSpans'
+import { type TraceChatLink, traceChatLink } from './lib/traceChatLink'
+import { withSessionScope } from './lib/traceFilters'
 import type { RowLabelConfig } from './lib/traceListItem'
 import {
   applyViewConfig,
@@ -83,6 +92,11 @@ import {
 } from './lib/traceTransform'
 
 const PAGE_SIZES = [25, 50, 100]
+// Keep each detail RPC well below the WebSocket payload limit. A trace may
+// contain thousands of spans with rich events and attributes; loading it in
+// pages preserves the complete detail without making one oversized response
+// stall the worker connection.
+const TRACE_DETAIL_PAGE_SIZE = 250
 
 export interface TracesV2Props {
   /** mount with a trace's detail already expanded (stories/deep links) */
@@ -136,9 +150,29 @@ export function TracesV2({ initialTraceId, onRequestClose }: TracesV2Props) {
     clearValidationWarnings,
   } = useTraceFilters()
 
+  // ── Automatic session scope ──
+  // The trace list FOLLOWS the active chat: selecting a conversation scopes
+  // the list to its `iii.session.id`, server-side via `withSessionScope`
+  // (the identity attrs live on child spans, so the scope needs the
+  // search-all-spans wire shape). Drafts have no session server-side yet and
+  // never scope; outside the app shell (Storybook) there is no chat to
+  // follow. Dismissable per session via the chip next to the views dropdown
+  // — selecting another conversation re-scopes.
+  const conversationsCtx = useConversationsCtxOptional()
+  const activeConversation = conversationsCtx?.active ?? null
+  const [scopeDismissedFor, setScopeDismissedFor] = useState<string | null>(
+    null,
+  )
+  const sessionScope =
+    activeConversation &&
+    !activeConversation.draft &&
+    activeConversation.id !== scopeDismissedFor
+      ? activeConversation.id
+      : null
+
   const filterParams = useMemo(
-    () => getFilterOnlyParams(),
-    [getFilterOnlyParams],
+    () => withSessionScope(getFilterOnlyParams(), sessionScope),
+    [getFilterOnlyParams, sessionScope],
   )
 
   const {
@@ -241,8 +275,14 @@ export function TracesV2({ initialTraceId, onRequestClose }: TracesV2Props) {
     })
   }, [traceGroups])
 
+  // Scoped to one session, grouping would collapse to a single group (and
+  // the group-by aggregate path doesn't consult the scope) — render the
+  // flat list instead. The view's row label (e.g. `iii.tag.message`) still
+  // applies, so scoped rows read as the session's turns.
   const groupByAttribute =
-    filterState.groupBy && filterState.groupBy !== 'none'
+    sessionScope === null &&
+    filterState.groupBy &&
+    filterState.groupBy !== 'none'
       ? filterState.groupBy
       : null
 
@@ -262,9 +302,8 @@ export function TracesV2({ initialTraceId, onRequestClose }: TracesV2Props) {
   // Follow toggle (strip header): auto-open the trace of the ACTIVE chat's
   // live turn, so sending a message lands the canvas on the work as it runs.
   // Scoped to user interactions — the active conversation's top-level
-  // `harness.turn` steps; sub-agent turns never steal the view. Null outside
-  // the app shell (Storybook), which also hides the strip's toggle.
-  const conversationsCtx = useConversationsCtxOptional()
+  // `harness.turn` steps; sub-agent turns never steal the view. The strip's
+  // toggle hides outside the app shell (no conversationsCtx in Storybook).
   const { followTurns, toggleFollowTurns } = useFollowTurns()
 
   // Span-filter fallout on the LIST: a row hides while its trace has no
@@ -326,7 +365,8 @@ export function TracesV2({ initialTraceId, onRequestClose }: TracesV2Props) {
   const containerRef = useRef<HTMLDivElement>(null)
   const spanPanel = useSpanPanelResize(containerRef)
 
-  // Live detail: the selected trace's spans are seeded once (one flat read),
+  // Live detail: the selected trace's spans are seeded on explicit open,
+  // paged so a very large trace never becomes one oversized RPC response;
   // then APPENDED from the engine `trace-spans` stream and rebuilt into the
   // waterfall via `toWaterfallData`. Accumulated by `span_id` so re-delivered
   // spans dedupe. Frozen while paused.
@@ -363,13 +403,31 @@ export function TracesV2({ initialTraceId, onRequestClose }: TracesV2Props) {
         setWaterfallData(null)
       }
       try {
-        const { spans } = await fetchTraces({
-          trace_id: traceId,
-          search_all_spans: true,
-          include_internal: false,
-          limit: 10000,
-        })
-        detailSpansRef.current = new Map(spans.map((s) => [s.span_id, s]))
+        const detailSpans = new Map<string, StoredSpan>()
+        let offset = 0
+        let total = Number.POSITIVE_INFINITY
+
+        while (offset < total) {
+          const page = await fetchTraces({
+            trace_id: traceId,
+            search_all_spans: true,
+            include_internal: false,
+            sort_by: 'start_time',
+            sort_order: 'asc',
+            offset,
+            limit: TRACE_DETAIL_PAGE_SIZE,
+          })
+
+          for (const span of page.spans) detailSpans.set(span.span_id, span)
+          total = page.total
+
+          // A short page prevents an incorrect or stale `total` from turning
+          // into an unbounded request loop while a trace is completing.
+          if (page.spans.length < TRACE_DETAIL_PAGE_SIZE) break
+          offset += page.spans.length
+        }
+
+        detailSpansRef.current = detailSpans
         const wf = rebuildDetail(traceId)
         if (!wf && !silent) {
           setSpansError('no span data available for this trace')
@@ -496,6 +554,37 @@ export function TracesV2({ initialTraceId, onRequestClose }: TracesV2Props) {
     onOpenTrace: selectTrace,
   })
 
+  // Chat linkage of the OPEN trace (session + turn), resolved from the row's
+  // merged trace tags with a span-attribute fallback for details opened
+  // without their row (timeline-strip click, deep link). The row tags come
+  // with the LIST fetch, so the link resolves — and the jump-to-chat works —
+  // while the paged detail is still loading; only the fallback path waits
+  // for spans. The buttons only render inside the app shell — outside it
+  // (Storybook) there is no conversation surface to open.
+  const chatLink = useMemo(() => {
+    if (selectedTraceId === null) return null
+    const tags = traceGroups.find(
+      (t) => t.traceId === selectedTraceId,
+    )?.traceTags
+    return traceChatLink(tags, waterfallData?.spans ?? [])
+  }, [waterfallData, traceGroups, selectedTraceId])
+
+  const openConversation = conversationsCtx?.openConversation
+  const handleOpenMessage = useMemo(() => {
+    if (!openConversation) return undefined
+    return (link: TraceChatLink) => {
+      // Focus first, open second: the store holds the request before the
+      // chat pane mounts, so a freshly placed ChatView reads it on render.
+      if (link.turnId) {
+        requestChatMessageFocus({
+          sessionId: link.sessionId,
+          turnId: link.turnId,
+        })
+      }
+      openConversation(link.sessionId)
+    }
+  }, [openConversation])
+
   // Deep-link seed: mount with a trace already expanded (used by stories).
   const initialAppliedRef = useRef(false)
   useEffect(() => {
@@ -524,7 +613,11 @@ export function TracesV2({ initialTraceId, onRequestClose }: TracesV2Props) {
     selectedTraceId !== null ? (
       <div className="bg-panel-raised shadow-raised">
         {isLoadingSpans && (
-          <TraceDetailSkeleton onClose={() => selectTrace(null)} />
+          <TraceDetailSkeleton
+            onClose={() => selectTrace(null)}
+            chatLink={chatLink}
+            onOpenMessage={handleOpenMessage}
+          />
         )}
         {!isLoadingSpans && spansError && (
           <div className="p-4 flex flex-col gap-3">
@@ -560,6 +653,8 @@ export function TracesV2({ initialTraceId, onRequestClose }: TracesV2Props) {
               traceId={selectedTraceId}
               onClose={() => selectTrace(null)}
               onSpanClick={setSelectedSpan}
+              chatLink={chatLink}
+              onOpenMessage={handleOpenMessage}
             />
             <div className="border-b border-rule-2 px-3 py-2">
               <ViewSwitcher
@@ -601,6 +696,29 @@ export function TracesV2({ initialTraceId, onRequestClose }: TracesV2Props) {
   const selectedInPage =
     selectedTraceId !== null && paged.some((t) => t.traceId === selectedTraceId)
 
+  // The scope chip: names the followed conversation; ✕ shows every session
+  // again (until another conversation is selected).
+  const sessionScopeChip = sessionScope ? (
+    <span
+      className="flex items-center gap-1 rounded-xs bg-surface py-0.5 pr-0.5 pl-2 font-mono text-[11px] text-ink-faint"
+      title="the list follows the active chat — showing only this session's traces"
+    >
+      <MessageSquare className="size-4 flex-shrink-0" />
+      <span className="max-w-[140px] truncate lowercase">
+        {activeConversation?.title ?? sessionScope}
+      </span>
+      <button
+        type="button"
+        onClick={() => setScopeDismissedFor(sessionScope)}
+        aria-label="show all sessions"
+        title="show all sessions"
+        className="p-0.5 transition-colors hover:text-ink"
+      >
+        <X className="size-4" />
+      </button>
+    </span>
+  ) : null
+
   return (
     <section
       aria-label="traces"
@@ -634,34 +752,37 @@ export function TracesV2({ initialTraceId, onRequestClose }: TracesV2Props) {
             stats={hasOtelConfigured ? stats : undefined}
             attributeKeySuggestions={attributeKeySuggestions}
             leading={
-              viewsAvailable ? (
-                <ViewsDropdown
-                  views={views}
-                  activeViewId={activeViewId}
-                  activeModified={activeViewModified}
-                  onSelectView={handleSelectView}
-                  onSaveNew={(name) => {
-                    void saveView(name, captureViewConfig(filterState)).then(
-                      (view) => setActiveViewId(view.id),
-                    )
-                  }}
-                  onUpdateActive={() => {
-                    if (activeViewId)
-                      void updateView(
-                        activeViewId,
-                        captureViewConfig(filterState),
+              <>
+                {viewsAvailable ? (
+                  <ViewsDropdown
+                    views={views}
+                    activeViewId={activeViewId}
+                    activeModified={activeViewModified}
+                    onSelectView={handleSelectView}
+                    onSaveNew={(name) => {
+                      void saveView(name, captureViewConfig(filterState)).then(
+                        (view) => setActiveViewId(view.id),
                       )
-                  }}
-                  onRenameActive={(name) => {
-                    if (activeViewId) void renameView(activeViewId, name)
-                  }}
-                  onDeleteActive={() => {
-                    // deleteView clears the selection itself, in the same
-                    // config write.
-                    if (activeViewId) void deleteView(activeViewId)
-                  }}
-                />
-              ) : undefined
+                    }}
+                    onUpdateActive={() => {
+                      if (activeViewId)
+                        void updateView(
+                          activeViewId,
+                          captureViewConfig(filterState),
+                        )
+                    }}
+                    onRenameActive={(name) => {
+                      if (activeViewId) void renameView(activeViewId, name)
+                    }}
+                    onDeleteActive={() => {
+                      // deleteView clears the selection itself, in the same
+                      // config write.
+                      if (activeViewId) void deleteView(activeViewId)
+                    }}
+                  />
+                ) : null}
+                {sessionScopeChip}
+              </>
             }
           />
         </ErrorBoundary>
@@ -724,8 +845,16 @@ export function TracesV2({ initialTraceId, onRequestClose }: TracesV2Props) {
                   <div className="p-9">
                     <EmptyState
                       icon={GitBranch}
-                      title="no traces recorded"
-                      description="traces appear here when functions execute. fire a request to your engine and refresh."
+                      title={
+                        sessionScope
+                          ? 'no traces for this session'
+                          : 'no traces recorded'
+                      }
+                      description={
+                        sessionScope
+                          ? 'the list follows the active chat. send a message to see its work here, or clear the session chip above to see every trace.'
+                          : 'traces appear here when functions execute. fire a request to your engine and refresh.'
+                      }
                     />
                   </div>
                 ) : (

--- a/console/web/src/pages/TracesV2/lib/traceChatLink.test.ts
+++ b/console/web/src/pages/TracesV2/lib/traceChatLink.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { traceChatLink } from './traceChatLink'
+
+describe('traceChatLink', () => {
+  it('resolves from merged trace tags alone', () => {
+    const link = traceChatLink(
+      {
+        'iii.session.id': 'console-1',
+        'iii.session.name': 'my chat',
+        'iii.message.id': 't_abc',
+      },
+      [],
+    )
+    expect(link).toEqual({
+      sessionId: 'console-1',
+      sessionName: 'my chat',
+      turnId: 't_abc',
+    })
+  })
+
+  it('falls back to span attributes when tags are absent (deep-linked detail)', () => {
+    const link = traceChatLink(undefined, [
+      { attributes: { 'other.key': 'x' } },
+      { attributes: { 'iii.session.id': 'console-2' } },
+      { attributes: { 'iii.message.id': 't_def' } },
+    ])
+    expect(link).toEqual({
+      sessionId: 'console-2',
+      sessionName: undefined,
+      turnId: 't_def',
+    })
+  })
+
+  it('trace tags win over span attributes', () => {
+    const link = traceChatLink({ 'iii.session.id': 'console-tags' }, [
+      { attributes: { 'iii.session.id': 'console-span' } },
+    ])
+    expect(link?.sessionId).toBe('console-tags')
+  })
+
+  it('returns null when no span carries a session id', () => {
+    expect(traceChatLink(undefined, [{ attributes: { a: 'b' } }])).toBeNull()
+    expect(traceChatLink({}, [])).toBeNull()
+  })
+
+  it('ignores empty and non-string values', () => {
+    const link = traceChatLink({ 'iii.session.id': '' }, [
+      { attributes: { 'iii.session.id': 42 } },
+      { attributes: { 'iii.session.id': 'console-3' } },
+    ])
+    expect(link?.sessionId).toBe('console-3')
+  })
+})

--- a/console/web/src/pages/TracesV2/lib/traceChatLink.ts
+++ b/console/web/src/pages/TracesV2/lib/traceChatLink.ts
@@ -1,0 +1,52 @@
+// Chat linkage of one trace: which conversation (and which turn of it)
+// produced the spans. Every span a harness turn spawns carries the identity
+// as baggage attributes (`harness/src/functions/turn.rs`), and
+// `engine::traces::list` merges them into the row's trace-level tags — so a
+// list row resolves from `trace_tags` alone, while a detail opened without
+// its row (timeline-strip click, deep link) falls back to scanning the
+// loaded spans' own attributes.
+
+import { SESSION_ID_ATTR } from './followTurn'
+
+/** `iii.message.id` — the harness TURN id (`t_<uuid>`), not the console's
+ *  `msg-<uuid>`. See timeline-span-tags.md. */
+export const MESSAGE_ID_ATTR = 'iii.message.id'
+export const SESSION_NAME_ATTR = 'iii.session.name'
+
+export interface TraceChatLink {
+  /** engine session_id (= the console's `Conversation.id`) */
+  sessionId: string
+  /** session title at emit time, for the button label */
+  sessionName?: string
+  /** harness turn id, when the trace belongs to a single turn */
+  turnId?: string
+}
+
+function str(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+/**
+ * Resolve a trace's chat linkage from its merged trace tags, falling back
+ * to the first span attributes that carry each key. Returns null when no
+ * span of the trace was stamped with a session id (engine-internal traces,
+ * non-harness workloads).
+ */
+export function traceChatLink(
+  traceTags: Record<string, string> | undefined,
+  spans: ReadonlyArray<{ attributes?: Record<string, unknown> }>,
+): TraceChatLink | null {
+  let sessionId = str(traceTags?.[SESSION_ID_ATTR])
+  let sessionName = str(traceTags?.[SESSION_NAME_ATTR])
+  let turnId = str(traceTags?.[MESSAGE_ID_ATTR])
+  for (const span of spans) {
+    if (sessionId && sessionName && turnId) break
+    const attrs = span.attributes
+    if (!attrs) continue
+    sessionId ??= str(attrs[SESSION_ID_ATTR])
+    sessionName ??= str(attrs[SESSION_NAME_ATTR])
+    turnId ??= str(attrs[MESSAGE_ID_ATTR])
+  }
+  if (!sessionId) return null
+  return { sessionId, sessionName, turnId }
+}

--- a/console/web/src/pages/TracesV2/lib/traceFilters.test.ts
+++ b/console/web/src/pages/TracesV2/lib/traceFilters.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { withSessionScope } from './traceFilters'
+
+describe('withSessionScope', () => {
+  it('is a no-op without a session', () => {
+    const params = { service_name: 'harness' }
+    expect(withSessionScope(params, null)).toBe(params)
+  })
+
+  it('adds the session attribute AND the all-spans search shape', () => {
+    // The identity attrs live on child spans — without search_all_spans a
+    // roots-only attribute filter matches nothing (verified live).
+    expect(withSessionScope({}, 'console-1')).toEqual({
+      attributes: [['iii.session.id', 'console-1']],
+      search_all_spans: true,
+    })
+  })
+
+  it('appends after user attribute filters instead of replacing them', () => {
+    const scoped = withSessionScope(
+      { attributes: [['iii.tag.kind', 'harness.turn']] },
+      'console-1',
+    )
+    expect(scoped.attributes).toEqual([
+      ['iii.tag.kind', 'harness.turn'],
+      ['iii.session.id', 'console-1'],
+    ])
+  })
+
+  it('does not mutate the input params', () => {
+    const params = { attributes: [['a', 'b']] as [string, string][] }
+    withSessionScope(params, 'console-1')
+    expect(params.attributes).toEqual([['a', 'b']])
+  })
+})

--- a/console/web/src/pages/TracesV2/lib/traceFilters.ts
+++ b/console/web/src/pages/TracesV2/lib/traceFilters.ts
@@ -7,6 +7,7 @@
 
 import type { TracesFilterParams } from '../api/traces'
 import type { TraceFilterState } from '../hooks/useTraceFilters'
+import { SESSION_ID_ATTR } from './followTurn'
 
 export interface FilterValidationWarnings {
   durationSwapped?: boolean
@@ -85,6 +86,32 @@ export function buildFilterParams(
   if (filters.sortOrder) params.sort_order = filters.sortOrder
 
   return { params, warnings }
+}
+
+/**
+ * Layer the automatic active-session scope onto built filter params.
+ *
+ * The session identity attributes (`iii.session.id`) live on WORKER child
+ * spans, never on a trace's root — a roots-only attribute filter matches
+ * nothing (verified against a live engine: 0 rows without
+ * `search_all_spans`, the session's real traces with it). So the scope
+ * rides the same wire shape as text search: match across all spans, and
+ * let the list's `dedupeToTraceRoots` collapse the response back to one
+ * row per trace. Appended after any user attribute filters, so both apply.
+ */
+export function withSessionScope(
+  params: TracesFilterParams,
+  sessionId: string | null,
+): TracesFilterParams {
+  if (!sessionId) return params
+  return {
+    ...params,
+    attributes: [
+      ...(params.attributes ?? []),
+      [SESSION_ID_ATTR, sessionId] as [string, string],
+    ],
+    search_all_spans: true,
+  }
 }
 
 /**


### PR DESCRIPTION
Links the Traces V2 screen and the chat in both directions, per MOT-4479.

## Chat → traces: the list follows the active conversation

Selecting a conversation scopes the trace list to its `iii.session.id`, server-side via `withSessionScope`. The identity attributes are stamped as baggage on worker **child** spans, never on a trace's root — a roots-only attribute filter matches nothing — so the scope rides the same `search_all_spans` wire shape as text search and the list's dedupe collapses the response back to one row per trace. A chip next to the views dropdown names the followed conversation and dismisses the scope per session; grouping is suspended while scoped (it would collapse to a single group).

## Traces → chat: "go to message"

An open trace resolves its session/turn from the row's merged trace tags (`iii.session.id` / `iii.session.name` / `iii.message.id` — the harness turn id), with a span-attribute fallback for details opened without their row (timeline-strip click, deep link). The button opens the conversation and lands the transcript on the turn's rows: the turn's entry ids embed the turn id (`e_<turn_id>_…`), the user row that started it is recovered positionally (`lib/turn-anchor.ts`), and MessageList centers + flashes the row with tail-follow paused. The focus request travels through a tiny latest-event store (`lib/trace-links.ts`) written **before** the chat pane mounts, and is consumed on landing — or dropped once a hydrated transcript provably lacks the turn, so a stale request can't fire on a later visit.

The link resolves from the list row's tags alone, so the jump is available **while the trace detail is still loading** — the button renders on the detail skeleton too, wired like its close affordance.

## Trace detail loads in pages

The detail seed used to be one flat read of up to 10k spans; a large trace could stall the worker connection with one oversized RPC response. It now pages at 250 spans (sorted by start time), with a short-page guard so a stale `total` can't loop.

## Tests

- `traceChatLink`, `trace-links`, `turn-anchor`, `traceFilters` unit tests (new)
- `pnpm typecheck` and the full `pnpm vitest run` suite (1649 tests) pass on top of main

Fixes MOT-4479

https://claude.ai/code/session_01PkBwsbShR6zyzkupCuxjoZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added links from trace details to the related chat conversation and message.
  * Selecting a trace link opens the relevant conversation and centers the associated message.
  * Added session-scoped trace views with dismissible scope indicators and tailored empty states.
  * Improved trace detail loading with paginated span retrieval.

* **Bug Fixes**
  * Improved message targeting and focus behavior as chat content loads.

* **Tests**
  * Added coverage for trace-to-chat links, session filtering, message anchoring, and focus handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->