### PR TITLE
chore(harness): migrate Compose ordering to start_after

### DIFF
--- a/harness/worker-compose.yaml
+++ b/harness/worker-compose.yaml
@@ -38,7 +38,7 @@ containers:
 
   llm-router:
     worker: path://../llm-router
-    depends_on:
+    start_after:
       - state
     environment:
       RUST_LOG: info
@@ -49,7 +49,7 @@ containers:
 
   provider-openai-codex:
     worker: path://../provider-openai-codex
-    depends_on:
+    start_after:
       - llm-router
       - state
     environment:
@@ -59,7 +59,7 @@ containers:
 
   provider-openai:
     worker: path://../provider-openai
-    depends_on:
+    start_after:
       - llm-router
       - state
     environment:
@@ -69,7 +69,7 @@ containers:
 
   provider-anthropic:
     worker: path://../provider-anthropic
-    depends_on:
+    start_after:
       - llm-router
       - state
     environment:
@@ -79,7 +79,7 @@ containers:
 
   context-manager:
     worker: path://../context-manager
-    depends_on:
+    start_after:
       - llm-router
     environment:
       RUST_LOG: info
@@ -116,7 +116,7 @@ containers:
 
   harness:
     worker: path://.
-    depends_on:
+    start_after:
       - state
       - queue
       - session-manager


### PR DESCRIPTION
## Summary

- migrate Harness startup ordering from `depends_on` to `start_after`
- preserve the existing worker dependency graph
- align the Harness manifest with iii-hq/iii#2080

## Validation

- `cargo test --locked`
- `cargo clippy --locked --all-targets -- -D warnings`
- parsed the full Harness manifest with the iii Compose parser from iii-hq/iii#2080 and verified that Harness starts last