### PR TITLE
chore(provider-integration-testkit): sync Cargo.lock to provider-command-code 0.1.3-experimental

### DIFF
--- a/crates/provider-integration-testkit/Cargo.lock
+++ b/crates/provider-integration-testkit/Cargo.lock
@@ -1360,7 +1360,7 @@ dependencies = [
 
 [[package]]
 name = "provider-command-code"
-version = "0.1.2-experimental"
+version = "0.1.3-experimental"
 dependencies = [
  "clap",
  "futures",


### PR DESCRIPTION
The v0.1.3-experimental release bump re-staled the testkit lockfile (create-tag's sync-lock only updates the released worker's own lock). Provider contract gate fails `cargo metadata --locked` on main until this lands. One-line version sync, same class as #909's testkit half. Every release bump of a provider path-dep will re-break this until create-tag also syncs the testkit lock.