### PR TITLE
(MOT-4533) fix(browser): console and network dock rows overlap in narrow panes

### DIFF
--- a/browser/ui/styles.css
+++ b/browser/ui/styles.css
@@ -1100,14 +1100,15 @@
   padding: 0;
   list-style: none;
   overflow-y: auto;
+  overflow-x: auto;
   display: flex;
   flex-direction: column-reverse;
 }
 [data-iii-ui="browser"] .br-ui-devtools-row {
   display: grid;
-  grid-template-columns: 8px 82px 74px minmax(220px, 1fr) minmax(90px, auto);
+  grid-template-columns: 8px 76px 64px minmax(0, 1fr) minmax(0, 140px);
   align-items: start;
-  min-width: 620px;
+  min-width: 480px;
   padding: 5px 10px;
   border-bottom: 1px solid var(--color-rule-2);
   color: var(--color-ink);
@@ -1196,8 +1197,8 @@
 [data-iii-ui="browser"] .br-ui-nhead,
 [data-iii-ui="browser"] .br-ui-nrow {
   display: grid;
-  grid-template-columns: 72px 52px 62px minmax(240px, 1fr) minmax(100px, auto);
-  min-width: 660px;
+  grid-template-columns: 72px 52px 62px minmax(0, 1fr) minmax(0, 150px);
+  min-width: 640px;
 }
 
 [data-iii-ui="browser"] .br-ui-nhead {

--- a/browser/ui/styles.css
+++ b/browser/ui/styles.css
@@ -1191,7 +1191,7 @@
 }
 
 [data-iii-ui="browser"] .br-ui-network-table > .br-ui-feed {
-  min-width: 660px;
+  min-width: 640px;
 }
 
 [data-iii-ui="browser"] .br-ui-nhead,


### PR DESCRIPTION
## What

The console and network dock rows in the browser page overlapped their right-hand column in narrow panes.

Two causes, both in the row grids:

- The console feed only scrolled vertically. Its rows carried `min-width: 620px`, so in a pane narrower than that the grid overflowed with no horizontal scroller and the right-aligned source column (`https://…:577`) rendered on top of the wrapping message text. It now gets `overflow-x: auto` like the network table already has.
- Both grids ended in an unbounded `minmax(90px, auto)` / `minmax(100px, auto)` track. A long URL in a nowrap cell grew that track without limit and squeezed the message/url column. Both last columns are now capped (`minmax(0, 140px)` console source, `minmax(0, 150px)` network mime) and the flexible columns use `minmax(0, 1fr)` so they shrink instead of pushing. The cells already truncate with ellipsis, so the cap reads as a clean trim, not a clip.

Row min-widths dropped accordingly (620→480 console, 660→640 network) so the horizontal scroller only appears when the columns genuinely cannot fit.

## How verified

- `tsc --noEmit`, `node build.mjs`, browser-ui tests (27) clean.
- The console message now wraps within its column with the source pinned to the right, no overlap, at pane widths down to the dock minimum.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved browser feed and network/devtools layouts for narrower screens.
  * Added horizontal scrolling to the feed.
  * Reduced devtools and network panel minimum widths and column sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->