### PR TITLE
(MOT-4376) build: refresh stale lockfiles after crate version bumps

### DIFF
--- a/approval-gate/Cargo.lock
+++ b/approval-gate/Cargo.lock
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "harness"
-version = "1.8.5"
+version = "1.8.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -559,6 +559,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "thiserror",
  "tokio",
  "tracing",
@@ -1691,6 +1692,17 @@ name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/provider-opencode-go/Cargo.lock
+++ b/provider-opencode-go/Cargo.lock
@@ -976,7 +976,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.13"
+version = "1.4.14"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-openrouter/Cargo.lock
+++ b/provider-openrouter/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.13"
+version = "1.4.14"
 dependencies = [
  "async-trait",
  "clap",


### PR DESCRIPTION
## What

Three standalone crates carry a Cargo.lock that no longer matches the
workspace: `cargo run --locked` (the compose run script) and
`cargo build --locked` exit before compiling anything.

- `provider-openrouter` and `provider-opencode-go` still pin `llm-router`
  1.4.13; the crate is 1.4.14 since #916.
- `approval-gate` still pins `harness` 1.8.5; the crate is 1.8.7, which also
  pulls `sha2` into the graph.

Hit for real on a running rig: `compose::up` on provider-openrouter looped on
"cannot update the lock file … because --locked was passed".

Locks refreshed with targeted `cargo update -p <crate>`; no registry
dependency moved except the `sha2` tree that harness 1.8.7 requires.

## How verified

- `cargo metadata --locked` passes in all three crates (failed before).
- `cargo build --locked --bin provider-openrouter` compiles clean.
