### PR TITLE
(MOT-4407) fix(shell,console): calm review churn, shield editor keys

### DIFF
--- a/console/web/src/hooks/use-keybindings.test.ts
+++ b/console/web/src/hooks/use-keybindings.test.ts
@@ -136,6 +136,22 @@ describe('createKeyDispatcher', () => {
     expect(seen).toEqual(['create'])
   })
 
+  it('stands down inside a declared standdown surface', () => {
+    const seen: string[] = []
+    const dispatcher = createKeyDispatcher(
+      () => ({ 'workspace.create': () => seen.push('create') }),
+      'mac',
+    )
+    const editorChild = {
+      tagName: 'DIV',
+      dataset: {},
+      closest: (selector: string) =>
+        selector.includes('data-keybindings-standdown') ? {} : null,
+    } as unknown as EventTarget
+    dispatcher.onKeyDown(key('t', { target: editorChild }))
+    expect(seen).toEqual([])
+  })
+
   it('never arms a chord from a field or a dialog', () => {
     const seen: string[] = []
     const dispatcher = createKeyDispatcher(

--- a/console/web/src/hooks/use-keybindings.ts
+++ b/console/web/src/hooks/use-keybindings.ts
@@ -39,6 +39,15 @@ function isTyping(target: EventTarget | null): boolean {
   const element = target as HTMLElement | null
   if (!element) return false
   if (element.isContentEditable) return true
+  // An editor surface (its gutters, widgets and fallbacks included) can
+  // declare every keystroke inside it content, whatever element focus
+  // happens to sit on.
+  if (
+    typeof element.closest === 'function' &&
+    element.closest('[data-keybindings-standdown]') !== null
+  ) {
+    return true
+  }
   const tag = element.tagName
   return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT'
 }

--- a/docs/sops/injectable-console-ui.md
+++ b/docs/sops/injectable-console-ui.md
@@ -448,6 +448,23 @@ registration when the worker's assets go. `run` usually calls
 context. Keys are **not** honoured here: the console's global keymap stays
 the console's.
 
+**Typing surfaces that are not form fields must stand down the bare keys.**
+The dispatcher already yields to a caret in an `input`, `textarea`, `select`,
+or contentEditable node. Anything else that consumes raw keystrokes — a code
+editor's gutters and widgets, a read-mode diff, a drawing surface — gives the
+dispatcher a plain element as the event target, and a bare binding like `t`
+(new workspace) fires mid-thought. Declare the surface:
+
+```tsx
+<div className="my-editor-body" data-keybindings-standdown="">…</div>
+```
+
+Every keystroke originating inside a `data-keybindings-standdown` element
+counts as typing: bindings without `firesWhileTyping` stand down, modifier
+chords still work. Put it on the smallest container that holds the whole
+interactive surface (the editor body, the diff card), never on the page root —
+the page chrome around it should keep answering the navigation keys.
+
 **`PageRenderProps.commands.register(commands)`** — render time, page
 level. Lives while the page is mounted in a pane. Keys are honoured and
 scoped to that pane: they fire only while focus is inside it, so two panes

--- a/shell/src/events.rs
+++ b/shell/src/events.rs
@@ -99,7 +99,7 @@ fn watch_root(config: &Value, resolver: &PathResolver) -> Result<PathBuf, Error>
 }
 
 /// Map a notify event kind onto the wire vocabulary.
-fn kind_of(kind: &notify::EventKind) -> &'static str {
+pub(crate) fn kind_of(kind: &notify::EventKind) -> &'static str {
     use notify::EventKind;
     match kind {
         EventKind::Create(_) => "created",
@@ -111,7 +111,7 @@ fn kind_of(kind: &notify::EventKind) -> &'static str {
 /// Reads and bare metadata touches are not workspace changes — reporting
 /// them would turn every `cat` and `chmod` into a phantom modification.
 /// Content writes carry their own Data events regardless.
-fn is_noise_kind(kind: &notify::EventKind) -> bool {
+pub(crate) fn is_noise_kind(kind: &notify::EventKind) -> bool {
     use notify::event::ModifyKind;
     use notify::EventKind;
     matches!(
@@ -123,7 +123,7 @@ fn is_noise_kind(kind: &notify::EventKind) -> bool {
 /// Git internals churn constantly during any git operation and mean
 /// nothing to a workspace surface — the visible outcome arrives as
 /// worktree events of its own.
-fn is_git_internal(path: &Path) -> bool {
+pub(crate) fn is_git_internal(path: &Path) -> bool {
     path.components()
         .any(|c| c.as_os_str().to_str() == Some(".git"))
 }
@@ -133,7 +133,7 @@ fn is_git_internal(path: &Path) -> bool {
 /// `.coder-tmp-`, the fs backend's `.iii-tmp-` and `.tmp.<uuid>`).
 /// Reporting them would hand every write a phantom neighbor — and the
 /// rename lands as an event on the REAL path regardless.
-fn is_own_temp(path: &Path) -> bool {
+pub(crate) fn is_own_temp(path: &Path) -> bool {
     let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
         return false;
     };
@@ -148,7 +148,7 @@ fn is_own_temp(path: &Path) -> bool {
 /// the write that fills the file is still a creation; a deletion
 /// supersedes what came before it; a creation after a deletion is a
 /// creation again.
-fn merge_kinds(prev: &'static str, next: &'static str) -> &'static str {
+pub(crate) fn merge_kinds(prev: &'static str, next: &'static str) -> &'static str {
     match (prev, next) {
         ("created", "modified") => "created",
         _ => next,

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -22,6 +22,7 @@ mod scode;
 mod target;
 mod telemetry;
 mod triggers;
+mod turn_observe;
 mod turns;
 mod ui;
 

--- a/shell/src/turn_observe.rs
+++ b/shell/src/turn_observe.rs
@@ -1,0 +1,273 @@
+//! Fold watched filesystem changes into the durable turn history.
+//!
+//! The turn log's harness hooks only see writes that go through a shell or
+//! coder function; a `sed -i` inside `shell::exec`, a formatter, a build
+//! step all bypass them, and a session reopened later showed "0 files" for
+//! turns full of such work. This module puts an OS watch on the session's
+//! workspace root for the duration of each turn and records what it sees as
+//! `observed` changes: no pre-image (the watch fires after the write), so a
+//! reopened review diffs them against the committed version when one exists
+//! and says "nothing to diff" quietly when one does not.
+//!
+//! The watch starts on the first hooked call of a turn — the pre-trigger
+//! hook is an awaited barrier, so the watcher is live before that call can
+//! write — and stops a grace window after the turn completes, letting the
+//! last coalesced burst land. Git internals, this worker's own temp files,
+//! the turn store itself, and gitignored paths stay out of the record.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::Duration;
+
+use notify::{RecursiveMode, Watcher};
+
+use crate::events::{is_git_internal, is_noise_kind, is_own_temp, kind_of, merge_kinds};
+use crate::turns::TurnLog;
+
+/// Raw OS events batch this long before folding into the record.
+const COALESCE_MS: u64 = 250;
+/// How long a watch outlives its turn, so the final burst still lands.
+const GRACE_MS: u64 = 1_200;
+
+struct ObserverEntry {
+    turn_id: String,
+    root: PathBuf,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for ObserverEntry {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+/// One live workspace watch per session with an active turn.
+pub struct TurnObservers {
+    log: Arc<TurnLog>,
+    entries: StdMutex<HashMap<String, ObserverEntry>>,
+    /// The turn store's own directory: folding a record writes here, and
+    /// watching those writes back would loop forever.
+    store_dir: PathBuf,
+}
+
+impl TurnObservers {
+    pub fn new(log: Arc<TurnLog>, store_dir: PathBuf) -> Arc<Self> {
+        Arc::new(Self {
+            log,
+            entries: StdMutex::new(HashMap::new()),
+            store_dir,
+        })
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<String, ObserverEntry>> {
+        self.entries
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    /// The turn currently observed for a session, read at fold time so a
+    /// burst that spans a turn boundary lands under the right id.
+    fn current_turn(&self, session_id: &str) -> Option<(String, PathBuf)> {
+        self.lock()
+            .get(session_id)
+            .map(|entry| (entry.turn_id.clone(), entry.root.clone()))
+    }
+
+    /// Make sure a watch covers this session's root for this turn. Called
+    /// from the awaited pre/post hooks, so by the time a hooked call runs
+    /// the watcher is already live.
+    pub fn ensure(self: &Arc<Self>, session_id: &str, turn_id: &str, root: Option<&str>) {
+        let Some(root) = root else { return };
+        let root = Path::new(root);
+        if !root.is_absolute() {
+            return;
+        }
+        // FSEvents reports resolved paths; an unresolved root would make
+        // every strip_prefix miss (macOS /tmp vs /private/tmp).
+        let Ok(root) = std::fs::canonicalize(root) else {
+            return;
+        };
+        if !root.is_dir() {
+            return;
+        }
+
+        let mut entries = self.lock();
+        if let Some(entry) = entries.get_mut(session_id) {
+            if entry.root == root {
+                entry.turn_id = turn_id.to_string();
+                return;
+            }
+            entries.remove(session_id);
+        }
+
+        let (tx, rx) = tokio::sync::mpsc::channel::<notify::Event>(1024);
+        let mut watcher = match notify::recommended_watcher(move |res| {
+            if let Ok(event) = res {
+                let _ = tx.try_send(event);
+            }
+        }) {
+            Ok(w) => w,
+            Err(e) => {
+                tracing::warn!(error = %e, "turn observe: watcher start failed");
+                return;
+            }
+        };
+        if let Err(e) = watcher.watch(&root, RecursiveMode::Recursive) {
+            tracing::warn!(error = %e, root = %root.display(), "turn observe: watch failed");
+            return;
+        }
+        tracing::info!(session_id, turn_id, root = %root.display(), "turn observe: watch started");
+        let task = tokio::spawn(pump(
+            Arc::clone(self),
+            session_id.to_string(),
+            root.clone(),
+            watcher,
+            rx,
+        ));
+        entries.insert(
+            session_id.to_string(),
+            ObserverEntry {
+                turn_id: turn_id.to_string(),
+                root,
+                task,
+            },
+        );
+    }
+
+    /// A turn ended: keep its watch alive for the grace window, then tear
+    /// it down — unless a newer turn took the session over meanwhile.
+    pub fn complete(self: &Arc<Self>, session_id: &str, turn_id: &str) {
+        let this = Arc::clone(self);
+        let session_id = session_id.to_string();
+        let turn_id = turn_id.to_string();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(GRACE_MS)).await;
+            let mut entries = this.lock();
+            if entries
+                .get(&session_id)
+                .is_some_and(|entry| entry.turn_id == turn_id)
+            {
+                entries.remove(&session_id);
+            }
+        });
+    }
+}
+
+/// Coalesce raw events and fold each batch into the session's current turn.
+/// Owns the watcher: aborting this task tears the watch down.
+async fn pump(
+    observers: Arc<TurnObservers>,
+    session_id: String,
+    root: PathBuf,
+    _watcher: notify::RecommendedWatcher,
+    mut rx: tokio::sync::mpsc::Receiver<notify::Event>,
+) {
+    let store_dir = observers.store_dir.clone();
+    loop {
+        let Some(first) = rx.recv().await else {
+            return;
+        };
+        let mut batch: HashMap<String, &'static str> = HashMap::new();
+        let mut fold = |event: notify::Event| {
+            if is_noise_kind(&event.kind) {
+                return;
+            }
+            let kind = kind_of(&event.kind);
+            for p in &event.paths {
+                if is_git_internal(p) || is_own_temp(p) || p.starts_with(&store_dir) {
+                    continue;
+                }
+                if p == &root || !p.starts_with(&root) {
+                    continue;
+                }
+                if kind != "deleted" && p.is_dir() {
+                    continue;
+                }
+                batch
+                    .entry(p.to_string_lossy().into_owned())
+                    .and_modify(|prev| *prev = merge_kinds(prev, kind))
+                    .or_insert(kind);
+            }
+        };
+        fold(first);
+        let window = tokio::time::sleep(Duration::from_millis(COALESCE_MS));
+        tokio::pin!(window);
+        loop {
+            tokio::select! {
+                more = rx.recv() => match more {
+                    Some(event) => fold(event),
+                    None => break,
+                },
+                () = &mut window => break,
+            }
+        }
+        if batch.is_empty() {
+            continue;
+        }
+        let Some((turn_id, turn_root)) = observers.current_turn(&session_id) else {
+            return;
+        };
+        let ignored = ignored_set(&root, batch.keys()).await;
+        let changes: Vec<(String, &'static str)> = batch
+            .drain()
+            .filter(|(path, _)| !ignored.contains(path))
+            .collect();
+        if changes.is_empty() {
+            continue;
+        }
+        let root_str = turn_root.to_string_lossy().into_owned();
+        observers
+            .log
+            .fold_observed(&session_id, &turn_id, &root_str, changes)
+            .await;
+    }
+}
+
+/// The subset of `paths` that git ignores under `root`. A root that is not
+/// a repository, or a host without git, ignores nothing.
+async fn ignored_set<'a>(root: &Path, paths: impl Iterator<Item = &'a String>) -> HashSet<String> {
+    let rels: Vec<(String, &'a String)> = paths
+        .filter_map(|abs| {
+            Path::new(abs)
+                .strip_prefix(root)
+                .ok()
+                .map(|rel| (rel.to_string_lossy().into_owned(), abs))
+        })
+        .collect();
+    if rels.is_empty() {
+        return HashSet::new();
+    }
+    let Ok(mut child) = tokio::process::Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["check-ignore", "--stdin", "-z"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+    else {
+        return HashSet::new();
+    };
+    if let Some(mut stdin) = child.stdin.take() {
+        use tokio::io::AsyncWriteExt;
+        let mut input = Vec::new();
+        for (rel, _) in &rels {
+            input.extend_from_slice(rel.as_bytes());
+            input.push(0);
+        }
+        let _ = stdin.write_all(&input).await;
+    }
+    let Ok(out) = child.wait_with_output().await else {
+        return HashSet::new();
+    };
+    let by_rel: HashMap<&str, &String> =
+        rels.iter().map(|(rel, abs)| (rel.as_str(), *abs)).collect();
+    out.stdout
+        .split(|b| *b == 0)
+        .filter_map(|chunk| std::str::from_utf8(chunk).ok())
+        .filter(|rel| !rel.is_empty())
+        .filter_map(|rel| by_rel.get(rel).map(|abs| (*abs).clone()))
+        .collect()
+}

--- a/shell/src/turns.rs
+++ b/shell/src/turns.rs
@@ -42,7 +42,10 @@ const PRE_HOOK_FN_ID: &str = "shell::turns::on-pre-trigger";
 const POST_HOOK_FN_ID: &str = "shell::turns::on-post-trigger";
 const STARTED_FN_ID: &str = "shell::turns::on-turn-started";
 const COMPLETED_FN_ID: &str = "shell::turns::on-turn-completed";
-const HOOK_FUNCTIONS: &[&str] = &["shell::fs::*", "coder::*"];
+// Every shell call is hooked, not only the file verbs: calls that name no
+// paths (`shell::exec`, pty writes) still tell the observer which
+// session, turn and root are live so the workspace watch can start.
+const HOOK_FUNCTIONS: &[&str] = &["shell::*", "coder::*"];
 const HOOK_TIMEOUT_MS: u64 = 3_000;
 
 pub const MAX_TURNS_PER_SESSION: usize = 40;
@@ -401,6 +404,37 @@ pub fn record_file(turn: &mut TurnRecord, change: FileRecord) {
     turn.files.push(change);
 }
 
+/// Fold a change the workspace watch saw into the turn. Unlike a hooked
+/// write there is no pre-image and no function id; when the path is already
+/// recorded from a hook, only the freshness and kind move — the hook's
+/// cause, pre-image and after-revision are the better record.
+pub fn record_observed(turn: &mut TurnRecord, path: String, root: &str, kind: &str, at: u64) {
+    if let Some(existing) = turn.files.iter_mut().find(|f| f.path == path) {
+        existing.last_seen = at;
+        existing.kind = match (existing.kind.as_str(), kind) {
+            (_, "deleted") => "deleted".to_string(),
+            ("created", _) => "created".to_string(),
+            ("deleted", "created") | ("deleted", "modified") => "modified".to_string(),
+            (_, next) => next.to_string(),
+        };
+        return;
+    }
+    if turn.files.len() >= MAX_FILES_PER_TURN {
+        return;
+    }
+    turn.files.push(FileRecord {
+        path,
+        root: Some(root.to_string()),
+        kind: kind.to_string(),
+        cause: "observed".to_string(),
+        first_seen: at,
+        last_seen: at,
+        from: None,
+        before: None,
+        after_revision: None,
+    });
+}
+
 /// Newest turns win once a session passes its cap.
 pub fn enforce_budgets(record: &mut SessionRecord) {
     if record.turns.len() > MAX_TURNS_PER_SESSION {
@@ -654,6 +688,28 @@ impl TurnLog {
         .await
     }
 
+    /// Record a batch of watch-observed changes under a turn.
+    pub async fn fold_observed(
+        &self,
+        session_id: &str,
+        turn_id: &str,
+        root: &str,
+        changes: Vec<(String, &'static str)>,
+    ) {
+        let at = now_ms();
+        let result = self
+            .update(session_id, |record| {
+                let turn = turn_mut(record, turn_id, at);
+                for (path, kind) in changes {
+                    record_observed(turn, path, root, kind, at);
+                }
+            })
+            .await;
+        if let Err(e) = result {
+            tracing::warn!(error = %e, session_id, "turn observe: fold not recorded");
+        }
+    }
+
     pub async fn on_turn_completed(&self, session_id: &str, turn_id: &str) -> Result<(), Error> {
         let at = now_ms();
         self.update(session_id, |record| {
@@ -807,18 +863,28 @@ pub struct GetOutput {
 }
 
 pub fn register(iii: &IIIClient, config: &TurnsConfig) -> Arc<TurnLog> {
+    let data_dir = config.resolved_data_dir();
     let log = Arc::new(TurnLog::new(TurnStore::new(
-        config.resolved_data_dir(),
+        data_dir.clone(),
         config.max_blob_bytes,
     )));
+    let observers = crate::turn_observe::TurnObservers::new(log.clone(), data_dir);
 
     {
         let log = log.clone();
+        let observers = observers.clone();
         iii.register_function(
             PRE_HOOK_FN_ID,
             RegisterFunction::new_async(move |input: HookInput| {
                 let log = log.clone();
+                let observers = observers.clone();
                 async move {
+                    if let (Some(session_id), Some(turn_id)) =
+                        (input.session_id.as_deref(), input.turn_id.as_deref())
+                    {
+                        let root = session_root(input.metadata.as_ref());
+                        observers.ensure(session_id, turn_id, root.as_deref());
+                    }
                     log.on_pre_trigger(input).await;
                     Ok::<HookOutput, Error>(HookOutput::default())
                 }
@@ -886,15 +952,18 @@ pub fn register(iii: &IIIClient, config: &TurnsConfig) -> Arc<TurnLog> {
     }
     {
         let log = log.clone();
+        let observers = observers.clone();
         iii.register_function(
             COMPLETED_FN_ID,
             RegisterFunction::new_async(move |event: TurnEvent| {
                 let log = log.clone();
+                let observers = observers.clone();
                 async move {
                     if let (Some(session_id), Some(turn_id)) = (event.session_id, event.turn_id) {
                         if let Err(e) = log.on_turn_completed(&session_id, &turn_id).await {
                             tracing::warn!(error = %e, "turn log: turn end not recorded");
                         }
+                        observers.complete(&session_id, &turn_id);
                     }
                     Ok::<Ack, Error>(Ack { ok: true })
                 }
@@ -1014,6 +1083,58 @@ mod tests {
             turn_id: Some(turn.to_string()),
             result: Some(HookResult { is_error: failed }),
         }
+    }
+
+    #[test]
+    fn observed_never_overwrites_a_hook_record() {
+        let mut turn = TurnRecord {
+            turn_id: "t1".into(),
+            started_at: 1,
+            ended_at: None,
+            files: vec![FileRecord {
+                path: "/w/a.txt".into(),
+                root: Some("/w".into()),
+                kind: "created".into(),
+                cause: "coder::create-file".into(),
+                first_seen: 1,
+                last_seen: 1,
+                from: None,
+                before: Some(PreImage {
+                    revision: Some("sha256:aa".into()),
+                    content: None,
+                    truncated: false,
+                    missing: false,
+                    binary: false,
+                    stored: true,
+                }),
+                after_revision: Some("sha256:bb".into()),
+            }],
+        };
+        record_observed(&mut turn, "/w/a.txt".into(), "/w", "modified", 9);
+        let file = &turn.files[0];
+        assert_eq!(file.cause, "coder::create-file");
+        assert_eq!(file.kind, "created");
+        assert_eq!(file.after_revision.as_deref(), Some("sha256:bb"));
+        assert!(file.before.is_some());
+        assert_eq!(file.last_seen, 9);
+    }
+
+    #[test]
+    fn observed_records_a_new_path_without_pre_image() {
+        let mut turn = TurnRecord {
+            turn_id: "t1".into(),
+            started_at: 1,
+            ended_at: None,
+            files: Vec::new(),
+        };
+        record_observed(&mut turn, "/w/gen.txt".into(), "/w", "created", 5);
+        record_observed(&mut turn, "/w/gen.txt".into(), "/w", "deleted", 8);
+        let file = &turn.files[0];
+        assert_eq!(file.cause, "observed");
+        assert_eq!(file.kind, "deleted");
+        assert!(file.before.is_none());
+        assert_eq!(file.first_seen, 5);
+        assert_eq!(file.last_seen, 8);
     }
 
     #[test]

--- a/shell/ui/src/page/EditorPane.tsx
+++ b/shell/ui/src/page/EditorPane.tsx
@@ -346,7 +346,7 @@ export function EditorPane({
         </button>
       </div>
 
-      <div className="shui-editor-body">
+      <div className="shui-editor-body" data-keybindings-standdown="">
         {pane.phase === 'loading' ? (
           <div className="shui-side-note">loading {relPath}…</div>
         ) : pane.phase === 'error' ? (

--- a/shell/ui/src/page/EditorPane.tsx
+++ b/shell/ui/src/page/EditorPane.tsx
@@ -16,6 +16,7 @@ import {
 import { Code, Eye } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { errorMessage, formatBytes } from '../lib/format'
+import { loadErrorMessage } from './load-error'
 import {
   coderReadFile,
   coderReadFileBase64,
@@ -205,7 +206,7 @@ export function EditorPane({
         })
         .catch((err: unknown) => {
           if (seqRef.current !== seq) return
-          setPane({ phase: 'error', message: errorMessage(err) })
+          setPane({ phase: 'error', message: loadErrorMessage(errorMessage(err)) })
         })
       return
     }
@@ -235,7 +236,7 @@ export function EditorPane({
         if (seqRef.current !== seq) return
         setPane({
           phase: 'error',
-          message: errorMessage(err),
+          message: loadErrorMessage(errorMessage(err)),
         })
       })
   }, [host, absPath, relPath, cache])

--- a/shell/ui/src/page/ReviewPane.tsx
+++ b/shell/ui/src/page/ReviewPane.tsx
@@ -320,9 +320,19 @@ function sameLoadDescriptor(
   right: FileLoadDescriptor,
 ): boolean {
   return (
+    left.refreshEpoch === right.refreshEpoch && sameLoadSource(left, right)
+  )
+}
+
+/** Same file from the same place, ignoring the refresh epoch: a newer epoch
+    means reload, not that the old contents stopped being worth showing. */
+function sameLoadSource(
+  left: FileLoadDescriptor,
+  right: FileLoadDescriptor,
+): boolean {
+  return (
     left.host === right.host &&
     left.root === right.root &&
-    left.refreshEpoch === right.refreshEpoch &&
     sameReviewSource(left.entry, right.entry)
   )
 }
@@ -367,6 +377,9 @@ export interface ReviewContents {
   newContents: string
   worktreeRevision?: string
   mode?: number | null
+  /** The turn snapshot missed this file and it has no committed version:
+      usually churn in an uncommitted data file. Nothing to diff. */
+  noBaseline?: true
   /** Raster image rows: data URL of the working copy, `null` once deleted.
       Text fields stay empty because the bytes are not diffable. */
   image?: string | null
@@ -456,9 +469,7 @@ export async function loadReviewContents(
   if (entry.baseline === null) {
     const committed = await loadCommittedFallback(host, root, entry)
     if (committed !== null) return committed
-    throw new Error(
-      'earlier content was not captured for this turn, and this file has no committed version to compare against',
-    )
+    return { oldContents: '', newContents: '', noBaseline: true }
   }
   const { change } = entry
   const oldPath = change.from ?? change.path
@@ -576,8 +587,14 @@ export function ReviewPane({
       }
 
       activeLoadsRef.current.add(path)
-      cacheRef.current.set(path, { ...descriptor, state: { phase: 'loading' } })
-      bumpCache()
+      const existing = cacheRef.current.get(path)
+      if (existing === undefined || existing.state.phase !== 'ready') {
+        cacheRef.current.set(path, {
+          ...descriptor,
+          state: { phase: 'loading' },
+        })
+        bumpCache()
+      }
       void loadReviewContents(descriptor.host, descriptor.root, descriptor.entry)
         .then<FileState>((contents) => ({ phase: 'ready', ...contents }))
         .catch<FileState>((error: unknown) => ({
@@ -625,7 +642,7 @@ export function ReviewPane({
 
     for (const [path, cached] of cacheRef.current) {
       const descriptor = available.get(path)
-      if (descriptor === undefined || !sameLoadDescriptor(cached, descriptor)) {
+      if (descriptor === undefined || !sameLoadSource(cached, descriptor)) {
         cacheRef.current.delete(path)
       }
     }
@@ -1258,6 +1275,11 @@ function ReviewFile({
         <div className="shui-review-message">loading diff…</div>
       ) : state.phase === 'error' ? (
         <div className="shui-review-message warn">{state.message}</div>
+      ) : state.noBaseline ? (
+        <div className="shui-review-message">
+          nothing to diff: this file is not committed and the turn snapshot
+          did not include an earlier version
+        </div>
       ) : !editing && options.richPreview && rich !== null ? (
         rich
       ) : !editing && state.imageUnavailable ? (

--- a/shell/ui/src/page/ReviewPane.tsx
+++ b/shell/ui/src/page/ReviewPane.tsx
@@ -1155,6 +1155,7 @@ function ReviewFile({
   return (
     <section
       ref={sectionRef}
+      data-keybindings-standdown=""
       className={`shui-review-file${active ? ' active' : ''}`}
       data-review-path={entry.path}
       aria-busy={saving}

--- a/shell/ui/src/page/__tests__/ReviewPane.test.ts
+++ b/shell/ui/src/page/__tests__/ReviewPane.test.ts
@@ -480,7 +480,7 @@ describe('loadReviewContents without a captured baseline', () => {
     )
   })
 
-  it('keeps failing closed when there is no committed body either', async () => {
+  it('returns a no-baseline explanation when there is no committed body either', async () => {
     const { host } = execHost({
       'shell::exec': {
         exit_code: 128,
@@ -492,9 +492,9 @@ describe('loadReviewContents without a captured baseline', () => {
       },
     })
 
-    await expect(loadReviewContents(host, '/root', uncaptured)).rejects.toThrow(
-      'earlier content was not captured for this turn',
-    )
+    await expect(
+      loadReviewContents(host, '/root', uncaptured),
+    ).resolves.toEqual({ oldContents: '', newContents: '', noBaseline: true })
   })
 
   it('compares a deleted file against its committed body', async () => {

--- a/shell/ui/src/page/__tests__/editor-load-error.test.ts
+++ b/shell/ui/src/page/__tests__/editor-load-error.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { loadErrorMessage } from '../load-error'
+
+describe('loadErrorMessage', () => {
+  it('turns a missing-file handler error into plain words', () => {
+    const raw =
+      'handler error: {"code":"C211","message":"/w/demo-b.txt: not found or not accessible. Verify the path with coder::list-folder or coder::tree."}'
+    expect(loadErrorMessage(raw)).toBe(
+      'this file no longer exists on disk: deleted or moved after this tab was opened',
+    )
+  })
+
+  it('unwraps other handler errors to their message', () => {
+    const raw = 'handler error: {"code":"C400","message":"permission denied: /etc/hosts"}'
+    expect(loadErrorMessage(raw)).toBe('permission denied: /etc/hosts')
+  })
+
+  it('leaves plain text alone', () => {
+    expect(loadErrorMessage('network unreachable')).toBe('network unreachable')
+  })
+})

--- a/shell/ui/src/page/__tests__/turns.test.ts
+++ b/shell/ui/src/page/__tests__/turns.test.ts
@@ -77,6 +77,39 @@ describe('reviewEntriesFromTurn', () => {
     ],
   }
 
+  it('gives an observed creation an empty baseline', () => {
+    const observed: SessionTurn = {
+      turn_id: 't2',
+      started_at: 1,
+      ended_at: 2,
+      files: [
+        {
+          path: '/r/gen/out.txt',
+          kind: 'created',
+          cause: 'observed',
+          first_seen: 1,
+          last_seen: 1,
+        },
+        {
+          path: '/r/gen/tweaked.txt',
+          kind: 'modified',
+          cause: 'observed',
+          first_seen: 1,
+          last_seen: 1,
+        },
+      ],
+    }
+    const { entries } = reviewEntriesFromTurn(observed, '/r')
+    expect(entries.get('gen/out.txt')).toMatchObject({
+      change: { status: 'added' },
+      baseline: '',
+    })
+    expect(entries.get('gen/tweaked.txt')).toMatchObject({
+      change: { status: 'modified' },
+      baseline: null,
+    })
+  })
+
   it('builds review entries under the root and counts the rest', () => {
     const { entries, outside } = reviewEntriesFromTurn(turn, '/r')
     expect(outside).toBe(1)

--- a/shell/ui/src/page/load-error.ts
+++ b/shell/ui/src/page/load-error.ts
@@ -1,0 +1,25 @@
+/** A load failure as a sentence, not a wire dump. The worker's read errors
+    arrive as `handler error: {json}`; a missing file (deleted or moved after
+    the tab opened) is the common case and deserves plain words. */
+export function loadErrorMessage(raw: string): string {
+  const brace = raw.indexOf('{')
+  if (brace !== -1) {
+    try {
+      const parsed = JSON.parse(raw.slice(brace)) as {
+        code?: string
+        message?: string
+      }
+      const detail = typeof parsed.message === 'string' ? parsed.message : ''
+      if (parsed.code === 'C211' || detail.includes('not found or not accessible')) {
+        return 'this file no longer exists on disk: deleted or moved after this tab was opened'
+      }
+      if (detail.length > 0) return detail
+    } catch {
+      // not JSON after all: fall through to the raw text
+    }
+  }
+  if (raw.includes('not found or not accessible')) {
+    return 'this file no longer exists on disk: deleted or moved after this tab was opened'
+  }
+  return raw
+}

--- a/shell/ui/src/page/turns.ts
+++ b/shell/ui/src/page/turns.ts
@@ -129,7 +129,12 @@ export function reviewEntriesFromTurn(turn: SessionTurn, root: string): TurnEntr
         staged: false,
         ...(from ? { from } : {}),
       },
-      baseline: baselineFor(file.before),
+      // An observed creation has no stored pre-image, but its true
+      // baseline is known anyway: the file did not exist before the turn.
+      baseline:
+        file.before == null && file.kind === 'created'
+          ? ''
+          : baselineFor(file.before),
     }
     entries.set(rel, entry)
   }


### PR DESCRIPTION
## What

Shell-page problems reported from live use, one root fix each.

**The review screen blinked constantly.** Every `shell::changed` burst bumps the
review refresh epoch, and the file cache treated a new epoch as a new identity:
the whole cache was evicted and every visible diff dropped back to its loading
row, twice a second while an agent turn churns state files. Reloads now happen
behind the contents already on screen — eviction compares the file's source
(host, root, review entry) without the epoch, a stale-epoch entry queues a
reload, and the loading row only shows when there is nothing ready to display.

**Uncommitted data files rendered a warning.** A file the turn snapshot missed
that also has no committed version (state/queue data churn, mostly) threw, and
the row showed an orange error. That situation is an explanation, not a
failure: `loadReviewContents` now returns a `noBaseline` result and the row
says plainly that there is nothing to diff.

**Bare keybindings fired while typing in the editor.** Single-key bindings
(`t` for a new workspace, and friends) reached the console dispatcher from
inside the shell editor whenever the event target was not literally an input
element (editor widgets, gutters, the degraded pre fallback, read-mode diff
text). A surface can now declare `data-keybindings-standdown`: any keystroke
originating inside it counts as typing for bindings that do not opt into
`firesWhileTyping`. The shell editor body and every review file card declare
it, and the contract is documented in the injectable-console-ui SOP.

**Turns that wrote through `shell::exec` showed "0 files" after reopen.** The
turn log's harness hooks only see `shell::fs::*`/`coder::*` calls; a command's
side effects (`sed -i`, a formatter, `echo > file`) bypassed them, so a
reopened session had no record of what the turn did. The worker now puts an OS
watch on the session's workspace root for the duration of each turn and folds
what it sees into the same durable history as `observed` changes: git
internals, its own temp files, the turn store itself and gitignored paths stay
out, a hook-recorded path keeps its richer record, and the watch starts inside
the awaited pre-trigger hook so it is live before the first call can write.
Observed changes carry no pre-image; the review pane diffs them against the
committed version when one exists, shows a full add for an observed creation
(its true baseline is empty), and says "nothing to diff" quietly otherwise.

**A deleted file's open tab dumped a raw handler error.** Reopening a tab
whose file was deleted or moved rendered the wire JSON
(`handler error: {"code":"C211",...}`). Load failures now read as a sentence,
and the missing-file case says what happened in plain words.

## How verified

- shell: cargo fmt/clippy clean, 1356 tests across both targets (two new
  cover the observed-fold record semantics).
- shell/ui: tsc clean, 312 tests across 31 files (new: no-baseline contract,
  load-error wording, observed-creation baseline).
- console/web: tsc clean, keybindings suite including a standdown-surface test.
- Live on the rig: a turn instructed to write only via `shell::exec` produced
  a durable turn record (`cause: "observed"`), and reopening the conversation
  restored the review with the file as a full green add; typing `t` inside the
  editor and inside a review diff card no longer opens a workspace while the
  binding still works outside typing surfaces; 30 review-pane samples during a
  churn-heavy turn showed zero loading-row flicker.

Refs MOT-4407.
