### PR TITLE
(MOT-4479) feat(console): link traces and chat in both directions

### DIFF
--- a/console/web/e2e/multi-turn-traces.spec.ts
+++ b/console/web/e2e/multi-turn-traces.spec.ts
@@ -35,6 +35,15 @@ test('shows two traces and exposes function arguments in trace events', async ({
   ).toHaveCount(1)
 
   const traces = page.getByRole('region', { name: 'traces' })
+  // The list follows the active chat (MOT-4479): scoped to this session,
+  // flat (grouping is suspended while scoped), with a dismissable chip.
+  // Assert the scoped arrival, then clear the scope to exercise the
+  // classic grouped flow below.
+  const clearScope = traces.getByRole('button', { name: 'show all sessions' })
+  await expect(clearScope).toBeVisible()
+  await expect(traces.locator('[data-trace-row-id]')).toHaveCount(2)
+  await clearScope.click()
+
   await traces.getByRole('button', { name: 'group traces by' }).click()
   await page
     .getByRole('listbox', { name: 'group traces by' })

--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -52,7 +52,12 @@ import {
   loadedSkillIds,
   slashChip,
 } from '@/lib/slash-commands'
-import { clearChatMessageFocus, useChatMessageFocus } from '@/lib/trace-links'
+import {
+  CHAT_FOCUS_DROP_GRACE_MS,
+  clearChatMessageFocus,
+  shouldDropChatFocus,
+  useChatMessageFocus,
+} from '@/lib/trace-links'
 import { turnAnchorMessageId } from '@/lib/turn-anchor'
 import { useExtSessionChips, useExtSessionTurnSummaries } from '@/lib/ui-slots'
 import {
@@ -1815,9 +1820,13 @@ export function ChatView({
 
   /* Trace → message landing: a pending turn-focus for THIS session resolves
      to the transcript row to center (see lib/turn-anchor), recomputed as the
-     transcript hydrates. Consumed when MessageList lands on it; dropped once
-     a hydrated transcript provably lacks the turn, so a stale request can't
-     fire on a later visit. */
+     transcript hydrates. Consumed when MessageList lands on it. A missing
+     anchor drops the request only when nothing can still produce it — the
+     transcript is hydrated AND no turn is running (a live turn writes its
+     durable rows as it goes, so the click means "land there once it
+     exists") — and only after a grace, because completion flips the status
+     idle before the turn's last rows reach the transcript. So a stale
+     request still can't fire on a later visit. */
   const chatFocusEvent = useChatMessageFocus()
   const chatFocus =
     chatFocusEvent && chatFocusEvent.sessionId === conversation.id
@@ -1832,10 +1841,24 @@ export function ChatView({
   )
   useEffect(() => {
     if (!chatFocus) return
-    if (conversation.hydrated !== false && focusMessageId === null) {
-      clearChatMessageFocus(chatFocus.id)
+    if (
+      !shouldDropChatFocus({
+        hydrated: conversation.hydrated,
+        working: conversation.status === 'working',
+        anchored: focusMessageId !== null,
+      })
+    ) {
+      return
     }
-  }, [chatFocus, conversation.hydrated, focusMessageId])
+    // Any dep change — anchor resolved, a turn (re)started, a new request —
+    // cancels the pending drop; the id guard in clearChatMessageFocus keeps
+    // a stale timer from ever dropping a newer request.
+    const timer = window.setTimeout(
+      () => clearChatMessageFocus(chatFocus.id),
+      CHAT_FOCUS_DROP_GRACE_MS,
+    )
+    return () => window.clearTimeout(timer)
+  }, [chatFocus, conversation.hydrated, conversation.status, focusMessageId])
   const chatFocusIdRef = useRef<number | null>(null)
   chatFocusIdRef.current = chatFocus?.id ?? null
   const handleFocusMessageHandled = useCallback(() => {

--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -52,6 +52,8 @@ import {
   loadedSkillIds,
   slashChip,
 } from '@/lib/slash-commands'
+import { clearChatMessageFocus, useChatMessageFocus } from '@/lib/trace-links'
+import { turnAnchorMessageId } from '@/lib/turn-anchor'
 import { useExtSessionChips, useExtSessionTurnSummaries } from '@/lib/ui-slots'
 import {
   activateWorkingDir,
@@ -1811,6 +1813,37 @@ export function ChatView({
     }
   })()
 
+  /* Trace → message landing: a pending turn-focus for THIS session resolves
+     to the transcript row to center (see lib/turn-anchor), recomputed as the
+     transcript hydrates. Consumed when MessageList lands on it; dropped once
+     a hydrated transcript provably lacks the turn, so a stale request can't
+     fire on a later visit. */
+  const chatFocusEvent = useChatMessageFocus()
+  const chatFocus =
+    chatFocusEvent && chatFocusEvent.sessionId === conversation.id
+      ? chatFocusEvent
+      : undefined
+  const focusMessageId = useMemo(
+    () =>
+      chatFocus
+        ? turnAnchorMessageId(conversation.messages, chatFocus.turnId)
+        : null,
+    [chatFocus, conversation.messages],
+  )
+  useEffect(() => {
+    if (!chatFocus) return
+    if (conversation.hydrated !== false && focusMessageId === null) {
+      clearChatMessageFocus(chatFocus.id)
+    }
+  }, [chatFocus, conversation.hydrated, focusMessageId])
+  const chatFocusIdRef = useRef<number | null>(null)
+  chatFocusIdRef.current = chatFocus?.id ?? null
+  const handleFocusMessageHandled = useCallback(() => {
+    if (chatFocusIdRef.current !== null) {
+      clearChatMessageFocus(chatFocusIdRef.current)
+    }
+  }, [])
+
   const isDock = density === 'dock'
   const compact = isDock || onBack !== undefined
   const headerPad = compact ? 'px-3 sm:px-4' : 'px-3 sm:px-6 lg:px-9'
@@ -2225,6 +2258,8 @@ export function ChatView({
             : undefined
         }
         triggersById={triggersById}
+        focusMessageId={focusMessageId}
+        onFocusMessageHandled={handleFocusMessageHandled}
       />
       <LiveRegion announcement={announcer.announcement} />
 

--- a/console/web/src/components/chat/MessageList.test.tsx
+++ b/console/web/src/components/chat/MessageList.test.tsx
@@ -72,6 +72,63 @@ describe('MessageList function-trigger groups', () => {
     expect(html).toContain('show latest')
   })
 
+  it('reveals a collapsed call targeted by an external landing', () => {
+    const html = renderToStaticMarkup(
+      <MessageList messages={transcript()} focusMessageId="c1" />,
+    )
+
+    // c1 hides behind the first group's collapse; the landing request must
+    // expand that group in the same render so the row exists to center.
+    expect(html.match(/data-message-role="function-call"/g)).toHaveLength(4)
+    expect(html).toContain('data-message-row="c1"')
+    expect(html).toContain('show latest')
+  })
+
+  it('keeps groups collapsed when the landing target is visible elsewhere', () => {
+    const html = renderToStaticMarkup(
+      <MessageList messages={transcript()} focusMessageId="intro" />,
+    )
+
+    expect(html.match(/data-message-role="function-call"/g)).toHaveLength(2)
+    expect(html).toContain('show all')
+  })
+
+  it('reveals a hidden wake pair when the landing targets its notification', () => {
+    const notification: UserMessage = {
+      id: 'e_fire_sub_1_1',
+      role: 'user',
+      content: '[notification] build: {"ok":true}',
+      createdAt: 0,
+      notification: true,
+    }
+    const fired: Message = {
+      id: 'e_trigfired_sub_1_1',
+      role: 'system',
+      kind: 'trigger-fired',
+      content: 'build · notified this chat',
+      trigger: {
+        subscription_id: 'sub_1',
+        target: 'harness::send',
+        once: false,
+        retired: false,
+        fired_at: 1,
+      },
+      createdAt: 0,
+    }
+    const html = renderToStaticMarkup(
+      <MessageList
+        messages={[notification, fired, call('c1'), call('c2')]}
+        focusMessageId="e_fire_sub_1_1"
+      />,
+    )
+
+    // The pair collapses to one row carrying both entry ids; the absorbed
+    // notification id must reveal it and be findable on the row.
+    expect(html).toContain(
+      'data-message-row="e_trigfired_sub_1_1 e_fire_sub_1_1"',
+    )
+  })
+
   it('exposes a pending approval as a focusable, named action target', () => {
     const pending: FunctionTriggerMessage = {
       ...call('approval'),

--- a/console/web/src/components/chat/MessageList.tsx
+++ b/console/web/src/components/chat/MessageList.tsx
@@ -118,6 +118,13 @@ interface MessageListProps {
   defaultOpenCalls?: boolean
   /** Registration rows by subscription id, for trigger-fired card detail. */
   triggersById?: ReadonlyMap<string, SessionTriggerInfo>
+  /**
+   * External landing request (trace → "go to message"): once this row's node
+   * exists, the list centers it, flashes it, and calls
+   * `onFocusMessageHandled` so the owner can consume the request.
+   */
+  focusMessageId?: string | null
+  onFocusMessageHandled?: () => void
 }
 
 /**
@@ -299,6 +306,8 @@ export function MessageList({
   worktreePicker,
   defaultOpenCalls,
   triggersById,
+  focusMessageId,
+  onFocusMessageHandled,
 }: MessageListProps) {
   const containerRef = useRef<HTMLElement>(null)
   const contentRef = useRef<HTMLDivElement>(null)
@@ -595,6 +604,70 @@ export function MessageList({
     writeScrollTop,
   ])
 
+  /* External landing (trace → "go to message"): center the requested row
+     once it exists, then hand the request back to the owner. Tail following
+     is paused first so a live tail can't yank the view back down; the flash
+     gives the jump a visible landmark. Gated on hydration so it never
+     centers against a partial history. */
+  const focusAppliedRef = useRef<string | null>(null)
+  // biome-ignore lint/correctness/useExhaustiveDependencies: message arrival is the retry trigger while the target row hasn't rendered yet.
+  useEffect(() => {
+    if (!focusMessageId) {
+      focusAppliedRef.current = null
+      return
+    }
+    if (!transcriptHydrated || focusAppliedRef.current === focusMessageId) {
+      return
+    }
+    const container = containerRef.current
+    const content = contentRef.current
+    if (!container || !content) return
+    // `data-message-row` is the transcript-row identity (top-level rows,
+    // group items, group summaries) — not `data-message-id`, which is the
+    // card-level attribute the approval jump uses.
+    const node = Array.from(
+      content.querySelectorAll<HTMLElement>('[data-message-row]'),
+    ).find((el) => el.dataset.messageRow === focusMessageId)
+    if (!node) return
+    focusAppliedRef.current = focusMessageId
+    cancelTailAnimation()
+    didInitialScrollRef.current = true
+    transitionTailState('paused')
+    const containerRect = container.getBoundingClientRect()
+    const nodeRect = node.getBoundingClientRect()
+    const centeredTop =
+      container.scrollTop +
+      nodeRect.top -
+      containerRect.top -
+      (container.clientHeight - nodeRect.height) / 2
+    const target = Math.max(
+      0,
+      Math.min(tailScrollTarget(container), centeredTop),
+    )
+    if (reducedMotionRef.current) writeScrollTop(container, target)
+    else container.scrollTo({ top: target, behavior: 'smooth' })
+    if (typeof node.animate === 'function') {
+      node.animate(
+        [
+          {
+            backgroundColor: 'color-mix(in srgb, currentColor 5%, transparent)',
+          },
+          { backgroundColor: 'transparent' },
+        ],
+        { duration: 900, easing: 'ease-out' },
+      )
+    }
+    onFocusMessageHandled?.()
+  }, [
+    focusMessageId,
+    transcriptHydrated,
+    messages,
+    onFocusMessageHandled,
+    cancelTailAnimation,
+    transitionTailState,
+    writeScrollTop,
+  ])
+
   if (messages.length === 0 && !header) {
     return (
       <EmptyState
@@ -830,7 +903,11 @@ function FunctionTriggerGroup({
             const notification =
               item.kind === 'trigger-activity' ? item.notification : undefined
             return (
-              <div key={item.id} className={cn(index > 0 && '-mt-6.5')}>
+              <div
+                key={item.id}
+                data-message-row={message.id}
+                className={cn(index > 0 && '-mt-6.5')}
+              >
                 <Message
                   message={message}
                   triggerNotification={notification}
@@ -853,7 +930,9 @@ function FunctionTriggerGroup({
         </div>
       </div>
       {row.summary ? (
-        <Message message={row.summary} copyText={summaryCopyText} />
+        <div data-message-row={row.summary.id}>
+          <Message message={row.summary} copyText={summaryCopyText} />
+        </div>
       ) : null}
     </section>
   )

--- a/console/web/src/components/chat/MessageList.tsx
+++ b/console/web/src/components/chat/MessageList.tsx
@@ -121,7 +121,8 @@ interface MessageListProps {
   /**
    * External landing request (trace → "go to message"): once this row's node
    * exists, the list centers it, flashes it, and calls
-   * `onFocusMessageHandled` so the owner can consume the request.
+   * `onFocusMessageHandled` so the owner can consume the request. A target
+   * hidden behind a collapsed activity group is revealed first.
    */
   focusMessageId?: string | null
   onFocusMessageHandled?: () => void
@@ -624,10 +625,11 @@ export function MessageList({
     if (!container || !content) return
     // `data-message-row` is the transcript-row identity (top-level rows,
     // group items, group summaries) — not `data-message-id`, which is the
-    // card-level attribute the approval jump uses.
+    // card-level attribute the approval jump uses. A row that absorbed a
+    // wake notification carries both entry ids, space-separated.
     const node = Array.from(
       content.querySelectorAll<HTMLElement>('[data-message-row]'),
-    ).find((el) => el.dataset.messageRow === focusMessageId)
+    ).find((el) => el.dataset.messageRow?.split(' ').includes(focusMessageId))
     if (!node) return
     focusAppliedRef.current = focusMessageId
     cancelTailAnimation()
@@ -733,6 +735,7 @@ export function MessageList({
                     renderers={renderers}
                     registrations={registrations}
                     defaultOpenCalls={defaultOpenCalls}
+                    focusMessageId={focusMessageId}
                     onResolveApproval={onResolveApproval}
                     onAlwaysAllow={onAlwaysAllow}
                     onResolveFilesystemAccess={onResolveFilesystemAccess}
@@ -828,6 +831,8 @@ interface FunctionTriggerGroupProps {
   onResolveFilesystemAccess?: MessageListProps['onResolveFilesystemAccess']
   onManageFilesystemAccess?: MessageListProps['onManageFilesystemAccess']
   workingDir?: string | null
+  /** External landing target — a hidden matching item expands the group. */
+  focusMessageId?: string | null
 }
 
 /**
@@ -847,6 +852,7 @@ function FunctionTriggerGroup({
   onResolveFilesystemAccess,
   onManageFilesystemAccess,
   workingDir,
+  focusMessageId,
 }: FunctionTriggerGroupProps) {
   const [expanded, setExpanded] = useState(!!defaultOpenCalls)
   const contentId = useId()
@@ -857,6 +863,24 @@ function FunctionTriggerGroup({
         renderer.isMatch(call.functionId),
     ),
   )
+  // External landing (trace → "go to message"): a target hidden behind the
+  // collapse must have a DOM row in the same render the request resolves, so
+  // the reveal happens here, via the render-phase setState pattern. Latched
+  // through `expanded` — not derived — so consuming the request doesn't
+  // re-collapse the revealed row. An absorbed wake notification is this
+  // row's transcript entry too, so it counts as a match.
+  const ownsFocusTarget = (item: (typeof row.items)[number]) =>
+    item.message.id === focusMessageId ||
+    (item.kind === 'trigger-activity' &&
+      item.notification?.id === focusMessageId)
+  if (
+    !expanded &&
+    focusMessageId != null &&
+    !collapsedItems.some(ownsFocusTarget) &&
+    row.items.some(ownsFocusTarget)
+  ) {
+    setExpanded(true)
+  }
   const hiddenCount = row.items.length - collapsedItems.length
   const visibleItems = expanded ? row.items : collapsedItems
   const canCollapse = hiddenCount > 0
@@ -905,7 +929,11 @@ function FunctionTriggerGroup({
             return (
               <div
                 key={item.id}
-                data-message-row={message.id}
+                // An item that absorbed its wake notification represents two
+                // transcript entries; the row id carries both, space-separated.
+                data-message-row={
+                  notification ? `${message.id} ${notification.id}` : message.id
+                }
                 className={cn(index > 0 && '-mt-6.5')}
               >
                 <Message

--- a/console/web/src/lib/conversations-context.tsx
+++ b/console/web/src/lib/conversations-context.tsx
@@ -42,6 +42,13 @@ const backend = getDefaultBackend()
 
 interface ConversationsContextValue extends ConversationsApi {
   backend: ChatBackend
+  /**
+   * Select a conversation AND ask the host to place the chat pane — the
+   * programmatic "open this session" other screens use (e.g. a trace's
+   * open-session button). Same behavior as an injected page's
+   * `ConversationAdapter.selectConversation`.
+   */
+  openConversation: (sessionId: string) => void
   modelOptions: ModelOption[]
   catalogLoading: boolean
   /** Providers present as harness workers (configured or not). */
@@ -230,9 +237,14 @@ export function ConversationsProvider({
     }
   }, [injectableUiRuntime])
 
+  const openConversation = useCallback((sessionId: string) => {
+    conversationAdapterRef.current?.selectConversation(sessionId)
+  }, [])
+
   const value: ConversationsContextValue = {
     ...api,
     backend,
+    openConversation,
     modelOptions,
     catalogLoading,
     presentProviders,

--- a/console/web/src/lib/session-id.ts
+++ b/console/web/src/lib/session-id.ts
@@ -1,12 +1,15 @@
 /**
  * Message / session ID helpers.
  *
- * One fresh `msg-<uuid>` per send. It flows into the engine via baggage so
- * the traces UI can "Group by message", and rides `harness::send` as the
+ * One fresh `msg-<uuid>` per send. It rides `harness::send` as the
  * `idempotency_key`, from which the harness derives the user message's
  * session-manager entry id (`e_idem_<message_id>`) — which is also how the
  * console's optimistic user row reconciles in place (see
- * `predictedUserEntryId` in lib/backend/harness-send.ts).
+ * `predictedUserEntryId` in lib/backend/harness-send.ts) — and travels in
+ * `options.metadata.message_id`. It does NOT reach the trace baggage: the
+ * `iii.message.id` span attribute the traces UI groups by is the harness
+ * TURN id (`t_<uuid>`, see harness/src/functions/turn.rs), correlated back
+ * to transcript rows via the `e_<turn_id>_…` entry ids (lib/turn-anchor.ts).
  *
  * (Conversation ids are minted with the `console-` prefix via
  * [`newSessionId`] and double as the engine session_id, so there is no
@@ -33,9 +36,9 @@ function mintId(prefix: string): string {
 }
 
 /**
- * Mint a fresh message_id for a single turn. Called once per `send()`
- * so every user turn lands under its own `iii.message.id` bucket in
- * the traces UI's "Group by message" view.
+ * Mint a fresh message_id for a single turn. Called once per `send()` so
+ * every user turn gets its own idempotency key (and thus its own
+ * `e_idem_<message_id>` transcript entry).
  */
 export function newMessageId(): string {
   return mintId(MESSAGE_PREFIX)

--- a/console/web/src/lib/trace-links.test.ts
+++ b/console/web/src/lib/trace-links.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  clearChatMessageFocus,
+  getChatMessageFocus,
+  requestChatMessageFocus,
+  resetTraceLinksForTests,
+} from './trace-links'
+
+beforeEach(resetTraceLinksForTests)
+
+describe('chat message focus (traces → chat)', () => {
+  it('carries the session and the harness turn id', () => {
+    const event = requestChatMessageFocus({
+      sessionId: 'console-1',
+      turnId: 't_abc',
+    })
+    expect(getChatMessageFocus()).toBe(event)
+    expect(event.sessionId).toBe('console-1')
+    expect(event.turnId).toBe('t_abc')
+  })
+
+  it('a newer request replaces the pending one', () => {
+    const first = requestChatMessageFocus({
+      sessionId: 'console-1',
+      turnId: 't_a',
+    })
+    const second = requestChatMessageFocus({
+      sessionId: 'console-1',
+      turnId: 't_b',
+    })
+    expect(second.id).toBe(first.id + 1)
+    expect(getChatMessageFocus()).toBe(second)
+  })
+
+  it('clear is id-guarded and idempotent', () => {
+    const first = requestChatMessageFocus({
+      sessionId: 'console-1',
+      turnId: 't_a',
+    })
+    const second = requestChatMessageFocus({
+      sessionId: 'console-1',
+      turnId: 't_b',
+    })
+    clearChatMessageFocus(first.id)
+    expect(getChatMessageFocus()).toBe(second)
+    clearChatMessageFocus(second.id)
+    expect(getChatMessageFocus()).toBeUndefined()
+    clearChatMessageFocus(second.id)
+  })
+})

--- a/console/web/src/lib/trace-links.test.ts
+++ b/console/web/src/lib/trace-links.test.ts
@@ -4,6 +4,7 @@ import {
   getChatMessageFocus,
   requestChatMessageFocus,
   resetTraceLinksForTests,
+  shouldDropChatFocus,
 } from './trace-links'
 
 beforeEach(resetTraceLinksForTests)
@@ -46,5 +47,39 @@ describe('chat message focus (traces → chat)', () => {
     clearChatMessageFocus(second.id)
     expect(getChatMessageFocus()).toBeUndefined()
     clearChatMessageFocus(second.id)
+  })
+})
+
+describe('shouldDropChatFocus', () => {
+  it('holds while the transcript is still hydrating', () => {
+    expect(
+      shouldDropChatFocus({ hydrated: false, working: false, anchored: false }),
+    ).toBe(false)
+  })
+
+  it('holds while a turn is running — its rows may still produce the anchor', () => {
+    expect(
+      shouldDropChatFocus({ hydrated: true, working: true, anchored: false }),
+    ).toBe(false)
+  })
+
+  it('never drops a resolved anchor', () => {
+    expect(
+      shouldDropChatFocus({ hydrated: true, working: false, anchored: true }),
+    ).toBe(false)
+  })
+
+  it('drops when hydrated, idle, and anchorless', () => {
+    expect(
+      shouldDropChatFocus({ hydrated: true, working: false, anchored: false }),
+    ).toBe(true)
+    // Backends that never track hydration count as hydrated.
+    expect(
+      shouldDropChatFocus({
+        hydrated: undefined,
+        working: false,
+        anchored: false,
+      }),
+    ).toBe(true)
   })
 })

--- a/console/web/src/lib/trace-links.ts
+++ b/console/web/src/lib/trace-links.ts
@@ -75,6 +75,30 @@ export function clearChatMessageFocus(id: number): void {
   emit()
 }
 
+/**
+ * Completion writes the turn's last transcript rows AFTER the session's
+ * status flips idle — dropping on the flip itself would eat a landing whose
+ * anchor is milliseconds away. Consumers wait this long in the droppable
+ * state before actually clearing the request.
+ */
+export const CHAT_FOCUS_DROP_GRACE_MS = 2_000
+
+/**
+ * Whether a pending focus request is provably dead: the transcript is
+ * hydrated, no anchor row resolved, and no turn is running that could still
+ * write it. A working session holds the request instead — a live turn
+ * persists its durable rows as it goes, and landing when they appear is
+ * still what the click asked for. `hydrated: undefined` counts as hydrated
+ * (backends that never track hydration).
+ */
+export function shouldDropChatFocus(state: {
+  hydrated?: boolean
+  working: boolean
+  anchored: boolean
+}): boolean {
+  return !state.anchored && state.hydrated !== false && !state.working
+}
+
 /** Test-only reset; exported to keep the store deterministic in unit tests. */
 export function resetTraceLinksForTests(): void {
   nextEventId = 1

--- a/console/web/src/lib/trace-links.ts
+++ b/console/web/src/lib/trace-links.ts
@@ -1,0 +1,83 @@
+/**
+ * Ephemeral link from the traces screen to the chat: "go to message".
+ *
+ * A tiny latest-event store modeled on `panel-context.ts`: the request is
+ * stored BEFORE listeners run, so a ChatView mounted in response to it reads
+ * the event on first render. The consumer clears the event after acting on
+ * it — a later remount of the same conversation must never re-apply a stale
+ * request.
+ *
+ * The identity this direction relies on is stamped as baggage on every span
+ * of a harness turn (`harness/src/functions/turn.rs`): `iii.session.id` is
+ * the engine session_id (= `Conversation.id`) and `iii.message.id` is the
+ * harness turn id (`t_<uuid>`) — NOT the console's `msg-<uuid>` message id.
+ *
+ * (The chat → traces direction needs no store: the traces screen follows the
+ * active conversation automatically — see the session scope in
+ * `pages/TracesV2/index.tsx`.)
+ */
+
+import { useSyncExternalStore } from 'react'
+
+/** Traces → chat: land the transcript on one turn's messages. */
+export interface ChatMessageFocusEvent {
+  id: number
+  /** engine session_id (= `Conversation.id`) */
+  sessionId: string
+  /** harness turn id (`t_<uuid>`) — the spans' `iii.message.id` */
+  turnId: string
+}
+
+let nextEventId = 1
+let chatMessageFocus: ChatMessageFocusEvent | undefined
+const chatMessageFocusListeners = new Set<() => void>()
+
+function emit(): void {
+  for (const listener of [...chatMessageFocusListeners]) listener()
+}
+
+function subscribeChatMessageFocus(listener: () => void): () => void {
+  chatMessageFocusListeners.add(listener)
+  return () => chatMessageFocusListeners.delete(listener)
+}
+
+/** Ask the chat to land on one turn's messages once its session is open. */
+export function requestChatMessageFocus(request: {
+  sessionId: string
+  turnId: string
+}): ChatMessageFocusEvent {
+  chatMessageFocus = {
+    id: nextEventId++,
+    sessionId: request.sessionId,
+    turnId: request.turnId,
+  }
+  emit()
+  return chatMessageFocus
+}
+
+export function getChatMessageFocus(): ChatMessageFocusEvent | undefined {
+  return chatMessageFocus
+}
+
+/** Reactive pending turn focus for the mounted chat view. */
+export function useChatMessageFocus(): ChatMessageFocusEvent | undefined {
+  return useSyncExternalStore(
+    subscribeChatMessageFocus,
+    () => chatMessageFocus,
+    () => undefined,
+  )
+}
+
+/** Consume a handled turn focus (id-guarded against a newer event). */
+export function clearChatMessageFocus(id: number): void {
+  if (chatMessageFocus?.id !== id) return
+  chatMessageFocus = undefined
+  emit()
+}
+
+/** Test-only reset; exported to keep the store deterministic in unit tests. */
+export function resetTraceLinksForTests(): void {
+  nextEventId = 1
+  chatMessageFocus = undefined
+  chatMessageFocusListeners.clear()
+}

--- a/console/web/src/lib/turn-anchor.test.ts
+++ b/console/web/src/lib/turn-anchor.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import type { Message } from '@/types/chat'
+import { turnAnchorMessageId } from './turn-anchor'
+
+function user(id: string): Message {
+  return { id, role: 'user', content: 'hi', createdAt: 1 }
+}
+
+function assistant(id: string): Message {
+  return { id, role: 'assistant', content: 'ok', createdAt: 2 }
+}
+
+function notice(id: string): Message {
+  return { id, role: 'system', content: 'note', createdAt: 2 }
+}
+
+describe('turnAnchorMessageId', () => {
+  it('lands on the user row that started the turn', () => {
+    const messages = [
+      user('e_idem_msg-1'),
+      assistant('e_t_aaa_0_assistant'),
+      user('e_idem_msg-2'),
+      assistant('e_t_bbb_0_assistant'),
+    ]
+    expect(turnAnchorMessageId(messages, 't_bbb')).toBe('e_idem_msg-2')
+    expect(turnAnchorMessageId(messages, 't_aaa')).toBe('e_idem_msg-1')
+  })
+
+  it('skips local-only notices between the user row and the turn', () => {
+    const messages = [
+      user('e_idem_msg-1'),
+      notice('local-uid-notice'),
+      assistant('e_t_aaa_0_assistant'),
+    ]
+    expect(turnAnchorMessageId(messages, 't_aaa')).toBe('e_idem_msg-1')
+  })
+
+  it('stops the backward walk at another durable entry', () => {
+    const messages = [
+      user('e_idem_msg-1'),
+      notice('e_t_aaa_stopped'),
+      assistant('e_t_bbb_0_assistant'),
+    ]
+    // msg-1 belongs to turn aaa's exchange — land on turn bbb itself.
+    expect(turnAnchorMessageId(messages, 't_bbb')).toBe('e_t_bbb_0_assistant')
+  })
+
+  it('falls back to the turn entry when no user row precedes it', () => {
+    const messages = [assistant('e_t_aaa_0_assistant')]
+    expect(turnAnchorMessageId(messages, 't_aaa')).toBe('e_t_aaa_0_assistant')
+  })
+
+  it('returns null for an unknown turn or empty turn id', () => {
+    const messages = [user('e_idem_msg-1'), assistant('e_t_aaa_0_assistant')]
+    expect(turnAnchorMessageId(messages, 't_zzz')).toBeNull()
+    expect(turnAnchorMessageId(messages, '')).toBeNull()
+  })
+
+  it('matches the turn id exactly, never a longer id sharing the prefix', () => {
+    const messages = [assistant('e_t_aaab_0_assistant')]
+    expect(turnAnchorMessageId(messages, 't_aaa')).toBeNull()
+  })
+})

--- a/console/web/src/lib/turn-anchor.ts
+++ b/console/web/src/lib/turn-anchor.ts
@@ -1,0 +1,34 @@
+import type { Message } from '@/types/chat'
+
+/**
+ * The transcript row a trace's "go to message" should land on, for one
+ * harness turn.
+ *
+ * Harness-derived entry ids embed the turn id — `e_<turn_id>_<step>_assistant`,
+ * `e_<turn_id>_<function_call_id>`, `e_<turn_id>_stopped` (harness/src/ids.rs)
+ * — so the turn's rows are found by prefix. The USER row that started the
+ * turn (`e_idem_<message_id>` / `e_q_<id>`) does not carry the turn id; it is
+ * recovered positionally as the nearest user row directly above the turn's
+ * first entry, which reads better as a landing point than an arbitrary tool
+ * call. The backward walk skips local-only rows (uid-based system notices)
+ * but stops at any other durable entry — a user row beyond one belongs to a
+ * different exchange.
+ *
+ * Returns null when the transcript holds no entry of that turn (e.g. a turn
+ * still streaming on optimistic local ids, or a pruned history).
+ */
+export function turnAnchorMessageId(
+  messages: ReadonlyArray<Message>,
+  turnId: string,
+): string | null {
+  if (!turnId) return null
+  const prefix = `e_${turnId}_`
+  const first = messages.findIndex((m) => m.id.startsWith(prefix))
+  if (first === -1) return null
+  for (let i = first - 1; i >= 0; i--) {
+    const m = messages[i]
+    if (m.role === 'user') return m.id
+    if (m.id.startsWith('e_')) break
+  }
+  return messages[first].id
+}

--- a/console/web/src/pages/TracesV2/api/traces.ts
+++ b/console/web/src/pages/TracesV2/api/traces.ts
@@ -57,6 +57,11 @@ export interface TracesResponse {
   total: number
   offset: number
   limit: number
+  /** Client-side marker: the engine answered "memory exporter not enabled".
+   *  Set only by `fetchTraces`, never by the wire — it is what separates
+   *  "observability is off" from an ordinary empty result, so the UI can
+   *  reserve its no-observability message for the real thing. */
+  memoryExporterDisabled?: true
 }
 
 export interface TracesFilterParams {
@@ -174,7 +179,7 @@ export async function fetchTraces(
     )
   } catch (err) {
     if (isMemoryExporterNotEnabled(err)) {
-      return { spans: [], total: 0, offset, limit }
+      return { spans: [], total: 0, offset, limit, memoryExporterDisabled: true }
     }
     throw asError(err, 'Failed to fetch traces')
   }

--- a/console/web/src/pages/TracesV2/components/TraceDetailSkeleton.tsx
+++ b/console/web/src/pages/TracesV2/components/TraceDetailSkeleton.tsx
@@ -1,6 +1,7 @@
-import { ChevronRight, Clock, Layers, X } from 'lucide-react'
+import { ChevronRight, Clock, Layers, LocateFixed, X } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import { Skeleton } from '@/components/ui/Skeleton'
+import type { TraceChatLink } from '../lib/traceChatLink'
 
 /**
  * Loading placeholder for the trace detail — mirrors the real composition
@@ -26,9 +27,17 @@ const TIMELINE_BARS: ReadonlyArray<readonly [number, number]> = [
 interface TraceDetailSkeletonProps {
   /** wired to the real close affordance so a slow load can be backed out of */
   onClose: () => void
+  /** chat linkage already resolved from the row's trace tags — live like the
+   *  close button, so the jump to the conversation never waits on the spans */
+  chatLink?: TraceChatLink | null
+  onOpenMessage?: (link: TraceChatLink) => void
 }
 
-export function TraceDetailSkeleton({ onClose }: TraceDetailSkeletonProps) {
+export function TraceDetailSkeleton({
+  onClose,
+  chatLink,
+  onOpenMessage,
+}: TraceDetailSkeletonProps) {
   return (
     <div className="flex flex-col overflow-hidden">
       {/* ── TraceHeader ── */}
@@ -67,6 +76,21 @@ export function TraceDetailSkeleton({ onClose }: TraceDetailSkeletonProps) {
           <span className="flex items-center gap-1 px-2 py-0.5 rounded-xs bg-surface">
             <Skeleton className="h-3 w-16" />
           </span>
+
+          {chatLink?.turnId && onOpenMessage ? (
+            <>
+              <span aria-hidden className="w-px h-3 bg-edge" />
+              <button
+                type="button"
+                onClick={() => onOpenMessage(chatLink)}
+                aria-label="go to message"
+                title="open the chat at this trace's message"
+                className="flex items-center px-1.5 py-0.5 rounded-xs bg-surface text-ink-faint hover:text-ink hover:bg-surface-hover transition-colors"
+              >
+                <LocateFixed className="size-4" />
+              </button>
+            </>
+          ) : null}
         </div>
 
         {/* worker share bar + names */}

--- a/console/web/src/pages/TracesV2/components/TraceHeader.tsx
+++ b/console/web/src/pages/TracesV2/components/TraceHeader.tsx
@@ -4,6 +4,7 @@ import {
   Clock,
   Copy,
   Layers,
+  Loader2,
   LocateFixed,
   X,
 } from 'lucide-react'
@@ -28,6 +29,9 @@ interface TraceHeaderProps {
   chatLink?: TraceChatLink | null
   /** Open the linked conversation AND land on this trace's turn. */
   onOpenMessage?: (link: TraceChatLink) => void
+  /** Non-null while the paged seed still sweeps — the painted detail is
+   *  incomplete and the span chip counts up instead of stating a total. */
+  loadingSpans?: { loaded: number; total: number } | null
 }
 
 export function TraceHeader({
@@ -37,6 +41,7 @@ export function TraceHeader({
   onSpanClick,
   chatLink,
   onOpenMessage,
+  loadingSpans,
 }: TraceHeaderProps) {
   const { copiedKey, copy } = useCopyToClipboard()
   const copied = copiedKey === 'traceId'
@@ -140,12 +145,29 @@ export function TraceHeader({
           </span>
         </span>
 
-        <span className="flex items-center gap-1 px-2 py-0.5 rounded-xs bg-surface">
-          <Layers className="size-4 text-ink-faint" />
-          <span className="text-[11px] font-mono text-ink-faint tabular-nums">
-            {data.span_count} spans
+        {loadingSpans ? (
+          <span
+            role="status"
+            title="spans still loading — the waterfall is filling in"
+            className="flex items-center gap-1 px-2 py-0.5 rounded-xs bg-surface"
+          >
+            <Loader2
+              aria-hidden
+              className="size-4 animate-spin text-ink-faint motion-reduce:animate-none"
+            />
+            <span className="text-[11px] font-mono text-ink-faint tabular-nums">
+              {Math.min(loadingSpans.loaded, loadingSpans.total)}/
+              {loadingSpans.total} spans
+            </span>
           </span>
-        </span>
+        ) : (
+          <span className="flex items-center gap-1 px-2 py-0.5 rounded-xs bg-surface">
+            <Layers className="size-4 text-ink-faint" />
+            <span className="text-[11px] font-mono text-ink-faint tabular-nums">
+              {data.span_count} spans
+            </span>
+          </span>
+        )}
 
         <span className="flex items-center gap-1 px-2 py-0.5 rounded-xs bg-surface">
           <span className="text-[11px] font-mono text-ink-faint tabular-nums">

--- a/console/web/src/pages/TracesV2/components/TraceHeader.tsx
+++ b/console/web/src/pages/TracesV2/components/TraceHeader.tsx
@@ -1,7 +1,16 @@
-import { AlertCircle, ChevronRight, Clock, Copy, Layers, X } from 'lucide-react'
+import {
+  AlertCircle,
+  ChevronRight,
+  Clock,
+  Copy,
+  Layers,
+  LocateFixed,
+  X,
+} from 'lucide-react'
 import { Fragment, useMemo } from 'react'
 import { Button } from '@/components/ui/Button'
 import { cn } from '@/lib/utils'
+import type { TraceChatLink } from '../lib/traceChatLink'
 import { getWorkerColor } from '../lib/traceColors'
 import type { VisualizationSpan, WaterfallData } from '../lib/traceTransform'
 import {
@@ -15,6 +24,10 @@ interface TraceHeaderProps {
   traceId: string
   onClose: () => void
   onSpanClick?: (span: VisualizationSpan) => void
+  /** The chat session/turn behind this trace, when its spans carry it. */
+  chatLink?: TraceChatLink | null
+  /** Open the linked conversation AND land on this trace's turn. */
+  onOpenMessage?: (link: TraceChatLink) => void
 }
 
 export function TraceHeader({
@@ -22,6 +35,8 @@ export function TraceHeader({
   traceId,
   onClose,
   onSpanClick,
+  chatLink,
+  onOpenMessage,
 }: TraceHeaderProps) {
   const { copiedKey, copy } = useCopyToClipboard()
   const copied = copiedKey === 'traceId'
@@ -146,6 +161,21 @@ export function TraceHeader({
             </span>
           </span>
         )}
+
+        {chatLink?.turnId && onOpenMessage ? (
+          <>
+            <span aria-hidden className="w-px h-3 bg-edge" />
+            <button
+              type="button"
+              onClick={() => onOpenMessage(chatLink)}
+              aria-label="go to message"
+              title="open the chat at this trace's message"
+              className="flex items-center px-1.5 py-0.5 rounded-xs bg-surface text-ink-faint hover:text-ink hover:bg-surface-hover transition-colors"
+            >
+              <LocateFixed className="size-4" />
+            </button>
+          </>
+        ) : null}
       </div>
 
       {workerList.length > 1 && (

--- a/console/web/src/pages/TracesV2/hooks/useTraceData.ts
+++ b/console/web/src/pages/TracesV2/hooks/useTraceData.ts
@@ -12,6 +12,7 @@ import {
   type TracesFilterParams,
   type TracesResponse,
 } from '../api/traces'
+import { collectRecentSpanWindow } from '../lib/traceDetailPages'
 import {
   dedupeToTraceRoots,
   fingerprintTraceList,
@@ -19,10 +20,21 @@ import {
 } from '../lib/traceListItem'
 
 const DEFAULT_TRACE_LIMIT = 500
+/**
+ * Span budget for `search_all_spans` seeds. Full-fat spans run 30-80KB and
+ * the server-side scan costs ~3.4s PER CALL regardless of limit/offset
+ * (measured live), so the window has to stay small: 250 recent spans cover a
+ * session's recent turns in 2-3 parallel reads. Deeper history stays
+ * reachable through the pager and text search.
+ */
+const SEARCH_SEED_MAX_SPANS = 250
 
 /** Coalesce window for the trace-tags refresh: batches the trace ids that
  *  arrived from the rows stream / activity feed into one `trace_ids` read. */
 const TAG_REFRESH_DEBOUNCE_MS = 1000
+/** Minimum gap between activity-driven reseeds of a filtered/searched list
+ *  (each one re-runs the parallel multi-MB window sweep). */
+const FILTERED_RESEED_COOLDOWN_MS = 10_000
 /** Ids per refresh read. Overflow is dropped, not queued — a still-active
  *  trace re-enters via its next activity window. */
 const TAG_REFRESH_MAX_IDS = 100
@@ -99,16 +111,42 @@ export function useTraceData({
     refetch,
   } = useQuery({
     queryKey: ['traces', filterParams, showSystem, debouncedSearch],
-    queryFn: () =>
-      fetchTraces({
+    queryFn: async (): Promise<TracesResponse> => {
+      const params = {
         ...filterParams,
         ...(debouncedSearch && !filterParams.name
           ? { name: debouncedSearch, search_all_spans: true }
           : {}),
-        offset: 0,
-        limit: DEFAULT_TRACE_LIMIT,
         include_internal: showSystem,
-      }),
+      }
+      if (params.search_all_spans !== true) {
+        // Roots-only responses carry thin spans — one read is light & safe.
+        return fetchTraces({ ...params, offset: 0, limit: DEFAULT_TRACE_LIMIT })
+      }
+      // A search_all_spans seed (session scope, text search) returns FULL
+      // spans: one big read can exceed the transport's ~16MiB delivery cap
+      // and hang forever — no error. Collect a byte-priced recency window
+      // instead, windows in parallel because the server-side scan costs
+      // seconds per call regardless of limit/offset.
+      let exporterDisabled = false
+      const { spans, total } = await collectRecentSpanWindow(
+        async (offset, limit) => {
+          const page = await fetchTraces({ ...params, offset, limit })
+          if (page.memoryExporterDisabled) exporterDisabled = true
+          return page
+        },
+        SEARCH_SEED_MAX_SPANS,
+      )
+      return exporterDisabled
+        ? {
+            spans: [],
+            total: 0,
+            offset: 0,
+            limit: SEARCH_SEED_MAX_SPANS,
+            memoryExporterDisabled: true,
+          }
+        : { spans, total, offset: 0, limit: SEARCH_SEED_MAX_SPANS }
+    },
     // This query is the one-time SEED read. Live updates arrive by APPEND over
     // the engine `iii:devtools:trace-rows` stream (see the stream effect
     // below), which merges new rows straight into this cache — no polling
@@ -116,6 +154,9 @@ export function useTraceData({
     // frames; manual Refresh re-reads on demand.
     refetchInterval: false,
     staleTime: 1000,
+    // The collector already ladders timeouts internally; stacking the
+    // default 3 retries on top would turn a failed seed into minutes.
+    retry: 1,
   })
 
   const hiddenKey = hiddenFunctions?.join(',') ?? ''
@@ -322,6 +363,30 @@ export function useTraceData({
       }, TAG_REFRESH_DEBOUNCE_MS)
     }
 
+    // Filtered/searched seeds are EXPENSIVE (parallel multi-MB windows —
+    // see the queryFn): under a busy session the rows stream would refetch
+    // them back-to-back and saturate the main thread with payload parses.
+    // Cool down to one reseed per window, trailing so the last burst lands.
+    let reseedCooldownTimer: ReturnType<typeof setTimeout> | undefined
+    let lastFilteredReseed = 0
+    const throttledFilteredReseed = () => {
+      const wait = Math.max(
+        0,
+        lastFilteredReseed + FILTERED_RESEED_COOLDOWN_MS - Date.now(),
+      )
+      if (wait === 0) {
+        lastFilteredReseed = Date.now()
+        qc.invalidateQueries({ queryKey: ['traces'] })
+        return
+      }
+      if (reseedCooldownTimer !== undefined) return
+      reseedCooldownTimer = setTimeout(() => {
+        reseedCooldownTimer = undefined
+        lastFilteredReseed = Date.now()
+        qc.invalidateQueries({ queryKey: ['traces'] })
+      }, wait)
+    }
+
     void (async () => {
       const client = await getIiiClient()
       if (disposed) return
@@ -347,7 +412,7 @@ export function useTraceData({
           // spans settle. (The filtered branch refetches, which re-reads tags.)
           scheduleTagRefresh(spans.map((s) => s.trace_id))
         } else {
-          qc.invalidateQueries({ queryKey: ['traces'] })
+          throttledFilteredReseed()
         }
         // The group-by aggregate (and any expanded group's member list)
         // can't be appended; refetch them on activity.
@@ -392,6 +457,10 @@ export function useTraceData({
         if (tagFlushTimer !== undefined) {
           clearTimeout(tagFlushTimer)
           tagFlushTimer = undefined
+        }
+        if (reseedCooldownTimer !== undefined) {
+          clearTimeout(reseedCooldownTimer)
+          reseedCooldownTimer = undefined
         }
       }
     })()

--- a/console/web/src/pages/TracesV2/hooks/useTraceData.ts
+++ b/console/web/src/pages/TracesV2/hooks/useTraceData.ts
@@ -63,7 +63,11 @@ export interface UseTraceDataReturn {
   traceGroups: TraceListItem[]
   newTraceIds: Set<string>
   setNewTraceIds: React.Dispatch<React.SetStateAction<Set<string>>>
-  hasOtelConfigured: boolean
+  /** `false` ONLY on the engine's definitive "memory exporter not enabled"
+   *  answer; `null` while no response has settled yet (render loading, not
+   *  the no-observability message); `true` once any response proves the
+   *  pipeline — an empty result is an empty list, not missing observability. */
+  hasOtelConfigured: boolean | null
   isQueryLoading: boolean
   refetch: () => void
   isHoveredRef: React.RefObject<boolean>
@@ -78,7 +82,9 @@ export function useTraceData({
   hiddenFunctions,
 }: UseTraceDataOptions): UseTraceDataReturn {
   const [traceGroups, setTraceListItems] = useState<TraceListItem[]>([])
-  const [hasOtelConfigured, setHasOtelConfigured] = useState(false)
+  const [hasOtelConfigured, setHasOtelConfigured] = useState<boolean | null>(
+    null,
+  )
   const [newTraceIds, setNewTraceIds] = useState<Set<string>>(new Set())
 
   const fingerprintRef = useRef<string>('')
@@ -113,8 +119,30 @@ export function useTraceData({
   })
 
   const hiddenKey = hiddenFunctions?.join(',') ?? ''
+
+  // A scope/filter change is a DIFFERENT question — the previous answer's
+  // rows must not linger under the new scope (measured live: the old
+  // session's trace stayed on screen, under the new session's chip, for the
+  // whole slow fetch). Dropping them also re-arms the loading skeleton.
+  const scopeKey = JSON.stringify([filterParams, showSystem, debouncedSearch])
+  const scopeKeyRef = useRef(scopeKey)
+  useEffect(() => {
+    if (scopeKeyRef.current === scopeKey) return
+    scopeKeyRef.current = scopeKey
+    setTraceListItems([])
+    fingerprintRef.current = ''
+    prevTraceIdsRef.current = new Set()
+    pendingTracesRef.current = null
+    setNewTraceIds(new Set())
+  }, [scopeKey])
+
   useEffect(() => {
     if (!tracesData) return
+    if (tracesData.memoryExporterDisabled) {
+      setTraceListItems([])
+      setHasOtelConfigured(false)
+      return
+    }
 
     if (tracesData.spans && tracesData.spans.length > 0) {
       // Search uses `search_all_spans`, which returns every span of each
@@ -157,8 +185,10 @@ export function useTraceData({
       setTraceListItems(traces)
       setHasOtelConfigured(true)
     } else {
+      // An empty answer from a working exporter is an empty list — the
+      // no-observability message is reserved for the marker above.
       setTraceListItems([])
-      setHasOtelConfigured(false)
+      setHasOtelConfigured(true)
     }
   }, [tracesData, hiddenKey])
 

--- a/console/web/src/pages/TracesV2/index.tsx
+++ b/console/web/src/pages/TracesV2/index.tsx
@@ -891,7 +891,10 @@ export function TracesV2({
       </div>
 
       <ErrorBoundary>
-        {!hasOtelConfigured ? (
+        {/* Only the engine's definitive answer earns this message — while
+            the seed is still unanswered (null) the list area renders its
+            loading skeleton instead. */}
+        {hasOtelConfigured === false ? (
           <div className="p-9">
             <Cell title="no observability">
               this engine does not have the trace exporter registered. configure

--- a/console/web/src/pages/TracesV2/index.tsx
+++ b/console/web/src/pages/TracesV2/index.tsx
@@ -430,6 +430,7 @@ export function TracesV2({
         // Pages sized by response bytes, not span count — an oversized page
         // hangs forever instead of erroring. See lib/traceDetailPages.
         let revealed = false
+        let lastPaint = 0
         const detailSpans = await collectTraceDetailSpans(
           (offset, limit) => {
             if (stale()) throw superseded
@@ -451,7 +452,15 @@ export function TracesV2({
               if (stale()) return
               detailSpansRef.current = accumulated
               setSeedProgress({ loaded: accumulated.size, total })
+              // Rebuilding the waterfall on EVERY page saturates the main
+              // thread on fat traces (measured live: no frame painted
+              // between the first page and the sweep's end). Repaint at
+              // most ~1/600ms; the chip above still counts every page, and
+              // the final rebuild after the sweep always runs.
+              const now = Date.now()
+              if (revealed && now - lastPaint < 600) return
               const wf = rebuildDetail(traceId)
+              if (wf) lastPaint = now
               if (!silent && !revealed && wf) {
                 revealed = true
                 setIsLoadingSpans(false)

--- a/console/web/src/pages/TracesV2/index.tsx
+++ b/console/web/src/pages/TracesV2/index.tsx
@@ -146,6 +146,13 @@ export function TracesV2({
   }, [selectedSpan, waterfallData])
   const [isLoadingSpans, setIsLoadingSpans] = useState(false)
   const [spansError, setSpansError] = useState<string | null>(null)
+  // Non-null while the paged seed still sweeps: the detail is painted but
+  // incomplete. Drives the header's live span counter so "still filling in"
+  // is legible after the skeleton is gone.
+  const [seedProgress, setSeedProgress] = useState<{
+    loaded: number
+    total: number
+  } | null>(null)
 
   const {
     filters: filterState,
@@ -411,6 +418,9 @@ export function TracesV2({
       const seq = ++seedSeqRef.current
       const stale = () => seedSeqRef.current !== seq
       const silent = opts?.silent ?? false
+      // Newest seed owns the progress chip from the start — a superseded
+      // sweep's last reading must not survive the switch.
+      setSeedProgress(null)
       if (!silent) {
         setIsLoadingSpans(true)
         setSpansError(null)
@@ -437,9 +447,10 @@ export function TracesV2({
             // Paint from the first page: a large trace fills in page by page
             // (the shape live appends already have) instead of holding the
             // skeleton through the whole multi-second sweep.
-            onPage: (accumulated) => {
+            onPage: (accumulated, total) => {
               if (stale()) return
               detailSpansRef.current = accumulated
+              setSeedProgress({ loaded: accumulated.size, total })
               const wf = rebuildDetail(traceId)
               if (!silent && !revealed && wf) {
                 revealed = true
@@ -463,7 +474,10 @@ export function TracesV2({
           )
         }
       } finally {
-        if (!stale() && !silent) setIsLoadingSpans(false)
+        if (!stale()) {
+          setSeedProgress(null)
+          if (!silent) setIsLoadingSpans(false)
+        }
       }
     },
     [rebuildDetail],
@@ -732,6 +746,7 @@ export function TracesV2({
               onSpanClick={setSelectedSpan}
               chatLink={chatLink}
               onOpenMessage={handleOpenMessage}
+              loadingSpans={seedProgress}
             />
             <div className="border-b border-rule-2 px-3 py-2">
               <ViewSwitcher

--- a/console/web/src/pages/TracesV2/index.tsx
+++ b/console/web/src/pages/TracesV2/index.tsx
@@ -909,12 +909,14 @@ export function TracesV2({
                       icon={GitBranch}
                       title={
                         sessionScope
-                          ? 'no traces for this session'
+                          ? 'no stored traces for this session'
                           : 'no traces recorded'
                       }
                       description={
                         sessionScope
-                          ? 'the list follows the active chat. send a message to see its work here, or clear the session chip above to see every trace.'
+                          ? // The client cannot tell "never ran" from "already
+                            // expired", so the copy owns both honestly.
+                            'the list follows the active chat, and nothing is stored for this conversation — no work recorded yet, or its traces already expired. new activity appears here as it runs, or clear the session chip above to see every trace.'
                           : 'traces appear here when functions execute. fire a request to your engine and refresh.'
                       }
                     />

--- a/console/web/src/pages/TracesV2/index.tsx
+++ b/console/web/src/pages/TracesV2/index.tsx
@@ -95,6 +95,9 @@ import {
 
 const PAGE_SIZES = [25, 50, 100]
 
+// Sentinel a superseded trace seed throws to abandon its own page sweep.
+const superseded = new Error('trace seed superseded')
+
 export interface TracesV2Props {
   /** mount with a trace's detail already expanded (stories/deep links) */
   initialTraceId?: string
@@ -398,8 +401,15 @@ export function TracesV2({
     return () => clearInterval(timer)
   }, [hasPendingSpans, selectedTraceId, isPaused, rebuildDetail])
 
+  // One seed at a time: selecting another trace supersedes the sweep in
+  // flight, which must neither clobber the new trace's spans nor surface
+  // its own late error. Progressive rendering makes this guard load-bearing
+  // — a stale sweep now touches state on every page, not just at the end.
+  const seedSeqRef = useRef(0)
   const loadTraceSpans = useCallback(
     async (traceId: string, opts?: { silent?: boolean }) => {
+      const seq = ++seedSeqRef.current
+      const stale = () => seedSeqRef.current !== seq
       const silent = opts?.silent ?? false
       if (!silent) {
         setIsLoadingSpans(true)
@@ -409,17 +419,36 @@ export function TracesV2({
       try {
         // Pages sized by response bytes, not span count — an oversized page
         // hangs forever instead of erroring. See lib/traceDetailPages.
-        const detailSpans = await collectTraceDetailSpans((offset, limit) =>
-          fetchTraces({
-            trace_id: traceId,
-            search_all_spans: true,
-            include_internal: false,
-            sort_by: 'start_time',
-            sort_order: 'asc',
-            offset,
-            limit,
-          }),
+        let revealed = false
+        const detailSpans = await collectTraceDetailSpans(
+          (offset, limit) => {
+            if (stale()) throw superseded
+            return fetchTraces({
+              trace_id: traceId,
+              search_all_spans: true,
+              include_internal: false,
+              sort_by: 'start_time',
+              sort_order: 'asc',
+              offset,
+              limit,
+            })
+          },
+          {
+            // Paint from the first page: a large trace fills in page by page
+            // (the shape live appends already have) instead of holding the
+            // skeleton through the whole multi-second sweep.
+            onPage: (accumulated) => {
+              if (stale()) return
+              detailSpansRef.current = accumulated
+              const wf = rebuildDetail(traceId)
+              if (!silent && !revealed && wf) {
+                revealed = true
+                setIsLoadingSpans(false)
+              }
+            },
+          },
         )
+        if (stale()) return
 
         detailSpansRef.current = detailSpans
         const wf = rebuildDetail(traceId)
@@ -427,13 +456,14 @@ export function TracesV2({
           setSpansError('no span data available for this trace')
         }
       } catch (err) {
+        if (stale() || err === superseded) return
         if (!silent) {
           setSpansError(
             err instanceof Error ? err.message : 'failed to load trace',
           )
         }
       } finally {
-        if (!silent) setIsLoadingSpans(false)
+        if (!stale() && !silent) setIsLoadingSpans(false)
       }
     },
     [rebuildDetail],

--- a/console/web/src/pages/TracesV2/index.tsx
+++ b/console/web/src/pages/TracesV2/index.tsx
@@ -76,6 +76,7 @@ import { useTraceFilters } from './hooks/useTraceFilters'
 import { useTraceViews } from './hooks/useTraceViews'
 import { isTraceLive } from './lib/timelineSpans'
 import { type TraceChatLink, traceChatLink } from './lib/traceChatLink'
+import { collectTraceDetailSpans } from './lib/traceDetailPages'
 import { withSessionScope } from './lib/traceFilters'
 import type { RowLabelConfig } from './lib/traceListItem'
 import {
@@ -93,11 +94,6 @@ import {
 } from './lib/traceTransform'
 
 const PAGE_SIZES = [25, 50, 100]
-// Keep each detail RPC well below the WebSocket payload limit. A trace may
-// contain thousands of spans with rich events and attributes; loading it in
-// pages preserves the complete detail without making one oversized response
-// stall the worker connection.
-const TRACE_DETAIL_PAGE_SIZE = 250
 
 export interface TracesV2Props {
   /** mount with a trace's detail already expanded (stories/deep links) */
@@ -411,29 +407,19 @@ export function TracesV2({
         setWaterfallData(null)
       }
       try {
-        const detailSpans = new Map<string, StoredSpan>()
-        let offset = 0
-        let total = Number.POSITIVE_INFINITY
-
-        while (offset < total) {
-          const page = await fetchTraces({
+        // Pages sized by response bytes, not span count — an oversized page
+        // hangs forever instead of erroring. See lib/traceDetailPages.
+        const detailSpans = await collectTraceDetailSpans((offset, limit) =>
+          fetchTraces({
             trace_id: traceId,
             search_all_spans: true,
             include_internal: false,
             sort_by: 'start_time',
             sort_order: 'asc',
             offset,
-            limit: TRACE_DETAIL_PAGE_SIZE,
-          })
-
-          for (const span of page.spans) detailSpans.set(span.span_id, span)
-          total = page.total
-
-          // A short page prevents an incorrect or stale `total` from turning
-          // into an unbounded request loop while a trace is completing.
-          if (page.spans.length < TRACE_DETAIL_PAGE_SIZE) break
-          offset += page.spans.length
-        }
+            limit,
+          }),
+        )
 
         detailSpansRef.current = detailSpans
         const wf = rebuildDetail(traceId)

--- a/console/web/src/pages/TracesV2/index.tsx
+++ b/console/web/src/pages/TracesV2/index.tsx
@@ -22,7 +22,13 @@
  * seed read from fixtures.
  */
 
-import { AlertCircle, GitBranch, RefreshCw } from 'lucide-react'
+import {
+  AlertCircle,
+  GitBranch,
+  MessageSquare,
+  RefreshCw,
+  X,
+} from 'lucide-react'
 import {
   useCallback,
   useEffect,
@@ -41,6 +47,7 @@ import { Skeleton } from '@/components/ui/Skeleton'
 import { StatusPanel } from '@/components/ui/StatusPanel'
 import { useConversationsCtxOptional } from '@/lib/conversations-context'
 import { getIiiClient } from '@/lib/iii-client'
+import { requestChatMessageFocus } from '@/lib/trace-links'
 import { startTraceSpansStream } from '@/lib/traces-stream'
 import { cn } from '@/lib/utils'
 import type { PageCommandsApi } from '@/types/injectable-ui'
@@ -68,6 +75,8 @@ import { useTraceData } from './hooks/useTraceData'
 import { useTraceFilters } from './hooks/useTraceFilters'
 import { useTraceViews } from './hooks/useTraceViews'
 import { isTraceLive } from './lib/timelineSpans'
+import { type TraceChatLink, traceChatLink } from './lib/traceChatLink'
+import { withSessionScope } from './lib/traceFilters'
 import type { RowLabelConfig } from './lib/traceListItem'
 import {
   applyViewConfig,
@@ -84,6 +93,11 @@ import {
 } from './lib/traceTransform'
 
 const PAGE_SIZES = [25, 50, 100]
+// Keep each detail RPC well below the WebSocket payload limit. A trace may
+// contain thousands of spans with rich events and attributes; loading it in
+// pages preserves the complete detail without making one oversized response
+// stall the worker connection.
+const TRACE_DETAIL_PAGE_SIZE = 250
 
 export interface TracesV2Props {
   /** mount with a trace's detail already expanded (stories/deep links) */
@@ -144,9 +158,29 @@ export function TracesV2({
     clearValidationWarnings,
   } = useTraceFilters()
 
+  // ── Automatic session scope ──
+  // The trace list FOLLOWS the active chat: selecting a conversation scopes
+  // the list to its `iii.session.id`, server-side via `withSessionScope`
+  // (the identity attrs live on child spans, so the scope needs the
+  // search-all-spans wire shape). Drafts have no session server-side yet and
+  // never scope; outside the app shell (Storybook) there is no chat to
+  // follow. Dismissable per session via the chip next to the views dropdown
+  // — selecting another conversation re-scopes.
+  const conversationsCtx = useConversationsCtxOptional()
+  const activeConversation = conversationsCtx?.active ?? null
+  const [scopeDismissedFor, setScopeDismissedFor] = useState<string | null>(
+    null,
+  )
+  const sessionScope =
+    activeConversation &&
+    !activeConversation.draft &&
+    activeConversation.id !== scopeDismissedFor
+      ? activeConversation.id
+      : null
+
   const filterParams = useMemo(
-    () => getFilterOnlyParams(),
-    [getFilterOnlyParams],
+    () => withSessionScope(getFilterOnlyParams(), sessionScope),
+    [getFilterOnlyParams, sessionScope],
   )
 
   const {
@@ -249,8 +283,14 @@ export function TracesV2({
     })
   }, [traceGroups])
 
+  // Scoped to one session, grouping would collapse to a single group (and
+  // the group-by aggregate path doesn't consult the scope) — render the
+  // flat list instead. The view's row label (e.g. `iii.tag.message`) still
+  // applies, so scoped rows read as the session's turns.
   const groupByAttribute =
-    filterState.groupBy && filterState.groupBy !== 'none'
+    sessionScope === null &&
+    filterState.groupBy &&
+    filterState.groupBy !== 'none'
       ? filterState.groupBy
       : null
 
@@ -270,9 +310,8 @@ export function TracesV2({
   // Follow toggle (strip header): auto-open the trace of the ACTIVE chat's
   // live turn, so sending a message lands the canvas on the work as it runs.
   // Scoped to user interactions — the active conversation's top-level
-  // `harness.turn` steps; sub-agent turns never steal the view. Null outside
-  // the app shell (Storybook), which also hides the strip's toggle.
-  const conversationsCtx = useConversationsCtxOptional()
+  // `harness.turn` steps; sub-agent turns never steal the view. The strip's
+  // toggle hides outside the app shell (no conversationsCtx in Storybook).
   const { followTurns, toggleFollowTurns } = useFollowTurns()
 
   // Span-filter fallout on the LIST: a row hides while its trace has no
@@ -334,7 +373,8 @@ export function TracesV2({
   const containerRef = useRef<HTMLDivElement>(null)
   const spanPanel = useSpanPanelResize(containerRef)
 
-  // Live detail: the selected trace's spans are seeded once (one flat read),
+  // Live detail: the selected trace's spans are seeded on explicit open,
+  // paged so a very large trace never becomes one oversized RPC response;
   // then APPENDED from the engine `trace-spans` stream and rebuilt into the
   // waterfall via `toWaterfallData`. Accumulated by `span_id` so re-delivered
   // spans dedupe. Frozen while paused.
@@ -371,13 +411,31 @@ export function TracesV2({
         setWaterfallData(null)
       }
       try {
-        const { spans } = await fetchTraces({
-          trace_id: traceId,
-          search_all_spans: true,
-          include_internal: false,
-          limit: 10000,
-        })
-        detailSpansRef.current = new Map(spans.map((s) => [s.span_id, s]))
+        const detailSpans = new Map<string, StoredSpan>()
+        let offset = 0
+        let total = Number.POSITIVE_INFINITY
+
+        while (offset < total) {
+          const page = await fetchTraces({
+            trace_id: traceId,
+            search_all_spans: true,
+            include_internal: false,
+            sort_by: 'start_time',
+            sort_order: 'asc',
+            offset,
+            limit: TRACE_DETAIL_PAGE_SIZE,
+          })
+
+          for (const span of page.spans) detailSpans.set(span.span_id, span)
+          total = page.total
+
+          // A short page prevents an incorrect or stale `total` from turning
+          // into an unbounded request loop while a trace is completing.
+          if (page.spans.length < TRACE_DETAIL_PAGE_SIZE) break
+          offset += page.spans.length
+        }
+
+        detailSpansRef.current = detailSpans
         const wf = rebuildDetail(traceId)
         if (!wf && !silent) {
           setSpansError('no span data available for this trace')
@@ -504,6 +562,37 @@ export function TracesV2({
     onOpenTrace: selectTrace,
   })
 
+  // Chat linkage of the OPEN trace (session + turn), resolved from the row's
+  // merged trace tags with a span-attribute fallback for details opened
+  // without their row (timeline-strip click, deep link). The row tags come
+  // with the LIST fetch, so the link resolves — and the jump-to-chat works —
+  // while the paged detail is still loading; only the fallback path waits
+  // for spans. The buttons only render inside the app shell — outside it
+  // (Storybook) there is no conversation surface to open.
+  const chatLink = useMemo(() => {
+    if (selectedTraceId === null) return null
+    const tags = traceGroups.find(
+      (t) => t.traceId === selectedTraceId,
+    )?.traceTags
+    return traceChatLink(tags, waterfallData?.spans ?? [])
+  }, [waterfallData, traceGroups, selectedTraceId])
+
+  const openConversation = conversationsCtx?.openConversation
+  const handleOpenMessage = useMemo(() => {
+    if (!openConversation) return undefined
+    return (link: TraceChatLink) => {
+      // Focus first, open second: the store holds the request before the
+      // chat pane mounts, so a freshly placed ChatView reads it on render.
+      if (link.turnId) {
+        requestChatMessageFocus({
+          sessionId: link.sessionId,
+          turnId: link.turnId,
+        })
+      }
+      openConversation(link.sessionId)
+    }
+  }, [openConversation])
+
   // Deep-link seed: mount with a trace already expanded (used by stories).
   const initialAppliedRef = useRef(false)
   useEffect(() => {
@@ -585,7 +674,11 @@ export function TracesV2({
     selectedTraceId !== null ? (
       <div className="bg-panel-raised shadow-raised">
         {isLoadingSpans && (
-          <TraceDetailSkeleton onClose={() => selectTrace(null)} />
+          <TraceDetailSkeleton
+            onClose={() => selectTrace(null)}
+            chatLink={chatLink}
+            onOpenMessage={handleOpenMessage}
+          />
         )}
         {!isLoadingSpans && spansError && (
           <div className="p-4 flex flex-col gap-3">
@@ -621,6 +714,8 @@ export function TracesV2({
               traceId={selectedTraceId}
               onClose={() => selectTrace(null)}
               onSpanClick={setSelectedSpan}
+              chatLink={chatLink}
+              onOpenMessage={handleOpenMessage}
             />
             <div className="border-b border-rule-2 px-3 py-2">
               <ViewSwitcher
@@ -662,6 +757,29 @@ export function TracesV2({
   const selectedInPage =
     selectedTraceId !== null && paged.some((t) => t.traceId === selectedTraceId)
 
+  // The scope chip: names the followed conversation; ✕ shows every session
+  // again (until another conversation is selected).
+  const sessionScopeChip = sessionScope ? (
+    <span
+      className="flex items-center gap-1 rounded-xs bg-surface py-0.5 pr-0.5 pl-2 font-mono text-[11px] text-ink-faint"
+      title="the list follows the active chat — showing only this session's traces"
+    >
+      <MessageSquare className="size-4 flex-shrink-0" />
+      <span className="max-w-[140px] truncate lowercase">
+        {activeConversation?.title ?? sessionScope}
+      </span>
+      <button
+        type="button"
+        onClick={() => setScopeDismissedFor(sessionScope)}
+        aria-label="show all sessions"
+        title="show all sessions"
+        className="p-0.5 transition-colors hover:text-ink"
+      >
+        <X className="size-4" />
+      </button>
+    </span>
+  ) : null
+
   return (
     <section
       ref={rootRef}
@@ -696,34 +814,37 @@ export function TracesV2({
             stats={hasOtelConfigured ? stats : undefined}
             attributeKeySuggestions={attributeKeySuggestions}
             leading={
-              viewsAvailable ? (
-                <ViewsDropdown
-                  views={views}
-                  activeViewId={activeViewId}
-                  activeModified={activeViewModified}
-                  onSelectView={handleSelectView}
-                  onSaveNew={(name) => {
-                    void saveView(name, captureViewConfig(filterState)).then(
-                      (view) => setActiveViewId(view.id),
-                    )
-                  }}
-                  onUpdateActive={() => {
-                    if (activeViewId)
-                      void updateView(
-                        activeViewId,
-                        captureViewConfig(filterState),
+              <>
+                {viewsAvailable ? (
+                  <ViewsDropdown
+                    views={views}
+                    activeViewId={activeViewId}
+                    activeModified={activeViewModified}
+                    onSelectView={handleSelectView}
+                    onSaveNew={(name) => {
+                      void saveView(name, captureViewConfig(filterState)).then(
+                        (view) => setActiveViewId(view.id),
                       )
-                  }}
-                  onRenameActive={(name) => {
-                    if (activeViewId) void renameView(activeViewId, name)
-                  }}
-                  onDeleteActive={() => {
-                    // deleteView clears the selection itself, in the same
-                    // config write.
-                    if (activeViewId) void deleteView(activeViewId)
-                  }}
-                />
-              ) : undefined
+                    }}
+                    onUpdateActive={() => {
+                      if (activeViewId)
+                        void updateView(
+                          activeViewId,
+                          captureViewConfig(filterState),
+                        )
+                    }}
+                    onRenameActive={(name) => {
+                      if (activeViewId) void renameView(activeViewId, name)
+                    }}
+                    onDeleteActive={() => {
+                      // deleteView clears the selection itself, in the same
+                      // config write.
+                      if (activeViewId) void deleteView(activeViewId)
+                    }}
+                  />
+                ) : null}
+                {sessionScopeChip}
+              </>
             }
           />
         </ErrorBoundary>
@@ -786,8 +907,16 @@ export function TracesV2({
                   <div className="p-9">
                     <EmptyState
                       icon={GitBranch}
-                      title="no traces recorded"
-                      description="traces appear here when functions execute. fire a request to your engine and refresh."
+                      title={
+                        sessionScope
+                          ? 'no traces for this session'
+                          : 'no traces recorded'
+                      }
+                      description={
+                        sessionScope
+                          ? 'the list follows the active chat. send a message to see its work here, or clear the session chip above to see every trace.'
+                          : 'traces appear here when functions execute. fire a request to your engine and refresh.'
+                      }
                     />
                   </div>
                 ) : (

--- a/console/web/src/pages/TracesV2/lib/traceChatLink.test.ts
+++ b/console/web/src/pages/TracesV2/lib/traceChatLink.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { traceChatLink } from './traceChatLink'
+
+describe('traceChatLink', () => {
+  it('resolves from merged trace tags alone', () => {
+    const link = traceChatLink(
+      {
+        'iii.session.id': 'console-1',
+        'iii.session.name': 'my chat',
+        'iii.message.id': 't_abc',
+      },
+      [],
+    )
+    expect(link).toEqual({
+      sessionId: 'console-1',
+      sessionName: 'my chat',
+      turnId: 't_abc',
+    })
+  })
+
+  it('falls back to span attributes when tags are absent (deep-linked detail)', () => {
+    const link = traceChatLink(undefined, [
+      { attributes: { 'other.key': 'x' } },
+      { attributes: { 'iii.session.id': 'console-2' } },
+      { attributes: { 'iii.message.id': 't_def' } },
+    ])
+    expect(link).toEqual({
+      sessionId: 'console-2',
+      sessionName: undefined,
+      turnId: 't_def',
+    })
+  })
+
+  it('trace tags win over span attributes', () => {
+    const link = traceChatLink({ 'iii.session.id': 'console-tags' }, [
+      { attributes: { 'iii.session.id': 'console-span' } },
+    ])
+    expect(link?.sessionId).toBe('console-tags')
+  })
+
+  it('returns null when no span carries a session id', () => {
+    expect(traceChatLink(undefined, [{ attributes: { a: 'b' } }])).toBeNull()
+    expect(traceChatLink({}, [])).toBeNull()
+  })
+
+  it('ignores empty and non-string values', () => {
+    const link = traceChatLink({ 'iii.session.id': '' }, [
+      { attributes: { 'iii.session.id': 42 } },
+      { attributes: { 'iii.session.id': 'console-3' } },
+    ])
+    expect(link?.sessionId).toBe('console-3')
+  })
+})

--- a/console/web/src/pages/TracesV2/lib/traceChatLink.ts
+++ b/console/web/src/pages/TracesV2/lib/traceChatLink.ts
@@ -1,0 +1,52 @@
+// Chat linkage of one trace: which conversation (and which turn of it)
+// produced the spans. Every span a harness turn spawns carries the identity
+// as baggage attributes (`harness/src/functions/turn.rs`), and
+// `engine::traces::list` merges them into the row's trace-level tags — so a
+// list row resolves from `trace_tags` alone, while a detail opened without
+// its row (timeline-strip click, deep link) falls back to scanning the
+// loaded spans' own attributes.
+
+import { SESSION_ID_ATTR } from './followTurn'
+
+/** `iii.message.id` — the harness TURN id (`t_<uuid>`), not the console's
+ *  `msg-<uuid>`. See timeline-span-tags.md. */
+export const MESSAGE_ID_ATTR = 'iii.message.id'
+export const SESSION_NAME_ATTR = 'iii.session.name'
+
+export interface TraceChatLink {
+  /** engine session_id (= the console's `Conversation.id`) */
+  sessionId: string
+  /** session title at emit time, for the button label */
+  sessionName?: string
+  /** harness turn id, when the trace belongs to a single turn */
+  turnId?: string
+}
+
+function str(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+/**
+ * Resolve a trace's chat linkage from its merged trace tags, falling back
+ * to the first span attributes that carry each key. Returns null when no
+ * span of the trace was stamped with a session id (engine-internal traces,
+ * non-harness workloads).
+ */
+export function traceChatLink(
+  traceTags: Record<string, string> | undefined,
+  spans: ReadonlyArray<{ attributes?: Record<string, unknown> }>,
+): TraceChatLink | null {
+  let sessionId = str(traceTags?.[SESSION_ID_ATTR])
+  let sessionName = str(traceTags?.[SESSION_NAME_ATTR])
+  let turnId = str(traceTags?.[MESSAGE_ID_ATTR])
+  for (const span of spans) {
+    if (sessionId && sessionName && turnId) break
+    const attrs = span.attributes
+    if (!attrs) continue
+    sessionId ??= str(attrs[SESSION_ID_ATTR])
+    sessionName ??= str(attrs[SESSION_NAME_ATTR])
+    turnId ??= str(attrs[MESSAGE_ID_ATTR])
+  }
+  if (!sessionId) return null
+  return { sessionId, sessionName, turnId }
+}

--- a/console/web/src/pages/TracesV2/lib/traceDetailPages.test.ts
+++ b/console/web/src/pages/TracesV2/lib/traceDetailPages.test.ts
@@ -87,12 +87,17 @@ describe('collectTraceDetailSpans', () => {
   it('reports each merged page so callers can render progressively', async () => {
     const all = spans(0, 700)
     const calls: Array<[number, number]> = []
-    const seen: number[] = []
+    const seen: Array<[number, number]> = []
     const out = await collectTraceDetailSpans(pagedFetch(all, calls), {
-      onPage: (accumulated) => seen.push(accumulated.size),
+      onPage: (accumulated, total) => seen.push([accumulated.size, total]),
     })
 
-    expect(seen).toEqual([50, 300, 550, 700])
+    expect(seen).toEqual([
+      [50, 700],
+      [300, 700],
+      [550, 700],
+      [700, 700],
+    ])
     expect(out.size).toBe(700)
   })
 

--- a/console/web/src/pages/TracesV2/lib/traceDetailPages.test.ts
+++ b/console/web/src/pages/TracesV2/lib/traceDetailPages.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+import {
+  collectTraceDetailSpans,
+  TRACE_DETAIL_MAX_PAGE_SIZE,
+  TRACE_DETAIL_MIN_PAGE_SIZE,
+  TRACE_DETAIL_PROBE_PAGE_SIZE,
+} from './traceDetailPages'
+
+interface Span {
+  span_id: string
+  payload?: string
+}
+
+function spans(from: number, count: number, payload = ''): Span[] {
+  return Array.from({ length: count }, (_, i) => ({
+    span_id: `s${from + i}`,
+    ...(payload ? { payload } : {}),
+  }))
+}
+
+/** Serve `all` in windows, recording each requested (offset, limit). */
+function pagedFetch(all: Span[], calls: Array<[number, number]>) {
+  return (offset: number, limit: number) => {
+    calls.push([offset, limit])
+    return Promise.resolve({
+      spans: all.slice(offset, offset + limit),
+      total: all.length,
+    })
+  }
+}
+
+describe('collectTraceDetailSpans', () => {
+  it('pages a thin-span trace at the max page size after the probe', async () => {
+    const all = spans(0, 700)
+    const calls: Array<[number, number]> = []
+    const out = await collectTraceDetailSpans(pagedFetch(all, calls))
+
+    expect(out.size).toBe(700)
+    expect(calls[0]).toEqual([0, TRACE_DETAIL_PROBE_PAGE_SIZE])
+    // Tiny spans price far above the cap — every later page rides the max.
+    for (const [, limit] of calls.slice(1)) {
+      expect(limit).toBe(TRACE_DETAIL_MAX_PAGE_SIZE)
+    }
+    // Windows chain without gap or overlap.
+    expect(calls.map(([offset]) => offset)).toEqual([0, 50, 300, 550])
+  })
+
+  it('prices fat spans down to smaller pages', async () => {
+    // ~200KB per span: the 8MiB budget prices ~40 spans per page.
+    const all = spans(0, 120, 'x'.repeat(200_000))
+    const calls: Array<[number, number]> = []
+    const out = await collectTraceDetailSpans(pagedFetch(all, calls))
+
+    expect(out.size).toBe(120)
+    const priced = calls[1][1]
+    expect(priced).toBeLessThan(TRACE_DETAIL_PROBE_PAGE_SIZE)
+    expect(priced).toBeGreaterThanOrEqual(TRACE_DETAIL_MIN_PAGE_SIZE)
+  })
+
+  it('halves and retries the same window when a page never arrives', async () => {
+    const all = spans(0, 80)
+    const calls: Array<[number, number]> = []
+    const fetch = (offset: number, limit: number) => {
+      calls.push([offset, limit])
+      // The first probe "hangs" (an oversized response is never delivered).
+      if (calls.length === 1) return new Promise<never>(() => {})
+      return Promise.resolve({
+        spans: all.slice(offset, offset + limit),
+        total: all.length,
+      })
+    }
+    const out = await collectTraceDetailSpans(fetch, 10)
+
+    expect(out.size).toBe(80)
+    expect(calls[0]).toEqual([0, TRACE_DETAIL_PROBE_PAGE_SIZE])
+    expect(calls[1]).toEqual([0, TRACE_DETAIL_MIN_PAGE_SIZE])
+  })
+
+  it('fails once the floor page size cannot be delivered either', async () => {
+    await expect(
+      collectTraceDetailSpans(() => new Promise<never>(() => {}), 5),
+    ).rejects.toThrow(/never arrived/)
+  })
+
+  it('propagates a fetch rejection as-is', async () => {
+    await expect(
+      collectTraceDetailSpans(() => Promise.reject(new Error('boom'))),
+    ).rejects.toThrow('boom')
+  })
+
+  it('returns empty for a trace with no spans', async () => {
+    const calls: Array<[number, number]> = []
+    const out = await collectTraceDetailSpans(pagedFetch([], calls))
+    expect(out.size).toBe(0)
+    expect(calls).toHaveLength(1)
+  })
+
+  it('dedupes spans re-served across page boundaries', async () => {
+    const all = spans(0, 60)
+    let first = true
+    const fetch = (offset: number, limit: number) => {
+      // Overlap the second window by one span, as a live re-sort might.
+      const start = first ? offset : offset - 1
+      first = false
+      return Promise.resolve({
+        spans: all.slice(start, start + limit),
+        total: all.length,
+      })
+    }
+    const out = await collectTraceDetailSpans(fetch)
+    expect(out.size).toBe(60)
+  })
+})

--- a/console/web/src/pages/TracesV2/lib/traceDetailPages.test.ts
+++ b/console/web/src/pages/TracesV2/lib/traceDetailPages.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  collectRecentSpanWindow,
   collectTraceDetailSpans,
   TRACE_DETAIL_MAX_PAGE_SIZE,
   TRACE_DETAIL_MIN_PAGE_SIZE,
@@ -136,5 +137,54 @@ describe('collectTraceDetailSpans', () => {
     }
     const out = await collectTraceDetailSpans(fetch)
     expect(out.size).toBe(60)
+  })
+})
+
+describe('collectRecentSpanWindow', () => {
+  it('stops at the span budget and reports the true total', async () => {
+    const all = spans(0, 2000)
+    const calls: Array<[number, number]> = []
+    const out = await collectRecentSpanWindow(pagedFetch(all, calls), 250)
+
+    expect(out.spans.length).toBe(250)
+    expect(out.total).toBe(2000)
+    expect(calls[0]).toEqual([0, TRACE_DETAIL_PROBE_PAGE_SIZE])
+    // Windows tile the remainder exactly up to the budget.
+    const fetched = calls.reduce((n, [, limit]) => n + limit, 0)
+    expect(fetched).toBe(250)
+  })
+
+  it('returns the probe alone when it already covers the data', async () => {
+    const all = spans(0, 30)
+    const calls: Array<[number, number]> = []
+    const out = await collectRecentSpanWindow(pagedFetch(all, calls), 250)
+    expect(out.spans.length).toBe(30)
+    expect(calls).toHaveLength(1)
+  })
+
+  it('splits a window in half when its response never arrives', async () => {
+    const all = spans(0, 150)
+    const calls: Array<[number, number]> = []
+    const fetch = (offset: number, limit: number) => {
+      calls.push([offset, limit])
+      // The first full post-probe window "hangs"; its halves deliver.
+      if (offset === 50 && limit === 100) return new Promise<never>(() => {})
+      return Promise.resolve({
+        spans: all.slice(offset, offset + limit),
+        total: all.length,
+      })
+    }
+    // Thin spans price to the max page; force a deterministic split by
+    // budgeting exactly one 100-span window after the probe.
+    const out = await collectRecentSpanWindow(fetch, 150, 15)
+    expect(out.spans.length).toBe(150)
+    expect(calls).toContainEqual([50, 50])
+    expect(calls).toContainEqual([100, 50])
+  })
+
+  it('fails when even the floor window cannot be delivered', async () => {
+    await expect(
+      collectRecentSpanWindow(() => new Promise<never>(() => {}), 100, 5),
+    ).rejects.toThrow(/never arrived/)
   })
 })

--- a/console/web/src/pages/TracesV2/lib/traceDetailPages.test.ts
+++ b/console/web/src/pages/TracesV2/lib/traceDetailPages.test.ts
@@ -69,7 +69,7 @@ describe('collectTraceDetailSpans', () => {
         total: all.length,
       })
     }
-    const out = await collectTraceDetailSpans(fetch, 10)
+    const out = await collectTraceDetailSpans(fetch, { timeoutMs: 10 })
 
     expect(out.size).toBe(80)
     expect(calls[0]).toEqual([0, TRACE_DETAIL_PROBE_PAGE_SIZE])
@@ -78,8 +78,30 @@ describe('collectTraceDetailSpans', () => {
 
   it('fails once the floor page size cannot be delivered either', async () => {
     await expect(
-      collectTraceDetailSpans(() => new Promise<never>(() => {}), 5),
+      collectTraceDetailSpans(() => new Promise<never>(() => {}), {
+        timeoutMs: 5,
+      }),
     ).rejects.toThrow(/never arrived/)
+  })
+
+  it('reports each merged page so callers can render progressively', async () => {
+    const all = spans(0, 700)
+    const calls: Array<[number, number]> = []
+    const seen: number[] = []
+    const out = await collectTraceDetailSpans(pagedFetch(all, calls), {
+      onPage: (accumulated) => seen.push(accumulated.size),
+    })
+
+    expect(seen).toEqual([50, 300, 550, 700])
+    expect(out.size).toBe(700)
+  })
+
+  it('never reports a page for an empty trace', async () => {
+    const seen: number[] = []
+    await collectTraceDetailSpans(pagedFetch([], []), {
+      onPage: (accumulated) => seen.push(accumulated.size),
+    })
+    expect(seen).toEqual([])
   })
 
   it('propagates a fetch rejection as-is', async () => {

--- a/console/web/src/pages/TracesV2/lib/traceDetailPages.ts
+++ b/console/web/src/pages/TracesV2/lib/traceDetailPages.ts
@@ -47,6 +47,17 @@ function withTimeout<T>(
   })
 }
 
+export interface CollectTraceDetailOptions<S> {
+  timeoutMs?: number
+  /**
+   * Called after each non-empty page merges, with the accumulated map (the
+   * same live map the promise resolves with — it keeps growing). Lets the
+   * caller render progressively: a large trace paints from its first page
+   * instead of behind the full multi-second sweep.
+   */
+  onPage?: (spans: Map<string, S>) => void
+}
+
 /**
  * Fetch every span of one trace through `fetchPage(offset, limit)`,
  * deduplicated by `span_id`. Stops on a short page (the end, per the
@@ -55,8 +66,9 @@ function withTimeout<T>(
  */
 export async function collectTraceDetailSpans<S extends { span_id: string }>(
   fetchPage: (offset: number, limit: number) => Promise<TraceDetailPage<S>>,
-  timeoutMs: number = TRACE_DETAIL_PAGE_TIMEOUT_MS,
+  opts?: CollectTraceDetailOptions<S>,
 ): Promise<Map<string, S>> {
+  const timeoutMs = opts?.timeoutMs ?? TRACE_DETAIL_PAGE_TIMEOUT_MS
   const spans = new Map<string, S>()
   let pageSize = TRACE_DETAIL_PROBE_PAGE_SIZE
   let priced = false
@@ -78,6 +90,7 @@ export async function collectTraceDetailSpans<S extends { span_id: string }>(
 
     for (const span of page.spans) spans.set(span.span_id, span)
     total = page.total
+    if (page.spans.length > 0) opts?.onPage?.(spans)
 
     if (!priced && page.spans.length > 0) {
       priced = true

--- a/console/web/src/pages/TracesV2/lib/traceDetailPages.ts
+++ b/console/web/src/pages/TracesV2/lib/traceDetailPages.ts
@@ -1,0 +1,99 @@
+// Paged loading of one trace's full span set, sized by RESPONSE BYTES rather
+// than span count. A span count is the wrong unit: measured against a live
+// engine, a trace of ~75KB spans (session::update-message payloads) served a
+// 200-span page as a 15MB response in ~1s, while a 230-span page — past the
+// transport's ~16MiB message cap — never arrived at all. No error, no
+// rejection: the RPC simply hangs forever, which is also why the fetch here
+// carries its own timeout (the client wrapper exposes none).
+//
+// The first page is a small probe; its serialized size prices the trace's
+// spans and sizes every following page to a budget well under the cap. The
+// timeout is the backstop for a mispriced page (one giant late span): shrink
+// and retry the same window, and only a page that cannot be delivered even
+// at the floor fails the load.
+
+export const TRACE_DETAIL_MAX_PAGE_SIZE = 250
+export const TRACE_DETAIL_PROBE_PAGE_SIZE = 50
+export const TRACE_DETAIL_MIN_PAGE_SIZE = 25
+/** Response budget per page — half the observed ~16MiB delivery cliff. */
+export const TRACE_DETAIL_SAFE_RESPONSE_BYTES = 8 * 1024 * 1024
+export const TRACE_DETAIL_PAGE_TIMEOUT_MS = 12_000
+
+export interface TraceDetailPage<S> {
+  spans: S[]
+  /** Count of the FILTERED span set (verified: `include_internal` applies
+   *  before pagination and `total`, so full pages mean more to fetch). */
+  total: number
+}
+
+const TIMED_OUT = Symbol('trace-detail-page-timeout')
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+): Promise<T | typeof TIMED_OUT> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => resolve(TIMED_OUT), ms)
+    promise.then(
+      (value) => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      (err) => {
+        clearTimeout(timer)
+        reject(err)
+      },
+    )
+  })
+}
+
+/**
+ * Fetch every span of one trace through `fetchPage(offset, limit)`,
+ * deduplicated by `span_id`. Stops on a short page (the end, per the
+ * verified filtered `total` semantics — also the guard that keeps a stale
+ * `total` from looping while a trace is completing).
+ */
+export async function collectTraceDetailSpans<S extends { span_id: string }>(
+  fetchPage: (offset: number, limit: number) => Promise<TraceDetailPage<S>>,
+  timeoutMs: number = TRACE_DETAIL_PAGE_TIMEOUT_MS,
+): Promise<Map<string, S>> {
+  const spans = new Map<string, S>()
+  let pageSize = TRACE_DETAIL_PROBE_PAGE_SIZE
+  let priced = false
+  let offset = 0
+  let total = Number.POSITIVE_INFINITY
+
+  while (offset < total) {
+    const limit = pageSize
+    const page = await withTimeout(fetchPage(offset, limit), timeoutMs)
+    if (page === TIMED_OUT) {
+      if (pageSize <= TRACE_DETAIL_MIN_PAGE_SIZE) {
+        throw new Error(
+          `trace page of ${pageSize} spans never arrived — spans too large to deliver`,
+        )
+      }
+      pageSize = Math.max(TRACE_DETAIL_MIN_PAGE_SIZE, Math.floor(pageSize / 2))
+      continue
+    }
+
+    for (const span of page.spans) spans.set(span.span_id, span)
+    total = page.total
+
+    if (!priced && page.spans.length > 0) {
+      priced = true
+      const bytesPerSpan = JSON.stringify(page.spans).length / page.spans.length
+      pageSize = Math.min(
+        TRACE_DETAIL_MAX_PAGE_SIZE,
+        Math.max(
+          TRACE_DETAIL_MIN_PAGE_SIZE,
+          Math.floor(TRACE_DETAIL_SAFE_RESPONSE_BYTES / bytesPerSpan),
+        ),
+      )
+    }
+
+    if (page.spans.length < limit) break
+    offset += page.spans.length
+  }
+
+  return spans
+}

--- a/console/web/src/pages/TracesV2/lib/traceDetailPages.ts
+++ b/console/web/src/pages/TracesV2/lib/traceDetailPages.ts
@@ -51,11 +51,12 @@ export interface CollectTraceDetailOptions<S> {
   timeoutMs?: number
   /**
    * Called after each non-empty page merges, with the accumulated map (the
-   * same live map the promise resolves with — it keeps growing). Lets the
-   * caller render progressively: a large trace paints from its first page
-   * instead of behind the full multi-second sweep.
+   * same live map the promise resolves with — it keeps growing) and the
+   * filtered span total the page reported. Lets the caller render
+   * progressively — and show how far along the sweep is — instead of
+   * holding a skeleton behind the full multi-second load.
    */
-  onPage?: (spans: Map<string, S>) => void
+  onPage?: (spans: Map<string, S>, total: number) => void
 }
 
 /**
@@ -90,7 +91,7 @@ export async function collectTraceDetailSpans<S extends { span_id: string }>(
 
     for (const span of page.spans) spans.set(span.span_id, span)
     total = page.total
-    if (page.spans.length > 0) opts?.onPage?.(spans)
+    if (page.spans.length > 0) opts?.onPage?.(spans, total)
 
     if (!priced && page.spans.length > 0) {
       priced = true

--- a/console/web/src/pages/TracesV2/lib/traceDetailPages.ts
+++ b/console/web/src/pages/TracesV2/lib/traceDetailPages.ts
@@ -65,6 +65,90 @@ export interface CollectTraceDetailOptions<S> {
  * verified filtered `total` semantics — also the guard that keeps a stale
  * `total` from looping while a trace is completing).
  */
+/** Windows fired together after the probe. The scoped/search list scan
+ *  costs seconds per call server-side REGARDLESS of limit or offset
+ *  (measured: ~3.4s flat), so sequential pages would multiply it. */
+export const SEED_WINDOW_PARALLELISM = 3
+
+/**
+ * Fetch the most-recent window of a `search_all_spans` query — up to
+ * `maxSpans` spans — as byte-priced pages: a probe first, then the
+ * remaining windows in parallel batches. A window whose response never
+ * arrives (oversized — the transport drops it silently) splits in half and
+ * retries; only a window undeliverable at the floor fails the read.
+ * Returns the deduped spans plus the server's filtered total.
+ */
+export async function collectRecentSpanWindow<S extends { span_id: string }>(
+  fetchPage: (offset: number, limit: number) => Promise<TraceDetailPage<S>>,
+  maxSpans: number,
+  timeoutMs: number = TRACE_DETAIL_PAGE_TIMEOUT_MS,
+): Promise<{ spans: S[]; total: number }> {
+  let probeSize = Math.min(TRACE_DETAIL_PROBE_PAGE_SIZE, maxSpans)
+  let probe: TraceDetailPage<S> | typeof TIMED_OUT
+  for (;;) {
+    probe = await withTimeout(fetchPage(0, probeSize), timeoutMs)
+    if (probe !== TIMED_OUT) break
+    if (probeSize <= TRACE_DETAIL_MIN_PAGE_SIZE) {
+      throw new Error(
+        `trace page of ${probeSize} spans never arrived — spans too large to deliver`,
+      )
+    }
+    probeSize = Math.max(TRACE_DETAIL_MIN_PAGE_SIZE, Math.floor(probeSize / 2))
+  }
+
+  const spans = new Map<string, S>()
+  for (const span of probe.spans) spans.set(span.span_id, span)
+  const target = Math.min(probe.total, maxSpans)
+  if (probe.spans.length < probeSize || spans.size >= target) {
+    return { spans: [...spans.values()], total: probe.total }
+  }
+
+  // A recency window mixes spans from different calls, so the probe samples
+  // only its thin end (measured: 28KB/span up front, ~83KB deeper in). Half
+  // the detail budget absorbs that heterogeneity — an under-priced window
+  // costs a full timeout+split round, far more than a smaller page does.
+  const bytesPerSpan =
+    JSON.stringify(probe.spans).length / Math.max(1, probe.spans.length)
+  const pageSize = Math.min(
+    TRACE_DETAIL_MAX_PAGE_SIZE,
+    Math.max(
+      TRACE_DETAIL_MIN_PAGE_SIZE,
+      Math.floor(TRACE_DETAIL_SAFE_RESPONSE_BYTES / 2 / bytesPerSpan),
+    ),
+  )
+
+  const fetchWindow = async (offset: number, limit: number): Promise<S[]> => {
+    const page = await withTimeout(fetchPage(offset, limit), timeoutMs)
+    if (page !== TIMED_OUT) return page.spans
+    if (limit <= TRACE_DETAIL_MIN_PAGE_SIZE) {
+      throw new Error(
+        `trace page of ${limit} spans never arrived — spans too large to deliver`,
+      )
+    }
+    const half = Math.ceil(limit / 2)
+    const halves = await Promise.all([
+      fetchWindow(offset, half),
+      fetchWindow(offset + half, limit - half),
+    ])
+    return halves.flat()
+  }
+
+  const windows: Array<[number, number]> = []
+  for (let offset = probe.spans.length; offset < target; offset += pageSize) {
+    windows.push([offset, Math.min(pageSize, target - offset)])
+  }
+  for (let i = 0; i < windows.length; i += SEED_WINDOW_PARALLELISM) {
+    const batch = windows.slice(i, i + SEED_WINDOW_PARALLELISM)
+    const results = await Promise.all(
+      batch.map(([offset, limit]) => fetchWindow(offset, limit)),
+    )
+    for (const win of results) {
+      for (const span of win) spans.set(span.span_id, span)
+    }
+  }
+  return { spans: [...spans.values()], total: probe.total }
+}
+
 export async function collectTraceDetailSpans<S extends { span_id: string }>(
   fetchPage: (offset: number, limit: number) => Promise<TraceDetailPage<S>>,
   opts?: CollectTraceDetailOptions<S>,

--- a/console/web/src/pages/TracesV2/lib/traceFilters.test.ts
+++ b/console/web/src/pages/TracesV2/lib/traceFilters.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { withSessionScope } from './traceFilters'
+
+describe('withSessionScope', () => {
+  it('is a no-op without a session', () => {
+    const params = { service_name: 'harness' }
+    expect(withSessionScope(params, null)).toBe(params)
+  })
+
+  it('adds the session attribute AND the all-spans search shape', () => {
+    // The identity attrs live on child spans — without search_all_spans a
+    // roots-only attribute filter matches nothing (verified live).
+    expect(withSessionScope({}, 'console-1')).toEqual({
+      attributes: [['iii.session.id', 'console-1']],
+      search_all_spans: true,
+    })
+  })
+
+  it('appends after user attribute filters instead of replacing them', () => {
+    const scoped = withSessionScope(
+      { attributes: [['iii.tag.kind', 'harness.turn']] },
+      'console-1',
+    )
+    expect(scoped.attributes).toEqual([
+      ['iii.tag.kind', 'harness.turn'],
+      ['iii.session.id', 'console-1'],
+    ])
+  })
+
+  it('does not mutate the input params', () => {
+    const params = { attributes: [['a', 'b']] as [string, string][] }
+    withSessionScope(params, 'console-1')
+    expect(params.attributes).toEqual([['a', 'b']])
+  })
+})

--- a/console/web/src/pages/TracesV2/lib/traceFilters.ts
+++ b/console/web/src/pages/TracesV2/lib/traceFilters.ts
@@ -7,6 +7,7 @@
 
 import type { TracesFilterParams } from '../api/traces'
 import type { TraceFilterState } from '../hooks/useTraceFilters'
+import { SESSION_ID_ATTR } from './followTurn'
 
 export interface FilterValidationWarnings {
   durationSwapped?: boolean
@@ -85,6 +86,32 @@ export function buildFilterParams(
   if (filters.sortOrder) params.sort_order = filters.sortOrder
 
   return { params, warnings }
+}
+
+/**
+ * Layer the automatic active-session scope onto built filter params.
+ *
+ * The session identity attributes (`iii.session.id`) live on WORKER child
+ * spans, never on a trace's root — a roots-only attribute filter matches
+ * nothing (verified against a live engine: 0 rows without
+ * `search_all_spans`, the session's real traces with it). So the scope
+ * rides the same wire shape as text search: match across all spans, and
+ * let the list's `dedupeToTraceRoots` collapse the response back to one
+ * row per trace. Appended after any user attribute filters, so both apply.
+ */
+export function withSessionScope(
+  params: TracesFilterParams,
+  sessionId: string | null,
+): TracesFilterParams {
+  if (!sessionId) return params
+  return {
+    ...params,
+    attributes: [
+      ...(params.attributes ?? []),
+      [SESSION_ID_ATTR, sessionId] as [string, string],
+    ],
+    search_all_spans: true,
+  }
 }
 
 /**


### PR DESCRIPTION
Links the Traces V2 screen and the chat in both directions, per MOT-4479. (Replaces #902, closed by a branch rename.)

## Chat → traces: the list follows the active conversation

Selecting a conversation scopes the trace list to its `iii.session.id`, server-side via `withSessionScope`. The identity attributes are stamped as baggage on worker **child** spans, never on a trace's root — a roots-only attribute filter matches nothing — so the scope rides the same `search_all_spans` wire shape as text search and the list's dedupe collapses the response back to one row per trace. A chip next to the views dropdown names the followed conversation and dismisses the scope per session; grouping is suspended while scoped (it would collapse to a single group).

## Traces → chat: "go to message"

An open trace resolves its session/turn from the row's merged trace tags (`iii.session.id` / `iii.session.name` / `iii.message.id` — the harness turn id), with a span-attribute fallback for details opened without their row (timeline-strip click, deep link). The button opens the conversation and lands the transcript on the turn's rows: the turn's entry ids embed the turn id (`e_<turn_id>_…`), the user row that started it is recovered positionally (`lib/turn-anchor.ts`), and MessageList centers + flashes the row with tail-follow paused. The focus request travels through a tiny latest-event store (`lib/trace-links.ts`) written **before** the chat pane mounts, and is consumed on landing — or dropped once a hydrated transcript provably lacks the turn, so a stale request can't fire on a later visit.

The link resolves from the list row's tags alone, so the jump is available **while the trace detail is still loading** — the button renders on the detail skeleton too, wired like its close affordance.

## Trace detail loads in pages

The detail seed used to be one flat read of up to 10k spans; a large trace could stall the worker connection with one oversized RPC response. It now pages at 250 spans (sorted by start time), with a short-page guard so a stale `total` can't loop.

## Tests

- `traceChatLink`, `trace-links`, `turn-anchor`, `traceFilters` unit tests (new)
- `pnpm typecheck` and the full `pnpm vitest run` suite (1649 tests) pass on top of main

Fixes MOT-4479

https://claude.ai/code/session_01PkBwsbShR6zyzkupCuxjoZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added “Go to message” actions in trace details and headers to jump to related chat messages.
  - Traces now follow the active chat session with session-specific filtering.
  - Chat navigation highlights, centers, and reveals selected transcript messages.
  - Trace details progressively load large results through paginated loading.

- **Bug Fixes**
  - Improved trace-to-chat matching across transcript entries and notifications.
  - Prevented stale trace results after changing session filters.
  - Improved observability status, loading progress, and empty-state accuracy.
  - Reduced unnecessary refreshes for filtered trace lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->