### PR TITLE
(MOT-4559) feat(harness): reuse function contracts in model context

### DIFF
--- a/.github/scripts/tests/test_rust_ci_workflows.py
+++ b/.github/scripts/tests/test_rust_ci_workflows.py
@@ -51,6 +51,18 @@ def test_prs_restore_rust_caches_and_main_pushes_publish_them() -> None:
     assert ci["jobs"]["harness-integration"]["with"]["save-cache"] == expected
 
 
+def test_interface_smoke_bounds_each_engine_readiness_probe() -> None:
+    steps = workflow("ci.yml")["jobs"]["interface-smoke"]["steps"]
+    run = named_step(steps, "Start III engine")["run"]
+
+    assert "deadline=$((SECONDS + 60))" in run
+    assert "while (( SECONDS < deadline )); do" in run
+    assert (
+        "timeout --signal=KILL 5s iii trigger 'engine::workers::list' "
+        "--json '{}' >/dev/null 2>&1"
+    ) in run
+
+
 def test_harness_integration_caches_the_final_engine_and_skips_rebuilds() -> None:
     integration = workflow("_harness-integration.yml")
     steps = integration["jobs"]["integration"]["steps"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -610,13 +610,14 @@ jobs:
           iii --config config.yaml --no-update-check > iii-engine.log 2>&1 &
           echo "$!" > iii-engine.pid
 
-          for _ in {1..60}; do
+          deadline=$((SECONDS + 60))
+          while (( SECONDS < deadline )); do
             if ! kill -0 "$(cat iii-engine.pid)" 2>/dev/null; then
               echo "::error::iii engine exited before becoming ready"
               cat iii-engine.log
               exit 1
             fi
-            if iii trigger 'engine::workers::list' --json '{}' >/dev/null 2>&1; then
+            if timeout --signal=KILL 5s iii trigger 'engine::workers::list' --json '{}' >/dev/null 2>&1; then
               exit 0
             fi
             sleep 1

--- a/crates/provider-integration-testkit/Cargo.lock
+++ b/crates/provider-integration-testkit/Cargo.lock
@@ -1465,7 +1465,6 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sha2",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/harness/Cargo.lock
+++ b/harness/Cargo.lock
@@ -635,6 +635,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror",
  "tokio",

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -46,6 +46,7 @@ uuid = { version = "1", features = ["v4"] }
 globset = "0.4"
 # Output-contract JSON Schema validation (json contracts with a schema).
 jsonschema = { version = "0.18", default-features = false }
+sha2 = "0.10"
 
 [dev-dependencies]
 serde_json = "1"

--- a/harness/prompts/default.txt
+++ b/harness/prompts/default.txt
@@ -59,6 +59,10 @@ again only when a call fails with `invalid_arguments` / `serialization error` / 
 field, or a registry-change notice appears. Need more than one contract at once? Pass
 `{ function_ids: ["a::b", "c::d"] }` and it returns `{ functions: [...] }`, one per id — one
 call, never one per id.
+An unchanged repeat may return
+`{"function_id":"worker::function","contract_status":"unchanged_in_context","source_function_call_id":"call_123"}`.
+This means the engine and hooks ran and the exact full contract is still in context at the named
+earlier result; reuse that full contract.
 
 Step 3. Call the function. Set `description` to a concise action label in the user's language
 (for example, "Reading configuration files"), without the function id or implementation

--- a/harness/prompts/subagent.txt
+++ b/harness/prompts/subagent.txt
@@ -35,6 +35,8 @@ Step 1. Find the id with `engine::functions::list` — filter with `{ search: "<
 `{ prefix: "<worker>::" }`. Never use a function id from memory.
 Step 2. Fetch the contract with `engine::functions::info { function_id: "<id>" }` — once per
 function; it stays valid all session. Batch several with `{ function_ids: [...] }`.
+An `unchanged_in_context` result names the earlier call containing the exact full contract; reuse
+that contract.
 Step 3. Call it. Set `description` to a concise action label in the user's language, without
 the function id or implementation jargon. `payload` is a JSON OBJECT, never a JSON-encoded
 string, and every argument goes INSIDE `payload`. Nested objects stay literal objects;

--- a/harness/src/deferred.rs
+++ b/harness/src/deferred.rs
@@ -7,7 +7,7 @@
 //! parent-resolve path below survives only so turns parked before the
 //! fire-and-forget deploy still resolve.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use serde_json::{json, Value};
 
@@ -17,7 +17,15 @@ use crate::functions::function_resolve::{FunctionResolveRequest, FunctionResolve
 use crate::ids;
 use crate::types::content::ContentBlock;
 use crate::types::message::{AgentMessage, FunctionResultMessage, FunctionResultRoleTag};
-use crate::types::turn::{CallState, TurnStatus};
+use crate::types::turn::{CallState, FunctionContractLedgerEntry, TurnStatus};
+
+fn apply_deferred_contract_updates_after_append(
+    ledger: &mut BTreeMap<String, FunctionContractLedgerEntry>,
+    call_id: &str,
+    updates: Vec<(String, FunctionContractLedgerEntry)>,
+) {
+    crate::trigger::apply_contract_updates_after_append(ledger, call_id, updates);
+}
 
 /// Settle a pending call and resume the parked turn.
 pub async fn resolve(
@@ -71,6 +79,11 @@ pub async fn resolve(
                     Some(&json!({ "turn_id": record.turn_id })),
                 )
                 .await?;
+            apply_deferred_contract_updates_after_append(
+                &mut record.function_contract_ledger,
+                &req.function_call_id,
+                Vec::new(),
+            );
 
             if let Some(cp) = record.calls.get_mut(&req.function_call_id) {
                 cp.state = CallState::Done;
@@ -145,6 +158,11 @@ pub async fn resolve(
                             Some(&json!({ "turn_id": record.turn_id })),
                         )
                         .await?;
+                    apply_deferred_contract_updates_after_append(
+                        &mut record.function_contract_ledger,
+                        &req.function_call_id,
+                        Vec::new(),
+                    );
                     if let Some(cp) = record.calls.get_mut(&req.function_call_id) {
                         cp.state = CallState::Done;
                         cp.entry_id = Some(entry_id);
@@ -222,6 +240,11 @@ pub async fn resolve(
                         Some(&json!({ "turn_id": record.turn_id })),
                     )
                     .await?;
+                apply_deferred_contract_updates_after_append(
+                    &mut record.function_contract_ledger,
+                    &req.function_call_id,
+                    Vec::new(),
+                );
                 if let Some(cp) = record.calls.get_mut(&req.function_call_id) {
                     cp.state = CallState::Done;
                     cp.entry_id = Some(entry_id);
@@ -283,6 +306,7 @@ pub async fn resolve(
                 )),
             )
             .await;
+            let info_raw = (function_id == "engine::functions::info").then(|| raw.clone());
             let post_outcome = deps
                 .hooks
                 .run_post_trigger(
@@ -318,6 +342,16 @@ pub async fn resolve(
                     });
                 }
             };
+            let (data, contract_updates) = match info_raw {
+                Some(raw) => crate::trigger::prepare_info_result(
+                    &req.function_call_id,
+                    &arguments,
+                    &data,
+                    &record.function_contract_ledger,
+                    raw == data,
+                ),
+                None => (data, Vec::new()),
+            };
 
             let entry_id = ids::function_result_entry_id(&record.turn_id, &req.function_call_id);
             let mut origin = serde_json::Map::new();
@@ -346,6 +380,11 @@ pub async fn resolve(
                     Some(&Value::Object(origin)),
                 )
                 .await?;
+            apply_deferred_contract_updates_after_append(
+                &mut record.function_contract_ledger,
+                &req.function_call_id,
+                contract_updates,
+            );
             if let Some(cp) = record.calls.get_mut(&req.function_call_id) {
                 cp.state = CallState::Done;
                 cp.entry_id = Some(entry_id);
@@ -564,7 +603,86 @@ fn union_roots(session_roots: Vec<String>, fs_scope_grants: Vec<String>) -> Vec<
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::turn::{CallCheckpoint, CallState};
+    use crate::types::turn::{CallCheckpoint, CallState, FunctionContractLedgerEntry};
+
+    #[test]
+    fn deferred_sibling_info_results_wait_for_context_validation_before_reuse() {
+        let details = json!({
+            "function_id": "worker::function",
+            "request_schema": { "type": "object" },
+            "response_schema": { "type": "object" }
+        });
+        let data = crate::trigger::ResultData {
+            content: vec![ContentBlock::text(details.to_string())],
+            is_error: false,
+            details,
+        };
+        let arguments = json!({ "function_id": "worker::function" });
+        let mut ledger = BTreeMap::new();
+
+        let (first, updates) =
+            crate::trigger::prepare_info_result("held-1", &arguments, &data, &ledger, true);
+        apply_deferred_contract_updates_after_append(&mut ledger, "held-1", updates);
+
+        let (second, updates) =
+            crate::trigger::prepare_info_result("held-2", &arguments, &data, &ledger, true);
+        assert_eq!(second.content, data.content, "a sibling result stays full");
+        apply_deferred_contract_updates_after_append(&mut ledger, "held-2", updates);
+
+        crate::trigger::retain_visible_contract_sources(
+            &mut ledger,
+            &[json!({
+                "role": "function_result",
+                "function_call_id": "held-2",
+                "function_id": "engine::functions::info",
+                "content": serde_json::to_value(&second.content).unwrap()
+            })],
+        );
+        let (third, updates) =
+            crate::trigger::prepare_info_result("held-3", &arguments, &data, &ledger, true);
+
+        assert_eq!(
+            third.content,
+            vec![ContentBlock::text(
+                json!({
+                    "function_id": "worker::function",
+                    "contract_status": "unchanged_in_context",
+                    "source_function_call_id": "held-2"
+                })
+                .to_string()
+            )]
+        );
+        assert!(updates.is_empty());
+        assert_eq!(first.content, data.content);
+    }
+
+    #[test]
+    fn deferred_result_append_invalidates_every_contract_using_its_reused_call_id() {
+        let reused_source = FunctionContractLedgerEntry {
+            contract_digest: "contract".into(),
+            source_function_call_id: "held-call".into(),
+            source_content_digest: "content".into(),
+            eligible: true,
+        };
+        let unrelated_source = FunctionContractLedgerEntry {
+            contract_digest: "other".into(),
+            source_function_call_id: "other-call".into(),
+            source_content_digest: "other-content".into(),
+            eligible: true,
+        };
+        let mut ledger = std::collections::BTreeMap::from([
+            ("worker::one".into(), reused_source.clone()),
+            ("worker::two".into(), reused_source),
+            ("worker::other".into(), unrelated_source.clone()),
+        ]);
+
+        apply_deferred_contract_updates_after_append(&mut ledger, "held-call", Vec::new());
+
+        assert_eq!(
+            ledger,
+            std::collections::BTreeMap::from([("worker::other".into(), unrelated_source)])
+        );
+    }
 
     fn cp(
         state: CallState,

--- a/harness/src/discovery.rs
+++ b/harness/src/discovery.rs
@@ -88,9 +88,24 @@ fn fingerprint_of(functions: &[FunctionDescriptor]) -> u64 {
 /// Swap the snapshot under the write lock, bumping the generation only when the
 /// incoming set's fingerprint differs from the current one.
 pub async fn apply(cell: &FunctionsCell, functions: Vec<FunctionDescriptor>) {
+    apply_inner(cell, functions, false).await;
+}
+
+/// Explicit availability events advance the generation even when list-visible
+/// fields stayed equal: the event may represent a response-schema-only change
+/// that native invocation descriptors do not carry.
+async fn apply_on_availability_event(cell: &FunctionsCell, functions: Vec<FunctionDescriptor>) {
+    apply_inner(cell, functions, true).await;
+}
+
+async fn apply_inner(
+    cell: &FunctionsCell,
+    functions: Vec<FunctionDescriptor>,
+    force_generation: bool,
+) {
     let fingerprint = fingerprint_of(&functions);
     let mut guard = cell.write().await;
-    if fingerprint == guard.fingerprint {
+    if !force_generation && fingerprint == guard.fingerprint {
         return;
     }
     let generation = guard.generation + 1;
@@ -189,12 +204,21 @@ async fn hydrate(
 
 /// Fetch the authoritative registry, hydrate schemas, and swap the snapshot;
 /// returns the count.
-async fn reload(iii: &Arc<IIIClient>, cell: &FunctionsCell, timeout_ms: u64) -> usize {
+async fn reload(
+    iii: &Arc<IIIClient>,
+    cell: &FunctionsCell,
+    timeout_ms: u64,
+    availability_event: bool,
+) -> usize {
     let engine = EngineClient::new(iii.clone(), timeout_ms);
     let functions = engine.functions_list().await;
     let functions = hydrate(&engine, cell, functions).await;
     let count = functions.len();
-    apply(cell, functions).await;
+    if availability_event {
+        apply_on_availability_event(cell, functions).await;
+    } else {
+        apply(cell, functions).await;
+    }
     count
 }
 
@@ -241,7 +265,7 @@ pub fn register_functions_trigger(iii: &Arc<IIIClient>, cell: FunctionsCell, tim
         ticker.tick().await; // consume the immediate first tick
         loop {
             ticker.tick().await;
-            let count = reload(&reload_iii, &reload_cell, timeout_ms).await;
+            let count = reload(&reload_iii, &reload_cell, timeout_ms, false).await;
             tracing::debug!(count, "function-registry cache safety-reloaded");
         }
     });
@@ -253,7 +277,7 @@ pub fn register_functions_trigger(iii: &Arc<IIIClient>, cell: FunctionsCell, tim
             let engine = engine.clone();
             let cell = cell.clone();
             async move {
-                let count = reload(&engine, &cell, timeout_ms).await;
+                let count = reload(&engine, &cell, timeout_ms, true).await;
                 tracing::debug!(count, "function-registry cache refreshed");
                 Ok::<OnFunctionsChangeResponse, Error>(OnFunctionsChangeResponse { ok: true })
             }
@@ -333,6 +357,17 @@ mod tests {
             ],
         )
         .await;
+        assert_eq!(cell.read().await.generation, 2);
+    }
+
+    #[tokio::test]
+    async fn explicit_availability_event_bumps_generation_for_unchanged_list_shape() {
+        let cell = new_cell();
+        let fns = vec![desc("a::b", Some(json!({ "type": "object" })))];
+        apply(&cell, fns.clone()).await;
+
+        apply_on_availability_event(&cell, fns).await;
+
         assert_eq!(cell.read().await.generation, 2);
     }
 

--- a/harness/src/functions/send.rs
+++ b/harness/src/functions/send.rs
@@ -416,6 +416,10 @@ pub async fn edit_queued(
 /// in the window gets a fresh turn seeded, whose step-0 drain delivers the
 /// row. A row landing after the loop's last queue check is appended by the
 /// finalize drain — queued messages are never silently dropped.
+fn reseed_prior<'a, T>(recheck: Option<&'a T>, existing: Option<&'a T>) -> Option<&'a T> {
+    recheck.or(existing)
+}
+
 async fn try_enqueue(
     deps: &Deps,
     cfg: &WorkerConfig,
@@ -424,8 +428,7 @@ async fn try_enqueue(
     d: &Delivery<'_>,
 ) -> Result<Option<(StartOutcome, String)>, HarnessError> {
     let existing = crate::state::get_turn(&deps.iii, session_id, cfg.session_timeout_ms).await?;
-    let prior_generation = existing.as_ref().and_then(|r| r.functions_generation);
-    match existing {
+    match existing.as_ref() {
         Some(rec) if rec.status == TurnStatus::Running => {}
         _ => return Ok(None),
     }
@@ -465,13 +468,13 @@ async fn try_enqueue(
                 deduplicated: false,
             }
         }
-        _ => {
+        prior => {
             let mut seeded = seed_new(
                 deps,
                 cfg,
                 session_id,
                 options.clone(),
-                prior_generation,
+                reseed_prior(prior.as_ref(), existing.as_ref()),
                 message_preview(d.message),
                 d.lineage,
             )
@@ -721,13 +724,12 @@ async fn seed_or_merge(
     let existing = crate::state::get_turn(&deps.iii, session_id, cfg.session_timeout_ms).await?;
     // Carry the session's last-acknowledged registry generation onto a new turn
     // so run_step can notice a registry change that landed between turns.
-    let prior_generation = existing.as_ref().and_then(|r| r.functions_generation);
     apply_default_filesystem_root(
         &mut options,
         existing.is_none(),
         cfg.resolved_default_filesystem_root().as_deref(),
     );
-    match existing {
+    match existing.as_ref() {
         Some(rec) if !rec.status.is_terminal() => {
             // Merge path: the message is already appended; the running loop's
             // steering check folds it in. Double-check the record didn't go
@@ -748,13 +750,13 @@ async fn seed_or_merge(
                         deduplicated: false,
                     })
                 }
-                _ => {
+                prior => {
                     seed_new(
                         deps,
                         cfg,
                         session_id,
                         options,
-                        prior_generation,
+                        reseed_prior(prior.as_ref(), existing.as_ref()),
                         message_preview,
                         lineage,
                     )
@@ -768,7 +770,7 @@ async fn seed_or_merge(
                 cfg,
                 session_id,
                 options,
-                prior_generation,
+                existing.as_ref(),
                 message_preview,
                 lineage,
             )
@@ -786,12 +788,16 @@ pub(crate) async fn seed_new(
     cfg: &WorkerConfig,
     session_id: &str,
     options: TurnOptions,
-    functions_generation: Option<u64>,
+    prior: Option<&TurnRecord>,
     message_preview: Option<String>,
     lineage: &TurnLineage,
 ) -> Result<StartOutcome, HarnessError> {
     let turn_id = ids::new_turn_id();
     let now = AgentMessage::now_ms();
+    let functions_generation = prior.and_then(|record| record.functions_generation);
+    let function_contract_ledger = prior
+        .map(|record| record.function_contract_ledger.clone())
+        .unwrap_or_default();
     let record = TurnRecord {
         turn_id: turn_id.clone(),
         session_id: session_id.to_string(),
@@ -808,6 +814,7 @@ pub(crate) async fn seed_new(
         parent: lineage.parent.clone(),
         display_parent_session_id: lineage.display_parent_session_id.clone(),
         functions_generation,
+        function_contract_ledger,
         context_snapshot: None,
         result: None,
         result_error: None,
@@ -838,6 +845,18 @@ pub(crate) async fn seed_new(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn terminal_recheck_wins_when_seeding_the_next_turn() {
+        let initial = 1;
+        let terminal = 2;
+
+        assert_eq!(
+            reseed_prior(Some(&terminal), Some(&initial)),
+            Some(&terminal)
+        );
+        assert_eq!(reseed_prior(None, Some(&initial)), Some(&initial));
+    }
 
     #[test]
     fn selected_skill_prompt_keeps_only_ordered_nonblank_bodies_in_resolved_prompt() {

--- a/harness/src/subagent.rs
+++ b/harness/src/subagent.rs
@@ -503,6 +503,7 @@ mod tests {
             parent: None,
             display_parent_session_id: None,
             functions_generation: None,
+            function_contract_ledger: Default::default(),
             context_snapshot: None,
             result: None,
             result_error: None,

--- a/harness/src/trigger.rs
+++ b/harness/src/trigger.rs
@@ -7,18 +7,261 @@
 //! P1 covers the glob policy + target + normalisation. The `pre_trigger` /
 //! `post_trigger` hook chain and `pending` deferral layer on in later phases.
 
+use std::collections::{BTreeMap, HashMap};
+
+use jsonschema::JSONSchema;
 use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
 
 use crate::clients::EngineClient;
 use crate::policy::CompiledPolicy;
 use crate::types::content::ContentBlock;
+use crate::types::turn::FunctionContractLedgerEntry;
 
 /// A normalised function result ready to become a `function_result` entry.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ResultData {
     pub content: Vec<ContentBlock>,
     pub is_error: bool,
     pub details: Value,
+}
+
+/// Discard ledger rows whose exact full source is not the only model-facing
+/// result for its call id.
+pub(crate) fn retain_visible_contract_sources(
+    ledger: &mut BTreeMap<String, FunctionContractLedgerEntry>,
+    messages: &[Value],
+) {
+    ledger.retain(|_, source| {
+        let eligible = unique_visible_result(messages, &source.source_function_call_id)
+            .is_some_and(|(function_id, content)| {
+                function_id == Some("engine::functions::info")
+                    && content.and_then(digest_value).as_deref()
+                        == Some(source.source_content_digest.as_str())
+            });
+        source.eligible = eligible;
+        eligible
+    });
+}
+
+/// Record a successful function-result append. Reusing a source call id
+/// invalidates every row that named it; such an ambiguous id cannot become a
+/// replacement source in the same append.
+pub(crate) fn apply_contract_updates_after_append(
+    ledger: &mut BTreeMap<String, FunctionContractLedgerEntry>,
+    call_id: &str,
+    updates: Vec<(String, FunctionContractLedgerEntry)>,
+) {
+    let reused_source = ledger
+        .values()
+        .any(|source| source.source_function_call_id == call_id);
+    ledger.retain(|_, source| source.source_function_call_id != call_id);
+    if !reused_source {
+        ledger.extend(updates);
+    }
+}
+
+fn unique_visible_result<'a>(
+    messages: &'a [Value],
+    call_id: &str,
+) -> Option<(Option<&'a str>, Option<&'a Value>)> {
+    let mut found = None;
+    let mut call_seen = false;
+    for message in messages {
+        for block in message
+            .get("content")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            match block.get("type").and_then(Value::as_str) {
+                Some("function_call")
+                    if block.get("id").and_then(Value::as_str) == Some(call_id) =>
+                {
+                    let function_id = block.get("function_id").and_then(Value::as_str);
+                    let wrapped_target = block
+                        .get("arguments")
+                        .and_then(|arguments| arguments.get("function"))
+                        .and_then(Value::as_str);
+                    let is_info = function_id == Some("engine::functions::info")
+                        || (function_id == Some("agent_trigger")
+                            && wrapped_target == Some("engine::functions::info"));
+                    if call_seen || !is_info {
+                        return None;
+                    }
+                    call_seen = true;
+                }
+                Some("function_result")
+                    if block.get("function_call_id").and_then(Value::as_str) == Some(call_id) =>
+                {
+                    if found.is_some() {
+                        return None;
+                    }
+                    // Inline provider-style results do not carry the source
+                    // function id, so they can never validate a top-level source.
+                    found = Some((None, block.get("content")));
+                }
+                _ => {}
+            }
+        }
+        if message.get("role").and_then(Value::as_str) == Some("function_result")
+            && message.get("function_call_id").and_then(Value::as_str) == Some(call_id)
+        {
+            if found.is_some() {
+                return None;
+            }
+            found = Some((
+                message.get("function_id").and_then(Value::as_str),
+                message.get("content"),
+            ));
+        }
+    }
+    found
+}
+
+/// Compact unchanged, successful `engine::functions::info` contracts while
+/// preserving the raw result in `details`. Returned ledger updates are applied
+/// only after the caller successfully appends the result.
+pub(crate) fn prepare_info_result(
+    call_id: &str,
+    arguments: &Value,
+    data: &ResultData,
+    ledger: &BTreeMap<String, FunctionContractLedgerEntry>,
+    hook_unchanged: bool,
+) -> (ResultData, Vec<(String, FunctionContractLedgerEntry)>) {
+    if data.is_error || !hook_unchanged || normalize(&data.details).0 != data.content {
+        return (data.clone(), Vec::new());
+    }
+
+    let requested_single = arguments.get("function_id").and_then(Value::as_str);
+    let requested_batch = arguments.get("function_ids").and_then(Value::as_array);
+    let mut display = data.details.clone();
+    let mut candidates = Vec::new();
+
+    if let (Some(requested), Some(item)) = (requested_single, display.as_object()) {
+        if valid_contract_id(&Value::Object(item.clone())) == Some(requested) {
+            candidates.push((None, requested.to_string()));
+        }
+    } else if let (Some(requested), Some(items)) = (
+        requested_batch,
+        display.get("functions").and_then(Value::as_array),
+    ) {
+        let requested_counts = counts(requested.iter().filter_map(Value::as_str));
+        let result_counts = counts(items.iter().filter_map(|item| {
+            item.get("function_id")
+                .or_else(|| item.get("id"))
+                .and_then(Value::as_str)
+        }));
+        for (index, item) in items.iter().enumerate() {
+            let Some(id) = valid_contract_id(item) else {
+                continue;
+            };
+            if requested_counts.get(id) == Some(&1) && result_counts.get(id) == Some(&1) {
+                candidates.push((Some(index), id.to_string()));
+            }
+        }
+    } else {
+        return (data.clone(), Vec::new());
+    }
+
+    let mut full = Vec::new();
+    let mut compacted = false;
+    for (index, function_id) in candidates {
+        let contract = match index {
+            Some(index) => &data.details["functions"][index],
+            None => &data.details,
+        };
+        let Some(contract_digest) = digest_value(contract) else {
+            continue;
+        };
+        match ledger.get(&function_id) {
+            Some(source)
+                if source.eligible
+                    && source.contract_digest == contract_digest
+                    && source.source_function_call_id != call_id =>
+            {
+                let marker = json!({
+                    "function_id": function_id,
+                    "contract_status": "unchanged_in_context",
+                    "source_function_call_id": source.source_function_call_id,
+                });
+                match index {
+                    Some(index) => display["functions"][index] = marker,
+                    None => display = marker,
+                }
+                compacted = true;
+            }
+            Some(source) if source.source_function_call_id == call_id => {}
+            _ => full.push((function_id, contract_digest)),
+        }
+    }
+
+    let mut prepared = data.clone();
+    if compacted {
+        prepared.content = normalize(&display).0;
+    }
+    let Some(source_content_digest) = digest_content(&prepared.content) else {
+        return (prepared, Vec::new());
+    };
+    let updates = full
+        .into_iter()
+        .map(|(function_id, contract_digest)| {
+            (
+                function_id,
+                FunctionContractLedgerEntry {
+                    contract_digest,
+                    source_function_call_id: call_id.to_string(),
+                    source_content_digest: source_content_digest.clone(),
+                    eligible: false,
+                },
+            )
+        })
+        .collect();
+    (prepared, updates)
+}
+
+fn valid_contract_id(value: &Value) -> Option<&str> {
+    let object = value.as_object()?;
+    if object.contains_key("error") || !contract_schemas_compile(object) {
+        return None;
+    }
+    object
+        .get("function_id")
+        .or_else(|| object.get("id"))
+        .and_then(Value::as_str)
+}
+
+fn contract_schemas_compile(object: &serde_json::Map<String, Value>) -> bool {
+    ["parameters", "request_format", "request_schema"]
+        .iter()
+        .find_map(|key| object.get(*key))
+        .is_some_and(|schema| JSONSchema::compile(schema).is_ok())
+        && ["response_format", "response_schema"]
+            .iter()
+            .find_map(|key| object.get(*key))
+            .is_some_and(|schema| JSONSchema::compile(schema).is_ok())
+}
+
+fn counts<'a>(ids: impl Iterator<Item = &'a str>) -> HashMap<&'a str, usize> {
+    let mut counts = HashMap::new();
+    for id in ids {
+        *counts.entry(id).or_default() += 1;
+    }
+    counts
+}
+
+fn digest_content(content: &[ContentBlock]) -> Option<String> {
+    serde_json::to_value(content)
+        .ok()
+        .as_ref()
+        .and_then(digest_value)
+}
+
+fn digest_value(value: &Value) -> Option<String> {
+    Some(format!(
+        "{:x}",
+        Sha256::digest(serde_json::to_vec(value).ok()?)
+    ))
 }
 
 /// The outcome of triggering one call.
@@ -271,6 +514,7 @@ fn post_filter_discovery(value: &mut Value, policy: &CompiledPolicy) {
 mod tests {
     use super::*;
     use crate::types::turn::FunctionPolicy;
+    use std::collections::BTreeMap;
 
     fn pol(allow: &[&str]) -> CompiledPolicy {
         CompiledPolicy::from(Some(&FunctionPolicy {
@@ -343,6 +587,520 @@ mod tests {
         assert!(arguments_degraded(&json!([1, 2])));
         assert!(!arguments_degraded(&json!({})));
         assert!(!arguments_degraded(&json!({ "path": "/tmp" })));
+    }
+
+    #[test]
+    fn unchanged_info_contract_reuses_an_exact_model_visible_source() {
+        let details = json!({
+            "function_id": "worker::function",
+            "description": "Does work",
+            "request_schema": { "type": "object" },
+            "response_schema": { "type": "object" }
+        });
+        let data = ResultData {
+            content: vec![ContentBlock::text(details.to_string())],
+            is_error: false,
+            details,
+        };
+        let mut ledger = BTreeMap::new();
+
+        let (first, updates) = prepare_info_result(
+            "call_123",
+            &json!({ "function_id": "worker::function" }),
+            &data,
+            &ledger,
+            true,
+        );
+        assert_eq!(
+            first.content, data.content,
+            "the first full result is retained"
+        );
+        ledger.extend(updates);
+
+        let source = json!({
+            "role": "function_result",
+            "function_call_id": "call_123",
+            "function_id": "engine::functions::info",
+            "content": serde_json::to_value(&first.content).unwrap(),
+            "details": first.details,
+            "is_error": false,
+            "timestamp": 1
+        });
+        retain_visible_contract_sources(&mut ledger, &[source]);
+
+        let (second, updates) = prepare_info_result(
+            "call_456",
+            &json!({ "function_id": "worker::function" }),
+            &data,
+            &ledger,
+            true,
+        );
+        assert_eq!(
+            second.content,
+            vec![ContentBlock::text(
+                json!({
+                    "function_id": "worker::function",
+                    "contract_status": "unchanged_in_context",
+                    "source_function_call_id": "call_123"
+                })
+                .to_string()
+            )]
+        );
+        assert_eq!(second.details, data.details, "details stay exact");
+        assert!(updates.is_empty(), "markers never replace the full source");
+    }
+
+    #[test]
+    fn info_batch_preserves_order_cardinality_unknowns_and_details() {
+        let details = json!({ "functions": [
+            {
+                "function_id": "a::one",
+                "request_schema": { "type": "object" },
+                "response_schema": { "type": "string" }
+            },
+            { "function_id": "missing::fn", "error": "not available" },
+            {
+                "function_id": "b::two",
+                "request_schema": { "type": "object" },
+                "response_schema": { "type": "number" }
+            }
+        ]});
+        let data = ResultData {
+            content: normalize(&details).0,
+            is_error: false,
+            details: details.clone(),
+        };
+        let args = json!({ "function_ids": ["a::one", "missing::fn", "b::two"] });
+        let (first, updates) =
+            prepare_info_result("batch-full", &args, &data, &BTreeMap::new(), true);
+        let mut ledger: BTreeMap<_, _> = updates.into_iter().collect();
+        let source = json!({
+            "role": "function_result",
+            "function_call_id": "batch-full",
+            "function_id": "engine::functions::info",
+            "content": serde_json::to_value(&first.content).unwrap()
+        });
+        retain_visible_contract_sources(&mut ledger, &[source]);
+
+        let (prepared, updates) = prepare_info_result("batch-repeat", &args, &data, &ledger, true);
+        let rendered: Value = serde_json::from_str(&ContentBlock::join_text(&prepared.content))
+            .expect("prepared batch content is JSON");
+        let functions = rendered["functions"].as_array().unwrap();
+        assert_eq!(functions.len(), 3);
+        assert_eq!(functions[0]["contract_status"], "unchanged_in_context");
+        assert_eq!(functions[1], details["functions"][1]);
+        assert_eq!(functions[2]["contract_status"], "unchanged_in_context");
+        assert_eq!(prepared.details, details);
+        assert!(updates.is_empty());
+    }
+
+    #[test]
+    fn ambiguous_or_unverifiable_info_sources_stay_full() {
+        let details = json!({
+            "function_id": "worker::function",
+            "request_schema": { "type": "object" },
+            "response_schema": { "type": "object" }
+        });
+        let data = ResultData {
+            content: normalize(&details).0,
+            is_error: false,
+            details,
+        };
+        let args = json!({ "function_id": "worker::function" });
+        let (first, updates) = prepare_info_result("source", &args, &data, &BTreeMap::new(), true);
+        let mut ledger: BTreeMap<_, _> = updates.into_iter().collect();
+        let exact = json!({
+            "role": "function_result",
+            "function_call_id": "source",
+            "function_id": "engine::functions::info",
+            "content": serde_json::to_value(&first.content).unwrap()
+        });
+        let mutated = json!({
+            "role": "user",
+            "content": [{
+                "type": "function_result",
+                "function_call_id": "source",
+                "content": [{ "type": "text", "text": "changed by a hook" }]
+            }]
+        });
+        retain_visible_contract_sources(&mut ledger, &[exact, mutated]);
+        assert!(ledger.is_empty(), "the exact last result must match");
+
+        let (without_source, updates) = prepare_info_result("repeat", &args, &data, &ledger, true);
+        assert_eq!(without_source.content, data.content);
+        assert_eq!(updates.len(), 1, "the new full result becomes the source");
+
+        let same_call_ledger: BTreeMap<_, _> = updates.into_iter().collect();
+        let (same_call, updates) =
+            prepare_info_result("repeat", &args, &data, &same_call_ledger, true);
+        assert_eq!(same_call.content, data.content);
+        assert!(updates.is_empty(), "a call id cannot source itself");
+
+        let (hook_mutated, updates) =
+            prepare_info_result("later", &args, &data, &same_call_ledger, false);
+        assert_eq!(hook_mutated, data);
+        assert!(updates.is_empty());
+
+        let changed_details = json!({
+            "function_id": "worker::function",
+            "request_schema": { "type": "object" },
+            "response_schema": { "type": "string" }
+        });
+        let changed = ResultData {
+            content: normalize(&changed_details).0,
+            is_error: false,
+            details: changed_details,
+        };
+        let (prepared, updates) =
+            prepare_info_result("changed", &args, &changed, &same_call_ledger, true);
+        assert_eq!(prepared, changed);
+        assert_eq!(updates.len(), 1, "a changed contract stays full");
+
+        let error = ResultData {
+            is_error: true,
+            ..data.clone()
+        };
+        let (prepared, updates) =
+            prepare_info_result("error", &args, &error, &same_call_ledger, true);
+        assert_eq!(prepared, error);
+        assert!(updates.is_empty());
+    }
+
+    #[test]
+    fn malformed_single_info_contract_stays_full_and_is_not_recorded() {
+        let details = json!({
+            "function_id": "worker::function",
+            "request_schema": null,
+            "response_schema": "not a schema"
+        });
+        let data = ResultData {
+            content: normalize(&details).0,
+            is_error: false,
+            details: details.clone(),
+        };
+        let ledger = BTreeMap::from([(
+            "worker::function".into(),
+            FunctionContractLedgerEntry {
+                contract_digest: digest_value(&details).unwrap(),
+                source_function_call_id: "source".into(),
+                source_content_digest: "source-content".into(),
+                eligible: true,
+            },
+        )]);
+
+        let (prepared, updates) = prepare_info_result(
+            "repeat",
+            &json!({ "function_id": "worker::function" }),
+            &data,
+            &ledger,
+            true,
+        );
+
+        assert_eq!(prepared, data);
+        assert!(updates.is_empty());
+    }
+
+    #[test]
+    fn malformed_batch_entry_stays_full_while_a_valid_sibling_reuses_its_source() {
+        let details = json!({ "functions": [
+            {
+                "function_id": "worker::bad",
+                "request_schema": { "type": 42 },
+                "response_schema": { "type": "object" }
+            },
+            {
+                "function_id": "worker::good",
+                "request_schema": { "type": "object" },
+                "response_schema": { "type": "string" }
+            }
+        ]});
+        let data = ResultData {
+            content: normalize(&details).0,
+            is_error: false,
+            details: details.clone(),
+        };
+        let ledger = BTreeMap::from([
+            (
+                "worker::bad".into(),
+                FunctionContractLedgerEntry {
+                    contract_digest: digest_value(&details["functions"][0]).unwrap(),
+                    source_function_call_id: "bad-source".into(),
+                    source_content_digest: "bad-content".into(),
+                    eligible: true,
+                },
+            ),
+            (
+                "worker::good".into(),
+                FunctionContractLedgerEntry {
+                    contract_digest: digest_value(&details["functions"][1]).unwrap(),
+                    source_function_call_id: "good-source".into(),
+                    source_content_digest: "good-content".into(),
+                    eligible: true,
+                },
+            ),
+        ]);
+
+        let (prepared, updates) = prepare_info_result(
+            "batch-repeat",
+            &json!({ "function_ids": ["worker::bad", "worker::good"] }),
+            &data,
+            &ledger,
+            true,
+        );
+        let rendered: Value = serde_json::from_str(&ContentBlock::join_text(&prepared.content))
+            .expect("prepared batch content is JSON");
+
+        assert_eq!(rendered["functions"][0], details["functions"][0]);
+        assert_eq!(
+            rendered["functions"][1],
+            json!({
+                "function_id": "worker::good",
+                "contract_status": "unchanged_in_context",
+                "source_function_call_id": "good-source"
+            })
+        );
+        assert_eq!(prepared.details, details);
+        assert!(updates.is_empty());
+    }
+
+    #[test]
+    fn malformed_same_id_batch_is_never_compacted_or_recorded() {
+        let details = json!({ "functions": [
+            {
+                "function_id": "worker::same",
+                "request_schema": { "type": 42 },
+                "response_schema": { "type": "object" }
+            },
+            {
+                "function_id": "worker::same",
+                "request_schema": { "type": "object" },
+                "response_schema": { "type": "string" }
+            }
+        ]});
+        let data = ResultData {
+            content: normalize(&details).0,
+            is_error: false,
+            details: details.clone(),
+        };
+        let ledger = BTreeMap::from([(
+            "worker::same".into(),
+            FunctionContractLedgerEntry {
+                contract_digest: digest_value(&details["functions"][1]).unwrap(),
+                source_function_call_id: "source".into(),
+                source_content_digest: "source-content".into(),
+                eligible: true,
+            },
+        )]);
+
+        let (prepared, updates) = prepare_info_result(
+            "repeat",
+            &json!({ "function_ids": ["worker::same"] }),
+            &data,
+            &ledger,
+            true,
+        );
+
+        assert_eq!(prepared, data);
+        assert!(updates.is_empty());
+    }
+
+    #[test]
+    fn duplicate_non_source_result_id_cannot_become_contract_source() {
+        let details = json!({
+            "function_id": "worker::function",
+            "request_schema": { "type": "object" },
+            "response_schema": { "type": "object" }
+        });
+        let data = ResultData {
+            content: normalize(&details).0,
+            is_error: false,
+            details,
+        };
+        let mut ledger = BTreeMap::new();
+        let (prepared, updates) = prepare_info_result(
+            "duplicate",
+            &json!({ "function_id": "worker::function" }),
+            &data,
+            &ledger,
+            true,
+        );
+        apply_contract_updates_after_append(&mut ledger, "duplicate", updates);
+        retain_visible_contract_sources(
+            &mut ledger,
+            &[
+                json!({
+                    "role": "function_result",
+                    "function_call_id": "duplicate",
+                    "function_id": "worker::other",
+                    "content": [{ "type": "text", "text": "earlier" }]
+                }),
+                json!({
+                    "role": "function_result",
+                    "function_call_id": "duplicate",
+                    "function_id": "engine::functions::info",
+                    "content": serde_json::to_value(&prepared.content).unwrap()
+                }),
+            ],
+        );
+
+        assert!(
+            ledger.is_empty(),
+            "a call id shared by visible results is ambiguous"
+        );
+    }
+
+    #[test]
+    fn duplicate_visible_calls_cannot_source_a_contract() {
+        let details = json!({
+            "function_id": "worker::function",
+            "request_schema": { "type": "object" },
+            "response_schema": { "type": "object" }
+        });
+        let data = ResultData {
+            content: normalize(&details).0,
+            is_error: false,
+            details,
+        };
+        let mut ledger = BTreeMap::new();
+        let (prepared, updates) = prepare_info_result(
+            "duplicate",
+            &json!({ "function_id": "worker::function" }),
+            &data,
+            &ledger,
+            true,
+        );
+        apply_contract_updates_after_append(&mut ledger, "duplicate", updates);
+        retain_visible_contract_sources(
+            &mut ledger,
+            &[
+                json!({
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "function_call",
+                            "id": "duplicate",
+                            "function_id": "engine::functions::info"
+                        },
+                        {
+                            "type": "function_call",
+                            "id": "duplicate",
+                            "function_id": "worker::other"
+                        }
+                    ]
+                }),
+                json!({
+                    "role": "function_result",
+                    "function_call_id": "duplicate",
+                    "function_id": "engine::functions::info",
+                    "content": serde_json::to_value(&prepared.content).unwrap()
+                }),
+            ],
+        );
+
+        assert!(
+            ledger.is_empty(),
+            "a call id shared by visible calls is ambiguous"
+        );
+    }
+
+    #[test]
+    fn visible_source_call_must_resolve_to_info() {
+        let details = json!({
+            "function_id": "worker::function",
+            "request_schema": { "type": "object" },
+            "response_schema": { "type": "object" }
+        });
+        let data = ResultData {
+            content: normalize(&details).0,
+            is_error: false,
+            details,
+        };
+        let mut ledger = BTreeMap::new();
+        let (prepared, updates) = prepare_info_result(
+            "source",
+            &json!({ "function_id": "worker::function" }),
+            &data,
+            &ledger,
+            true,
+        );
+        apply_contract_updates_after_append(&mut ledger, "source", updates);
+        let result = json!({
+            "role": "function_result",
+            "function_call_id": "source",
+            "function_id": "engine::functions::info",
+            "content": serde_json::to_value(&prepared.content).unwrap()
+        });
+
+        let mut wrapper_ledger = ledger.clone();
+        retain_visible_contract_sources(
+            &mut wrapper_ledger,
+            &[
+                json!({
+                    "role": "assistant",
+                    "content": [{
+                        "type": "function_call",
+                        "id": "source",
+                        "function_id": "agent_trigger",
+                        "arguments": { "function": "engine::functions::info" }
+                    }]
+                }),
+                result.clone(),
+            ],
+        );
+        assert!(wrapper_ledger["worker::function"].eligible);
+
+        retain_visible_contract_sources(
+            &mut ledger,
+            &[
+                json!({
+                    "role": "assistant",
+                    "content": [{
+                        "type": "function_call",
+                        "id": "source",
+                        "function_id": "worker::other",
+                        "arguments": {}
+                    }]
+                }),
+                result,
+            ],
+        );
+        assert!(
+            ledger.is_empty(),
+            "a mismatched visible call cannot identify the info result"
+        );
+    }
+
+    #[test]
+    fn duplicate_batch_entries_are_never_compacted_or_recorded() {
+        let contract = json!({
+            "function_id": "worker::function",
+            "request_schema": { "type": "object" },
+            "response_schema": { "type": "object" }
+        });
+        let details = json!({ "functions": [contract.clone(), contract] });
+        let data = ResultData {
+            content: normalize(&details).0,
+            is_error: false,
+            details,
+        };
+
+        let (prepared, updates) = prepare_info_result(
+            "duplicates",
+            &json!({ "function_ids": ["worker::function", "worker::function"] }),
+            &data,
+            &BTreeMap::new(),
+            true,
+        );
+        assert_eq!(prepared, data);
+        assert!(updates.is_empty());
+    }
+
+    #[test]
+    fn persisted_contract_digests_are_stable_sha256() {
+        assert_eq!(
+            digest_value(&json!({ "a": 1 })).as_deref(),
+            Some("015abd7f5cc57a2dd94b7590f04ad8084273905ee33ec5cebeae62276a97f862")
+        );
     }
 
     #[test]

--- a/harness/src/turn_loop.rs
+++ b/harness/src/turn_loop.rs
@@ -661,6 +661,11 @@ pub async fn run_step(
         }
     };
 
+    // A contract may be compacted only while its exact earlier full result is
+    // still present in the final request after assembly, hooks, and orphan
+    // repair. Persisted pruning happens with the normal pre-generation write.
+    trigger::retain_visible_contract_sources(&mut record.function_contract_ledger, &gen_messages);
+
     let assistant_origin = origin_with(&record.turn_id, &gen_annotations);
 
     // Generate: append an empty assistant under a deterministic id, stream
@@ -1032,7 +1037,7 @@ pub async fn run_step(
             match record.calls.get(&call.id).map(|c| c.state) {
                 Some(CallState::Done) | Some(CallState::Pending) => continue,
                 Some(CallState::Triggered) => {
-                    append_interrupted(&session, &record, call).await?;
+                    append_interrupted(&session, &mut record, call).await?;
                     let eid = record_entry_id(&record, &call.id);
                     mark_done(&mut record, &call.id, &eid);
                     crate::state::put_turn(&deps.iii, &record, cfg.session_timeout_ms).await?;
@@ -1058,6 +1063,11 @@ pub async fn run_step(
                     &origin(&record.turn_id),
                 )
                 .await?;
+                trigger::apply_contract_updates_after_append(
+                    &mut record.function_contract_ledger,
+                    &call.id,
+                    Vec::new(),
+                );
                 mark_done(&mut record, &call.id, &entry_id);
                 crate::state::put_turn(&deps.iii, &record, cfg.session_timeout_ms).await?;
                 continue;
@@ -1082,6 +1092,11 @@ pub async fn run_step(
                     &origin(&record.turn_id),
                 )
                 .await?;
+                trigger::apply_contract_updates_after_append(
+                    &mut record.function_contract_ledger,
+                    &call.id,
+                    Vec::new(),
+                );
                 mark_done(&mut record, &call.id, &entry_id);
                 crate::state::put_turn(&deps.iii, &record, cfg.session_timeout_ms).await?;
                 continue;
@@ -1101,6 +1116,11 @@ pub async fn run_step(
                     &origin(&record.turn_id),
                 )
                 .await?;
+                trigger::apply_contract_updates_after_append(
+                    &mut record.function_contract_ledger,
+                    &call.id,
+                    Vec::new(),
+                );
                 mark_done(&mut record, &call.id, &entry_id);
                 crate::state::put_turn(&deps.iii, &record, cfg.session_timeout_ms).await?;
                 continue;
@@ -1158,6 +1178,11 @@ pub async fn run_step(
                         &origin(&record.turn_id),
                     )
                     .await?;
+                    trigger::apply_contract_updates_after_append(
+                        &mut record.function_contract_ledger,
+                        &call.id,
+                        Vec::new(),
+                    );
                     mark_done(&mut record, &call.id, &entry_id);
                     crate::state::put_turn(&deps.iii, &record, cfg.session_timeout_ms).await?;
                     continue;
@@ -1201,6 +1226,11 @@ pub async fn run_step(
                     &origin(&record.turn_id),
                 )
                 .await?;
+                trigger::apply_contract_updates_after_append(
+                    &mut record.function_contract_ledger,
+                    &call.id,
+                    Vec::new(),
+                );
                 // Done immediately, but the child ids stay on the checkpoint:
                 // they feed the fan-out guard, `harness::status` children, and
                 // the stop cascade.
@@ -1254,6 +1284,7 @@ pub async fn run_step(
                 )),
             )
             .await;
+            let info_raw = (call.function_id == "engine::functions::info").then(|| raw.clone());
             let post_outcome = deps
                 .hooks
                 .run_post_trigger(
@@ -1292,10 +1323,25 @@ pub async fn run_step(
             for (k, v) in post_ann {
                 annotations.insert(k, v);
             }
+            let (data, contract_updates) = match info_raw {
+                Some(raw) => trigger::prepare_info_result(
+                    &call.id,
+                    &eff_args,
+                    &data,
+                    &record.function_contract_ledger,
+                    raw == data,
+                ),
+                None => (data, Vec::new()),
+            };
             let entry_origin = origin_with(&record.turn_id, &annotations);
             let entry_id = ids::function_result_entry_id(&record.turn_id, &call.id);
             append_function_result(&session, &record, call, &data, &entry_id, &entry_origin)
                 .await?;
+            trigger::apply_contract_updates_after_append(
+                &mut record.function_contract_ledger,
+                &call.id,
+                contract_updates,
+            );
             mark_done(&mut record, &call.id, &entry_id);
             crate::state::put_turn(&deps.iii, &record, cfg.session_timeout_ms).await?;
         }
@@ -1443,7 +1489,7 @@ async fn reseed_after_finalize_drain(deps: &Deps, record: &TurnRecord) {
         &cfg,
         &record.session_id,
         record.options.clone(),
-        record.functions_generation,
+        Some(record),
         None,
         &lineage,
     )
@@ -1493,6 +1539,11 @@ async fn handle_submit(
         &origin(&record.turn_id),
     )
     .await?;
+    trigger::apply_contract_updates_after_append(
+        &mut record.function_contract_ledger,
+        &submit.id,
+        Vec::new(),
+    );
     match validation {
         Ok(()) => complete_validated(deps, session, record, value).await,
         Err(msg) => retry_or_giveup(deps, session, record, &msg, value).await,
@@ -2276,7 +2327,7 @@ fn retryable_function_result_append_error(error: &HarnessError) -> bool {
 
 async fn append_interrupted(
     session: &SessionClient,
-    record: &TurnRecord,
+    record: &mut TurnRecord,
     call: &policy::PlannedCall,
 ) -> Result<(), HarnessError> {
     let data = trigger::ResultData {
@@ -2296,7 +2347,13 @@ async fn append_interrupted(
         &entry_id,
         &origin(&record.turn_id),
     )
-    .await
+    .await?;
+    trigger::apply_contract_updates_after_append(
+        &mut record.function_contract_ledger,
+        &call.id,
+        Vec::new(),
+    );
+    Ok(())
 }
 
 /// Steering: are there user-role entries after the assemble-time watermark?
@@ -2833,6 +2890,7 @@ fn concrete_allowed_tools(
             execution_mode: Some("sequential".to_string()),
         });
     }
+    tools.sort_by(|a, b| a.name.cmp(&b.name));
     tools
 }
 
@@ -2893,14 +2951,134 @@ impl Clone for SessionStreamSink {
 #[cfg(test)]
 mod tests {
     use super::{
-        cancel_requested, count_model_visible, retryable_function_result_append_error,
-        transient_resume_allowed, turn_step_matches,
+        cancel_requested, concrete_allowed_tools, count_model_visible,
+        retryable_function_result_append_error, transient_resume_allowed, turn_step_matches,
     };
     use crate::clients::router::ChatError;
     use crate::error::HarnessError;
     use crate::types::content::ContentBlock;
     use crate::types::event::{ErrorKind, StopReason};
     use crate::types::message::{AgentMessage, CustomMessage, CustomRoleTag};
+
+    #[test]
+    fn normal_sibling_info_results_wait_for_context_validation_before_reuse() {
+        let details = serde_json::json!({
+            "function_id": "worker::function",
+            "request_schema": { "type": "object" },
+            "response_schema": { "type": "object" }
+        });
+        let data = crate::trigger::ResultData {
+            content: vec![ContentBlock::text(details.to_string())],
+            is_error: false,
+            details,
+        };
+        let arguments = serde_json::json!({ "function_id": "worker::function" });
+        let mut ledger = std::collections::BTreeMap::new();
+
+        let (first, updates) =
+            crate::trigger::prepare_info_result("call-1", &arguments, &data, &ledger, true);
+        crate::trigger::apply_contract_updates_after_append(&mut ledger, "call-1", updates);
+
+        let (second, updates) =
+            crate::trigger::prepare_info_result("call-2", &arguments, &data, &ledger, true);
+        assert_eq!(second.content, data.content, "a sibling result stays full");
+        crate::trigger::apply_contract_updates_after_append(&mut ledger, "call-2", updates);
+
+        crate::trigger::retain_visible_contract_sources(
+            &mut ledger,
+            &[serde_json::json!({
+                "role": "function_result",
+                "function_call_id": "call-2",
+                "function_id": "engine::functions::info",
+                "content": serde_json::to_value(&second.content).unwrap()
+            })],
+        );
+        let (third, updates) =
+            crate::trigger::prepare_info_result("call-3", &arguments, &data, &ledger, true);
+
+        assert_eq!(
+            third.content,
+            vec![ContentBlock::text(
+                serde_json::json!({
+                    "function_id": "worker::function",
+                    "contract_status": "unchanged_in_context",
+                    "source_function_call_id": "call-2"
+                })
+                .to_string()
+            )]
+        );
+        assert!(updates.is_empty());
+        assert_eq!(first.content, data.content);
+    }
+
+    #[test]
+    fn normal_result_append_invalidates_a_reused_source_id_without_replacing_it() {
+        use crate::types::turn::FunctionContractLedgerEntry;
+
+        let old_source = FunctionContractLedgerEntry {
+            contract_digest: "old".into(),
+            source_function_call_id: "reused-call".into(),
+            source_content_digest: "old-content".into(),
+            eligible: true,
+        };
+        let unrelated_source = FunctionContractLedgerEntry {
+            contract_digest: "other".into(),
+            source_function_call_id: "other-call".into(),
+            source_content_digest: "other-content".into(),
+            eligible: true,
+        };
+        let replacement = FunctionContractLedgerEntry {
+            contract_digest: "new".into(),
+            source_function_call_id: "reused-call".into(),
+            source_content_digest: "new-content".into(),
+            eligible: false,
+        };
+        let mut ledger = std::collections::BTreeMap::from([
+            ("worker::function".into(), old_source),
+            ("worker::other".into(), unrelated_source.clone()),
+        ]);
+
+        crate::trigger::apply_contract_updates_after_append(
+            &mut ledger,
+            "reused-call",
+            vec![("worker::function".into(), replacement)],
+        );
+
+        assert_eq!(
+            ledger,
+            std::collections::BTreeMap::from([("worker::other".into(), unrelated_source)])
+        );
+    }
+
+    #[test]
+    fn concrete_native_tools_are_sorted_by_function_id() {
+        let policy =
+            crate::policy::CompiledPolicy::from(Some(&crate::types::turn::FunctionPolicy {
+                allow: vec!["*".into()],
+                deny: vec![],
+                expose: crate::types::turn::ExposeMode::Native,
+            }));
+        let descriptors = vec![
+            crate::clients::FunctionDescriptor {
+                function_id: "z::last".into(),
+                description: None,
+                parameters: None,
+            },
+            crate::clients::FunctionDescriptor {
+                function_id: "a::first".into(),
+                description: None,
+                parameters: None,
+            },
+        ];
+
+        let names: Vec<_> = concrete_allowed_tools(&policy, &descriptors)
+            .into_iter()
+            .map(|tool| tool.name)
+            .collect();
+        let mut sorted = names.clone();
+        sorted.sort();
+        assert_eq!(names, sorted);
+    }
 
     #[test]
     fn estimated_prompt_categories_split_and_clamp_named_skills() {

--- a/harness/src/types/turn.rs
+++ b/harness/src/types/turn.rs
@@ -214,6 +214,20 @@ pub struct ParentLink {
     pub function_call_id: String,
 }
 
+/// A model-visible function contract retained for reuse within one session.
+/// Digests keep the durable turn record small; raw contracts remain only in
+/// the session transcript.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct FunctionContractLedgerEntry {
+    pub contract_digest: String,
+    pub source_function_call_id: String,
+    pub source_content_digest: String,
+    /// True only after final context assembly confirmed the exact source is
+    /// still model-visible. Newly appended and legacy rows start ineligible.
+    #[serde(default)]
+    pub eligible: bool,
+}
+
 /// The durable loop record (`harness_turn/<session_id>`). Seeded by CAS from
 /// `harness::send` / `spawn`, advanced one step per `harness::turn`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
@@ -253,6 +267,10 @@ pub struct TurnRecord {
     /// contracts get re-fetched.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub functions_generation: Option<u64>,
+    /// Function contracts whose exact full source result was retained in the
+    /// most recently assembled model context for this session.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub function_contract_ledger: BTreeMap<String, FunctionContractLedgerEntry>,
     /// Latest generation's context accounting (also stored under
     /// `harness_context/<session_id>` once the generation completes).
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -345,6 +363,7 @@ mod tests {
             parent: None,
             display_parent_session_id: None,
             functions_generation: None,
+            function_contract_ledger: Default::default(),
             context_snapshot: None,
             result: None,
             result_error: None,
@@ -353,6 +372,30 @@ mod tests {
             created_at: 1,
             updated_at: 1,
         }
+    }
+
+    #[test]
+    fn legacy_turn_records_default_to_an_empty_function_contract_ledger() {
+        let mut value = serde_json::to_value(record()).unwrap();
+        value
+            .as_object_mut()
+            .unwrap()
+            .remove("function_contract_ledger");
+
+        let decoded: TurnRecord = serde_json::from_value(value).unwrap();
+        assert!(decoded.function_contract_ledger.is_empty());
+    }
+
+    #[test]
+    fn legacy_contract_ledger_entries_default_to_ineligible() {
+        let decoded: FunctionContractLedgerEntry = serde_json::from_value(serde_json::json!({
+            "contract_digest": "contract",
+            "source_function_call_id": "call-1",
+            "source_content_digest": "content"
+        }))
+        .unwrap();
+
+        assert!(!decoded.eligible);
     }
 
     fn cp(state: CallState, child: Option<&str>) -> CallCheckpoint {

--- a/harness/tests/integration/README.md
+++ b/harness/tests/integration/README.md
@@ -32,6 +32,7 @@ No provider key or network access is required.
 | INT-022 | `idempotency-key-collision` | direct | distinct idempotency keys whose punctuation previously collapsed retain two durable user messages and turns |
 | INT-023 | `function-call-id-collision` | direct | distinct function-call ids whose punctuation previously collapsed retain both executed function results |
 | INT-024 | `truncated-function-call-stream` | direct | a provider stream cut inside function-call arguments keeps the partial text, never executes the degraded call, resumes once, runs the re-issued call exactly once, and a follow-up on the same session is answered without a restart |
+| INT-025 | `function-contract-reuse` | direct | a repeated `engine::functions::info` call still executes and retains exact details while its unchanged model-facing contract reuses the full earlier result |
 | UI-001 | `console-streamed-text` | playground | a message sent by the Console streams to durable completion |
 | UI-002 | `multi-turn-traces` | playground | a native function turn and a Console turn expose distinct traces and function-call events |
 | UI-003 | `console-anthropic-messages-error` | playground | an Anthropic Messages permanent provider failure is shown and the chat recovers |

--- a/harness/tests/integration/src/expand.rs
+++ b/harness/tests/integration/src/expand.rs
@@ -10,6 +10,8 @@ use crate::types::script::RouterScriptV1;
 
 pub(crate) use tokens::Placeholders;
 
+pub(crate) const ALLOWED_FUNCTIONS_MARKER: &str = "__ALLOWED_FUNCTIONS__";
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct CompiledFixtureV1 {
@@ -27,21 +29,26 @@ pub(crate) struct ExpandedFixtureV1 {
 
 /// Resolve all run-scoped placeholders in a compiled fixture.
 ///
-/// The system prompt must be expanded first because its digest is itself a
-/// placeholder consumed by the router script.
+/// The system prompt is expanded before the router script because its digest
+/// is itself a placeholder consumed by that script.
 pub(crate) fn expand_compiled_fixture(
     fixture: &CompiledFixtureV1,
     run_id: &str,
     session_id: &str,
 ) -> anyhow::Result<ExpandedFixtureV1> {
     let base = Placeholders::new(run_id, session_id);
-    let system_prompt = base.expand_str(&fixture.system_prompt_template)?;
+    let mut scenario = serde_json::to_value(&fixture.scenario)?;
+    base.expand_value(&mut scenario)?;
+    let scenario: CompiledScenarioV1 = serde_json::from_value(scenario)?;
+
+    let mut allowed_functions = scenario.send.options.functions.allow.clone();
+    allowed_functions.sort_unstable();
+    allowed_functions.dedup();
+    let system_prompt = base
+        .expand_str(&fixture.system_prompt_template)?
+        .replace(ALLOWED_FUNCTIONS_MARKER, &allowed_functions.join(", "));
     let digest = crate::canonical::sha256_of_bytes(system_prompt.as_bytes());
     let placeholders = base.with_system_prompt_sha256(&digest);
-
-    let mut scenario = serde_json::to_value(&fixture.scenario)?;
-    placeholders.expand_value(&mut scenario)?;
-    let scenario = serde_json::from_value(scenario)?;
 
     let mut script = serde_json::to_value(&fixture.script)?;
     placeholders.expand_value(&mut script)?;

--- a/harness/tests/integration/src/fixtures/tests.rs
+++ b/harness/tests/integration/src/fixtures/tests.rs
@@ -30,6 +30,7 @@ fn all_selection_returns_the_checked_in_fixtures() {
             "INT-022",
             "INT-023",
             "INT-024",
+            "INT-025",
             "UI-001",
             "UI-002",
             "UI-003",
@@ -43,7 +44,7 @@ fn all_selection_returns_the_checked_in_fixtures() {
             .iter()
             .filter(|fixture| fixture.driver == crate::scenarios::ScenarioDriver::Direct)
             .count(),
-        20
+        21
     );
 }
 

--- a/harness/tests/integration/src/scenarios/dsl.rs
+++ b/harness/tests/integration/src/scenarios/dsl.rs
@@ -1434,6 +1434,8 @@ fn system_prompt(allowed_functions: &[String]) -> String {
     let policy = if allowed_functions.is_empty() {
         "Function dispatch is entirely disabled this turn — do not call any function.".to_string()
     } else {
+        let mut allowed_functions = allowed_functions.to_vec();
+        allowed_functions.sort();
         format!(
             "Your dispatch policy allows ONLY these functions: {}. This narrowed-policy \
              instruction OVERRIDES the general discovery requirement for this turn: call the \

--- a/harness/tests/integration/src/scenarios/dsl.rs
+++ b/harness/tests/integration/src/scenarios/dsl.rs
@@ -7,6 +7,7 @@
 use serde_json::{json, Value};
 
 use super::{ScenarioDriver, VerifyFn};
+use crate::expand::ALLOWED_FUNCTIONS_MARKER;
 use crate::fixtures::{ScenarioFixture, ScenarioIntervention};
 use crate::types::frames::{
     AssistantMessage, AssistantMessageEvent, AssistantRoleTag, ContentBlock, ErrorKind, ErrorShape,
@@ -1434,8 +1435,6 @@ fn system_prompt(allowed_functions: &[String]) -> String {
     let policy = if allowed_functions.is_empty() {
         "Function dispatch is entirely disabled this turn — do not call any function.".to_string()
     } else {
-        let mut allowed_functions = allowed_functions.to_vec();
-        allowed_functions.sort();
         format!(
             "Your dispatch policy allows ONLY these functions: {}. This narrowed-policy \
              instruction OVERRIDES the general discovery requirement for this turn: call the \
@@ -1443,7 +1442,7 @@ fn system_prompt(allowed_functions: &[String]) -> String {
              else — including discovery (engine::functions::list / ::info) unless listed above — \
              is denied. Do not probe: if the task genuinely needs an unlisted function or an \
              unknown contract, report that blocker and finish.",
-            allowed_functions.join(", ")
+            ALLOWED_FUNCTIONS_MARKER
         )
     };
     format!("{base}\n\nYour session id is {{{{session_id}}}}.\n{policy}")

--- a/harness/tests/integration/src/scenarios/function_contract_reuse.rs
+++ b/harness/tests/integration/src/scenarios/function_contract_reuse.rs
@@ -1,0 +1,157 @@
+//! INT-025 — unchanged function contracts reuse a retained full result.
+
+use serde_json::json;
+
+use super::dsl::{
+    ControlledFunction, Generation, Message, Model, Request, Response, Scenario, Send,
+};
+use super::ScenarioDriver;
+use crate::fixtures::ScenarioFixture;
+
+const INFO: &str = "engine::functions::info";
+const FULL_CONTRACT: &str = r#"{"description":"Record one integration fixture value.","function_id":"{{run_id}}::record","namespace":"default","registered_triggers":[],"request_schema":{"properties":{"value":{"type":"string"}},"required":["value"],"type":"object"},"response_schema":{"$schema":"http://json-schema.org/draft-07/schema#","const":{"content":[{"text":"recorded","type":"text"}],"is_error":false}},"worker_name":"integration-probe"}"#;
+
+pub(super) fn scenario() -> ScenarioFixture {
+    const ID: &str = "INT-025";
+    const MESSAGE: &str = "Fetch the recorder contract twice.";
+
+    let model = Model::scripted("fixture-model");
+    let record = ControlledFunction::new(
+        "{{run_id}}::record",
+        "Record one integration fixture value.",
+    )
+    .request_schema(json!({
+        "type": "object",
+        "properties": { "value": { "type": "string" } },
+        "required": ["value"]
+    }))
+    .returns_text("recorded");
+    let info_arguments = json!({ "function_id": "{{run_id}}::record" });
+
+    Scenario::new(
+        ID,
+        "function-contract-reuse",
+        "A repeated contract lookup still invokes the engine and retains details, but sends the model an unchanged marker while the exact first result remains in context.",
+        ScenarioDriver::Direct,
+        model.clone(),
+    )
+    .send(
+        Send::message(MESSAGE)
+            .allow_function(&record)
+            .allow_id(INFO),
+    )
+    .function(record.clone())
+    .generation(
+        Generation::new(1)
+            .expect(
+                Request::new()
+                    .turn_request_step(0)
+                    .system_prompt_sha256("{{system_prompt_sha256}}")
+                    .messages_exact([Message::user(MESSAGE)])
+                    .tools_exact([record.tool()]),
+            )
+            .respond(Response::function_call_raw(
+                "call-info-1",
+                INFO,
+                info_arguments.clone(),
+                8,
+                4,
+            )),
+    )
+    .generation(
+        Generation::new(2)
+            .expect(
+                Request::new()
+                    .turn_request_step(1)
+                    .system_prompt_sha256("{{system_prompt_sha256}}")
+                    .messages_subset([
+                        json!({ "role": "user" }),
+                        json!({ "role": "assistant", "content": [{
+                            "type": "function_call", "id": "call-info-1", "function_id": INFO
+                        }] }),
+                        json!({
+                            "role": "function_result",
+                            "function_call_id": "call-info-1",
+                            "function_id": INFO,
+                            "is_error": false,
+                            "content": [{ "type": "text", "text": FULL_CONTRACT }],
+                            "details": { "function_id": "{{run_id}}::record" }
+                        }),
+                    ])
+                    .tools_exact([record.tool()]),
+            )
+            .respond(Response::function_call_raw(
+                "call-info-2",
+                INFO,
+                info_arguments,
+                8,
+                4,
+            )),
+    )
+    .generation(
+        Generation::new(3)
+            .expect(
+                Request::new()
+                    .turn_request_step(2)
+                    .system_prompt_sha256("{{system_prompt_sha256}}")
+                    .messages_subset([
+                        json!({ "role": "user" }),
+                        json!({ "role": "assistant" }),
+                        json!({
+                            "role": "function_result",
+                            "function_call_id": "call-info-1",
+                            "details": { "function_id": "{{run_id}}::record" }
+                        }),
+                        json!({ "role": "assistant", "content": [{
+                            "type": "function_call", "id": "call-info-2", "function_id": INFO
+                        }] }),
+                        json!({
+                            "role": "function_result",
+                            "function_call_id": "call-info-2",
+                            "function_id": INFO,
+                            "is_error": false,
+                            "content": [{
+                                "type": "text",
+                                "text": "{\"contract_status\":\"unchanged_in_context\",\"function_id\":\"{{run_id}}::record\",\"source_function_call_id\":\"call-info-1\"}"
+                            }],
+                            "details": { "function_id": "{{run_id}}::record" }
+                        }),
+                    ])
+                    .tools_exact([record.tool()]),
+            )
+            .respond(Response::text("contract reused", 8, 2)),
+    )
+    .verify(|run| {
+        run.expect_assistant_texts(["contract reused"])?;
+        let info_calls = run.spans_named("call engine::functions::info");
+        anyhow::ensure!(
+            info_calls.len() == 2,
+            "engine::functions::info ran {} times, expected 2",
+            info_calls.len()
+        );
+        run.expect_target_calls(0)?;
+        run.expect_no_duplicate_messages()
+    })
+    .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fixture_requires_full_then_marker_provider_visible_results() {
+        let fixture = scenario();
+        fixture.validate().unwrap();
+        let first_gate =
+            serde_json::to_string(&fixture.script.generations[1].match_.messages).unwrap();
+        assert!(first_gate.contains("\"content\""), "{first_gate}");
+        assert!(first_gate.contains("request_schema"), "{first_gate}");
+        assert!(first_gate.contains("response_schema"), "{first_gate}");
+
+        let gate = serde_json::to_string(&fixture.script.generations[2].match_.messages).unwrap();
+        assert!(gate.contains("call-info-2"), "{gate}");
+        assert!(gate.contains("unchanged_in_context"), "{gate}");
+        assert!(gate.contains("call-info-1"), "{gate}");
+    }
+}

--- a/harness/tests/integration/src/scenarios/function_contract_reuse.rs
+++ b/harness/tests/integration/src/scenarios/function_contract_reuse.rs
@@ -9,7 +9,7 @@ use super::ScenarioDriver;
 use crate::fixtures::ScenarioFixture;
 
 const INFO: &str = "engine::functions::info";
-const FULL_CONTRACT: &str = r#"{"description":"Record one integration fixture value.","function_id":"{{run_id}}::record","namespace":"default","registered_triggers":[],"request_schema":{"properties":{"value":{"type":"string"}},"required":["value"],"type":"object"},"response_schema":{"$schema":"http://json-schema.org/draft-07/schema#","const":{"content":[{"text":"recorded","type":"text"}],"is_error":false}},"worker_name":"integration-probe"}"#;
+const FULL_CONTRACT: &str = r#"{"description":"Record one integration fixture value.","function_id":"{{run_id}}::record","registered_triggers":[],"request_schema":{"properties":{"value":{"type":"string"}},"required":["value"],"type":"object"},"response_schema":{"$schema":"http://json-schema.org/draft-07/schema#","const":{"content":[{"text":"recorded","type":"text"}],"is_error":false}},"worker_name":"integration-probe"}"#;
 
 pub(super) fn scenario() -> ScenarioFixture {
     const ID: &str = "INT-025";

--- a/harness/tests/integration/src/scenarios/leaf_denied_control_plane.rs
+++ b/harness/tests/integration/src/scenarios/leaf_denied_control_plane.rs
@@ -21,6 +21,7 @@ use super::dsl::{
 };
 use super::ScenarioDriver;
 use crate::fixtures::ScenarioFixture;
+use crate::types::script::RouterDispatchV1;
 
 const REGISTER: &str = "engine::register_trigger";
 const SPAWN: &str = "harness::spawn";
@@ -47,7 +48,7 @@ pub(super) fn scenario() -> ScenarioFixture {
         "session_id": "{{run_id}}-leaf",
     });
 
-    Scenario::new(
+    let mut fixture = Scenario::new(
         ID,
         "leaf-denied-control-plane",
         "A spawned child without the orchestrator grant is policy-denied trigger registration \
@@ -84,9 +85,8 @@ pub(super) fn scenario() -> ScenarioFixture {
                 4,
             )),
     )
-    // The child's opening step arrives BEFORE the parent's post-spawn step
-    // (its turn job is enqueued during the spawn dispatch, ahead of the
-    // parent's re-enqueued next step). Its ONLY visible tool is the recorder:
+    // The child's opening step may race the parent's post-spawn step. Its ONLY
+    // visible tool is the recorder:
     // the leaf deny globs filtered `harness::spawn` out of the native toolset
     // even though the inherited allow covers it — this tools_exact IS
     // acceptance criterion 4.
@@ -210,7 +210,10 @@ pub(super) fn scenario() -> ScenarioFixture {
         }
         run.expect_no_duplicate_messages()
     })
-    .build()
+    .build();
+    // Spawn schedules the parent continuation and child independently.
+    fixture.script.dispatch = RouterDispatchV1::MatchAny;
+    fixture
 }
 
 #[cfg(test)]
@@ -225,5 +228,6 @@ mod tests {
         assert_eq!(fixture.await_target_calls, Some(1));
         assert_eq!(fixture.expected_traces(), 1);
         assert_eq!(fixture.script.generations.len(), 6);
+        assert_eq!(fixture.script.dispatch, RouterDispatchV1::MatchAny);
     }
 }

--- a/harness/tests/integration/src/scenarios/mod.rs
+++ b/harness/tests/integration/src/scenarios/mod.rs
@@ -10,6 +10,7 @@ mod dsl;
 mod engine_restart_recovery;
 mod exactly_once_function;
 mod function_call_id_collision;
+mod function_contract_reuse;
 mod idempotency_key_collision;
 mod leaf_denied_control_plane;
 mod multi_turn_traces;
@@ -50,6 +51,7 @@ pub fn all() -> Vec<ScenarioFixture> {
         engine_restart_recovery::scenario(),
         exactly_once_function::scenario(),
         function_call_id_collision::scenario(),
+        function_contract_reuse::scenario(),
         idempotency_key_collision::scenario(),
         leaf_denied_control_plane::scenario(),
         multi_turn_traces::scenario(),
@@ -76,7 +78,7 @@ mod tests {
     #[test]
     fn every_fixture_is_unique_and_valid() {
         let fixtures = all();
-        assert_eq!(fixtures.len(), 26);
+        assert_eq!(fixtures.len(), 27);
         let mut slugs = std::collections::BTreeSet::new();
         let mut ids = std::collections::BTreeSet::new();
         for fixture in fixtures {

--- a/harness/tests/integration/src/scenarios/spawn_reuse_guard.rs
+++ b/harness/tests/integration/src/scenarios/spawn_reuse_guard.rs
@@ -65,8 +65,7 @@ pub(super) fn scenario() -> ScenarioFixture {
     .send(
         Send::message(MESSAGE)
             .idempotency_key("{{run_id}}:integration-018")
-            // Sorted: the harness renders the policy prompt line in id order,
-            // and the dsl template joins this list verbatim.
+            // Expansion renders the policy prompt line in sorted id order.
             .allow_id(SPAWN)
             .allow_function(&record)
             .allow_id(ENSURE),
@@ -307,6 +306,18 @@ pub(super) fn scenario() -> ScenarioFixture {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::expand::expand_compiled_fixture;
+
+    #[test]
+    fn fixture_prompt_sorts_expanded_allowed_function_ids() {
+        let fixture = scenario();
+        let expanded =
+            expand_compiled_fixture(&fixture.compiled(), "ir123456789abc", "session-123").unwrap();
+
+        assert!(expanded
+            .system_prompt
+            .contains("harness::spawn, ir123456789abc::record, session::ensure"));
+    }
 
     #[test]
     fn fixture_pins_the_refusal_and_the_own_child_reuse() {

--- a/llm-router/src/provider_scaffold/cache.rs
+++ b/llm-router/src/provider_scaffold/cache.rs
@@ -16,12 +16,30 @@ use std::time::{Duration, Instant};
 
 use iii_sdk::errors::Error;
 use iii_sdk::IIIClient;
+use sha2::{Digest, Sha256};
 
 use crate::types::router::ProviderResolveResponse;
 
 /// Staleness bound after an unobservable operator edit to the router's
 /// provider slice (credential/api_url/max_tokens).
 pub const RESOLVE_TTL: Duration = Duration::from_secs(30);
+
+/// Header-safe UUID derived from a stable conversation identity.
+pub fn derive_affinity_id(session_id: &str) -> Option<String> {
+    if session_id.trim().is_empty() {
+        return None;
+    }
+    let digest = Sha256::digest(session_id.as_bytes());
+    let mut bytes = [0u8; 16];
+    bytes.copy_from_slice(&digest[..16]);
+    bytes[6] = (bytes[6] & 0x0F) | 0x40;
+    bytes[8] = (bytes[8] & 0x3F) | 0x80;
+    Some(format!(
+        "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+        bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
+        bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]
+    ))
+}
 
 /// The per-provider scaffold state a stream/register/ready handler clones.
 #[derive(Clone, Default)]
@@ -101,6 +119,15 @@ impl ScaffoldCache {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn derives_a_stable_uuid_v4_from_a_nonblank_session() {
+        assert_eq!(
+            derive_affinity_id("s_conversation").as_deref(),
+            Some("3e66265f-70e5-4dda-a97f-4fabfc61b5ed")
+        );
+        assert_eq!(derive_affinity_id("  "), None);
+    }
 
     fn resolved(url: &str) -> ProviderResolveResponse {
         serde_json::from_value(serde_json::json!({

--- a/llm-router/src/types/router.rs
+++ b/llm-router/src/types/router.rs
@@ -192,6 +192,9 @@ pub struct ModelsReconcileResponse {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ProviderStreamInput {
     pub writer_ref: StreamChannelRef, // direction "write" (router-owned in relay mode)
+    /// Stable conversation identity for provider cache affinity.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system_prompt: Option<String>,
     pub model: String,

--- a/provider-anthropic/src/sse.rs
+++ b/provider-anthropic/src/sse.rs
@@ -686,6 +686,24 @@ mod tests {
     }
 
     #[test]
+    fn cache_usage_fields_are_preserved_separately_from_input() {
+        let mut usage = Usage::default();
+        merge_usage(
+            &serde_json::json!({
+                "input_tokens": 7,
+                "cache_read_input_tokens": 11,
+                "cache_creation_input_tokens": 13,
+                "output_tokens": 17,
+            }),
+            &mut usage,
+        );
+        assert_eq!(usage.input, Some(7));
+        assert_eq!(usage.cache_read, Some(11));
+        assert_eq!(usage.cache_write, Some(13));
+        assert_eq!(usage.output, Some(17));
+    }
+
+    #[test]
     fn unknown_block_type_does_not_corrupt_prior_tool_use() {
         let (state, events) = run(&[
             "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_1\",\"name\":\"shell__exec\"}}",

--- a/provider-anthropic/src/wire/cache.rs
+++ b/provider-anthropic/src/wire/cache.rs
@@ -48,12 +48,30 @@ pub fn apply_tools_cache_control(tools: &mut [Value], enabled: bool) {
     }
 }
 
-/// Anchor on the last stable assistant turn, on its last block that accepts
-/// cache_control — Anthropic rejects it on thinking/redacted_thinking blocks,
-/// which can trail a turn under interleaved thinking.
+/// Anchor on the newest user turn's last tool_result when present; otherwise
+/// fall back to the last stable assistant turn. Anthropic rejects cache_control
+/// on thinking/redacted_thinking blocks, which can trail a turn under
+/// interleaved thinking.
 pub fn apply_messages_cache_anchor(wire: &mut [Value], enabled: bool) {
     if !enabled || wire.is_empty() {
         return;
+    }
+    if let Some(block) = wire
+        .iter_mut()
+        .rev()
+        .find(|message| message.get("role").and_then(Value::as_str) == Some("user"))
+        .and_then(|message| message.get_mut("content").and_then(Value::as_array_mut))
+        .and_then(|content| {
+            content
+                .iter_mut()
+                .rev()
+                .find(|block| block.get("type").and_then(Value::as_str) == Some("tool_result"))
+        })
+    {
+        if let Some(obj) = block.as_object_mut() {
+            obj.insert("cache_control".into(), ephemeral());
+            return;
+        }
     }
     let Some(last_stable) = (0..wire.len())
         .rev()
@@ -168,6 +186,57 @@ mod tests {
     }
 
     #[test]
+    fn newest_user_tool_result_wins_over_stable_assistant() {
+        let mut wire = vec![
+            json!({ "role": "assistant", "content": [{ "type": "text", "text": "old stable" }] }),
+            json!({ "role": "user", "content": [{ "type": "tool_result", "tool_use_id": "t1", "content": "old result" }] }),
+            json!({ "role": "assistant", "content": [{ "type": "text", "text": "latest stable" }] }),
+            json!({ "role": "user", "content": [{ "type": "tool_result", "tool_use_id": "t2", "content": "fresh" }] }),
+        ];
+        apply_messages_cache_anchor(&mut wire, true);
+        assert!(wire[0]["content"][0].get("cache_control").is_none());
+        assert!(wire[1]["content"][0].get("cache_control").is_none());
+        assert!(wire[2]["content"][0].get("cache_control").is_none());
+        assert_eq!(wire[3]["content"][0]["cache_control"]["type"], "ephemeral");
+    }
+
+    #[test]
+    fn last_tool_result_wins_over_other_blocks_in_the_newest_user_message() {
+        let mut wire = vec![
+            json!({ "role": "assistant", "content": [{ "type": "text", "text": "stable" }] }),
+            json!({ "role": "user", "content": [
+                { "type": "tool_result", "tool_use_id": "t1", "content": "first" },
+                { "type": "tool_result", "tool_use_id": "t2", "content": "last" },
+                { "type": "text", "text": "trailing" },
+            ] }),
+        ];
+        apply_messages_cache_anchor(&mut wire, true);
+        assert!(wire[0]["content"][0].get("cache_control").is_none());
+        assert!(wire[1]["content"][0].get("cache_control").is_none());
+        assert_eq!(wire[1]["content"][1]["cache_control"]["type"], "ephemeral");
+        assert!(wire[1]["content"][2].get("cache_control").is_none());
+    }
+
+    #[test]
+    fn stable_assistant_remains_the_fallback_without_a_newest_user_tool_result() {
+        let mut wire = vec![
+            json!({ "role": "assistant", "content": [{ "type": "text", "text": "stable" }] }),
+            json!({ "role": "user", "content": [{ "type": "text", "text": "next" }] }),
+        ];
+        apply_messages_cache_anchor(&mut wire, true);
+        assert_eq!(wire[0]["content"][0]["cache_control"]["type"], "ephemeral");
+    }
+
+    #[test]
+    fn disabled_cache_leaves_the_newest_user_tool_result_unmarked() {
+        let mut wire = vec![json!({ "role": "user", "content": [
+            { "type": "tool_result", "tool_use_id": "t1", "content": "fresh" },
+        ] })];
+        apply_messages_cache_anchor(&mut wire, false);
+        assert!(wire[0]["content"][0].get("cache_control").is_none());
+    }
+
+    #[test]
     fn unstable_assistant_with_orphan_tool_use_not_anchored() {
         let mut wire = vec![
             json!({ "role": "assistant", "content": [{ "type": "text", "text": "old" }] }),
@@ -182,7 +251,7 @@ mod tests {
     }
 
     #[test]
-    fn resolved_tool_use_is_stable() {
+    fn tool_result_is_preferred_over_a_resolved_tool_use() {
         let mut wire = vec![
             json!({ "role": "assistant", "content": [
                 { "type": "tool_use", "id": "t1", "name": "f", "input": {} },
@@ -192,7 +261,8 @@ mod tests {
             ] }),
         ];
         apply_messages_cache_anchor(&mut wire, true);
-        assert_eq!(wire[0]["content"][0]["cache_control"]["type"], "ephemeral");
+        assert!(wire[0]["content"][0].get("cache_control").is_none());
+        assert_eq!(wire[1]["content"][0]["cache_control"]["type"], "ephemeral");
     }
 
     #[test]
@@ -204,8 +274,7 @@ mod tests {
     }
 
     #[test]
-    fn partially_resolved_assistant_is_unstable() {
-        // two tool_uses, only one resolved downstream → not a stable anchor
+    fn tool_result_is_preferred_even_when_the_assistant_is_unstable() {
         let mut wire = vec![
             json!({ "role": "assistant", "content": [{ "type": "text", "text": "old" }] }),
             json!({ "role": "assistant", "content": [
@@ -217,10 +286,10 @@ mod tests {
             ] }),
         ];
         apply_messages_cache_anchor(&mut wire, true);
-        // falls back to the earlier fully-stable assistant
-        assert_eq!(wire[0]["content"][0]["cache_control"]["type"], "ephemeral");
+        assert!(wire[0]["content"][0].get("cache_control").is_none());
         assert!(wire[1]["content"][0].get("cache_control").is_none());
         assert!(wire[1]["content"][1].get("cache_control").is_none());
+        assert_eq!(wire[2]["content"][0]["cache_control"]["type"], "ephemeral");
     }
 
     #[test]

--- a/provider-anthropic/tests/golden/schemas/provider.anthropic.stream.json
+++ b/provider-anthropic/tests/golden/schemas/provider.anthropic.stream.json
@@ -716,6 +716,13 @@
           }
         ]
       },
+      "session_id": {
+        "description": "Stable conversation identity for provider cache affinity.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
       "system_prompt": {
         "type": [
           "string",

--- a/provider-claude-code/src/sse.rs
+++ b/provider-claude-code/src/sse.rs
@@ -686,6 +686,24 @@ mod tests {
     }
 
     #[test]
+    fn cache_usage_fields_are_preserved_separately_from_input() {
+        let mut usage = Usage::default();
+        merge_usage(
+            &serde_json::json!({
+                "input_tokens": 7,
+                "cache_read_input_tokens": 11,
+                "cache_creation_input_tokens": 13,
+                "output_tokens": 17,
+            }),
+            &mut usage,
+        );
+        assert_eq!(usage.input, Some(7));
+        assert_eq!(usage.cache_read, Some(11));
+        assert_eq!(usage.cache_write, Some(13));
+        assert_eq!(usage.output, Some(17));
+    }
+
+    #[test]
     fn unknown_block_type_does_not_corrupt_prior_tool_use() {
         let (state, events) = run(&[
             "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_1\",\"name\":\"shell__exec\"}}",

--- a/provider-claude-code/src/wire/cache.rs
+++ b/provider-claude-code/src/wire/cache.rs
@@ -57,12 +57,30 @@ pub fn apply_tools_cache_control(tools: &mut [Value], enabled: bool) {
     }
 }
 
-/// Anchor on the last stable assistant turn, on its last block that accepts
-/// cache_control — Anthropic rejects it on thinking/redacted_thinking blocks,
-/// which can trail a turn under interleaved thinking.
+/// Anchor on the newest user turn's last tool_result when present; otherwise
+/// fall back to the last stable assistant turn. Anthropic rejects cache_control
+/// on thinking/redacted_thinking blocks, which can trail a turn under
+/// interleaved thinking.
 pub fn apply_messages_cache_anchor(wire: &mut [Value], enabled: bool) {
     if !enabled || wire.is_empty() {
         return;
+    }
+    if let Some(block) = wire
+        .iter_mut()
+        .rev()
+        .find(|message| message.get("role").and_then(Value::as_str) == Some("user"))
+        .and_then(|message| message.get_mut("content").and_then(Value::as_array_mut))
+        .and_then(|content| {
+            content
+                .iter_mut()
+                .rev()
+                .find(|block| block.get("type").and_then(Value::as_str) == Some("tool_result"))
+        })
+    {
+        if let Some(obj) = block.as_object_mut() {
+            obj.insert("cache_control".into(), ephemeral());
+            return;
+        }
     }
     let Some(last_stable) = (0..wire.len())
         .rev()
@@ -189,6 +207,57 @@ mod tests {
     }
 
     #[test]
+    fn newest_user_tool_result_wins_over_stable_assistant() {
+        let mut wire = vec![
+            json!({ "role": "assistant", "content": [{ "type": "text", "text": "old stable" }] }),
+            json!({ "role": "user", "content": [{ "type": "tool_result", "tool_use_id": "t1", "content": "old result" }] }),
+            json!({ "role": "assistant", "content": [{ "type": "text", "text": "latest stable" }] }),
+            json!({ "role": "user", "content": [{ "type": "tool_result", "tool_use_id": "t2", "content": "fresh" }] }),
+        ];
+        apply_messages_cache_anchor(&mut wire, true);
+        assert!(wire[0]["content"][0].get("cache_control").is_none());
+        assert!(wire[1]["content"][0].get("cache_control").is_none());
+        assert!(wire[2]["content"][0].get("cache_control").is_none());
+        assert_eq!(wire[3]["content"][0]["cache_control"]["type"], "ephemeral");
+    }
+
+    #[test]
+    fn last_tool_result_wins_over_other_blocks_in_the_newest_user_message() {
+        let mut wire = vec![
+            json!({ "role": "assistant", "content": [{ "type": "text", "text": "stable" }] }),
+            json!({ "role": "user", "content": [
+                { "type": "tool_result", "tool_use_id": "t1", "content": "first" },
+                { "type": "tool_result", "tool_use_id": "t2", "content": "last" },
+                { "type": "text", "text": "trailing" },
+            ] }),
+        ];
+        apply_messages_cache_anchor(&mut wire, true);
+        assert!(wire[0]["content"][0].get("cache_control").is_none());
+        assert!(wire[1]["content"][0].get("cache_control").is_none());
+        assert_eq!(wire[1]["content"][1]["cache_control"]["type"], "ephemeral");
+        assert!(wire[1]["content"][2].get("cache_control").is_none());
+    }
+
+    #[test]
+    fn stable_assistant_remains_the_fallback_without_a_newest_user_tool_result() {
+        let mut wire = vec![
+            json!({ "role": "assistant", "content": [{ "type": "text", "text": "stable" }] }),
+            json!({ "role": "user", "content": [{ "type": "text", "text": "next" }] }),
+        ];
+        apply_messages_cache_anchor(&mut wire, true);
+        assert_eq!(wire[0]["content"][0]["cache_control"]["type"], "ephemeral");
+    }
+
+    #[test]
+    fn disabled_cache_leaves_the_newest_user_tool_result_unmarked() {
+        let mut wire = vec![json!({ "role": "user", "content": [
+            { "type": "tool_result", "tool_use_id": "t1", "content": "fresh" },
+        ] })];
+        apply_messages_cache_anchor(&mut wire, false);
+        assert!(wire[0]["content"][0].get("cache_control").is_none());
+    }
+
+    #[test]
     fn unstable_assistant_with_orphan_tool_use_not_anchored() {
         let mut wire = vec![
             json!({ "role": "assistant", "content": [{ "type": "text", "text": "old" }] }),
@@ -203,7 +272,7 @@ mod tests {
     }
 
     #[test]
-    fn resolved_tool_use_is_stable() {
+    fn tool_result_is_preferred_over_a_resolved_tool_use() {
         let mut wire = vec![
             json!({ "role": "assistant", "content": [
                 { "type": "tool_use", "id": "t1", "name": "f", "input": {} },
@@ -213,7 +282,8 @@ mod tests {
             ] }),
         ];
         apply_messages_cache_anchor(&mut wire, true);
-        assert_eq!(wire[0]["content"][0]["cache_control"]["type"], "ephemeral");
+        assert!(wire[0]["content"][0].get("cache_control").is_none());
+        assert_eq!(wire[1]["content"][0]["cache_control"]["type"], "ephemeral");
     }
 
     #[test]
@@ -225,8 +295,7 @@ mod tests {
     }
 
     #[test]
-    fn partially_resolved_assistant_is_unstable() {
-        // two tool_uses, only one resolved downstream → not a stable anchor
+    fn tool_result_is_preferred_even_when_the_assistant_is_unstable() {
         let mut wire = vec![
             json!({ "role": "assistant", "content": [{ "type": "text", "text": "old" }] }),
             json!({ "role": "assistant", "content": [
@@ -238,10 +307,10 @@ mod tests {
             ] }),
         ];
         apply_messages_cache_anchor(&mut wire, true);
-        // falls back to the earlier fully-stable assistant
-        assert_eq!(wire[0]["content"][0]["cache_control"]["type"], "ephemeral");
+        assert!(wire[0]["content"][0].get("cache_control").is_none());
         assert!(wire[1]["content"][0].get("cache_control").is_none());
         assert!(wire[1]["content"][1].get("cache_control").is_none());
+        assert_eq!(wire[2]["content"][0]["cache_control"]["type"], "ephemeral");
     }
 
     #[test]

--- a/provider-claude-code/tests/golden/schemas/provider.claude-code.stream.json
+++ b/provider-claude-code/tests/golden/schemas/provider.claude-code.stream.json
@@ -716,6 +716,13 @@
           }
         ]
       },
+      "session_id": {
+        "description": "Stable conversation identity for provider cache affinity.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
       "system_prompt": {
         "type": [
           "string",

--- a/provider-command-code/tests/golden/schemas/provider.command-code.stream.json
+++ b/provider-command-code/tests/golden/schemas/provider.command-code.stream.json
@@ -716,6 +716,13 @@
           }
         ]
       },
+      "session_id": {
+        "description": "Stable conversation identity for provider cache affinity.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
       "system_prompt": {
         "type": [
           "string",

--- a/provider-deepseek/tests/golden/schemas/provider.deepseek.stream.json
+++ b/provider-deepseek/tests/golden/schemas/provider.deepseek.stream.json
@@ -716,6 +716,13 @@
           }
         ]
       },
+      "session_id": {
+        "description": "Stable conversation identity for provider cache affinity.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
       "system_prompt": {
         "type": [
           "string",

--- a/provider-github-copilot/src/sse.rs
+++ b/provider-github-copilot/src/sse.rs
@@ -184,25 +184,36 @@ pub fn map_finish_reason(s: &str) -> StopReason {
 /// values — overwriting is correct for both, adding double-counts.
 pub fn merge_usage(raw: &Value, into: &mut Usage) {
     let num = |k: &str| raw.get(k).and_then(Value::as_u64);
-    if let Some(v) = num("prompt_tokens").or_else(|| num("input_tokens")) {
-        into.input = Some(v);
-    }
-    if let Some(v) = num("completion_tokens").or_else(|| num("output_tokens")) {
-        into.output = Some(v);
-    }
+    let mut cache_read = None;
+    let mut cache_write = None;
     for parent in ["prompt_tokens_details", "input_tokens_details"] {
         if let Some(v) = raw
             .pointer(&format!("/{parent}/cached_tokens"))
             .and_then(Value::as_u64)
         {
-            into.cache_read = Some(v);
+            cache_read = Some(v);
+        }
+        if let Some(v) = raw
+            .pointer(&format!("/{parent}/cache_write_tokens"))
+            .and_then(Value::as_u64)
+        {
+            cache_write = Some(v);
         }
     }
-    if let Some(v) = raw
-        .pointer("/prompt_tokens_details/cache_write_tokens")
-        .and_then(Value::as_u64)
-    {
+    if let Some(v) = cache_read {
+        into.cache_read = Some(v);
+    }
+    if let Some(v) = cache_write {
         into.cache_write = Some(v);
+    }
+    if let Some(v) = num("prompt_tokens").or_else(|| num("input_tokens")) {
+        into.input = Some(
+            v.saturating_sub(cache_read.unwrap_or(0))
+                .saturating_sub(cache_write.unwrap_or(0)),
+        );
+    }
+    if let Some(v) = num("completion_tokens").or_else(|| num("output_tokens")) {
+        into.output = Some(v);
     }
     if let Some(v) = raw
         .pointer("/completion_tokens_details/reasoning_tokens")
@@ -452,7 +463,7 @@ mod tests {
         assert_eq!(final_msg.stop_reason, StopReason::End);
         assert_eq!(final_msg.native_stop_reason.as_deref(), Some("stop"));
         let usage = final_msg.usage.unwrap();
-        assert_eq!(usage.input, Some(12));
+        assert_eq!(usage.input, Some(8));
         assert_eq!(usage.output, Some(2));
         assert_eq!(usage.cache_read, Some(4));
         assert_eq!(usage.reasoning, Some(0));
@@ -658,6 +669,18 @@ mod tests {
         assert_eq!(*tags(&events).last().unwrap(), "usage");
         let usage = build_final(&state, "m").usage.unwrap();
         assert_eq!(usage.cost_usd, Some(0.00014));
+        assert_eq!(usage.cache_read, Some(6));
+        assert_eq!(usage.cache_write, Some(2));
+    }
+
+    #[test]
+    fn usage_keeps_cache_reads_and_writes_disjoint_from_input() {
+        let (state, _) = run(&[json!({"choices":[],"usage":{
+            "prompt_tokens":12,
+            "prompt_tokens_details":{"cached_tokens":6,"cache_write_tokens":2}
+        }})]);
+        let usage = build_final(&state, "m").usage.unwrap();
+        assert_eq!(usage.input, Some(4));
         assert_eq!(usage.cache_read, Some(6));
         assert_eq!(usage.cache_write, Some(2));
     }

--- a/provider-github-copilot/src/upstream.rs
+++ b/provider-github-copilot/src/upstream.rs
@@ -256,7 +256,7 @@ mod tests {
         );
         match events.last() {
             Some(AssistantMessageEvent::Done { message }) => {
-                assert_eq!(message.usage.as_ref().unwrap().input, Some(12));
+                assert_eq!(message.usage.as_ref().unwrap().input, Some(8));
                 assert_eq!(message.usage.as_ref().unwrap().output, Some(2));
                 assert_eq!(message.usage.as_ref().unwrap().cache_read, Some(4));
                 assert_eq!(message.native_stop_reason.as_deref(), Some("stop"));

--- a/provider-github-copilot/tests/golden/schemas/provider.github-copilot.stream.json
+++ b/provider-github-copilot/tests/golden/schemas/provider.github-copilot.stream.json
@@ -716,6 +716,13 @@
           }
         ]
       },
+      "session_id": {
+        "description": "Stable conversation identity for provider cache affinity.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
       "system_prompt": {
         "type": [
           "string",

--- a/provider-github-copilot/tests/integration.rs
+++ b/provider-github-copilot/tests/integration.rs
@@ -464,7 +464,7 @@ async fn chat_streams_end_to_end_through_the_ready_bearer_path() {
         res["usage"]["cost_usd"].is_null(),
         "no cost on this wire: {res}"
     );
-    assert_eq!(res["usage"]["input"], 12);
+    assert_eq!(res["usage"]["input"], 8);
 
     let _ = tokio::time::timeout(Duration::from_secs(5), pump).await;
     let frames = frames.lock().unwrap();

--- a/provider-kimi/src/request.rs
+++ b/provider-kimi/src/request.rs
@@ -18,6 +18,7 @@ pub struct BodyArgs {
     pub messages: Vec<AgentMessage>,
     pub tools: Vec<AgentFunction>,
     pub response_format: Option<ResponseFormat>,
+    pub prompt_cache_key: Option<String>,
 }
 
 /// Moonshot supports only JSON mode (`{"type":"json_object"}`) — there is no
@@ -48,6 +49,9 @@ pub fn build_body(args: &BodyArgs) -> Value {
     if let Some(rf) = &args.response_format {
         body["response_format"] = build_response_format(rf);
     }
+    if let Some(key) = &args.prompt_cache_key {
+        body["prompt_cache_key"] = json!(key);
+    }
     body
 }
 
@@ -76,6 +80,7 @@ mod tests {
             })],
             tools: vec![],
             response_format: None,
+            prompt_cache_key: None,
         }
     }
 
@@ -139,6 +144,13 @@ mod tests {
             schema: None,
         });
         assert_eq!(build_body(&a)["response_format"]["type"], "json_object");
+    }
+
+    #[test]
+    fn body_carries_a_prompt_cache_key_when_supplied() {
+        let mut a = args();
+        a.prompt_cache_key = Some("stable-session-key".into());
+        assert_eq!(build_body(&a)["prompt_cache_key"], "stable-session-key");
     }
 
     #[test]

--- a/provider-kimi/src/sse.rs
+++ b/provider-kimi/src/sse.rs
@@ -184,7 +184,7 @@ pub fn merge_usage(raw: &Value, into: &mut Usage) {
     // (pricing bills the splits additively). The wire's `prompt_tokens` is a
     // TOTAL that includes the cached slice, so the miss slice is derived —
     // mapping the total verbatim would bill the cached prefix twice.
-    let mut cached = None;
+    let mut cached = raw.get("cached_tokens").and_then(Value::as_u64);
     for parent in ["prompt_tokens_details", "input_tokens_details"] {
         if let Some(v) = raw
             .pointer(&format!("/{parent}/cached_tokens"))
@@ -435,6 +435,22 @@ mod tests {
         assert_eq!(usage.output, Some(2));
         assert_eq!(usage.cache_read, Some(4));
         assert_eq!(usage.reasoning, Some(0));
+    }
+
+    #[test]
+    fn top_level_cached_tokens_are_disjoint_from_input() {
+        let mut usage = Usage::default();
+        merge_usage(
+            &json!({
+                "prompt_tokens": 10,
+                "completion_tokens": 2,
+                "cached_tokens": 4,
+            }),
+            &mut usage,
+        );
+        assert_eq!(usage.input, Some(6));
+        assert_eq!(usage.cache_read, Some(4));
+        assert_eq!(usage.output, Some(2));
     }
 
     #[test]

--- a/provider-kimi/src/stream_fn.rs
+++ b/provider-kimi/src/stream_fn.rs
@@ -13,6 +13,7 @@ use iii_sdk::IIIClient;
 use llm_router::channels::open_sink;
 use llm_router::chat::relay::FrameSink;
 use llm_router::provider_scaffold::aborts::{AbortGuard, StreamAborts};
+use llm_router::provider_scaffold::cache::derive_affinity_id;
 use llm_router::provider_scaffold::pump::pump_abortable;
 use llm_router::types::events::{AssistantMessageEvent, ErrorKind};
 use llm_router::types::router::{ProviderStreamInput, ProviderStreamOutput};
@@ -21,6 +22,18 @@ use tokio::sync::mpsc;
 
 /// Heartbeat cadence while the upstream is silent (spec: at least every 30s).
 pub const PING_INTERVAL: Duration = Duration::from_secs(30);
+
+fn resolve_prompt_cache_key(
+    provider_options: Option<&serde_json::Value>,
+    session_id: Option<&str>,
+) -> Option<String> {
+    provider_options
+        .and_then(|options| options.get("prompt_cache_key"))
+        .and_then(serde_json::Value::as_str)
+        .filter(|key| !key.trim().is_empty())
+        .map(str::to_string)
+        .or_else(|| session_id.and_then(derive_affinity_id))
+}
 
 pub fn make_stream(
     iii: IIIClient,
@@ -121,6 +134,10 @@ async fn run_stream_call(
         messages: input.messages,
         tools: input.tools.unwrap_or_default(),
         response_format: input.response_format,
+        prompt_cache_key: resolve_prompt_cache_key(
+            input.provider_options.as_ref(),
+            input.session_id.as_deref(),
+        ),
     });
     let headers = build_headers(&cfg);
 
@@ -193,6 +210,28 @@ mod tests {
         AssistantMessageEvent::Done {
             message: empty_assistant("gpt-test"),
         }
+    }
+
+    #[test]
+    fn prompt_cache_key_prefers_an_explicit_option_then_session_affinity() {
+        let options = serde_json::json!({ "prompt_cache_key": "caller-key" });
+        assert_eq!(
+            resolve_prompt_cache_key(Some(&options), Some("s_conversation")).as_deref(),
+            Some("caller-key")
+        );
+        assert_eq!(
+            resolve_prompt_cache_key(None, Some("s_conversation")),
+            llm_router::provider_scaffold::cache::derive_affinity_id("s_conversation")
+        );
+        for blank in ["", "   "] {
+            let options = serde_json::json!({ "prompt_cache_key": blank });
+            assert_eq!(
+                resolve_prompt_cache_key(Some(&options), Some("s_conversation")),
+                llm_router::provider_scaffold::cache::derive_affinity_id("s_conversation")
+            );
+        }
+        assert_eq!(resolve_prompt_cache_key(None, Some("   ")), None);
+        assert_eq!(resolve_prompt_cache_key(None, None), None);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/provider-kimi/tests/golden/schemas/provider.kimi.stream.json
+++ b/provider-kimi/tests/golden/schemas/provider.kimi.stream.json
@@ -716,6 +716,13 @@
           }
         ]
       },
+      "session_id": {
+        "description": "Stable conversation identity for provider cache affinity.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
       "system_prompt": {
         "type": [
           "string",

--- a/provider-llamacpp/tests/golden/schemas/provider.llamacpp.stream.json
+++ b/provider-llamacpp/tests/golden/schemas/provider.llamacpp.stream.json
@@ -716,6 +716,13 @@
           }
         ]
       },
+      "session_id": {
+        "description": "Stable conversation identity for provider cache affinity.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
       "system_prompt": {
         "type": [
           "string",

--- a/provider-openai-codex/Cargo.lock
+++ b/provider-openai-codex/Cargo.lock
@@ -1296,7 +1296,6 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sha2",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/provider-openai-codex/Cargo.toml
+++ b/provider-openai-codex/Cargo.toml
@@ -33,8 +33,6 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 # JWT payload (account id / exp) decode — unsigned, no verification.
 base64 = "0.22"
-# Header-safe cache-affinity UUID derived from the stable session id.
-sha2 = "0.10"
 
 [dev-dependencies]
 uuid = { version = "1", features = ["v4"] }

--- a/provider-openai-codex/src/request.rs
+++ b/provider-openai-codex/src/request.rs
@@ -3,10 +3,10 @@
 use crate::config::{CodexBackendConfig, CodexConfig};
 use crate::wire::messages::to_wire_messages;
 use crate::wire::tools::functions_to_wire;
+use llm_router::provider_scaffold::cache::derive_affinity_id;
 use llm_router::types::messages::AgentMessage;
 use llm_router::types::model::AgentFunction;
 use serde_json::{json, Value};
-use sha2::{Digest, Sha256};
 
 /// Codex client version whose Responses contract this worker mirrors.
 ///
@@ -61,23 +61,6 @@ pub fn build_body(args: &BodyArgs) -> Value {
         body["prompt_cache_key"] = json!(key);
     }
     body
-}
-
-/// Header-safe UUID derived from a stable conversation identity.
-pub fn derive_affinity_id(conversation_id: &str) -> Option<String> {
-    if conversation_id.trim().is_empty() {
-        return None;
-    }
-    let digest = Sha256::digest(conversation_id.as_bytes());
-    let mut b = [0u8; 16];
-    b.copy_from_slice(&digest[..16]);
-    b[6] = (b[6] & 0x0F) | 0x40;
-    b[8] = (b[8] & 0x3F) | 0x80;
-    Some(format!(
-        "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
-        b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7], b[8], b[9], b[10], b[11], b[12], b[13],
-        b[14], b[15]
-    ))
 }
 
 /// Resolve header affinity and body cache keys independently. The durable

--- a/provider-openai-codex/src/sse.rs
+++ b/provider-openai-codex/src/sse.rs
@@ -178,15 +178,25 @@ pub fn merge_usage(data: &Value, into: &mut Usage) {
     // `input_tokens` is a TOTAL that includes the cached slice, so the miss
     // slice is derived — mapping the total verbatim would bill the cached
     // prefix twice.
-    let cached = u
+    let cache_read = u
         .pointer("/input_tokens_details/cached_tokens")
         .or_else(|| u.get("cached_tokens"))
         .and_then(Value::as_u64);
-    if let Some(v) = cached {
+    let cache_write = u
+        .pointer("/input_tokens_details/cache_write_tokens")
+        .or_else(|| u.pointer("/prompt_tokens_details/cache_write_tokens"))
+        .and_then(Value::as_u64);
+    if let Some(v) = cache_read {
         into.cache_read = Some(v);
     }
+    if let Some(v) = cache_write {
+        into.cache_write = Some(v);
+    }
     if let Some(v) = num("input_tokens").or_else(|| num("prompt_tokens")) {
-        into.input = Some(v.saturating_sub(cached.unwrap_or(0)));
+        into.input = Some(
+            v.saturating_sub(cache_read.unwrap_or(0))
+                .saturating_sub(cache_write.unwrap_or(0)),
+        );
     }
     if let Some(v) = num("output_tokens").or_else(|| num("completion_tokens")) {
         into.output = Some(v);
@@ -420,6 +430,18 @@ mod tests {
             out.extend(handle_chunk(c, &mut state, "codex/gpt-5.5"));
         }
         (state, out)
+    }
+
+    #[test]
+    fn usage_keeps_cache_reads_and_writes_disjoint_from_input() {
+        let (state, _) = run(&[json!({"type":"response.completed","response":{"usage":{
+            "input_tokens":12,
+            "input_tokens_details":{"cached_tokens":6,"cache_write_tokens":2}
+        }}})]);
+        let usage = build_final(&state, "codex/gpt-test").usage.unwrap();
+        assert_eq!(usage.input, Some(4));
+        assert_eq!(usage.cache_read, Some(6));
+        assert_eq!(usage.cache_write, Some(2));
     }
 
     /// Contract pin (llm-router types::events): delta frames are slim —

--- a/provider-openai-codex/src/stream_fn.rs
+++ b/provider-openai-codex/src/stream_fn.rs
@@ -23,26 +23,16 @@ use llm_router::types::router::{
     CredentialSource, ProviderResolveResponse, ProviderStreamInput, ProviderStreamOutput,
 };
 
-#[derive(Debug, Clone, serde::Deserialize, schemars::JsonSchema)]
-#[schemars(rename = "ProviderStreamInput")]
-pub struct CodexStreamInput {
-    #[serde(flatten)]
-    pub input: ProviderStreamInput,
-    /// Durable conversation identity used only to derive header affinity.
-    #[serde(default)]
-    pub session_id: Option<String>,
-}
-
 pub fn make_stream(
     iii: IIIClient,
     http: reqwest::Client,
     cache: ScaffoldCache,
     aborts: StreamAborts,
-) -> impl Fn(CodexStreamInput) -> BoxFuture<'static, Result<ProviderStreamOutput, Error>>
+) -> impl Fn(ProviderStreamInput) -> BoxFuture<'static, Result<ProviderStreamOutput, Error>>
        + Send
        + Sync
        + 'static {
-    move |input: CodexStreamInput| {
+    move |input: ProviderStreamInput| {
         let (iii, http, cache, aborts) = (iii.clone(), http.clone(), cache.clone(), aborts.clone());
         Box::pin(async move {
             // Register BEFORE the first await: an abort landing while the sink
@@ -50,11 +40,10 @@ pub fn make_stream(
             // deregisters on every exit — early returns and an executor
             // cancelling this future mid-await alike.
             let abort_reg = input
-                .input
                 .resolution_key
                 .as_ref()
                 .map(|rid| aborts.register(rid));
-            let sink = open_sink(&iii, &input.input.writer_ref).await?;
+            let sink = open_sink(&iii, &input.writer_ref).await?;
             run_stream_call(&iii, http, &cache, abort_reg.as_ref(), input, sink.as_ref()).await;
             sink.close();
             Ok(ProviderStreamOutput { ok: true })
@@ -77,10 +66,9 @@ async fn run_stream_call(
     http: reqwest::Client,
     cache: &ScaffoldCache,
     abort_reg: Option<&AbortGuard>,
-    input: CodexStreamInput,
+    input: ProviderStreamInput,
     sink: &dyn FrameSink,
 ) {
-    let CodexStreamInput { input, session_id } = input;
     let model = input.model.clone(); // router id (e.g. codex/gpt-5.5)
     let mut warnings = Vec::new();
 
@@ -166,7 +154,7 @@ async fn run_stream_call(
     let system_prompt = input.system_prompt.unwrap_or_default();
     let (affinity_headers, prompt_cache_key) = resolve_cache_routing(
         input.provider_options.as_ref(),
-        session_id.as_deref(),
+        input.session_id.as_deref(),
         input.resolution_key.as_deref(),
     );
     tracing::debug!(

--- a/provider-openai-codex/src/surface.rs
+++ b/provider-openai-codex/src/surface.rs
@@ -9,8 +9,8 @@
 //! registration emits.
 
 use llm_router::types::router::{
-    ProviderAbortRequest, ProviderAbortResponse, ProviderReadyAck, ProviderStreamOutput,
-    RefreshModelsRequest, RefreshModelsResponse, RouterReadyEvent,
+    ProviderAbortRequest, ProviderAbortResponse, ProviderReadyAck, ProviderStreamInput,
+    ProviderStreamOutput, RefreshModelsRequest, RefreshModelsResponse, RouterReadyEvent,
 };
 
 pub const STREAM_ID: &str = "provider::openai-codex::stream";
@@ -67,7 +67,7 @@ where
 /// `tests/schemas.rs`; keep in lockstep with `register::register_provider`.
 pub fn catalog() -> Vec<FunctionSpec> {
     vec![
-        spec::<crate::stream_fn::CodexStreamInput, ProviderStreamOutput>(STREAM_ID, STREAM_DESC),
+        spec::<ProviderStreamInput, ProviderStreamOutput>(STREAM_ID, STREAM_DESC),
         spec::<ProviderAbortRequest, ProviderAbortResponse>(ABORT_ID, ABORT_DESC),
         spec::<RefreshModelsRequest, RefreshModelsResponse>(REFRESH_MODELS_ID, REFRESH_MODELS_DESC),
         spec::<RouterReadyEvent, ProviderReadyAck>(ON_ROUTER_READY_ID, ON_ROUTER_READY_DESC),

--- a/provider-openai-codex/tests/golden/schemas/provider.openai-codex.stream.json
+++ b/provider-openai-codex/tests/golden/schemas/provider.openai-codex.stream.json
@@ -717,8 +717,7 @@
         ]
       },
       "session_id": {
-        "default": null,
-        "description": "Durable conversation identity used only to derive header affinity.",
+        "description": "Stable conversation identity for provider cache affinity.",
         "type": [
           "string",
           "null"

--- a/provider-openai/src/curated.rs
+++ b/provider-openai/src/curated.rs
@@ -34,12 +34,28 @@ pub fn is_legacy_generation(model_id: &str) -> bool {
 /// Hand-maintained metadata for the families we know (USD per MTok; verify
 /// against openai.com/pricing before release). A missing row only degrades
 /// display polish and cost enrichment, never routing.
-fn family_meta(base: &str) -> Option<(&'static str, u64, u64, bool, Pricing)> {
+fn family_meta(base: &str) -> Option<(&'static str, u64, u64, bool, Option<Pricing>)> {
     match base {
-        "gpt-5.2" => Some(("GPT-5.2", 400_000, 128_000, true, price(1.75, 14.0))),
-        "gpt-5.1" => Some(("GPT-5.1", 400_000, 128_000, false, price(1.25, 10.0))),
-        "gpt-5-mini" => Some(("GPT-5 Mini", 400_000, 128_000, false, price(0.25, 2.0))),
-        "gpt-5-nano" => Some(("GPT-5 Nano", 400_000, 128_000, false, price(0.05, 0.40))),
+        "gpt-5.2" => Some(("GPT-5.2", 400_000, 128_000, true, Some(price(1.75, 14.0)))),
+        "gpt-5.1" => Some(("GPT-5.1", 400_000, 128_000, false, Some(price(1.25, 10.0)))),
+        "gpt-5-mini" => Some((
+            "GPT-5 Mini",
+            400_000,
+            128_000,
+            false,
+            Some(price(0.25, 2.0)),
+        )),
+        "gpt-5-nano" => Some((
+            "GPT-5 Nano",
+            400_000,
+            128_000,
+            false,
+            Some(price(0.05, 0.40)),
+        )),
+        // GPT-5.6 changes rates above 272K input; flat pricing would misstate cost.
+        "gpt-5.6" | "gpt-5.6-sol" => Some(("GPT-5.6 Sol", 1_050_000, 128_000, true, None)),
+        "gpt-5.6-terra" => Some(("GPT-5.6 Terra", 1_050_000, 128_000, true, None)),
+        "gpt-5.6-luna" => Some(("GPT-5.6 Luna", 1_050_000, 128_000, true, None)),
         _ => None,
     }
 }
@@ -67,7 +83,7 @@ pub fn enrich(id: &str) -> Model {
             supports_cache: Some(true),
             supports_structured_output: Some(true), // native json_schema mode
             thinking_budgets: None,                 // effort enum, not token budgets
-            pricing: Some(pricing),
+            pricing,
         },
         None => Model {
             id: id.into(),
@@ -150,6 +166,19 @@ mod tests {
         assert_eq!(m.supports_structured_output, Some(true));
         assert_eq!(m.pricing.as_ref().unwrap().input, Some(1.25));
         assert!(m.pricing.as_ref().unwrap().cache_write.is_none());
+    }
+
+    #[test]
+    fn enrich_applies_gpt_5_6_metadata_without_flat_pricing() {
+        for id in ["gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"] {
+            let model = enrich(id);
+            assert_eq!(model.context_window, 1_050_000);
+            assert_eq!(model.max_output_tokens, 128_000);
+            assert!(
+                model.pricing.is_none(),
+                "the >272K pricing tier cannot be represented by flat rates"
+            );
+        }
     }
 
     #[test]

--- a/provider-openai/src/request.rs
+++ b/provider-openai/src/request.rs
@@ -17,6 +17,7 @@ pub struct BodyArgs {
     /// Pre-resolved effort string (Task 6); None omits the param.
     pub reasoning_effort: Option<&'static str>,
     pub response_format: Option<ResponseFormat>,
+    pub prompt_cache_key: Option<String>,
 }
 
 /// `ResponseFormat { type: "json", schema? }` → native OpenAI knob.
@@ -57,6 +58,9 @@ fn build_chat_body(args: &BodyArgs) -> Value {
     if let Some(rf) = &args.response_format {
         body["response_format"] = build_chat_response_format(rf);
     }
+    if let Some(key) = &args.prompt_cache_key {
+        body["prompt_cache_key"] = json!(key);
+    }
     body
 }
 
@@ -90,6 +94,9 @@ fn build_responses_body(args: &BodyArgs) -> Value {
     }
     if let Some(response_format) = &args.response_format {
         body["text"] = build_responses_text(response_format);
+    }
+    if let Some(key) = &args.prompt_cache_key {
+        body["prompt_cache_key"] = json!(key);
     }
     body
 }
@@ -128,6 +135,7 @@ mod tests {
             tools: vec![],
             reasoning_effort: None,
             response_format: None,
+            prompt_cache_key: None,
         }
     }
 
@@ -220,6 +228,20 @@ mod tests {
         assert_eq!(body["text"]["format"]["type"], "json_schema");
         assert!(body.get("messages").is_none());
         assert!(body.get("reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn both_api_modes_send_the_prompt_cache_key() {
+        let mut a = args();
+        a.prompt_cache_key = Some("stable-session-key".into());
+        assert_eq!(
+            build_body(&a, ApiMode::Responses)["prompt_cache_key"],
+            "stable-session-key"
+        );
+        assert_eq!(
+            build_body(&a, ApiMode::ChatCompletions)["prompt_cache_key"],
+            "stable-session-key"
+        );
     }
 
     #[test]

--- a/provider-openai/src/sse.rs
+++ b/provider-openai/src/sse.rs
@@ -180,20 +180,33 @@ pub fn merge_usage(raw: &Value, into: &mut Usage) {
     // (pricing bills the splits additively). The wire's `prompt_tokens` is a
     // TOTAL that includes the cached slice, so the miss slice is derived —
     // mapping the total verbatim would bill the cached prefix twice.
-    let mut cached = None;
+    let mut cache_read = None;
+    let mut cache_write = None;
     for parent in ["prompt_tokens_details", "input_tokens_details"] {
         if let Some(v) = raw
             .pointer(&format!("/{parent}/cached_tokens"))
             .and_then(Value::as_u64)
         {
-            cached = Some(v);
+            cache_read = Some(v);
+        }
+        if let Some(v) = raw
+            .pointer(&format!("/{parent}/cache_write_tokens"))
+            .and_then(Value::as_u64)
+        {
+            cache_write = Some(v);
         }
     }
-    if let Some(v) = cached {
+    if let Some(v) = cache_read {
         into.cache_read = Some(v);
     }
+    if let Some(v) = cache_write {
+        into.cache_write = Some(v);
+    }
     if let Some(v) = num("prompt_tokens").or_else(|| num("input_tokens")) {
-        into.input = Some(v.saturating_sub(cached.unwrap_or(0)));
+        into.input = Some(
+            v.saturating_sub(cache_read.unwrap_or(0))
+                .saturating_sub(cache_write.unwrap_or(0)),
+        );
     }
     if let Some(v) = num("completion_tokens").or_else(|| num("output_tokens")) {
         into.output = Some(v);
@@ -640,6 +653,18 @@ mod tests {
         assert_eq!(usage.output, Some(2));
         assert_eq!(usage.cache_read, Some(4));
         assert_eq!(usage.reasoning, Some(0));
+    }
+
+    #[test]
+    fn usage_keeps_cache_reads_and_writes_disjoint_from_input() {
+        let (state, _) = run(&[json!({"choices":[],"usage":{
+            "prompt_tokens":12,
+            "prompt_tokens_details":{"cached_tokens":6,"cache_write_tokens":2}
+        }})]);
+        let usage = build_final(&state, "gpt-test").usage.unwrap();
+        assert_eq!(usage.input, Some(4));
+        assert_eq!(usage.cache_read, Some(6));
+        assert_eq!(usage.cache_write, Some(2));
     }
 
     #[test]

--- a/provider-openai/src/stream_fn.rs
+++ b/provider-openai/src/stream_fn.rs
@@ -14,6 +14,7 @@ use iii_sdk::IIIClient;
 use llm_router::channels::open_sink;
 use llm_router::chat::relay::FrameSink;
 use llm_router::provider_scaffold::aborts::{AbortGuard, StreamAborts};
+use llm_router::provider_scaffold::cache::derive_affinity_id;
 use llm_router::provider_scaffold::cache::ScaffoldCache;
 use llm_router::provider_scaffold::pump::{pump, pump_abortable, send_event, PING_INTERVAL};
 use llm_router::types::events::ErrorKind;
@@ -34,6 +35,18 @@ fn compatible_reasoning_effort(
     } else {
         (effort, false)
     }
+}
+
+fn resolve_prompt_cache_key(
+    provider_options: Option<&serde_json::Value>,
+    session_id: Option<&str>,
+) -> Option<String> {
+    provider_options
+        .and_then(|options| options.get("prompt_cache_key"))
+        .and_then(serde_json::Value::as_str)
+        .filter(|key| !key.trim().is_empty())
+        .map(str::to_string)
+        .or_else(|| session_id.and_then(derive_affinity_id))
 }
 
 pub fn make_stream(
@@ -165,6 +178,10 @@ async fn run_stream_call(
             tools,
             reasoning_effort,
             response_format: input.response_format,
+            prompt_cache_key: resolve_prompt_cache_key(
+                input.provider_options.as_ref(),
+                input.session_id.as_deref(),
+            ),
         },
         cfg.api_mode,
     );
@@ -198,6 +215,26 @@ async fn run_stream_call(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cache_key_prefers_a_nonblank_provider_option_to_the_session() {
+        assert_eq!(
+            resolve_prompt_cache_key(
+                Some(&serde_json::json!({ "prompt_cache_key": "shared-key" })),
+                Some("s_conversation"),
+            )
+            .as_deref(),
+            Some("shared-key")
+        );
+        assert_eq!(
+            resolve_prompt_cache_key(
+                Some(&serde_json::json!({ "prompt_cache_key": "  " })),
+                Some("s_conversation"),
+            )
+            .as_deref(),
+            Some("3e66265f-70e5-4dda-a97f-4fabfc61b5ed")
+        );
+    }
 
     #[test]
     fn luna_tools_disable_effort_only_on_chat_completions() {

--- a/provider-openai/tests/golden/schemas/provider.openai.stream.json
+++ b/provider-openai/tests/golden/schemas/provider.openai.stream.json
@@ -716,6 +716,13 @@
           }
         ]
       },
+      "session_id": {
+        "description": "Stable conversation identity for provider cache affinity.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
       "system_prompt": {
         "type": [
           "string",

--- a/provider-opencode-go/Cargo.lock
+++ b/provider-opencode-go/Cargo.lock
@@ -976,7 +976,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.12"
+version = "1.4.13"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-opencode-go/src/sse.rs
+++ b/provider-opencode-go/src/sse.rs
@@ -173,19 +173,36 @@ pub fn map_finish_reason(s: &str) -> StopReason {
 
 pub fn merge_usage(raw: &Value, into: &mut Usage) {
     let num = |k: &str| raw.get(k).and_then(Value::as_u64);
-    if let Some(v) = num("prompt_tokens").or_else(|| num("input_tokens")) {
-        into.input = Some(v);
-    }
-    if let Some(v) = num("completion_tokens").or_else(|| num("output_tokens")) {
-        into.output = Some(v);
-    }
+    let mut cache_read = None;
+    let mut cache_write = None;
     for parent in ["prompt_tokens_details", "input_tokens_details"] {
         if let Some(v) = raw
             .pointer(&format!("/{parent}/cached_tokens"))
             .and_then(Value::as_u64)
         {
-            into.cache_read = Some(v);
+            cache_read = Some(v);
         }
+        if let Some(v) = raw
+            .pointer(&format!("/{parent}/cache_write_tokens"))
+            .and_then(Value::as_u64)
+        {
+            cache_write = Some(v);
+        }
+    }
+    if let Some(v) = cache_read {
+        into.cache_read = Some(v);
+    }
+    if let Some(v) = cache_write {
+        into.cache_write = Some(v);
+    }
+    if let Some(v) = num("prompt_tokens").or_else(|| num("input_tokens")) {
+        into.input = Some(
+            v.saturating_sub(cache_read.unwrap_or(0))
+                .saturating_sub(cache_write.unwrap_or(0)),
+        );
+    }
+    if let Some(v) = num("completion_tokens").or_else(|| num("output_tokens")) {
+        into.output = Some(v);
     }
     if let Some(v) = raw
         .pointer("/completion_tokens_details/reasoning_tokens")
@@ -422,6 +439,24 @@ mod tests {
         assert!(events
             .iter()
             .any(|e| matches!(e, AssistantMessageEvent::Usage { .. })));
+    }
+
+    #[test]
+    fn cache_read_and_write_are_disjoint_from_input_with_saturation() {
+        let mut usage = Usage::default();
+        merge_usage(
+            &json!({
+                "input_tokens": 8,
+                "input_tokens_details": {
+                    "cached_tokens": 6,
+                    "cache_write_tokens": 4,
+                },
+            }),
+            &mut usage,
+        );
+        assert_eq!(usage.input, Some(0));
+        assert_eq!(usage.cache_read, Some(6));
+        assert_eq!(usage.cache_write, Some(4));
     }
 
     #[test]

--- a/provider-opencode-go/src/upstream.rs
+++ b/provider-opencode-go/src/upstream.rs
@@ -242,7 +242,7 @@ mod tests {
         );
         match events.last() {
             Some(AssistantMessageEvent::Done { message }) => {
-                assert_eq!(message.usage.as_ref().unwrap().input, Some(12));
+                assert_eq!(message.usage.as_ref().unwrap().input, Some(8));
                 assert_eq!(message.usage.as_ref().unwrap().output, Some(2));
                 assert_eq!(message.usage.as_ref().unwrap().cache_read, Some(4));
                 assert_eq!(message.native_stop_reason.as_deref(), Some("stop"));

--- a/provider-opencode-go/tests/golden/schemas/provider.opencode_go.stream.json
+++ b/provider-opencode-go/tests/golden/schemas/provider.opencode_go.stream.json
@@ -716,6 +716,13 @@
           }
         ]
       },
+      "session_id": {
+        "description": "Stable conversation identity for provider cache affinity.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
       "system_prompt": {
         "type": [
           "string",

--- a/provider-opencode-go/tests/integration.rs
+++ b/provider-opencode-go/tests/integration.rs
@@ -407,7 +407,10 @@ async fn upstream_401_surfaces_as_auth_expired_error_frame() {
         .await
         .expect("chat resolves even on upstream failure");
     assert_eq!(res["ok"], false, "chat response: {res}");
-    assert_eq!(res["error"]["code"], "auth_expired", "chat response: {res}");
+    assert_eq!(
+        res["error"]["code"], "router/provider_auth_expired",
+        "chat response: {res}"
+    );
     let _ = tokio::time::timeout(Duration::from_secs(5), pump).await;
     let frames = frames.lock();
     let last: Value = serde_json::from_str(frames.last().unwrap()).unwrap();

--- a/provider-openrouter/Cargo.lock
+++ b/provider-openrouter/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.12"
+version = "1.4.13"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-openrouter/src/request.rs
+++ b/provider-openrouter/src/request.rs
@@ -33,6 +33,7 @@ pub struct BodyArgs {
     /// Whether the model declares strict `json_schema` support; without it a
     /// requested schema degrades to `json_object` (with a warning upstream).
     pub allow_json_schema: bool,
+    pub session_id: Option<String>,
 }
 
 /// A requested schema maps to OpenRouter's strict `json_schema` mode when the
@@ -75,6 +76,9 @@ pub fn build_body(args: &BodyArgs) -> Value {
     if let Some(effort) = &args.reasoning_effort {
         body["reasoning"] = json!({ "effort": effort });
     }
+    if let Some(session_id) = &args.session_id {
+        body["session_id"] = json!(session_id);
+    }
     body
 }
 
@@ -107,6 +111,7 @@ mod tests {
             response_format: None,
             reasoning_effort: None,
             allow_json_schema: true,
+            session_id: None,
         }
     }
 
@@ -150,6 +155,13 @@ mod tests {
         a.reasoning_effort = Some("high".into());
         let body = build_body(&a);
         assert_eq!(body["reasoning"]["effort"], "high");
+    }
+
+    #[test]
+    fn body_carries_a_session_id_when_supplied() {
+        let mut a = args();
+        a.session_id = Some("stable-session-key".into());
+        assert_eq!(build_body(&a)["session_id"], "stable-session-key");
     }
 
     #[test]

--- a/provider-openrouter/src/sse.rs
+++ b/provider-openrouter/src/sse.rs
@@ -188,25 +188,36 @@ pub fn map_finish_reason(s: &str) -> StopReason {
 /// values — overwriting is correct for both, adding double-counts.
 pub fn merge_usage(raw: &Value, into: &mut Usage) {
     let num = |k: &str| raw.get(k).and_then(Value::as_u64);
-    if let Some(v) = num("prompt_tokens").or_else(|| num("input_tokens")) {
-        into.input = Some(v);
-    }
-    if let Some(v) = num("completion_tokens").or_else(|| num("output_tokens")) {
-        into.output = Some(v);
-    }
+    let mut cache_read = None;
+    let mut cache_write = None;
     for parent in ["prompt_tokens_details", "input_tokens_details"] {
         if let Some(v) = raw
             .pointer(&format!("/{parent}/cached_tokens"))
             .and_then(Value::as_u64)
         {
-            into.cache_read = Some(v);
+            cache_read = Some(v);
+        }
+        if let Some(v) = raw
+            .pointer(&format!("/{parent}/cache_write_tokens"))
+            .and_then(Value::as_u64)
+        {
+            cache_write = Some(v);
         }
     }
-    if let Some(v) = raw
-        .pointer("/prompt_tokens_details/cache_write_tokens")
-        .and_then(Value::as_u64)
-    {
+    if let Some(v) = cache_read {
+        into.cache_read = Some(v);
+    }
+    if let Some(v) = cache_write {
         into.cache_write = Some(v);
+    }
+    if let Some(v) = num("prompt_tokens").or_else(|| num("input_tokens")) {
+        into.input = Some(
+            v.saturating_sub(cache_read.unwrap_or(0))
+                .saturating_sub(cache_write.unwrap_or(0)),
+        );
+    }
+    if let Some(v) = num("completion_tokens").or_else(|| num("output_tokens")) {
+        into.output = Some(v);
     }
     if let Some(v) = raw
         .pointer("/completion_tokens_details/reasoning_tokens")
@@ -456,10 +467,30 @@ mod tests {
         assert_eq!(final_msg.stop_reason, StopReason::End);
         assert_eq!(final_msg.native_stop_reason.as_deref(), Some("stop"));
         let usage = final_msg.usage.unwrap();
-        assert_eq!(usage.input, Some(12));
+        assert_eq!(usage.input, Some(8));
         assert_eq!(usage.output, Some(2));
         assert_eq!(usage.cache_read, Some(4));
         assert_eq!(usage.reasoning, Some(0));
+    }
+
+    #[test]
+    fn cache_read_and_write_are_disjoint_from_input_with_saturation() {
+        let mut usage = Usage::default();
+        merge_usage(
+            &json!({
+                "prompt_tokens": 8,
+                "prompt_tokens_details": {
+                    "cached_tokens": 6,
+                    "cache_write_tokens": 4,
+                },
+                "cost": 0.00014,
+            }),
+            &mut usage,
+        );
+        assert_eq!(usage.input, Some(0));
+        assert_eq!(usage.cache_read, Some(6));
+        assert_eq!(usage.cache_write, Some(4));
+        assert_eq!(usage.cost_usd, Some(0.00014));
     }
 
     #[test]

--- a/provider-openrouter/src/stream_fn.rs
+++ b/provider-openrouter/src/stream_fn.rs
@@ -14,6 +14,7 @@ use iii_sdk::IIIClient;
 use llm_router::channels::open_sink;
 use llm_router::chat::relay::FrameSink;
 use llm_router::provider_scaffold::aborts::{AbortGuard, StreamAborts};
+use llm_router::provider_scaffold::cache::derive_affinity_id;
 use llm_router::provider_scaffold::pump::pump_abortable;
 use llm_router::types::events::{AssistantMessageEvent, ErrorKind};
 use llm_router::types::model::{Model, ThinkingLevel};
@@ -23,6 +24,18 @@ use tokio::sync::mpsc;
 
 /// Heartbeat cadence while the upstream is silent (spec: at least every 30s).
 pub const PING_INTERVAL: Duration = Duration::from_secs(30);
+
+fn resolve_session_id(
+    provider_options: Option<&serde_json::Value>,
+    session_id: Option<&str>,
+) -> Option<String> {
+    provider_options
+        .and_then(|options| options.get("session_id"))
+        .and_then(serde_json::Value::as_str)
+        .filter(|key| !key.trim().is_empty())
+        .map(str::to_string)
+        .or_else(|| session_id.and_then(derive_affinity_id))
+}
 
 pub fn make_stream(
     iii: IIIClient,
@@ -173,6 +186,10 @@ async fn run_stream_call(
         response_format: input.response_format,
         reasoning_effort,
         allow_json_schema,
+        session_id: resolve_session_id(
+            input.provider_options.as_ref(),
+            input.session_id.as_deref(),
+        ),
     });
     let headers = build_headers(&cfg);
 
@@ -246,6 +263,28 @@ mod tests {
         AssistantMessageEvent::Done {
             message: empty_assistant("gpt-test"),
         }
+    }
+
+    #[test]
+    fn session_id_prefers_an_explicit_option_then_session_affinity() {
+        let options = serde_json::json!({ "session_id": "caller-key" });
+        assert_eq!(
+            resolve_session_id(Some(&options), Some("s_conversation")).as_deref(),
+            Some("caller-key")
+        );
+        assert_eq!(
+            resolve_session_id(None, Some("s_conversation")),
+            llm_router::provider_scaffold::cache::derive_affinity_id("s_conversation")
+        );
+        for blank in ["", "   "] {
+            let options = serde_json::json!({ "session_id": blank });
+            assert_eq!(
+                resolve_session_id(Some(&options), Some("s_conversation")),
+                llm_router::provider_scaffold::cache::derive_affinity_id("s_conversation")
+            );
+        }
+        assert_eq!(resolve_session_id(None, Some("   ")), None);
+        assert_eq!(resolve_session_id(None, None), None);
     }
 
     fn meta_with_efforts(efforts: &[&str]) -> Model {

--- a/provider-openrouter/src/upstream.rs
+++ b/provider-openrouter/src/upstream.rs
@@ -235,7 +235,7 @@ mod tests {
         );
         match events.last() {
             Some(AssistantMessageEvent::Done { message }) => {
-                assert_eq!(message.usage.as_ref().unwrap().input, Some(12));
+                assert_eq!(message.usage.as_ref().unwrap().input, Some(8));
                 assert_eq!(message.usage.as_ref().unwrap().output, Some(2));
                 assert_eq!(message.usage.as_ref().unwrap().cache_read, Some(4));
                 assert_eq!(message.native_stop_reason.as_deref(), Some("stop"));

--- a/provider-openrouter/tests/golden/schemas/provider.openrouter.stream.json
+++ b/provider-openrouter/tests/golden/schemas/provider.openrouter.stream.json
@@ -716,6 +716,13 @@
           }
         ]
       },
+      "session_id": {
+        "description": "Stable conversation identity for provider cache affinity.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
       "system_prompt": {
         "type": [
           "string",

--- a/provider-xai/src/count_tokens.rs
+++ b/provider-xai/src/count_tokens.rs
@@ -100,7 +100,7 @@ pub async fn handle(
         req.tools.as_deref().unwrap_or(&[]),
         &req.messages,
     );
-    let headers = build_headers(&cfg)
+    let headers = build_headers(&cfg, None)
         .into_iter()
         .map(|(name, value)| (name.to_string(), value))
         .collect();

--- a/provider-xai/src/request.rs
+++ b/provider-xai/src/request.rs
@@ -60,11 +60,18 @@ pub fn build_body(args: &BodyArgs) -> Value {
     body
 }
 
-pub fn build_headers(cfg: &XaiConfig) -> Vec<(&'static str, String)> {
-    vec![
+pub fn build_headers(
+    cfg: &XaiConfig,
+    conversation_id: Option<&str>,
+) -> Vec<(&'static str, String)> {
+    let mut headers = vec![
         ("authorization", format!("Bearer {}", cfg.credential_value)),
         ("content-type", "application/json".to_string()),
-    ]
+    ];
+    if let Some(conversation_id) = conversation_id {
+        headers.push(("x-grok-conv-id", conversation_id.to_string()));
+    }
+    headers
 }
 
 #[cfg(test)]
@@ -157,8 +164,12 @@ mod tests {
             max_tokens: 4096,
             api_url: "https://api.x.ai/v1/chat/completions".into(),
         };
-        let h = build_headers(&cfg);
+        let h = build_headers(&cfg, Some("stable-session-key"));
         assert!(h.contains(&("authorization", "Bearer sk-test".to_string())));
         assert!(h.contains(&("content-type", "application/json".to_string())));
+        assert!(h.contains(&("x-grok-conv-id", "stable-session-key".to_string())));
+        assert!(!build_headers(&cfg, None)
+            .iter()
+            .any(|(name, _)| *name == "x-grok-conv-id"));
     }
 }

--- a/provider-xai/src/responses.rs
+++ b/provider-xai/src/responses.rs
@@ -48,16 +48,21 @@ pub fn build_responses_body(
     messages: &[AgentMessage],
     tools: &[String],
     max_tokens: u64,
+    prompt_cache_key: Option<&str>,
 ) -> Value {
     let input = to_wire_messages(messages, system_prompt);
     let tool_specs: Vec<Value> = tools.iter().map(|t| json!({ "type": t })).collect();
-    json!({
+    let mut body = json!({
         "model": model,
         "input": input,
         "tools": tool_specs,
         "max_output_tokens": max_tokens,
         "stream": true,
-    })
+    });
+    if let Some(key) = prompt_cache_key {
+        body["prompt_cache_key"] = json!(key);
+    }
+    body
 }
 
 /// Accumulated Responses-stream state; folded into the terminal message.
@@ -456,6 +461,7 @@ mod tests {
             &[user("hi")],
             &["x_search".into(), "web_search".into()],
             8192,
+            Some("stable-session-key"),
         );
         assert_eq!(b["model"], "grok-4.3");
         assert_eq!(b["stream"], true);
@@ -464,6 +470,12 @@ mod tests {
         assert_eq!(b["input"][1]["content"], "hi");
         assert_eq!(b["tools"][0]["type"], "x_search");
         assert_eq!(b["tools"][1]["type"], "web_search");
+        assert_eq!(b["prompt_cache_key"], "stable-session-key");
+        assert!(
+            build_responses_body("grok-4.3", "be brief", &[user("hi")], &[], 8192, None)
+                .get("prompt_cache_key")
+                .is_none()
+        );
     }
 
     fn run(events: &[(&str, Value)]) -> (ResponsesState, Vec<AssistantMessageEvent>) {
@@ -584,6 +596,23 @@ mod tests {
         assert_eq!(u.output, Some(4));
         assert_eq!(u.reasoning, Some(2));
         assert_eq!(state.tool_calls, vec!["x_search"]);
+    }
+
+    #[test]
+    fn cached_input_tokens_are_disjoint_from_responses_input() {
+        let (state, events) = run(&[(
+            "response.completed",
+            json!({"response":{"usage":{
+                "input_tokens": 10,
+                "output_tokens": 4,
+                "input_tokens_details":{"cached_tokens":6}
+            }}}),
+        )]);
+        assert_eq!(tags(&events), vec!["usage"]);
+        let usage = build_final(&state, "grok-4.3").usage.unwrap();
+        assert_eq!(usage.input, Some(4));
+        assert_eq!(usage.cache_read, Some(6));
+        assert_eq!(usage.output, Some(4));
     }
 
     #[test]

--- a/provider-xai/src/stream_fn.rs
+++ b/provider-xai/src/stream_fn.rs
@@ -18,6 +18,7 @@ use iii_sdk::IIIClient;
 use llm_router::channels::open_sink;
 use llm_router::chat::relay::FrameSink;
 use llm_router::provider_scaffold::aborts::{AbortGuard, StreamAborts};
+use llm_router::provider_scaffold::cache::derive_affinity_id;
 use llm_router::provider_scaffold::cache::ScaffoldCache;
 use llm_router::provider_scaffold::pump::{pump, pump_abortable, send_event, PING_INTERVAL};
 use llm_router::types::events::{AssistantMessageEvent, ErrorKind};
@@ -85,6 +86,13 @@ async fn pump_stream(
     }
 }
 
+fn uses_responses_agent_tools(
+    config: &crate::config::WorkerConfig,
+    has_client_functions: bool,
+) -> bool {
+    config.tools_enabled && !config.tool_sources.is_empty() && !has_client_functions
+}
+
 async fn run_stream_call(
     iii: &IIIClient,
     http: reqwest::Client,
@@ -138,22 +146,14 @@ async fn run_stream_call(
             return;
         }
     };
+    let affinity_id = input.session_id.as_deref().and_then(derive_affinity_id);
+    let has_client_functions = input.tools.as_ref().is_some_and(|tools| !tools.is_empty());
 
-    // Agent Tools path (opt-in via the console config): when enabled, route to
-    // the /v1/responses API with server-side tools (x_search / web_search) so
-    // the model can pull live X / web data. Otherwise fall through to the plain
-    // Chat Completions path below.
-    if wc.tools_enabled && !wc.tool_sources.is_empty() {
-        // Report-and-continue: the Responses path carries the conversation +
-        // server-side tools, but not the chat-path per-request controls, so
-        // name each dropped one instead of silently ignoring it.
-        if input.tools.as_ref().is_some_and(|t| !t.is_empty()) {
-            warnings.push(
-                "client function tools are not sent on the xAI Agent Tools path; \
-                 disable provider-xai tools to use function calling"
-                    .to_string(),
-            );
-        }
+    // Agent Tools are a server-tool-only path. Client function calls retain
+    // Chat Completions so their tool definitions are forwarded intact.
+    if uses_responses_agent_tools(wc, has_client_functions) {
+        // Report-and-continue: the Responses path carries server-side tools,
+        // but not the Chat Completions per-request controls.
         if input.response_format.is_some() {
             warnings.push("response_format is not applied on the xAI Agent Tools path".to_string());
         }
@@ -172,8 +172,9 @@ async fn run_stream_call(
             &input.messages,
             &tool_types,
             cfg.max_tokens,
+            affinity_id.as_deref(),
         );
-        let headers = build_headers(&cfg);
+        let headers = build_headers(&cfg, None);
         // Aborted while we were setting up — never start the upstream request.
         if abort_reg.is_some_and(|g| g.is_fired()) {
             return;
@@ -234,7 +235,7 @@ async fn run_stream_call(
         reasoning_effort,
         response_format: input.response_format,
     });
-    let headers = build_headers(&cfg);
+    let headers = build_headers(&cfg, affinity_id.as_deref());
 
     // Aborted while we were setting up — never start the upstream request.
     if abort_reg.is_some_and(|g| g.is_fired()) {
@@ -254,5 +255,21 @@ async fn run_stream_call(
     // out from under us: drop the cache so the next attempt re-resolves.
     if pump_stream(rx, sink, abort_reg.map(|g| g.watch())).await == Some(ErrorKind::AuthExpired) {
         cache.invalidate();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{ToolSource, WorkerConfig};
+
+    #[test]
+    fn client_functions_force_chat_while_server_tool_only_calls_use_responses() {
+        let agent_tools = WorkerConfig {
+            tools_enabled: true,
+            tool_sources: vec![ToolSource::XSearch],
+        };
+        assert!(uses_responses_agent_tools(&agent_tools, false));
+        assert!(!uses_responses_agent_tools(&agent_tools, true));
     }
 }

--- a/provider-xai/tests/golden/schemas/provider.xai.stream.json
+++ b/provider-xai/tests/golden/schemas/provider.xai.stream.json
@@ -716,6 +716,13 @@
           }
         ]
       },
+      "session_id": {
+        "description": "Stable conversation identity for provider cache affinity.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
       "system_prompt": {
         "type": [
           "string",

--- a/provider-zai/tests/golden/schemas/provider.zai.stream.json
+++ b/provider-zai/tests/golden/schemas/provider.zai.stream.json
@@ -716,6 +716,13 @@
           }
         ]
       },
+      "session_id": {
+        "description": "Stable conversation identity for provider cache affinity.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
       "system_prompt": {
         "type": [
           "string",


### PR DESCRIPTION
Repeated function lookups now reuse an unchanged contract already present in the conversation, reducing context use while keeping the complete contract available for inspection.

## Technical details

- Track exact, uniquely identifiable `engine::functions::info` results and replace only safe unchanged repeats with a source-call marker.
- Preserve complete result details and invalidate reuse after errors, hook rewrites, ambiguous batches or call IDs, registry changes, and context pruning.
- Carry reuse state across ordinary and deferred turns without making newly appended results eligible inside the same response.
- Use the latest function result as the Anthropic/Claude prompt-cache boundary and propagate stable per-session cache affinity to compatible providers.
- Report cache reads and writes separately from uncached input, and omit flat GPT-5.6 pricing where long-context tiers cannot be represented accurately.
- Cover single, batch, deferred, collision, cache-mapping, and provider-schema behavior.

Fixes MOT-4559

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added stable session identity support for provider cache affinity.
  - Added prompt-cache key support with session-based fallback.
  - Repeated function-contract lookups can reuse unchanged contracts while retaining full details.
  - Improved xAI routing for tool-enabled requests.

- **Bug Fixes**
  - Corrected cache read/write token accounting.
  - Improved message cache anchoring around tool results.
  - Preserved accurate pricing metadata for tiered model variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->