### PR TITLE
fix(harness): use stable shell and console ranges

### DIFF
--- a/.github/scripts/tests/test_worker_dependency_compatibility.py
+++ b/.github/scripts/tests/test_worker_dependency_compatibility.py
@@ -19,7 +19,7 @@ EXPERIMENTAL_WORKERS = {
 }
 DEPENDENCY_RANGES = {
     "configuration": "0.x",
-    "console": "^1.9.12",
+    "console": "^1.9.11",
     "context-manager": "^1.1.3",
     "cron": "^0.21.9",
     "harness": "^1.8.5",
@@ -38,11 +38,7 @@ DEPENDENCY_RANGES = {
     "state": "^0.22.2",
 }
 
-# Harness is installed from its candidate channel while its stable release is
-# pending. Stable workers must resolve only stable dependency releases.
-WORKER_DEPENDENCY_RANGE_OVERRIDES = {
-    "harness": {"shell": "^0.11.10"},
-}
+WORKER_DEPENDENCY_RANGE_OVERRIDES: dict[str, dict[str, str]] = {}
 
 
 def dependencies(worker: str) -> dict[str, str]:

--- a/harness/iii.worker.yaml
+++ b/harness/iii.worker.yaml
@@ -22,5 +22,5 @@ dependencies:
   provider-openai-codex: "^0.4.4"
   provider-anthropic: "^1.2.8"
   provider-openai: "^1.2.7"
-  shell: "^0.11.10"
-  console: "^1.9.12"
+  shell: "^0.11.9"
+  console: "^1.9.11"

--- a/harness/tests/manifest.rs
+++ b/harness/tests/manifest.rs
@@ -108,8 +108,8 @@ fn worker_manifest_uses_the_tested_harness_stack() {
         ("iii-directory", "^1.2.3"),
         ("provider-anthropic", "^1.2.8"),
         ("provider-openai", "^1.2.7"),
-        ("shell", "^0.11.10"),
-        ("console", "^1.9.12"),
+        ("shell", "^0.11.9"),
+        ("console", "^1.9.11"),
     ] {
         assert_eq!(
             dependencies.get(serde_yaml::Value::String(worker.into())),


### PR DESCRIPTION
## Summary

- align the Harness Shell dependency with the stable version resolved by the Registry
- align the Harness Console dependency with the stable version resolved by the Registry
- remove the candidate-only Harness dependency override

## Why

Harness 1.8.6 cannot resolve its dependency graph because transitive dependencies use stable releases. Shell 0.11.10 and Console 1.9.12 are available only through the next channel.

## Validation

- added Shell through compose::add and verified version 0.11.9, connected status, project namespace, and 43 registered functions
- added Console through compose::add and verified version 1.9.11, connected status, project namespace, and 7 registered functions
- ran the worker dependency compatibility test suite: 6 passed
- ran git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated worker dependency compatibility checks to support the validated dependency versions.
  * Aligned worker configuration and manifest validation with the supported `shell` and `console` releases.
  * Removed outdated worker-specific version overrides to keep dependency validation consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->