### PR TITLE
(MOT-4533) feat(browser): act drag gesture and arrow ghost cursor

### DIFF
--- a/browser/src/functions/act.rs
+++ b/browser/src/functions/act.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ActInput {
     pub session_id: String,
-    /// `click`, `hover`, `type`, `press`, or `scroll`.
+    /// `click`, `hover`, `type`, `press`, `scroll`, or `drag`.
     pub action: String,
     /// Mouse button for `click`: `left` (default), `right`, or `middle`.
     #[serde(default)]
@@ -35,6 +35,13 @@ pub struct ActInput {
     /// Scroll distance in pixels; positive scrolls down (`scroll`).
     #[serde(default)]
     pub delta_y: Option<f64>,
+    /// Drag end x, in viewport pixels (`drag`). The start is `x`/`y` or a
+    /// `ref`; the end is `x2`/`y2`.
+    #[serde(default)]
+    pub x2: Option<f64>,
+    /// Drag end y, in viewport pixels (`drag`).
+    #[serde(default)]
+    pub y2: Option<f64>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]

--- a/browser/src/functions/mod.rs
+++ b/browser/src/functions/mod.rs
@@ -83,8 +83,8 @@ pub const SCREENSHOT_DESC: &str =
 pub const ACT_ID: &str = "browser::act";
 pub const ACT_DESC: &str =
     "Interact with the page: click (left/right/middle, single or double), hover, type, press, \
-     or scroll. Address elements with a [ref=eN] handle from browser::snapshot (or a pick), or \
-     raw viewport coordinates.";
+     scroll, or drag (press at the start point, glide to x2/y2, release). Address elements with \
+     a [ref=eN] handle from browser::snapshot (or a pick), or raw viewport coordinates.";
 pub const EVALUATE_ID: &str = "browser::evaluate";
 pub const EVALUATE_DESC: &str =
     "Evaluate a JavaScript expression in the page and return its completion value. Use for \
@@ -773,6 +773,58 @@ async fn dispatch_hover(session: &Session, x: f64, y: f64) -> Result<(), Error> 
     Ok(())
 }
 
+/// Press at (x1, y1), glide to (x2, y2) over a few steps, release. The
+/// interpolated moves make the drag read as a real gesture so listeners that
+/// track pointer movement (drawing surfaces, sliders) follow it.
+async fn dispatch_drag(session: &Session, x1: f64, y1: f64, x2: f64, y2: f64) -> Result<(), Error> {
+    use input::{DispatchMouseEventParams, DispatchMouseEventType, MouseButton};
+    let send = |params| async {
+        session
+            .page
+            .execute(params)
+            .await
+            .map_err(|e| handler_err(format!("mouse event failed: {e}")))?;
+        Ok::<(), Error>(())
+    };
+    let moved = DispatchMouseEventParams::builder()
+        .r#type(DispatchMouseEventType::MouseMoved)
+        .x(x1)
+        .y(y1)
+        .build()
+        .map_err(handler_err)?;
+    send(moved).await?;
+    let pressed = DispatchMouseEventParams::builder()
+        .r#type(DispatchMouseEventType::MousePressed)
+        .x(x1)
+        .y(y1)
+        .button(MouseButton::Left)
+        .click_count(1)
+        .build()
+        .map_err(handler_err)?;
+    send(pressed).await?;
+    const STEPS: i64 = 8;
+    for step in 1..=STEPS {
+        let t = step as f64 / STEPS as f64;
+        let step_move = DispatchMouseEventParams::builder()
+            .r#type(DispatchMouseEventType::MouseMoved)
+            .x(x1 + (x2 - x1) * t)
+            .y(y1 + (y2 - y1) * t)
+            .button(MouseButton::Left)
+            .build()
+            .map_err(handler_err)?;
+        send(step_move).await?;
+    }
+    let released = DispatchMouseEventParams::builder()
+        .r#type(DispatchMouseEventType::MouseReleased)
+        .x(x2)
+        .y(y2)
+        .button(MouseButton::Left)
+        .click_count(1)
+        .build()
+        .map_err(handler_err)?;
+    send(released).await
+}
+
 fn register_act(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
     let sx = sessions.clone();
     iii.register_function(
@@ -892,9 +944,19 @@ fn register_act(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
                             .map_err(|e| handler_err(format!("scroll failed: {e}")))?;
                         format!("scrolled {delta_y:.0}px")
                     }
+                    "drag" => {
+                        let (x1, y1) = action_point(&session, &req).await?;
+                        let (x2, y2) = match (req.x2, req.y2) {
+                            (Some(x), Some(y)) => (x, y),
+                            _ => return Err(handler_err("drag needs x2 and y2")),
+                        };
+                        dispatch_drag(&session, x1, y1, x2, y2).await?;
+                        move_ghost_cursor(&session, x2, y2, true).await;
+                        format!("dragged ({x1:.0}, {y1:.0}) to ({x2:.0}, {y2:.0})")
+                    }
                     other => {
                         return Err(handler_err(format!(
-                            "unknown action '{other}' (click, hover, type, press, scroll)"
+                            "unknown action '{other}' (click, hover, type, press, scroll, drag)"
                         )))
                     }
                 };

--- a/browser/src/functions/mod.rs
+++ b/browser/src/functions/mod.rs
@@ -802,17 +802,22 @@ async fn dispatch_drag(session: &Session, x1: f64, y1: f64, x2: f64, y2: f64) ->
         .build()
         .map_err(handler_err)?;
     send(pressed).await?;
+    move_ghost_cursor(session, x1, y1, true).await;
     const STEPS: i64 = 8;
     for step in 1..=STEPS {
         let t = step as f64 / STEPS as f64;
+        let (xi, yi) = (x1 + (x2 - x1) * t, y1 + (y2 - y1) * t);
         let step_move = DispatchMouseEventParams::builder()
             .r#type(DispatchMouseEventType::MouseMoved)
-            .x(x1 + (x2 - x1) * t)
-            .y(y1 + (y2 - y1) * t)
+            .x(xi)
+            .y(yi)
             .button(MouseButton::Left)
             .build()
             .map_err(handler_err)?;
         send(step_move).await?;
+        // Glide the ghost cursor with the drag so a viewer watching the
+        // stream sees the gesture, not a jump to the end.
+        move_ghost_cursor(session, xi, yi, false).await;
     }
     let released = DispatchMouseEventParams::builder()
         .r#type(DispatchMouseEventType::MouseReleased)
@@ -951,7 +956,6 @@ fn register_act(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
                             _ => return Err(handler_err("drag needs x2 and y2")),
                         };
                         dispatch_drag(&session, x1, y1, x2, y2).await?;
-                        move_ghost_cursor(&session, x2, y2, true).await;
                         format!("dragged ({x1:.0}, {y1:.0}) to ({x2:.0}, {y2:.0})")
                     }
                     other => {

--- a/browser/src/functions/overlays.rs
+++ b/browser/src/functions/overlays.rs
@@ -7,21 +7,30 @@
 /// Mount (once) the ghost-cursor element and move it to `(x, y)`. `click`
 /// flashes it. Injected on each act so the overlay follows the agent.
 pub fn ghost_cursor_script(x: f64, y: f64, click: bool) -> String {
+    // An arrow pointer (lucide MousePointer2), the console's icon language,
+    // with a white outline so it reads on any background. Its tip is the
+    // top-left of the 24x24 box, so the element anchors there and the tip
+    // lands on (x, y).
     format!(
         r#"(() => {{
   let c = document.getElementById('iii-ghost-cursor');
   if (!c) {{
     c = document.createElement('div');
     c.id = 'iii-ghost-cursor';
-    c.style.cssText = 'position:fixed;width:18px;height:18px;margin:-9px 0 0 -9px;'
-      + 'border-radius:50%;background:rgba(16,185,129,.6);border:2px solid #10b981;'
-      + 'z-index:2147483646;pointer-events:none;transition:left .08s,top .08s,transform .1s';
+    c.style.cssText = 'position:fixed;width:22px;height:22px;margin:-2px 0 0 -2px;'
+      + 'z-index:2147483646;pointer-events:none;transform-origin:4px 4px;'
+      + 'filter:drop-shadow(0 1px 2px rgba(0,0,0,.45));'
+      + 'transition:left .08s,top .08s,transform .1s';
+    c.innerHTML = '<svg width="22" height="22" viewBox="0 0 24 24" '
+      + 'fill="rgb(16,185,129)" stroke="rgb(255,255,255)" stroke-width="1.5" '
+      + 'stroke-linejoin="round"><path d="M4 4 L11.5 20.5 L13.9 13.9 L20.5 11.5 Z"/>'
+      + '</svg>';
     (document.body || document.documentElement).appendChild(c);
   }}
   c.style.left = {x} + 'px';
   c.style.top = {y} + 'px';
   if ({click}) {{
-    c.style.transform = 'scale(1.8)';
+    c.style.transform = 'scale(1.35)';
     setTimeout(() => {{ const e = document.getElementById('iii-ghost-cursor'); if (e) e.style.transform = 'scale(1)'; }}, 120);
   }}
   return true;

--- a/browser/tests/golden/schemas/browser.act.json
+++ b/browser/tests/golden/schemas/browser.act.json
@@ -1,6 +1,6 @@
 {
   "function_id": "browser::act",
-  "description": "Interact with the page: click (left/right/middle, single or double), hover, type, press, or scroll. Address elements with a [ref=eN] handle from browser::snapshot (or a pick), or raw viewport coordinates.",
+  "description": "Interact with the page: click (left/right/middle, single or double), hover, type, press, scroll, or drag (press at the start point, glide to x2/y2, release). Address elements with a [ref=eN] handle from browser::snapshot (or a pick), or raw viewport coordinates.",
   "request_schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "ActInput",
@@ -11,7 +11,7 @@
     ],
     "properties": {
       "action": {
-        "description": "`click`, `hover`, `type`, `press`, or `scroll`.",
+        "description": "`click`, `hover`, `type`, `press`, `scroll`, or `drag`.",
         "type": "string"
       },
       "button": {
@@ -77,8 +77,26 @@
         ],
         "format": "double"
       },
+      "x2": {
+        "description": "Drag end x, in viewport pixels (`drag`). The start is `x`/`y` or a `ref`; the end is `x2`/`y2`.",
+        "default": null,
+        "type": [
+          "number",
+          "null"
+        ],
+        "format": "double"
+      },
       "y": {
         "description": "Viewport y, when acting by coordinates instead of ref.",
+        "default": null,
+        "type": [
+          "number",
+          "null"
+        ],
+        "format": "double"
+      },
+      "y2": {
+        "description": "Drag end y, in viewport pixels (`drag`).",
         "default": null,
         "type": [
           "number",


### PR DESCRIPTION
## What

`browser::act` gains a `drag` gesture, and the ghost cursor becomes a real pointer.

**drag.** A new action that presses at a start point, glides to `x2`/`y2` over a few interpolated steps, and releases. The start is `x`/`y` or a `ref`; the end is `x2`/`y2`. Chromium synthesizes pointer events from the CDP mouse events, so a drag drives anything that tracks pointer movement: drawing surfaces, sliders, range inputs, drag-and-drop. This closes the last gap for driving a page end to end from `browser-use` (previously only click/hover/type/press/scroll existed, so a drag could not be tested).

**ghost cursor.** The overlay a human sees while an agent acts was a green dot. It is now an arrow pointer (the MousePointer2 glyph), accent fill with a white outline so it reads on any background, its tip anchored on the action point. During a drag it glides along the path step by step, so a viewer watching the stream sees the gesture instead of a jump to the end.

## How verified

- 214 lib tests, clippy `-D warnings`, `cargo fmt`, golden schema round-trip — clean. New golden for the extended `browser.act` input (`x2`/`y2`).
- Live on the rig: a spawned harness agent (glm-5.3) looked up the `browser::act` contract itself and ran the drag on a session, returning `ok: true` and the detail `"dragged (200, 300) to (500, 520)"` — proving the whole loop from an agent turn through the worker.

Stacked off main, part of MOT-4533.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for dragging from an element or screen coordinates to a specified endpoint.
  - Added drag action details and endpoint fields to the browser action interface.

- **UI Improvements**
  - Updated the on-screen cursor indicator with a clearer arrow design and refined click animation.

- **Documentation**
  - Expanded action descriptions and schemas to include drag interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->