### PR TITLE
(MOT-3732) test(security-scan): manifest test expects policy ranges

### DIFF
--- a/security-scan/tests/manifest.rs
+++ b/security-scan/tests/manifest.rs
@@ -34,9 +34,9 @@ fn worker_manifest_names_the_same_worker_and_description() {
     assert!(source.contains(manifest::DESCRIPTION));
     assert!(source.lines().any(|line| line.starts_with("tags: [")));
     assert!(source.lines().any(|line| line == "  github: \"^0.3.0\""));
-    assert!(source.lines().any(|line| line == "  harness: \"^1.0.0\""));
-    assert!(source.lines().any(|line| line == "  cron: \"^0.21.4\""));
-    assert!(source.lines().any(|line| line == "  queue: \"^0.21.3\""));
+    assert!(source.lines().any(|line| line == "  harness: \"^1.8.5\""));
+    assert!(source.lines().any(|line| line == "  cron: \"^0.21.9\""));
+    assert!(source.lines().any(|line| line == "  queue: \"^0.21.5\""));
     assert!(source.lines().any(|line| line == "  worktree: \"^0.3.0\""));
     assert!(source.lines().any(|line| line == "  storage: \"^0.1.0\""));
 }


### PR DESCRIPTION
The dependency-policy fix (#918) bumped harness/cron/queue ranges in the manifest, but the worker's own manifest test still asserts the old literal lines, so `security-scan: rust lint + test` fails on main. This updates the three expectations to the policy ranges. Full local suite: 12 result blocks, 0 failures.
