### PR TITLE
(MOT-4354) fix(console): workers page renders the fleet without a supervisor

### DIFF
--- a/console/web/src/pages/Workers/api/workers.ts
+++ b/console/web/src/pages/Workers/api/workers.ts
@@ -86,10 +86,16 @@ export async function mapWithConcurrency<T, R>(
 }
 
 export async function fetchRawWorkersSnapshot(): Promise<RawWorkersSnapshot> {
+  // Supervisor and configuration reads are enrichment: an engine without
+  // worker::list (a compose-managed engine, or one booted with no
+  // supervisor) must not blank the whole page - the connected fleet from
+  // engine::workers::list still renders, just without stop/config detail.
   const [engineList, supervisorList, configurations] = await Promise.all([
     fetchEngineWorkersList(),
-    fetchSupervisorWorkersList(),
-    fetchConfigurationIds(),
+    fetchSupervisorWorkersList().catch(
+      (): WorkerListResponse => ({ workers: [] }),
+    ),
+    fetchConfigurationIds().catch((): ConfigurationSchemaView[] => []),
   ])
 
   const connected = engineList.workers.filter(
@@ -100,7 +106,7 @@ export async function fetchRawWorkersSnapshot(): Promise<RawWorkersSnapshot> {
     .filter((name, i, arr) => arr.indexOf(name) === i)
 
   const infoEntries = await mapWithConcurrency(names, 8, async (name) => {
-    const info = await fetchEngineWorkerInfo(name)
+    const info = await fetchEngineWorkerInfo(name).catch(() => null)
     return [name, info?.worker ?? null] as const
   })
 


### PR DESCRIPTION
## What

The workers page fetched its snapshot with one `Promise.all` over `engine::workers::list`, `worker::list` and `configuration::list`. On an engine without a supervisor (a compose-managed engine boots none, so `worker::list` does not exist in the namespace) the second call rejects and the whole page collapses to "failed to load workers", even though the engine list succeeded and the fleet is fully connected.

Supervisor and configuration reads are enrichment, not the page. They now degrade to empty on failure: the connected fleet still renders, the stop action and configuration links are simply absent. Per-worker `engine::workers::info` reads inside the bounded map get the same guard so one failing worker cannot reject the batch.

## How verified

- `tsc --noEmit`, `biome check`, `vitest run src/pages/Workers` (13 tests) all clean.
- Live on a compose-managed rig (engine 0.22.1-alpha.19, 16 workers, no supervisor): before the fix the page shows the failure banner with an empty list; after it renders all 16 connected workers.

Part of the console parity family (MOT-4354): the workers-page resilience item noted there.
