### PR TITLE
(MOT-4533) feat(browser): per-origin access policy and file uploads

### DIFF
--- a/browser/README.md
+++ b/browser/README.md
@@ -115,6 +115,15 @@ presets), `browser::cookies::list` / `set` / `clear` (import a cookie file),
 panel backing), and `browser::sessions::list` / `browser::sessions::stop`.
 Function ids and schemas live in the code and `iii worker info browser`.
 
+File transfer functions:
+
+| Function | Purpose |
+|---|---|
+| `browser::downloads::list` | List files the session downloaded |
+| `browser::download` | Read one recorded download as base64 |
+| `browser::download::remove` | Delete and forget one recorded download |
+| `browser::upload` | Attach up to eight base64 files to exactly one `input[type=file]` selected by CSS |
+
 Beyond single actions: `browser::execute` runs a multi-step async script in
 the page — top-level await, `log(...)`, `sleep(ms)`, `waitFor(selector)`, and
 a `state` object that persists across execute calls for the session — so one
@@ -346,6 +355,18 @@ browser:
   screenshot_quality: 60    # JPEG quality 1-100
   allowed_schemes: [http, https, file]  # `file` lets a local document be rendered; see below
   max_snapshot_nodes: 2000  # a11y outline size cap
+  default_origin_policy:    # omitted fields default to allow
+    access: allow
+    downloads: allow
+    uploads: allow
+    scripting: allow
+  origin_policies:
+    'https://app.example.com:8443':
+      uploads: deny
+    app.example.com:
+      scripting: deny
+  allow_history_access: true
+  allow_cookie_import: true
   allow_attach: false       # true = allow sessions::attach into a running browser's real profile
 
   scrapling:
@@ -373,6 +394,11 @@ worth knowing what that permits: navigation is not checked against a session's
 filesystem scope the way the workers that read files directly are, so anything
 that can reach `browser::navigate` can open any file this process can read.
 Narrow the list on a shared machine.
+
+Origin policy keys do not accept wildcards. An exact origin, including its
+scheme and non-default port, wins over a bare host; a bare host matches any
+scheme or port. URLs with no matching key use `default_origin_policy`. Each
+policy field defaults to `allow` when omitted.
 
 The compatibility fields are part of the stable configuration surface.
 Non-Tier-1 or artifact-free builds retain safe mode and reject compat

--- a/browser/README.md
+++ b/browser/README.md
@@ -397,8 +397,15 @@ Narrow the list on a shared machine.
 
 Origin policy keys do not accept wildcards. An exact origin, including its
 scheme and non-default port, wins over a bare host; a bare host matches any
-scheme or port. URLs with no matching key use `default_origin_policy`. Each
-policy field defaults to `allow` when omitted.
+scheme or port. Origin keys are URL-normalized before matching, including
+lowercased hosts and removal of explicit default ports; bare-host keys match
+case-insensitively. URLs with no matching key use `default_origin_policy`.
+Each policy field defaults to `allow` when omitted.
+
+Sessions started while any origin policy is configured reload the policy on
+every top-document request, so edits apply to their later navigations. A
+session started with no origin policy does not enable interception; adding the
+first policy later applies the navigation gate to new sessions.
 
 The compatibility fields are part of the stable configuration surface.
 Non-Tier-1 or artifact-free builds retain safe mode and reject compat

--- a/browser/src/config.rs
+++ b/browser/src/config.rs
@@ -5,6 +5,7 @@
 //! applies to sessions started after it — running sessions keep the browser
 //! they were launched with.
 
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use arc_swap::ArcSwap;
@@ -108,6 +109,99 @@ pub const fn scrapling_compat_supported() -> bool {
     ))
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum OriginPolicyDecision {
+    Allow,
+    Deny,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(default)]
+pub struct OriginPolicy {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub access: Option<OriginPolicyDecision>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub downloads: Option<OriginPolicyDecision>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uploads: Option<OriginPolicyDecision>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scripting: Option<OriginPolicyDecision>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResolvedOriginPolicy {
+    pub access: bool,
+    pub downloads: bool,
+    pub uploads: bool,
+    pub scripting: bool,
+}
+
+impl Default for ResolvedOriginPolicy {
+    fn default() -> Self {
+        Self {
+            access: true,
+            downloads: true,
+            uploads: true,
+            scripting: true,
+        }
+    }
+}
+
+impl OriginPolicy {
+    fn resolve(&self) -> ResolvedOriginPolicy {
+        let allowed = |decision| decision != Some(OriginPolicyDecision::Deny);
+        ResolvedOriginPolicy {
+            access: allowed(self.access),
+            downloads: allowed(self.downloads),
+            uploads: allowed(self.uploads),
+            scripting: allowed(self.scripting),
+        }
+    }
+}
+
+fn configured_origin_policy_for<'a>(
+    config: &'a WorkerConfig,
+    raw_url: &str,
+) -> Option<&'a OriginPolicy> {
+    let policies = config.origin_policies.as_ref()?;
+    let parsed = url::Url::parse(raw_url).ok()?;
+    let origin = parsed.origin().ascii_serialization();
+    if origin != "null" {
+        if let Some(policy) = policies.get(&origin) {
+            return Some(policy);
+        }
+    }
+    parsed.host_str().and_then(|host| policies.get(host))
+}
+
+pub fn origin_policy_for(config: &WorkerConfig, raw_url: &str) -> ResolvedOriginPolicy {
+    configured_origin_policy_for(config, raw_url)
+        .or(config.default_origin_policy.as_ref())
+        .map(OriginPolicy::resolve)
+        .unwrap_or_default()
+}
+
+pub fn origin_policy_config_key_for(config: &WorkerConfig, raw_url: &str) -> &'static str {
+    if configured_origin_policy_for(config, raw_url).is_some() {
+        "origin_policies"
+    } else {
+        "default_origin_policy"
+    }
+}
+
+pub fn origin_label(raw_url: &str) -> String {
+    let Ok(parsed) = url::Url::parse(raw_url) else {
+        return raw_url.to_string();
+    };
+    let origin = parsed.origin().ascii_serialization();
+    if origin == "null" {
+        raw_url.to_string()
+    } else {
+        origin
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(default)]
 pub struct WorkerConfig {
@@ -153,6 +247,16 @@ pub struct WorkerConfig {
     pub allowed_schemes: Vec<String>,
     /// Maximum nodes serialized by `browser::snapshot` before truncation.
     pub max_snapshot_nodes: u64,
+    /// Fallback access policy when no exact-origin or bare-host entry matches.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_origin_policy: Option<OriginPolicy>,
+    /// Exact-origin and bare-host policies. Exact origins take precedence.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub origin_policies: Option<BTreeMap<String, OriginPolicy>>,
+    /// Expose the session's visited-page list.
+    pub allow_history_access: bool,
+    /// Let callers import cookies with `browser::cookies::set`.
+    pub allow_cookie_import: bool,
     /// Allow `browser::sessions::attach` to connect to an already-running
     /// browser and adopt its tabs. Off by default: attaching reaches the
     /// user's real profile with its logged-in sessions, so it is opt-in.
@@ -189,6 +293,10 @@ impl Default for WorkerConfig {
             screenshot_quality: 60,
             allowed_schemes: vec!["http".to_string(), "https".to_string(), "file".to_string()],
             max_snapshot_nodes: 2_000,
+            default_origin_policy: None,
+            origin_policies: None,
+            allow_history_access: true,
+            allow_cookie_import: true,
             allow_attach: false,
             scrapling: ScraplingConfig::default(),
             allow_loopback: false,
@@ -273,6 +381,10 @@ mod tests {
         assert_eq!(c.screenshot_quality, 60);
         assert_eq!(c.allowed_schemes, vec!["http", "https", "file"]);
         assert_eq!(c.max_snapshot_nodes, 2_000);
+        assert!(c.default_origin_policy.is_none());
+        assert!(c.origin_policies.is_none());
+        assert!(c.allow_history_access);
+        assert!(c.allow_cookie_import);
         assert!(!c.allow_attach);
         assert_eq!(c.scrapling.security_mode, SecurityMode::Safe);
         assert_eq!(c.scrapling.chromium_executable, "");
@@ -327,6 +439,25 @@ mod tests {
         let v = serde_json::json!({ "browser": { "headless": false } });
         let c = WorkerConfig::from_json(&v).unwrap();
         assert!(!c.headless);
+    }
+
+    #[test]
+    fn from_json_parses_origin_and_surface_policies() {
+        let config = WorkerConfig::from_json(&serde_json::json!({
+            "default_origin_policy": {"access": "deny"},
+            "origin_policies": {
+                "example.com": {"access": "allow", "uploads": "deny"}
+            },
+            "allow_history_access": false,
+            "allow_cookie_import": false
+        }))
+        .unwrap();
+
+        let policy = origin_policy_for(&config, "https://example.com/path");
+        assert!(policy.access);
+        assert!(!policy.uploads);
+        assert!(!config.allow_history_access);
+        assert!(!config.allow_cookie_import);
     }
 
     #[test]
@@ -452,6 +583,106 @@ mod tests {
         assert_eq!(c.clamp_timeout(Some(600_000)), 120_000);
     }
 
+    fn policy(access: OriginPolicyDecision) -> OriginPolicy {
+        OriginPolicy {
+            access: Some(access),
+            ..OriginPolicy::default()
+        }
+    }
+
+    #[test]
+    fn origin_policy_exact_origin_precedes_host_and_default() {
+        let config = WorkerConfig {
+            default_origin_policy: Some(policy(OriginPolicyDecision::Deny)),
+            origin_policies: Some(BTreeMap::from([
+                (
+                    "app.example.com".to_string(),
+                    policy(OriginPolicyDecision::Deny),
+                ),
+                (
+                    "https://app.example.com:8443".to_string(),
+                    policy(OriginPolicyDecision::Allow),
+                ),
+            ])),
+            ..WorkerConfig::default()
+        };
+
+        assert!(origin_policy_for(&config, "https://app.example.com:8443/a").access);
+        assert!(!origin_policy_for(&config, "https://app.example.com/a").access);
+        assert!(!origin_policy_for(&config, "https://other.example.com/a").access);
+    }
+
+    #[test]
+    fn origin_policy_exact_origin_includes_port_and_scheme() {
+        let config = WorkerConfig {
+            origin_policies: Some(BTreeMap::from([(
+                "https://app.example.com:8443".to_string(),
+                policy(OriginPolicyDecision::Deny),
+            )])),
+            ..WorkerConfig::default()
+        };
+
+        assert!(!origin_policy_for(&config, "https://app.example.com:8443/a").access);
+        assert!(origin_policy_for(&config, "https://app.example.com/a").access);
+        assert!(origin_policy_for(&config, "http://app.example.com:8443/a").access);
+    }
+
+    #[test]
+    fn origin_policy_bare_host_matches_any_scheme_or_port() {
+        let config = WorkerConfig {
+            origin_policies: Some(BTreeMap::from([(
+                "app.example.com".to_string(),
+                policy(OriginPolicyDecision::Deny),
+            )])),
+            ..WorkerConfig::default()
+        };
+
+        assert!(!origin_policy_for(&config, "https://app.example.com/a").access);
+        assert!(!origin_policy_for(&config, "http://app.example.com:8080/a").access);
+    }
+
+    #[test]
+    fn origin_policy_unparseable_url_falls_back_to_default() {
+        let config = WorkerConfig {
+            default_origin_policy: Some(OriginPolicy {
+                uploads: Some(OriginPolicyDecision::Deny),
+                ..OriginPolicy::default()
+            }),
+            origin_policies: Some(BTreeMap::from([(
+                "not a url".to_string(),
+                OriginPolicy::default(),
+            )])),
+            ..WorkerConfig::default()
+        };
+
+        let resolved = origin_policy_for(&config, "not a url");
+        assert!(resolved.access);
+        assert!(resolved.downloads);
+        assert!(!resolved.uploads);
+        assert!(resolved.scripting);
+    }
+
+    #[test]
+    fn omitted_policy_fields_default_to_allow() {
+        let config = WorkerConfig {
+            default_origin_policy: Some(OriginPolicy {
+                access: Some(OriginPolicyDecision::Deny),
+                ..OriginPolicy::default()
+            }),
+            ..WorkerConfig::default()
+        };
+
+        assert_eq!(
+            origin_policy_for(&config, "https://example.com"),
+            ResolvedOriginPolicy {
+                access: false,
+                downloads: true,
+                uploads: true,
+                scripting: true,
+            }
+        );
+    }
+
     #[test]
     fn schema_lists_fields() {
         let s = WorkerConfig::json_schema();
@@ -459,6 +690,10 @@ mod tests {
         assert!(props.get("executable").is_some());
         assert!(props.get("headless").is_some());
         assert!(props.get("allowed_schemes").is_some());
+        assert!(props.get("default_origin_policy").is_some());
+        assert!(props.get("origin_policies").is_some());
+        assert!(props.get("allow_history_access").is_some());
+        assert!(props.get("allow_cookie_import").is_some());
         let scrapling = &props["scrapling"];
         assert_eq!(
             scrapling["default"],

--- a/browser/src/config.rs
+++ b/browser/src/config.rs
@@ -167,12 +167,24 @@ fn configured_origin_policy_for<'a>(
     let policies = config.origin_policies.as_ref()?;
     let parsed = url::Url::parse(raw_url).ok()?;
     let origin = parsed.origin().ascii_serialization();
-    if origin != "null" {
-        if let Some(policy) = policies.get(&origin) {
-            return Some(policy);
+    let host = parsed.host_str();
+    let mut host_match = None;
+
+    for (key, policy) in policies {
+        if let Ok(key_url) = url::Url::parse(key) {
+            if key_url.host_str().is_some() {
+                if origin != "null" && key_url.origin().ascii_serialization() == origin {
+                    return Some(policy);
+                }
+                continue;
+            }
+        }
+        if host.is_some_and(|request_host| key.eq_ignore_ascii_case(request_host)) {
+            host_match = Some(policy);
         }
     }
-    parsed.host_str().and_then(|host| policies.get(host))
+
+    host_match
 }
 
 pub fn origin_policy_for(config: &WorkerConfig, raw_url: &str) -> ResolvedOriginPolicy {
@@ -639,6 +651,32 @@ mod tests {
 
         assert!(!origin_policy_for(&config, "https://app.example.com/a").access);
         assert!(!origin_policy_for(&config, "http://app.example.com:8080/a").access);
+    }
+
+    #[test]
+    fn origin_policy_bare_host_is_case_insensitive() {
+        let config = WorkerConfig {
+            origin_policies: Some(BTreeMap::from([(
+                "App.Example.com".to_string(),
+                policy(OriginPolicyDecision::Deny),
+            )])),
+            ..WorkerConfig::default()
+        };
+
+        assert!(!origin_policy_for(&config, "https://app.example.com/a").access);
+    }
+
+    #[test]
+    fn origin_policy_origin_drops_an_explicit_default_port() {
+        let config = WorkerConfig {
+            origin_policies: Some(BTreeMap::from([(
+                "https://app.example.com:443".to_string(),
+                policy(OriginPolicyDecision::Deny),
+            )])),
+            ..WorkerConfig::default()
+        };
+
+        assert!(!origin_policy_for(&config, "https://app.example.com/a").access);
     }
 
     #[test]

--- a/browser/src/functions/doctor.rs
+++ b/browser/src/functions/doctor.rs
@@ -30,6 +30,10 @@ pub struct DoctorOutput {
     pub max_sessions: u64,
     pub active_sessions: u64,
     pub allowed_schemes: Vec<String>,
+    pub configured_origin_policies: u64,
+    pub default_origin_policy_set: bool,
+    pub allow_history_access: bool,
+    pub allow_cookie_import: bool,
     /// Whether attach mode is enabled (allow_attach).
     pub attach_enabled: bool,
     /// Whether ffmpeg is on PATH, which browser::recording requires.

--- a/browser/src/functions/mod.rs
+++ b/browser/src/functions/mod.rs
@@ -29,6 +29,7 @@ pub mod screenshot;
 pub mod sessions;
 pub mod snapshot;
 pub mod styles;
+pub mod upload;
 pub mod zoom;
 
 use std::sync::Arc;
@@ -40,6 +41,7 @@ use chromiumoxide::cdp::browser_protocol::accessibility as cdp_ax;
 use chromiumoxide::cdp::browser_protocol::css as cdp_css;
 use chromiumoxide::cdp::browser_protocol::dom as cdp_dom;
 use chromiumoxide::cdp::browser_protocol::emulation as cdp_emulation;
+use chromiumoxide::cdp::browser_protocol::fetch as cdp_fetch;
 use chromiumoxide::cdp::browser_protocol::input;
 use chromiumoxide::cdp::browser_protocol::network as cdp_network;
 use chromiumoxide::cdp::browser_protocol::overlay;
@@ -48,11 +50,13 @@ use chromiumoxide::cdp::browser_protocol::page::CaptureScreenshotFormat;
 use chromiumoxide::cdp::browser_protocol::storage as cdp_storage;
 use chromiumoxide::cdp::js_protocol::runtime as cdp_rt;
 use chromiumoxide::page::ScreenshotParams;
+use futures::StreamExt;
 use iii_sdk::errors::Error;
 use iii_sdk::{IIIClient, RegisterFunction};
 use serde_json::json;
 use tokio::time::timeout;
 
+use crate::config::{origin_label, origin_policy_config_key_for, origin_policy_for, WorkerConfig};
 use crate::events::{EventKind, HandoffRequestedEvent, HandoffResolvedEvent, SessionStartedEvent};
 use crate::session::{now_ms, Session, Sessions};
 
@@ -216,6 +220,10 @@ pub const DOWNLOAD_DESC: &str =
 pub const DOWNLOAD_REMOVE_ID: &str = "browser::download::remove";
 pub const DOWNLOAD_REMOVE_DESC: &str =
     "Forget a download and delete its file from the session's download dir.";
+pub const UPLOAD_ID: &str = "browser::upload";
+pub const UPLOAD_DESC: &str =
+    "Attach up to eight base64 files to exactly one input[type=file] selected by CSS. Files are \
+     staged privately for the session and removed when it stops.";
 pub const RESIZE_ID: &str = "browser::resize";
 pub const RESIZE_DESC: &str =
     "Set the session's live viewport size (CSS pixels). The console calls this as its browser \
@@ -338,6 +346,7 @@ pub fn catalog() -> Vec<FunctionSpec> {
             DOWNLOAD_REMOVE_ID,
             DOWNLOAD_REMOVE_DESC,
         ),
+        spec::<upload::UploadInput, upload::UploadOutput>(UPLOAD_ID, UPLOAD_DESC),
         spec::<resize::ResizeInput, resize::ResizeOutput>(RESIZE_ID, RESIZE_DESC),
         spec::<cookies::CookiesListInput, cookies::CookiesListOutput>(
             COOKIES_LIST_ID,
@@ -392,6 +401,7 @@ pub fn register_all(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
     register_downloads_list(iii, sessions);
     register_download(iii, sessions);
     register_download_remove(iii, sessions);
+    register_upload(iii, sessions);
     register_resize(iii, sessions);
     register_cookies_list(iii, sessions);
     register_cookies_set(iii, sessions);
@@ -450,6 +460,59 @@ fn ensure_writable(session: &Session, what: &str) -> Result<(), Error> {
     Ok(())
 }
 
+#[derive(Clone, Copy)]
+enum OriginPermission {
+    Access,
+    Downloads,
+    Uploads,
+    Scripting,
+}
+
+impl OriginPermission {
+    fn key(self) -> &'static str {
+        match self {
+            Self::Access => "access",
+            Self::Downloads => "downloads",
+            Self::Uploads => "uploads",
+            Self::Scripting => "scripting",
+        }
+    }
+
+    fn allowed(self, config: &WorkerConfig, url: &str) -> bool {
+        let policy = origin_policy_for(config, url);
+        match self {
+            Self::Access => policy.access,
+            Self::Downloads => policy.downloads,
+            Self::Uploads => policy.uploads,
+            Self::Scripting => policy.scripting,
+        }
+    }
+}
+
+fn check_origin_permission(
+    config: &WorkerConfig,
+    url: &str,
+    permission: OriginPermission,
+) -> Result<(), String> {
+    if permission.allowed(config, url) {
+        return Ok(());
+    }
+    Err(format!(
+        "origin '{}' is denied by {} ({})",
+        origin_label(url),
+        origin_policy_config_key_for(config, url),
+        permission.key()
+    ))
+}
+
+fn ensure_origin_permission(
+    config: &WorkerConfig,
+    url: &str,
+    permission: OriginPermission,
+) -> Result<(), Error> {
+    check_origin_permission(config, url, permission).map_err(handler_err)
+}
+
 fn register_sessions_start(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
     let sx = sessions.clone();
     iii.register_function(
@@ -458,7 +521,9 @@ fn register_sessions_start(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
             let sx = sx.clone();
             async move {
                 if let Some(url) = &req.url {
-                    sessions::check_scheme(&sx.config.load(), url).map_err(handler_err)?;
+                    let config = sx.config.load();
+                    sessions::check_scheme(&config, url).map_err(handler_err)?;
+                    ensure_origin_permission(&config, url, OriginPermission::Access)?;
                 }
                 let session = sx
                     .start(req.url, req.headful, req.read_only.unwrap_or(false))
@@ -654,9 +719,11 @@ fn register_navigate(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
             async move {
                 let cfg = sx.config.load_full();
                 sessions::check_scheme(&cfg, &req.url).map_err(handler_err)?;
+                ensure_origin_permission(&cfg, &req.url, OriginPermission::Access)?;
                 let session = get_session(&sx, &req.session_id)?;
                 session.touch();
                 let wait = Duration::from_millis(cfg.clamp_timeout(req.timeout_ms));
+                let _navigation = session.navigation_lock.lock().await;
 
                 session
                     .page
@@ -1161,8 +1228,11 @@ fn register_execute(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
                 let session = get_session(&sx, &req.session_id)?;
                 ensure_writable(&session, "browser::execute")?;
                 session.touch();
-                let cfg = sx.config.load();
+                let cfg = sx.config.load_full();
+                let page_url = session.page.url().await.ok().flatten().unwrap_or_default();
+                ensure_origin_permission(&cfg, &page_url, OriginPermission::Scripting)?;
                 let wait = Duration::from_millis(cfg.clamp_timeout(req.timeout_ms));
+                let _navigation = session.navigation_lock.lock().await;
 
                 let state_json = {
                     let state = session.exec_state.lock().unwrap_or_else(|p| p.into_inner());
@@ -1176,7 +1246,98 @@ fn register_execute(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
                     .return_by_value(true)
                     .build()
                     .map_err(handler_err)?;
+
+                let main_frame = session.page.mainframe().await.ok().flatten();
+                let mut navigation_events = session
+                    .page
+                    .event_listener::<cdp_fetch::EventRequestPaused>()
+                    .await
+                    .map_err(|error| {
+                        handler_err(format!("script navigation gate failed: {error}"))
+                    })?;
+                let document_pattern = cdp_fetch::RequestPattern::builder()
+                    .resource_type(cdp_network::ResourceType::Document)
+                    .build();
+                session
+                    .page
+                    .execute(
+                        cdp_fetch::EnableParams::builder()
+                            .pattern(document_pattern)
+                            .build(),
+                    )
+                    .await
+                    .map_err(|error| {
+                        handler_err(format!("script navigation gate failed: {error}"))
+                    })?;
+
+                let navigation_error = Arc::new(std::sync::Mutex::new(None::<String>));
+                let gate_error = navigation_error.clone();
+                let gate_page = session.page.clone();
+                let gate_config = cfg.clone();
+                let navigation_gate = tokio::spawn(async move {
+                    while let Some(event) = navigation_events.next().await {
+                        let is_top_document = main_frame
+                            .as_ref()
+                            .map(|frame_id| *frame_id == event.frame_id)
+                            .unwrap_or(true);
+                        let denial = if is_top_document {
+                            sessions::check_scheme(&gate_config, &event.request.url)
+                                .err()
+                                .or_else(|| {
+                                    check_origin_permission(
+                                        &gate_config,
+                                        &event.request.url,
+                                        OriginPermission::Access,
+                                    )
+                                    .err()
+                                })
+                        } else {
+                            None
+                        };
+
+                        if let Some(error) = denial {
+                            {
+                                let mut slot = gate_error
+                                    .lock()
+                                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                                if slot.is_none() {
+                                    *slot = Some(error);
+                                }
+                            }
+                            let _ = gate_page
+                                .execute(cdp_fetch::FailRequestParams::new(
+                                    event.request_id.clone(),
+                                    cdp_network::ErrorReason::AccessDenied,
+                                ))
+                                .await;
+                        } else {
+                            let _ = gate_page
+                                .execute(cdp_fetch::ContinueRequestParams::new(
+                                    event.request_id.clone(),
+                                ))
+                                .await;
+                        }
+                    }
+                });
+
                 let evaluated = timeout(wait, session.page.execute(params)).await;
+                let disabled = session
+                    .page
+                    .execute(cdp_fetch::DisableParams::default())
+                    .await;
+                if let Err(error) = disabled {
+                    return Err(handler_err(format!(
+                        "script navigation gate cleanup failed: {error}"
+                    )));
+                }
+                navigation_gate.abort();
+                if let Some(error) = navigation_error
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .clone()
+                {
+                    return Err(handler_err(error));
+                }
                 session.touch();
 
                 let current_state = || {
@@ -1440,6 +1601,14 @@ fn register_doctor(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
                     max_sessions: cfg.max_sessions,
                     active_sessions,
                     allowed_schemes: cfg.allowed_schemes.clone(),
+                    configured_origin_policies: cfg
+                        .origin_policies
+                        .as_ref()
+                        .map(|policies| policies.len() as u64)
+                        .unwrap_or(0),
+                    default_origin_policy_set: cfg.default_origin_policy.is_some(),
+                    allow_history_access: cfg.allow_history_access,
+                    allow_cookie_import: cfg.allow_cookie_import,
                     attach_enabled: cfg.allow_attach,
                     recording_available,
                     issues,
@@ -1834,6 +2003,11 @@ fn register_cookies_set(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
             async move {
                 let session = get_session(&sx, &req.session_id)?;
                 ensure_writable(&session, "browser::cookies::set")?;
+                if !sx.config.load().allow_cookie_import {
+                    return Err(handler_err(
+                        "browser::cookies::set is denied by allow_cookie_import=false",
+                    ));
+                }
                 session.touch();
                 let page_url = session.page.url().await.ok().flatten().unwrap_or_default();
                 let count = req.cookies.len();
@@ -1959,6 +2133,11 @@ fn register_history_list(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
         RegisterFunction::new_async(move |req: history_list::HistoryListInput| {
             let sx = sx.clone();
             async move {
+                if !sx.config.load().allow_history_access {
+                    return Err(handler_err(
+                        "browser::history::list is denied by allow_history_access=false",
+                    ));
+                }
                 let session = get_session(&sx, &req.session_id)?;
                 let visits = session.history.lock().unwrap_or_else(|p| p.into_inner());
                 let out =
@@ -2047,14 +2226,19 @@ fn register_download(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
             let sx = sx.clone();
             async move {
                 let session = get_session(&sx, &req.session_id)?;
-                let (file_name, dir) = {
+                let (file_name, url, dir) = {
                     let downloads = session.downloads.lock().unwrap_or_else(|p| p.into_inner());
                     let record = downloads
                         .iter()
                         .find(|d| d.guid == req.guid)
                         .ok_or_else(|| handler_err(format!("no download '{}'", req.guid)))?;
-                    (record.file_name.clone(), session.downloads_dir.clone())
+                    (
+                        record.file_name.clone(),
+                        record.url.clone(),
+                        session.downloads_dir.clone(),
+                    )
                 };
+                ensure_origin_permission(&sx.config.load(), &url, OriginPermission::Downloads)?;
                 let dir = dir.ok_or_else(|| {
                     handler_err("this session does not own downloads (attached session)")
                 })?;
@@ -2116,6 +2300,119 @@ fn register_download_remove(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
             }
         })
         .description(DOWNLOAD_REMOVE_DESC),
+    );
+}
+
+fn register_upload(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
+    let sx = sessions.clone();
+    iii.register_function(
+        UPLOAD_ID,
+        RegisterFunction::new_async(move |req: upload::UploadInput| {
+            let sx = sx.clone();
+            async move {
+                let session = get_session(&sx, &req.session_id)?;
+                ensure_writable(&session, "browser::upload")?;
+                let config = sx.config.load_full();
+                let url = session.page.url().await.ok().flatten().unwrap_or_default();
+                ensure_origin_permission(&config, &url, OriginPermission::Uploads)?;
+                upload::validate_files(&req.files).map_err(handler_err)?;
+                session.touch();
+
+                session
+                    .page
+                    .execute(cdp_dom::EnableParams::default())
+                    .await
+                    .map_err(|error| handler_err(format!("enable DOM failed: {error}")))?;
+                let document = session
+                    .page
+                    .execute(cdp_dom::GetDocumentParams::default())
+                    .await
+                    .map_err(|error| handler_err(format!("document read failed: {error}")))?;
+                let selected = session
+                    .page
+                    .execute(cdp_dom::QuerySelectorParams::new(
+                        document.root.node_id,
+                        req.selector.clone(),
+                    ))
+                    .await
+                    .map_err(|error| handler_err(format!("selector failed: {error}")))?;
+                let matches = session
+                    .page
+                    .execute(cdp_dom::QuerySelectorAllParams::new(
+                        document.root.node_id,
+                        req.selector.clone(),
+                    ))
+                    .await
+                    .map_err(|error| handler_err(format!("selector failed: {error}")))?;
+                if matches.node_ids.len() != 1 {
+                    return Err(handler_err(format!(
+                        "selector '{}' matched {} elements; expected exactly one input[type=file]",
+                        req.selector,
+                        matches.node_ids.len()
+                    )));
+                }
+
+                let described = session
+                    .page
+                    .execute(
+                        cdp_dom::DescribeNodeParams::builder()
+                            .node_id(selected.node_id)
+                            .build(),
+                    )
+                    .await
+                    .map_err(|error| handler_err(format!("describe file input failed: {error}")))?;
+                let is_file_input = described.node.node_name.eq_ignore_ascii_case("input")
+                    && described
+                        .node
+                        .attributes
+                        .as_deref()
+                        .unwrap_or_default()
+                        .chunks(2)
+                        .any(|pair| {
+                            pair.len() == 2
+                                && pair[0].eq_ignore_ascii_case("type")
+                                && pair[1].eq_ignore_ascii_case("file")
+                        });
+                if !is_file_input {
+                    return Err(handler_err(format!(
+                        "selector '{}' must match an input[type=file]",
+                        req.selector
+                    )));
+                }
+
+                let file_names: Vec<String> =
+                    req.files.iter().map(|file| file.name.clone()).collect();
+                let staging_dir = session.create_upload_dir().map_err(handler_err)?;
+                let paths = tokio::task::spawn_blocking(move || {
+                    upload::stage_files(&staging_dir, req.files)
+                })
+                .await
+                .map_err(|error| handler_err(format!("stage upload files failed: {error}")))?
+                .map_err(handler_err)?;
+                let path_strings: Vec<String> = paths
+                    .iter()
+                    .map(|path| path.to_string_lossy().to_string())
+                    .collect();
+                session
+                    .page
+                    .execute(
+                        cdp_dom::SetFileInputFilesParams::builder()
+                            .files(path_strings)
+                            .node_id(selected.node_id)
+                            .build()
+                            .map_err(handler_err)?,
+                    )
+                    .await
+                    .map_err(|error| handler_err(format!("attach upload files failed: {error}")))?;
+                session.touch();
+                Ok::<_, Error>(upload::UploadOutput {
+                    ok: true,
+                    attached: file_names.len(),
+                    file_names,
+                })
+            }
+        })
+        .description(UPLOAD_DESC),
     );
 }
 
@@ -2698,4 +2995,30 @@ fn register_frame(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
         .description(FRAME_DESC)
         .metadata(json!({ "internal": true })),
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{OriginPolicy, OriginPolicyDecision};
+
+    #[test]
+    fn origin_denial_names_the_origin_source_and_permission() {
+        let config = WorkerConfig {
+            origin_policies: Some(std::collections::BTreeMap::from([(
+                "https://x.y".to_string(),
+                OriginPolicy {
+                    access: Some(OriginPolicyDecision::Deny),
+                    ..OriginPolicy::default()
+                },
+            )])),
+            ..WorkerConfig::default()
+        };
+
+        assert_eq!(
+            check_origin_permission(&config, "https://x.y/path", OriginPermission::Access)
+                .unwrap_err(),
+            "origin 'https://x.y' is denied by origin_policies (access)"
+        );
+    }
 }

--- a/browser/src/functions/mod.rs
+++ b/browser/src/functions/mod.rs
@@ -41,7 +41,6 @@ use chromiumoxide::cdp::browser_protocol::accessibility as cdp_ax;
 use chromiumoxide::cdp::browser_protocol::css as cdp_css;
 use chromiumoxide::cdp::browser_protocol::dom as cdp_dom;
 use chromiumoxide::cdp::browser_protocol::emulation as cdp_emulation;
-use chromiumoxide::cdp::browser_protocol::fetch as cdp_fetch;
 use chromiumoxide::cdp::browser_protocol::input;
 use chromiumoxide::cdp::browser_protocol::network as cdp_network;
 use chromiumoxide::cdp::browser_protocol::overlay;
@@ -50,7 +49,6 @@ use chromiumoxide::cdp::browser_protocol::page::CaptureScreenshotFormat;
 use chromiumoxide::cdp::browser_protocol::storage as cdp_storage;
 use chromiumoxide::cdp::js_protocol::runtime as cdp_rt;
 use chromiumoxide::page::ScreenshotParams;
-use futures::StreamExt;
 use iii_sdk::errors::Error;
 use iii_sdk::{IIIClient, RegisterFunction};
 use serde_json::json;
@@ -724,15 +722,20 @@ fn register_navigate(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
                 session.touch();
                 let wait = Duration::from_millis(cfg.clamp_timeout(req.timeout_ms));
                 let _navigation = session.navigation_lock.lock().await;
+                session.clear_navigation_error();
 
-                session
-                    .page
-                    .goto(req.url.as_str())
-                    .await
-                    .map_err(|e| handler_err(format!("navigation failed: {e}")))?;
+                if let Err(error) = session.page.goto(req.url.as_str()).await {
+                    if let Some(policy_error) = session.take_navigation_error() {
+                        return Err(handler_err(policy_error));
+                    }
+                    return Err(handler_err(format!("navigation failed: {error}")));
+                }
                 let timed_out = timeout(wait, session.page.wait_for_navigation())
                     .await
                     .is_err();
+                if let Some(policy_error) = session.take_navigation_error() {
+                    return Err(handler_err(policy_error));
+                }
 
                 let url = session.page.url().await.ok().flatten().unwrap_or(req.url);
                 let title = session.page.get_title().await.ok().flatten();
@@ -1229,10 +1232,11 @@ fn register_execute(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
                 ensure_writable(&session, "browser::execute")?;
                 session.touch();
                 let cfg = sx.config.load_full();
-                let page_url = session.page.url().await.ok().flatten().unwrap_or_default();
-                ensure_origin_permission(&cfg, &page_url, OriginPermission::Scripting)?;
                 let wait = Duration::from_millis(cfg.clamp_timeout(req.timeout_ms));
                 let _navigation = session.navigation_lock.lock().await;
+                let page_url = session.page.url().await.ok().flatten().unwrap_or_default();
+                ensure_origin_permission(&cfg, &page_url, OriginPermission::Scripting)?;
+                session.clear_navigation_error();
 
                 let state_json = {
                     let state = session.exec_state.lock().unwrap_or_else(|p| p.into_inner());
@@ -1247,95 +1251,8 @@ fn register_execute(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
                     .build()
                     .map_err(handler_err)?;
 
-                let main_frame = session.page.mainframe().await.ok().flatten();
-                let mut navigation_events = session
-                    .page
-                    .event_listener::<cdp_fetch::EventRequestPaused>()
-                    .await
-                    .map_err(|error| {
-                        handler_err(format!("script navigation gate failed: {error}"))
-                    })?;
-                let document_pattern = cdp_fetch::RequestPattern::builder()
-                    .resource_type(cdp_network::ResourceType::Document)
-                    .build();
-                session
-                    .page
-                    .execute(
-                        cdp_fetch::EnableParams::builder()
-                            .pattern(document_pattern)
-                            .build(),
-                    )
-                    .await
-                    .map_err(|error| {
-                        handler_err(format!("script navigation gate failed: {error}"))
-                    })?;
-
-                let navigation_error = Arc::new(std::sync::Mutex::new(None::<String>));
-                let gate_error = navigation_error.clone();
-                let gate_page = session.page.clone();
-                let gate_config = cfg.clone();
-                let navigation_gate = tokio::spawn(async move {
-                    while let Some(event) = navigation_events.next().await {
-                        let is_top_document = main_frame
-                            .as_ref()
-                            .map(|frame_id| *frame_id == event.frame_id)
-                            .unwrap_or(true);
-                        let denial = if is_top_document {
-                            sessions::check_scheme(&gate_config, &event.request.url)
-                                .err()
-                                .or_else(|| {
-                                    check_origin_permission(
-                                        &gate_config,
-                                        &event.request.url,
-                                        OriginPermission::Access,
-                                    )
-                                    .err()
-                                })
-                        } else {
-                            None
-                        };
-
-                        if let Some(error) = denial {
-                            {
-                                let mut slot = gate_error
-                                    .lock()
-                                    .unwrap_or_else(|poisoned| poisoned.into_inner());
-                                if slot.is_none() {
-                                    *slot = Some(error);
-                                }
-                            }
-                            let _ = gate_page
-                                .execute(cdp_fetch::FailRequestParams::new(
-                                    event.request_id.clone(),
-                                    cdp_network::ErrorReason::AccessDenied,
-                                ))
-                                .await;
-                        } else {
-                            let _ = gate_page
-                                .execute(cdp_fetch::ContinueRequestParams::new(
-                                    event.request_id.clone(),
-                                ))
-                                .await;
-                        }
-                    }
-                });
-
                 let evaluated = timeout(wait, session.page.execute(params)).await;
-                let disabled = session
-                    .page
-                    .execute(cdp_fetch::DisableParams::default())
-                    .await;
-                if let Err(error) = disabled {
-                    return Err(handler_err(format!(
-                        "script navigation gate cleanup failed: {error}"
-                    )));
-                }
-                navigation_gate.abort();
-                if let Some(error) = navigation_error
-                    .lock()
-                    .unwrap_or_else(|poisoned| poisoned.into_inner())
-                    .clone()
-                {
+                if let Some(error) = session.take_navigation_error() {
                     return Err(handler_err(error));
                 }
                 session.touch();
@@ -2312,11 +2229,12 @@ fn register_upload(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
             async move {
                 let session = get_session(&sx, &req.session_id)?;
                 ensure_writable(&session, "browser::upload")?;
+                upload::validate_files(&req.files).map_err(handler_err)?;
+                session.touch();
+                let _navigation = session.navigation_lock.lock().await;
                 let config = sx.config.load_full();
                 let url = session.page.url().await.ok().flatten().unwrap_or_default();
                 ensure_origin_permission(&config, &url, OriginPermission::Uploads)?;
-                upload::validate_files(&req.files).map_err(handler_err)?;
-                session.touch();
 
                 session
                     .page

--- a/browser/src/functions/upload.rs
+++ b/browser/src/functions/upload.rs
@@ -1,0 +1,140 @@
+//! `browser::upload` — attach local bytes to one page file input.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use base64::engine::general_purpose::STANDARD;
+use base64::Engine;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+pub const MAX_FILES: usize = 8;
+pub const MAX_FILE_BYTES: usize = 25 * 1024 * 1024;
+const MAX_ENCODED_BYTES: usize = MAX_FILE_BYTES.div_ceil(3) * 4;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct UploadFile {
+    /// File name exposed to the page. Path components are rejected.
+    pub name: String,
+    /// File bytes, base64.
+    pub data: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct UploadInput {
+    pub session_id: String,
+    /// CSS selector that must match exactly one input[type=file].
+    pub selector: String,
+    /// Up to eight files, each at most 25 MB decoded.
+    pub files: Vec<UploadFile>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct UploadOutput {
+    pub ok: bool,
+    pub attached: usize,
+    pub file_names: Vec<String>,
+}
+
+pub fn validate_files(files: &[UploadFile]) -> Result<(), String> {
+    if files.len() > MAX_FILES {
+        return Err(format!(
+            "upload has {} files; at most {MAX_FILES} are allowed",
+            files.len()
+        ));
+    }
+    for file in files {
+        if file.name.is_empty()
+            || file.name == "."
+            || file.name.contains(['/', '\\'])
+            || file.name.contains("..")
+        {
+            return Err(format!(
+                "upload file name '{}' must not contain path parts",
+                file.name
+            ));
+        }
+        if file.data.len() > MAX_ENCODED_BYTES {
+            return Err(format!(
+                "upload file '{}' is over the {MAX_FILE_BYTES} byte decoded cap",
+                file.name
+            ));
+        }
+    }
+    Ok(())
+}
+
+pub fn stage_files(dir: &Path, files: Vec<UploadFile>) -> Result<Vec<PathBuf>, String> {
+    validate_files(&files)?;
+    let mut paths = Vec::with_capacity(files.len());
+    for file in files {
+        let bytes = STANDARD
+            .decode(&file.data)
+            .map_err(|e| format!("upload file '{}' has invalid base64: {e}", file.name))?;
+        if bytes.len() > MAX_FILE_BYTES {
+            return Err(format!(
+                "upload file '{}' is {} bytes, over the {MAX_FILE_BYTES} byte cap",
+                file.name,
+                bytes.len()
+            ));
+        }
+        let path = dir.join(&file.name);
+        let mut output = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .map_err(|e| format!("stage upload file '{}' failed: {e}", file.name))?;
+        output
+            .write_all(&bytes)
+            .map_err(|e| format!("stage upload file '{}' failed: {e}", file.name))?;
+        paths.push(path);
+    }
+    Ok(paths)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn file(name: &str, bytes: &[u8]) -> UploadFile {
+        UploadFile {
+            name: name.to_string(),
+            data: STANDARD.encode(bytes),
+        }
+    }
+
+    #[test]
+    fn rejects_path_parts_and_too_many_files() {
+        for name in ["../secret", "a/b", "a\\b", "report..pdf", ".", ""] {
+            assert!(validate_files(&[file(name, b"x")]).is_err(), "{name}");
+        }
+        let files: Vec<_> = (0..=MAX_FILES)
+            .map(|index| file(&format!("{index}.txt"), b"x"))
+            .collect();
+        assert!(validate_files(&files).is_err());
+    }
+
+    #[test]
+    fn stages_decoded_bytes_with_the_requested_name() {
+        let dir = std::env::temp_dir().join(format!(
+            "iii-browser-upload-test-{}-{}",
+            std::process::id(),
+            crate::session::now_ms()
+        ));
+        std::fs::create_dir(&dir).unwrap();
+        let paths = stage_files(&dir, vec![file("report.txt", b"hello")]).unwrap();
+        assert_eq!(paths, vec![dir.join("report.txt")]);
+        assert_eq!(std::fs::read(&paths[0]).unwrap(), b"hello");
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn rejects_invalid_base64() {
+        let input = UploadFile {
+            name: "bad.txt".to_string(),
+            data: "not base64".to_string(),
+        };
+        let error = stage_files(Path::new("/unused"), vec![input]).unwrap_err();
+        assert!(error.contains("invalid base64"), "{error}");
+    }
+}

--- a/browser/src/session.rs
+++ b/browser/src/session.rs
@@ -22,7 +22,7 @@ use futures::StreamExt;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::config::{SharedConfig, WorkerConfig};
+use crate::config::{origin_policy_for, SharedConfig, WorkerConfig};
 use crate::events::{
     Bounds, ConsoleEventPayload, DownloadChangedEvent, Emitter, EventKind, NavigatedEvent,
     PickedElement, PickedEvent, SessionStoppedEvent,
@@ -43,6 +43,32 @@ pub fn now_ms() -> i64 {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_millis() as i64)
         .unwrap_or(0)
+}
+
+fn temp_nonce() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0)
+}
+
+fn create_private_temp_dir(
+    prefix: &str,
+    owner: &str,
+    nonce: u128,
+) -> std::io::Result<std::path::PathBuf> {
+    let path = std::env::temp_dir().join(format!(
+        "{prefix}-{}-{owner}-{nonce:032x}",
+        std::process::id()
+    ));
+    let mut builder = std::fs::DirBuilder::new();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        builder.mode(0o700);
+    }
+    builder.create(&path)?;
+    Ok(path)
 }
 
 pub fn truncate(s: &str, max: usize) -> String {
@@ -350,6 +376,8 @@ pub struct Session {
     /// Cross-call state for `browser::execute`; lives until the session
     /// stops.
     pub exec_state: Mutex<serde_json::Value>,
+    /// Serializes explicit navigation and execute's temporary document gate.
+    pub navigation_lock: tokio::sync::Mutex<()>,
     /// Committed top-document navigations, newest last, for the history
     /// panel and address-bar suggestions. Capped like the other buffers.
     pub history: Mutex<Vec<HistoryVisit>>,
@@ -358,6 +386,10 @@ pub struct Session {
     pub downloads: Mutex<Vec<DownloadRecord>>,
     /// Where `allowAndName` writes files (named by guid); removed on stop.
     pub downloads_dir: Option<std::path::PathBuf>,
+    /// File-input staging directories retained while Chromium may still read
+    /// their paths, then removed on stop.
+    upload_dirs: Mutex<Vec<std::path::PathBuf>>,
+    upload_counter: AtomicU64,
     pick_counter: AtomicU64,
     tasks: Mutex<Vec<tokio::task::JoinHandle<()>>>,
 }
@@ -437,13 +469,37 @@ impl Session {
     }
 
     /// Update a download's progress and state by guid.
-    pub fn download_progress(&self, guid: &str, received: u64, total: u64, state: &str) {
+    pub fn download_progress(&self, guid: &str, received: u64, total: u64, state: &str) -> bool {
         let mut downloads = self.downloads.lock().unwrap_or_else(|p| p.into_inner());
         if let Some(record) = downloads.iter_mut().find(|d| d.guid == guid) {
             record.received_bytes = received;
             record.total_bytes = total.max(received);
             record.state = state.to_string();
+            true
+        } else {
+            false
         }
+    }
+
+    pub fn remove_download_file(&self, guid: &str) {
+        if guid.contains(['/', '\\']) || guid.contains("..") {
+            return;
+        }
+        if let Some(dir) = &self.downloads_dir {
+            let _ = std::fs::remove_file(dir.join(guid));
+        }
+    }
+
+    pub fn create_upload_dir(&self) -> Result<std::path::PathBuf, String> {
+        let sequence = self.upload_counter.fetch_add(1, Ordering::Relaxed) + 1;
+        let owner = format!("{}-{sequence}", self.id);
+        let path = create_private_temp_dir("iii-browser-upload", &owner, temp_nonce())
+            .map_err(|error| format!("create upload staging dir failed: {error}"))?;
+        self.upload_dirs
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .push(path.clone());
+        Ok(path)
     }
 
     pub fn next_seq(&self) -> u64 {
@@ -590,6 +646,14 @@ impl Session {
                 }
             }
         }
+        for dir in self
+            .upload_dirs
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .drain(..)
+        {
+            let _ = std::fs::remove_dir_all(dir);
+        }
     }
 }
 
@@ -713,22 +777,9 @@ impl Sessions {
         // that refuses leaves downloads disabled, not the session broken.
         // The dir name carries a nonce so it cannot be squatted in advance,
         // and it is created fresh, owner-only, refusing a pre-existing path.
-        let nonce = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.subsec_nanos())
-            .unwrap_or(0);
-        let downloads_dir = std::env::temp_dir().join(format!(
-            "iii-browser-dl-{}-{slot}-{nonce:08x}",
-            std::process::id()
-        ));
-        let mut dir_builder = std::fs::DirBuilder::new();
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::DirBuilderExt;
-            dir_builder.mode(0o700);
-        }
-        let dir_ok = dir_builder.create(&downloads_dir).is_ok();
-        if dir_ok {
+        let downloads_dir =
+            create_private_temp_dir("iii-browser-dl", &slot.to_string(), temp_nonce()).ok();
+        if let Some(downloads_dir) = &downloads_dir {
             if let Ok(params) = cdp_browser::SetDownloadBehaviorParams::builder()
                 .behavior(cdp_browser::SetDownloadBehaviorBehavior::AllowAndName)
                 .download_path(downloads_dir.to_string_lossy().to_string())
@@ -765,9 +816,12 @@ impl Sessions {
             generation: AtomicU64::new(1),
             snapshot_keys: Mutex::new(None),
             exec_state: Mutex::new(serde_json::Value::Object(serde_json::Map::new())),
+            navigation_lock: tokio::sync::Mutex::new(()),
             history: Mutex::new(Vec::new()),
             downloads: Mutex::new(Vec::new()),
-            downloads_dir: dir_ok.then(|| downloads_dir.clone()),
+            downloads_dir,
+            upload_dirs: Mutex::new(Vec::new()),
+            upload_counter: AtomicU64::new(0),
             pick_counter: AtomicU64::new(0),
             tasks: Mutex::new(vec![handler_task]),
         });
@@ -863,9 +917,12 @@ impl Sessions {
             generation: AtomicU64::new(1),
             snapshot_keys: Mutex::new(None),
             exec_state: Mutex::new(serde_json::Value::Object(serde_json::Map::new())),
+            navigation_lock: tokio::sync::Mutex::new(()),
             history: Mutex::new(Vec::new()),
             downloads: Mutex::new(Vec::new()),
             downloads_dir: None,
+            upload_dirs: Mutex::new(Vec::new()),
+            upload_counter: AtomicU64::new(0),
             pick_counter: AtomicU64::new(0),
             tasks: Mutex::new(vec![handler_task]),
         });
@@ -1651,6 +1708,15 @@ async fn spawn_event_pumps(
             let sx = sessions.clone();
             tasks.push(tokio::spawn(async move {
                 while let Some(event) = events.next().await {
+                    let current_url = s.page.url().await.ok().flatten().unwrap_or_default();
+                    if !origin_policy_for(&sx.config.load(), &current_url).downloads {
+                        let _ = s
+                            .page
+                            .execute(cdp_browser::CancelDownloadParams::new(event.guid.clone()))
+                            .await;
+                        s.remove_download_file(&event.guid);
+                        continue;
+                    }
                     s.download_begin(&event.guid, &event.suggested_filename, &event.url);
                     emit_download_changed(&sx, &s).await;
                 }
@@ -1673,12 +1739,16 @@ async fn spawn_event_pumps(
                         cdp_browser::DownloadProgressState::Completed => "completed",
                         cdp_browser::DownloadProgressState::Canceled => "canceled",
                     };
-                    s.download_progress(
+                    let recorded = s.download_progress(
                         &event.guid,
                         event.received_bytes as u64,
                         event.total_bytes as u64,
                         state,
                     );
+                    if !recorded {
+                        s.remove_download_file(&event.guid);
+                        continue;
+                    }
                     if state != "in_progress" || last_emit.elapsed().as_millis() >= 250 {
                         last_emit = std::time::Instant::now();
                         emit_download_changed(&sx, &s).await;
@@ -2010,5 +2080,20 @@ mod tests {
         assert_eq!(b.y, 20.0);
         assert_eq!(b.width, 100.0);
         assert_eq!(b.height, 40.0);
+    }
+
+    #[test]
+    fn private_temp_dir_is_fresh_and_owner_only() {
+        let owner = format!("test-{}", temp_nonce());
+        let nonce = temp_nonce();
+        let path = create_private_temp_dir("iii-browser-dir-test", &owner, nonce).unwrap();
+        assert!(create_private_temp_dir("iii-browser-dir-test", &owner, nonce).is_err());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o700);
+        }
+        std::fs::remove_dir(path).unwrap();
     }
 }

--- a/browser/src/session.rs
+++ b/browser/src/session.rs
@@ -14,6 +14,7 @@ use base64::Engine;
 use chromiumoxide::browser::{Browser, BrowserConfig};
 use chromiumoxide::cdp::browser_protocol::browser as cdp_browser;
 use chromiumoxide::cdp::browser_protocol::dom;
+use chromiumoxide::cdp::browser_protocol::fetch as cdp_fetch;
 use chromiumoxide::cdp::browser_protocol::log as cdp_log;
 use chromiumoxide::cdp::browser_protocol::network as cdp_network;
 use chromiumoxide::cdp::js_protocol::runtime;
@@ -22,7 +23,9 @@ use futures::StreamExt;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::config::{origin_policy_for, SharedConfig, WorkerConfig};
+use crate::config::{
+    origin_label, origin_policy_config_key_for, origin_policy_for, SharedConfig, WorkerConfig,
+};
 use crate::events::{
     Bounds, ConsoleEventPayload, DownloadChangedEvent, Emitter, EventKind, NavigatedEvent,
     PickedElement, PickedEvent, SessionStoppedEvent,
@@ -157,6 +160,23 @@ const HISTORY_CAP: usize = 200;
 /// How many downloads a session keeps; the oldest record and its file are
 /// dropped past this, like the other per-session buffers.
 const DOWNLOADS_CAP: usize = 100;
+
+/// How many upload staging directories a session retains while the page may
+/// still read their files.
+const UPLOAD_DIRS_CAP: usize = 16;
+
+fn remove_oldest_upload_dir(upload_dirs: &mut Vec<std::path::PathBuf>) -> Result<(), String> {
+    let Some(oldest) = upload_dirs.first() else {
+        return Ok(());
+    };
+    match std::fs::remove_dir_all(oldest) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(format!("remove oldest upload staging dir failed: {error}")),
+    }
+    upload_dirs.remove(0);
+    Ok(())
+}
 
 /// A download Chromium started, tracked by its CDP guid.
 #[derive(Debug, Clone, serde::Serialize, schemars::JsonSchema)]
@@ -376,8 +396,11 @@ pub struct Session {
     /// Cross-call state for `browser::execute`; lives until the session
     /// stops.
     pub exec_state: Mutex<serde_json::Value>,
-    /// Serializes explicit navigation and execute's temporary document gate.
+    /// Serializes explicit navigation, execute, and file-input attachment.
     pub navigation_lock: tokio::sync::Mutex<()>,
+    /// Loud policy denial captured by the session navigation gate for the
+    /// explicit navigation or execute call currently holding the lock.
+    navigation_error: Mutex<Option<String>>,
     /// Committed top-document navigations, newest last, for the history
     /// panel and address-bar suggestions. Capped like the other buffers.
     pub history: Mutex<Vec<HistoryVisit>>,
@@ -397,6 +420,30 @@ pub struct Session {
 impl Session {
     pub fn touch(&self) {
         self.last_used_ms.store(now_ms() as u64, Ordering::Relaxed);
+    }
+
+    pub fn clear_navigation_error(&self) {
+        *self
+            .navigation_error
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+    }
+
+    pub fn record_navigation_error(&self, error: String) {
+        let mut slot = self
+            .navigation_error
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if slot.is_none() {
+            *slot = Some(error);
+        }
+    }
+
+    pub fn take_navigation_error(&self) -> Option<String> {
+        self.navigation_error
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take()
     }
 
     pub fn viewport(&self) -> (u32, u32) {
@@ -491,14 +538,18 @@ impl Session {
     }
 
     pub fn create_upload_dir(&self) -> Result<std::path::PathBuf, String> {
+        let mut upload_dirs = self
+            .upload_dirs
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if upload_dirs.len() >= UPLOAD_DIRS_CAP {
+            remove_oldest_upload_dir(&mut upload_dirs)?;
+        }
         let sequence = self.upload_counter.fetch_add(1, Ordering::Relaxed) + 1;
         let owner = format!("{}-{sequence}", self.id);
         let path = create_private_temp_dir("iii-browser-upload", &owner, temp_nonce())
             .map_err(|error| format!("create upload staging dir failed: {error}"))?;
-        self.upload_dirs
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .push(path.clone());
+        upload_dirs.push(path.clone());
         Ok(path)
     }
 
@@ -742,6 +793,7 @@ impl Sessions {
         };
         let slot = self.counter.fetch_add(1, Ordering::Relaxed) + 1;
         let (browser_config, ephemeral_profile) = build_browser_config(&cfg, headless, slot)?;
+        let origin_gate_enabled = origin_gate_configured(&cfg);
 
         let (browser, mut handler) = Browser::launch(browser_config)
             .await
@@ -755,10 +807,12 @@ impl Sessions {
             }
         });
 
-        let page = match browser
-            .new_page(url.as_deref().unwrap_or("about:blank"))
-            .await
-        {
+        let initial_url = if origin_gate_enabled {
+            "about:blank"
+        } else {
+            url.as_deref().unwrap_or("about:blank")
+        };
+        let page = match browser.new_page(initial_url).await {
             Ok(p) => p,
             Err(e) => {
                 handler_task.abort();
@@ -817,6 +871,7 @@ impl Sessions {
             snapshot_keys: Mutex::new(None),
             exec_state: Mutex::new(serde_json::Value::Object(serde_json::Map::new())),
             navigation_lock: tokio::sync::Mutex::new(()),
+            navigation_error: Mutex::new(None),
             history: Mutex::new(Vec::new()),
             downloads: Mutex::new(Vec::new()),
             downloads_dir,
@@ -826,12 +881,35 @@ impl Sessions {
             tasks: Mutex::new(vec![handler_task]),
         });
 
-        let pumps = spawn_event_pumps(self.clone(), session.clone()).await;
+        let pumps =
+            match spawn_event_pumps(self.clone(), session.clone(), origin_gate_enabled).await {
+                Ok(pumps) => pumps,
+                Err(error) => {
+                    session.shutdown().await;
+                    return Err(error);
+                }
+            };
         session
             .tasks
             .lock()
             .unwrap_or_else(|p| p.into_inner())
             .extend(pumps);
+
+        if origin_gate_enabled {
+            if let Some(url) = url.as_deref() {
+                session.clear_navigation_error();
+                let navigation = session.page.goto(url).await;
+                let policy_error = session.take_navigation_error();
+                if let Some(error) = policy_error {
+                    session.shutdown().await;
+                    return Err(error);
+                }
+                if let Err(error) = navigation {
+                    session.shutdown().await;
+                    return Err(format!("failed to open page: {error}"));
+                }
+            }
+        }
 
         self.lock().insert(id, session.clone());
         Ok(session)
@@ -856,6 +934,7 @@ impl Sessions {
                 cfg.max_sessions
             ));
         }
+        let origin_gate_enabled = origin_gate_configured(&cfg);
 
         let (browser, mut handler) = Browser::connect(cdp_url.clone())
             .await
@@ -874,7 +953,11 @@ impl Sessions {
                 Err(e) => Err(e),
             },
             None => browser
-                .new_page(url.as_deref().unwrap_or("about:blank"))
+                .new_page(if origin_gate_enabled {
+                    "about:blank"
+                } else {
+                    url.as_deref().unwrap_or("about:blank")
+                })
                 .await
                 .map(|p| (p, true))
                 .map_err(|e| format!("failed to open tab: {e}")),
@@ -918,6 +1001,7 @@ impl Sessions {
             snapshot_keys: Mutex::new(None),
             exec_state: Mutex::new(serde_json::Value::Object(serde_json::Map::new())),
             navigation_lock: tokio::sync::Mutex::new(()),
+            navigation_error: Mutex::new(None),
             history: Mutex::new(Vec::new()),
             downloads: Mutex::new(Vec::new()),
             downloads_dir: None,
@@ -927,12 +1011,36 @@ impl Sessions {
             tasks: Mutex::new(vec![handler_task]),
         });
 
-        let pumps = spawn_event_pumps(self.clone(), session.clone()).await;
+        let pumps =
+            match spawn_event_pumps(self.clone(), session.clone(), origin_gate_enabled).await {
+                Ok(pumps) => pumps,
+                Err(error) => {
+                    self.release_adopted_page(&session);
+                    session.shutdown().await;
+                    return Err(error);
+                }
+            };
         session
             .tasks
             .lock()
             .unwrap_or_else(|p| p.into_inner())
             .extend(pumps);
+
+        if origin_gate_enabled && owns_page {
+            if let Some(url) = url.as_deref() {
+                session.clear_navigation_error();
+                let navigation = session.page.goto(url).await;
+                let policy_error = session.take_navigation_error();
+                if let Some(error) = policy_error {
+                    session.shutdown().await;
+                    return Err(error);
+                }
+                if let Err(error) = navigation {
+                    session.shutdown().await;
+                    return Err(format!("failed to open tab: {error}"));
+                }
+            }
+        }
 
         self.lock().insert(id, session.clone());
         Ok(session)
@@ -1020,6 +1128,16 @@ impl Sessions {
         }
     }
 
+    fn release_adopted_page(&self, session: &Session) {
+        if let SessionKind::Attached { owns_page: false } = session.kind {
+            let target = session.page.target_id().as_ref().to_string();
+            self.adopted_targets
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .remove(&target);
+        }
+    }
+
     /// Remove + shut down. Returns whether the session was running —
     /// stopping an unknown id succeeds (delete semantics: the caller wants
     /// it gone, and it is).
@@ -1027,13 +1145,7 @@ impl Sessions {
         let session = self.lock().remove(id);
         match session {
             Some(session) => {
-                if let SessionKind::Attached { owns_page: false } = session.kind {
-                    let target = session.page.target_id().as_ref().to_string();
-                    self.adopted_targets
-                        .lock()
-                        .unwrap_or_else(|p| p.into_inner())
-                        .remove(&target);
-                }
+                self.release_adopted_page(&session);
                 // Drop any handoff parked on this session so its call
                 // unblocks (its receiver errors) instead of waiting for the
                 // full timeout against a dead page.
@@ -1387,15 +1499,105 @@ fn build_browser_config(
     Ok((builder.build()?, ephemeral))
 }
 
+fn origin_gate_configured(config: &WorkerConfig) -> bool {
+    config.origin_policies.is_some() || config.default_origin_policy.is_some()
+}
+
+fn origin_access_denial(config: &WorkerConfig, url: &str) -> Option<String> {
+    if origin_policy_for(config, url).access {
+        return None;
+    }
+    Some(format!(
+        "origin '{}' is denied by {} (access)",
+        origin_label(url),
+        origin_policy_config_key_for(config, url)
+    ))
+}
+
 /// Arm the per-session CDP event listeners. Each pump owns one event stream,
 /// pushes into the ring buffer, and (console + pick) forwards to trigger
 /// subscribers.
 async fn spawn_event_pumps(
     sessions: Arc<Sessions>,
     session: Arc<Session>,
-) -> Vec<tokio::task::JoinHandle<()>> {
+    origin_gate_enabled: bool,
+) -> Result<Vec<tokio::task::JoinHandle<()>>, String> {
     let mut tasks = Vec::new();
     let page = &session.page;
+
+    if origin_gate_enabled {
+        let main_frame = page
+            .mainframe()
+            .await
+            .map_err(|error| format!("origin policy gate failed to read main frame: {error}"))?
+            .ok_or_else(|| "origin policy gate found no main frame".to_string())?;
+        let mut events = page
+            .event_listener::<cdp_fetch::EventRequestPaused>()
+            .await
+            .map_err(|error| format!("origin policy gate failed to listen: {error}"))?;
+        let document_pattern = cdp_fetch::RequestPattern::builder()
+            .resource_type(cdp_network::ResourceType::Document)
+            .build();
+        page.execute(
+            cdp_fetch::EnableParams::builder()
+                .pattern(document_pattern)
+                .build(),
+        )
+        .await
+        .map_err(|error| format!("origin policy gate failed to enable: {error}"))?;
+
+        let s = session.clone();
+        let sx = sessions.clone();
+        tasks.push(tokio::spawn(async move {
+            while let Some(event) = events.next().await {
+                let is_top_document = event.resource_type == cdp_network::ResourceType::Document
+                    && event.frame_id == main_frame;
+                if !is_top_document {
+                    let _ = s
+                        .page
+                        .execute(cdp_fetch::ContinueRequestParams::new(
+                            event.request_id.clone(),
+                        ))
+                        .await;
+                    continue;
+                }
+
+                let denial = {
+                    let config = sx.config.load();
+                    origin_access_denial(&config, &event.request.url)
+                };
+                if let Some(error) = denial {
+                    s.record_navigation_error(error);
+                    if let Err(command_error) = s
+                        .page
+                        .execute(cdp_fetch::FailRequestParams::new(
+                            event.request_id.clone(),
+                            cdp_network::ErrorReason::BlockedByClient,
+                        ))
+                        .await
+                    {
+                        tracing::warn!(
+                            session_id = %s.id,
+                            error = %command_error,
+                            "origin policy request failure command failed"
+                        );
+                    }
+                } else if let Err(command_error) = s
+                    .page
+                    .execute(cdp_fetch::ContinueRequestParams::new(
+                        event.request_id.clone(),
+                    ))
+                    .await
+                {
+                    tracing::debug!(
+                        session_id = %s.id,
+                        error = %command_error,
+                        "origin policy request continue failed"
+                    );
+                }
+            }
+        }));
+    }
 
     // console.* calls
     if let Ok(mut events) = page
@@ -1708,8 +1910,7 @@ async fn spawn_event_pumps(
             let sx = sessions.clone();
             tasks.push(tokio::spawn(async move {
                 while let Some(event) = events.next().await {
-                    let current_url = s.page.url().await.ok().flatten().unwrap_or_default();
-                    if !origin_policy_for(&sx.config.load(), &current_url).downloads {
+                    if !origin_policy_for(&sx.config.load(), &event.url).downloads {
                         let _ = s
                             .page
                             .execute(cdp_browser::CancelDownloadParams::new(event.guid.clone()))
@@ -1758,7 +1959,7 @@ async fn spawn_event_pumps(
         }
     }
 
-    tasks
+    Ok(tasks)
 }
 
 async fn emit_download_changed(sessions: &Arc<Sessions>, session: &Arc<Session>) {
@@ -2095,5 +2296,25 @@ mod tests {
             assert_eq!(mode, 0o700);
         }
         std::fs::remove_dir(path).unwrap();
+    }
+
+    #[test]
+    fn upload_dir_cap_removes_the_oldest_directory() {
+        let owner = format!("upload-cap-test-{}", temp_nonce());
+        let root = create_private_temp_dir("iii-browser-dir-test", &owner, temp_nonce()).unwrap();
+        let mut upload_dirs = Vec::new();
+        for index in 0..UPLOAD_DIRS_CAP {
+            let path = root.join(index.to_string());
+            std::fs::create_dir(&path).unwrap();
+            upload_dirs.push(path);
+        }
+        let oldest = upload_dirs[0].clone();
+
+        remove_oldest_upload_dir(&mut upload_dirs).unwrap();
+
+        assert_eq!(upload_dirs.len(), UPLOAD_DIRS_CAP - 1);
+        assert!(!oldest.exists());
+        assert_eq!(upload_dirs[0], root.join("1"));
+        std::fs::remove_dir_all(root).unwrap();
     }
 }

--- a/browser/tests/golden/schemas/browser.doctor.json
+++ b/browser/tests/golden/schemas/browser.doctor.json
@@ -12,8 +12,12 @@
     "type": "object",
     "required": [
       "active_sessions",
+      "allow_cookie_import",
+      "allow_history_access",
       "allowed_schemes",
       "attach_enabled",
+      "configured_origin_policies",
+      "default_origin_policy_set",
       "headless_default",
       "issues",
       "max_sessions",
@@ -25,6 +29,12 @@
         "type": "integer",
         "format": "uint64",
         "minimum": 0.0
+      },
+      "allow_cookie_import": {
+        "type": "boolean"
+      },
+      "allow_history_access": {
+        "type": "boolean"
       },
       "allowed_schemes": {
         "type": "array",
@@ -47,6 +57,14 @@
           "string",
           "null"
         ]
+      },
+      "configured_origin_policies": {
+        "type": "integer",
+        "format": "uint64",
+        "minimum": 0.0
+      },
+      "default_origin_policy_set": {
+        "type": "boolean"
       },
       "headless_default": {
         "type": "boolean"

--- a/browser/tests/golden/schemas/browser.upload.json
+++ b/browser/tests/golden/schemas/browser.upload.json
@@ -1,0 +1,75 @@
+{
+  "function_id": "browser::upload",
+  "description": "Attach up to eight base64 files to exactly one input[type=file] selected by CSS. Files are staged privately for the session and removed when it stops.",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "UploadInput",
+    "type": "object",
+    "required": [
+      "files",
+      "selector",
+      "session_id"
+    ],
+    "properties": {
+      "files": {
+        "description": "Up to eight files, each at most 25 MB decoded.",
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/UploadFile"
+        }
+      },
+      "selector": {
+        "description": "CSS selector that must match exactly one input[type=file].",
+        "type": "string"
+      },
+      "session_id": {
+        "type": "string"
+      }
+    },
+    "definitions": {
+      "UploadFile": {
+        "type": "object",
+        "required": [
+          "data",
+          "name"
+        ],
+        "properties": {
+          "data": {
+            "description": "File bytes, base64.",
+            "type": "string"
+          },
+          "name": {
+            "description": "File name exposed to the page. Path components are rejected.",
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "UploadOutput",
+    "type": "object",
+    "required": [
+      "attached",
+      "file_names",
+      "ok"
+    ],
+    "properties": {
+      "attached": {
+        "type": "integer",
+        "format": "uint",
+        "minimum": 0.0
+      },
+      "file_names": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "ok": {
+        "type": "boolean"
+      }
+    }
+  }
+}

--- a/browser/tests/schemas.rs
+++ b/browser/tests/schemas.rs
@@ -1,4 +1,4 @@
-//! Wire-schema snapshots for the forty-one `browser::*` functions.
+//! Wire-schema snapshots for the forty-two `browser::*` functions.
 //!
 //! `browser::functions::catalog()` is the single source of truth for each
 //! function's id, registration description, and schemars-derived
@@ -32,7 +32,7 @@ fn spec_to_pretty_json(spec: &FunctionSpec) -> String {
     pretty
 }
 
-/// The catalog must cover exactly the forty-one registered functions, in
+/// The catalog must cover exactly the forty-two registered functions, in
 /// registration order (kept in lockstep with `register_all`).
 #[test]
 fn catalog_lists_all_functions_in_registration_order() {
@@ -77,6 +77,7 @@ fn catalog_lists_all_functions_in_registration_order() {
             "browser::downloads::list",
             "browser::download",
             "browser::download::remove",
+            "browser::upload",
             "browser::resize",
             "browser::cookies::list",
             "browser::cookies::set",


### PR DESCRIPTION
## What

Per-origin access policy for the browser worker, and file uploads into a page.

**Origin policy.** The worker config gains `default_origin_policy` and an
`origin_policies` map. A policy holds four allow/deny switches: `access`,
`downloads`, `uploads`, `scripting`. Resolution precedence for a URL: exact
origin (`https://app.example.com:8443`) first, then bare host
(`app.example.com`), then the default policy; everything is allow when
unconfigured. Two standalone switches join them: `allow_history_access` and
`allow_cookie_import`.

Enforcement:
- `access` gates `sessions::start`, `navigate`, and navigations that happen
  inside `execute` (a request-event listener checks each top-level navigation,
  so redirects are covered too)
- `downloads` gates the download record path and `browser::download` (the read
  checks the recorded download's own origin)
- `scripting` gates `browser::execute` only; the worker's internal feature
  scripts (zoom, find-in-page, pick hints) are not agent scripting and stay
  exempt
- `allow_history_access` gates `history::list`; `allow_cookie_import` gates
  `cookies::set`
- a denied call errors loudly, naming the origin and the config key that
  denied it

**Uploads (new `browser::upload`).** Base64 files land in a session-owned
staging directory (nonce-named, owner-only 0o700, created fresh, refused if
pre-existing — the same hardening as the downloads dir, now a shared helper),
then attach to a CSS-selected `input[type=file]` via the DOM file-input
protocol command. Caps: 8 files, 25 MB decoded each (the encoded length is
bounded before decoding), file names with path parts are rejected, staging
files are created with `create_new` so nothing is overwritten, and the dirs
are removed with the session. Gated by `read_only` and the `uploads` policy
of the page's current origin.

`browser::doctor` reports the effective policy shape: how many origins are
configured, whether a default policy is set, and the two standalone switches.

## How verified

- 220 lib tests (11 new: policy precedence incl. ports, scheme mismatch,
  unparseable URLs; upload validation incl. path parts, caps, base64),
  clippy `-D warnings`, `cargo fmt`, golden schema round-trip — all clean.
- New golden schemas for `browser::upload` and the extended doctor output.

Stacked on the browser-page epic; part of MOT-4533.
