### PR TITLE
Run isolated Harness E2E campaign groups

### DIFF
--- a/.github/scripts/harness_e2e_shadow_contract.py
+++ b/.github/scripts/harness_e2e_shadow_contract.py
@@ -18,6 +18,21 @@ VERSION = re.compile(
     r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
     r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
 )
+CAMPAIGN_EXECUTION_KINDS = {
+    "harness_turn",
+    "scripted_dialogue",
+    "composite_flow",
+    "adaptive_flow",
+    "fault_injection",
+}
+DIFFICULTY_WEIGHTS = {
+    "L0": 1,
+    "L1": 1,
+    "L2": 2,
+    "L3": 3,
+    "L4": 4,
+    "L5": 5,
+}
 
 # These workers are hosted by the pinned iii engine rather than installed from
 # the Registry. `iii worker add` intentionally reports them as built-in, so a
@@ -90,6 +105,116 @@ def require_positive_integer(value: Any, label: str) -> int:
     if not isinstance(value, int) or isinstance(value, bool) or value < 1:
         raise ValueError(f"{label} must be a positive integer")
     return value
+
+
+def require_nonnegative_integer(value: Any, label: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ValueError(f"{label} must be a non-negative integer")
+    return value
+
+
+def validate_identity(definition: dict[str, Any], role: str) -> None:
+    identity = definition.get(role)
+    if not isinstance(identity, dict):
+        raise ValueError(f"plan.definition.{role} must be an object")
+    require_text(identity.get("provider"), f"plan.definition.{role}.provider")
+    require_text(identity.get("model"), f"plan.definition.{role}.model")
+
+
+def validate_campaign_definition(definition: dict[str, Any]) -> None:
+    if definition.get("entrypoint") != "e2e::run":
+        raise ValueError("campaign plan must use e2e::run")
+    require_text(definition.get("label"), "plan.definition.label")
+    lane = require_text(definition.get("lane"), "plan.definition.lane")
+    if lane not in {"manual", "daily", "weekly", "post-release"}:
+        raise ValueError("campaign lane must be manual, daily, weekly, or post-release")
+    if definition.get("failurePolicy") != "advisory":
+        raise ValueError("campaign failurePolicy must be advisory")
+    validate_identity(definition, "subject")
+    validate_identity(definition, "judge")
+
+    manifest = definition.get("manifest")
+    if not isinstance(manifest, dict):
+        raise ValueError("plan.definition.manifest must be an object")
+    require_text(manifest.get("id"), "plan.definition.manifest.id")
+    require_digest(manifest.get("sha256"), "plan.definition.manifest.sha256")
+
+    scoring = definition.get("scoring")
+    if not isinstance(scoring, dict) or scoring.get("profile") != "difficulty-weighted-v1":
+        raise ValueError("campaign scoring profile must be difficulty-weighted-v1")
+    require_digest(scoring.get("sha256"), "plan.definition.scoring.sha256")
+
+    catalog = definition.get("catalog")
+    if not isinstance(catalog, dict):
+        raise ValueError("plan.definition.catalog must be an object")
+    require_text(catalog.get("revision"), "plan.definition.catalog.revision")
+    require_digest(catalog.get("sha256"), "plan.definition.catalog.sha256")
+    require_positive_integer(catalog.get("seed"), "plan.definition.catalog.seed")
+
+    groups = definition.get("groups")
+    if not isinstance(groups, list) or not groups:
+        raise ValueError("campaign groups must be a non-empty array")
+    seen: set[str] = set()
+    for index, group in enumerate(groups):
+        label = f"plan.definition.groups[{index}]"
+        if not isinstance(group, dict):
+            raise ValueError(f"{label} must be an object")
+        group_id = require_text(group.get("id"), f"{label}.id")
+        if not re.fullmatch(r"[a-z][a-z0-9-]{0,63}", group_id) or group_id in seen:
+            raise ValueError("campaign group ids must be unique kebab-case values")
+        seen.add(group_id)
+        execution_kind = require_text(group.get("executionKind"), f"{label}.executionKind")
+        if execution_kind not in CAMPAIGN_EXECUTION_KINDS:
+            raise ValueError(f"{label}.executionKind is unsupported")
+        runs = require_positive_integer(group.get("runs"), f"{label}.runs")
+        retries = require_nonnegative_integer(
+            group.get("technicalRetries"), f"{label}.technicalRetries"
+        )
+        tier = require_text(group.get("difficultyTier"), f"{label}.difficultyTier")
+        expected_weight = DIFFICULTY_WEIGHTS.get(tier)
+        if expected_weight is None or group.get("difficultyWeight") != expected_weight:
+            raise ValueError(f"{label}.difficultyWeight does not match {tier}")
+        scenarios = group.get("scenarios")
+        if execution_kind == "fault_injection":
+            if scenarios not in (None, []):
+                raise ValueError(f"{label}.scenarios must be empty for fault injection")
+            if retries != 0 or runs < 3 or group.get("soakMinutes") != 60:
+                raise ValueError(
+                    f"{label} fault injection requires runs>=3, technicalRetries=0, and soakMinutes=60"
+                )
+            require_text(group.get("faultProfile"), f"{label}.faultProfile")
+            require_text(group.get("faultScenario"), f"{label}.faultScenario")
+        else:
+            if not isinstance(scenarios, list) or not scenarios or len(set(scenarios)) != len(scenarios):
+                raise ValueError(f"{label}.scenarios must be a non-empty unique array")
+            if not all(isinstance(item, str) and item for item in scenarios):
+                raise ValueError(f"{label}.scenarios must contain non-empty strings")
+
+
+def campaign_matrix(contract: dict[str, Any]) -> dict[str, Any]:
+    validate_contract(contract)
+    definition = contract["plan"]["definition"]
+    if definition["mode"] != "campaign":
+        return {
+            "include": [
+                {
+                    "group_id": "legacy",
+                    "execution_kind": "demonstrative",
+                    "runs_on": ["ubuntu-latest"],
+                }
+            ]
+        }
+    include = []
+    for group in definition["groups"]:
+        is_fault = group["executionKind"] == "fault_injection"
+        include.append(
+            {
+                "group_id": group["id"],
+                "execution_kind": group["executionKind"],
+                "runs_on": ["self-hosted", "harness-e2e"] if is_fault else ["ubuntu-latest"],
+            }
+        )
+    return {"include": include}
 
 
 def v2_target_member(contract: dict[str, Any], target: dict[str, Any], name: str) -> Any:
@@ -218,16 +343,16 @@ def validate_v2_contract(contract: dict[str, Any], target: dict[str, Any], runne
 
 def validate_contract(contract: dict[str, Any]) -> dict[str, Any]:
     schema_version = contract.get("schema_version")
-    if schema_version not in {1, 2}:
-        raise ValueError("execution contract schema_version must be 1 or 2")
+    if schema_version not in {1, 2, 3}:
+        raise ValueError("execution contract schema_version must be 1, 2, or 3")
     require_uuid(contract.get("campaign_id"), "campaign_id")
     require_uuid(contract.get("execution_id"), "execution_id")
     attempt = contract.get("attempt")
     if not isinstance(attempt, int) or attempt < 1:
         raise ValueError("attempt must be a positive integer")
     key = require_text(contract.get("idempotency_key"), "idempotency_key")
-    if not re.fullmatch(r"rc:d0:[0-9a-f]{64}", key):
-        raise ValueError("idempotency_key must be rc:d0:<sha256>")
+    if not re.fullmatch(r"rc:(?:d0|e2e):[0-9a-f]{64}", key):
+        raise ValueError("idempotency_key must be rc:d0:<sha256> or rc:e2e:<sha256>")
 
     target = contract.get("target")
     if not isinstance(target, dict) or target.get("application") != "harness":
@@ -265,22 +390,23 @@ def validate_contract(contract: dict[str, Any]) -> dict[str, Any]:
     definition = plan.get("definition")
     if not isinstance(definition, dict):
         raise ValueError("plan.definition must be an object")
-    if definition.get("mode") != "demonstrative" or definition.get("entrypoint") != "e2e::run":
-        raise ValueError("plan must be demonstrative and use e2e::run")
-    scenarios = definition.get("scenarios")
-    if not isinstance(scenarios, list) or not scenarios or len(set(scenarios)) != len(scenarios):
-        raise ValueError("plan scenarios must be a non-empty unique list")
-    if not all(isinstance(item, str) and item for item in scenarios):
-        raise ValueError("plan scenarios must contain non-empty strings")
-    for field in ("runs", "seed", "technicalRetries", "progressIntervalSeconds"):
-        if not isinstance(definition.get(field), int) or definition[field] < 1:
-            raise ValueError(f"plan.definition.{field} must be a positive integer")
-    for role in ("subject", "judge"):
-        identity = definition.get(role)
-        if not isinstance(identity, dict):
-            raise ValueError(f"plan.definition.{role} must be an object")
-        require_text(identity.get("provider"), f"plan.definition.{role}.provider")
-        require_text(identity.get("model"), f"plan.definition.{role}.model")
+    if schema_version == 3:
+        if definition.get("mode") != "campaign":
+            raise ValueError("schema v3 plan mode must be campaign")
+        validate_campaign_definition(definition)
+    else:
+        if definition.get("mode") != "demonstrative" or definition.get("entrypoint") != "e2e::run":
+            raise ValueError("plan must be demonstrative and use e2e::run")
+        scenarios = definition.get("scenarios")
+        if not isinstance(scenarios, list) or not scenarios or len(set(scenarios)) != len(scenarios):
+            raise ValueError("plan scenarios must be a non-empty unique list")
+        if not all(isinstance(item, str) and item for item in scenarios):
+            raise ValueError("plan scenarios must contain non-empty strings")
+        for field in ("runs", "seed", "technicalRetries", "progressIntervalSeconds"):
+            if not isinstance(definition.get(field), int) or definition[field] < 1:
+                raise ValueError(f"plan.definition.{field} must be a positive integer")
+        validate_identity(definition, "subject")
+        validate_identity(definition, "judge")
 
     runner = contract.get("runner")
     if not isinstance(runner, dict):
@@ -290,12 +416,29 @@ def validate_contract(contract: dict[str, Any]) -> dict[str, Any]:
     runner_ref = require_text(runner.get("registry_ref"), "runner.registry_ref")
     if not re.fullmatch(r"[A-Za-z0-9._-]+", runner_ref):
         raise ValueError("runner.registry_ref is invalid")
-    if schema_version == 2:
+    if schema_version in {2, 3}:
         validate_v2_contract(contract, target, runner)
+    if schema_version == 3:
+        definition = contract["plan"]["definition"]
+        require_digest(runner.get("catalog_sha256"), "runner.catalog_sha256")
+        require_digest(runner.get("manifest_sha256"), "runner.manifest_sha256")
+        require_digest(
+            runner.get("scoring_profile_sha256"),
+            "runner.scoring_profile_sha256",
+        )
+        require_digest(runner.get("assets_sha256"), "runner.assets_sha256")
+        if runner.get("catalog_sha256") != definition["catalog"]["sha256"]:
+            raise ValueError("runner catalog digest must match the campaign definition")
+        if runner.get("manifest_sha256") != definition["manifest"]["sha256"]:
+            raise ValueError("runner manifest digest must match the campaign definition")
+        if runner.get("scoring_profile_sha256") != definition["scoring"]["sha256"]:
+            raise ValueError("runner scoring digest must match the campaign definition")
     return contract
 
 
-def materialize_request(contract: dict[str, Any], catalog: dict[str, Any]) -> dict[str, Any]:
+def materialize_request(
+    contract: dict[str, Any], catalog: dict[str, Any], group_id: str | None = None
+) -> dict[str, Any]:
     validate_contract(contract)
     if catalog.get("schema") != "e2e-scenario-catalog/v1":
         raise ValueError("unsupported scenario catalog schema")
@@ -305,7 +448,7 @@ def materialize_request(contract: dict[str, Any], catalog: dict[str, Any]) -> di
     for field in ("name", "version", "revision"):
         require_text(runner.get(field), f"catalog.runner.{field}")
     catalog_sha256 = require_digest(catalog.get("catalog_sha256"), "catalog.catalog_sha256")
-    if contract["schema_version"] == 2:
+    if contract["schema_version"] in {2, 3}:
         expected_runner = contract["runner"]
         if runner.get("name") != expected_runner["registry_worker"] or runner.get("version") != expected_runner["registry_ref"]:
             raise ValueError("scenario catalog runner does not match the exact runner pin")
@@ -322,23 +465,42 @@ def materialize_request(contract: dict[str, Any], catalog: dict[str, Any]) -> di
             by_id[item["scenario_id"]] = item
 
     definition = contract["plan"]["definition"]
+    group = None
+    scenarios = definition.get("scenarios")
+    runs = definition.get("runs")
+    technical_retries = definition.get("technicalRetries")
+    plan_seed = definition.get("seed")
+    label = definition["label"]
+    if definition["mode"] == "campaign":
+        group = next(
+            (item for item in definition["groups"] if item["id"] == group_id), None
+        )
+        if group is None:
+            raise ValueError("a valid campaign group id is required")
+        if group["executionKind"] == "fault_injection":
+            raise ValueError("fault injection groups are executed by the protected supervisor")
+        scenarios = group["scenarios"]
+        runs = group["runs"]
+        technical_retries = group["technicalRetries"]
+        plan_seed = definition["catalog"]["seed"]
+        label = f"{definition['label']} · {group['id']}"
     selected_cases: list[dict[str, Any]] = []
-    for scenario_id in definition["scenarios"]:
+    for scenario_id in scenarios:
         descriptor = by_id.get(scenario_id)
         if descriptor is None:
             raise ValueError(f"scenario catalog is missing {scenario_id}")
         scenario_version = descriptor.get("scenario_version")
-        seed = descriptor.get("seed")
+        descriptor_seed = descriptor.get("seed")
         if not isinstance(scenario_version, int) or scenario_version < 1:
             raise ValueError(f"scenario {scenario_id} has an invalid version")
-        if seed != definition["seed"]:
+        if descriptor_seed != plan_seed:
             raise ValueError(f"scenario {scenario_id} seed does not match the plan")
         selected_cases.append(
             {
                 "scenario_id": scenario_id,
                 "scenario_version": scenario_version,
                 "case_id": require_text(descriptor.get("case_id"), f"{scenario_id}.case_id"),
-                "seed": seed,
+                "seed": descriptor_seed,
                 "inputs_sha256": require_digest(
                     descriptor.get("inputs_sha256"), f"{scenario_id}.inputs_sha256"
                 ),
@@ -350,7 +512,7 @@ def materialize_request(contract: dict[str, Any], catalog: dict[str, Any]) -> di
 
     target_stack = contract["target"]["stack_versions"]
     target_stack_digest = contract["target"]["stack_digest"]
-    if contract["schema_version"] == 2:
+    if contract["schema_version"] in {2, 3}:
         stack = v2_target_member(contract, contract["target"], "stack")
         target_stack = stack["resolved_versions"]
         target_stack_digest = stack["resolution_sha256"]
@@ -371,6 +533,9 @@ def materialize_request(contract: dict[str, Any], catalog: dict[str, Any]) -> di
             "revision": str(contract["plan"]["revision"]),
             "sha256": contract["plan"]["sha256"],
             "catalog_sha256": catalog_sha256,
+            "group_id": group_id,
+            "manifest_sha256": definition.get("manifest", {}).get("sha256"),
+            "scoring_profile": definition.get("scoring"),
         },
         "runner": runner,
         "attempt": contract["attempt"],
@@ -382,18 +547,18 @@ def materialize_request(contract: dict[str, Any], catalog: dict[str, Any]) -> di
         },
     }
     request = {
-        "label": f"{definition['label']} · Harness {contract['target']['version']}",
+        "label": f"{label} · Harness {contract['target']['version']}",
         "lane": definition["lane"],
         "model": definition["subject"]["model"],
         "provider": definition["subject"]["provider"],
         "judge_model": definition["judge"]["model"],
         "judge_provider": definition["judge"]["provider"],
-        "scenarios": definition["scenarios"],
-        "runs": definition["runs"],
-        "seed": definition["seed"],
+        "scenarios": scenarios,
+        "runs": runs,
+        "seed": plan_seed,
         "rotating_seeds": [],
-        "technical_retries": definition["technicalRetries"],
-        "progress_interval_seconds": definition["progressIntervalSeconds"],
+        "technical_retries": technical_retries,
+        "progress_interval_seconds": definition.get("progressIntervalSeconds", 15),
         "run_contract": run_contract,
     }
     # The runner validates a D0 key over the fully materialized request,
@@ -439,7 +604,7 @@ def verify_lock(contract: dict[str, Any], lock_path: Path) -> dict[str, Any]:
     }
 
     target = contract["target"]
-    if contract["schema_version"] == 2:
+    if contract["schema_version"] in {2, 3}:
         stack = v2_target_member(contract, target, "stack")
         expected_target = stack["resolved_versions"]
         target_digest = stack["resolution_sha256"]
@@ -479,7 +644,11 @@ def verify_lock(contract: dict[str, Any], lock_path: Path) -> dict[str, Any]:
         for worker in sorted(engine_managed)
     }
 
-    target_stack = v2_target_member(contract, target, "stack") if contract["schema_version"] == 2 else None
+    target_stack = (
+        v2_target_member(contract, target, "stack")
+        if contract["schema_version"] in {2, 3}
+        else None
+    )
     return {
         "schema": "e2e-stack-manifest/v1",
         "contract_schema_version": contract["schema_version"],
@@ -517,8 +686,16 @@ def verify_lock(contract: dict[str, Any], lock_path: Path) -> dict[str, Any]:
             "worker_count": len(observed),
             "resolved_versions": dict(sorted(observed.items())),
         },
-        "origin": v2_target_member(contract, target, "origin") if contract["schema_version"] == 2 else None,
-        "base": v2_target_member(contract, target, "base") if contract["schema_version"] == 2 else None,
+        "origin": (
+            v2_target_member(contract, target, "origin")
+            if contract["schema_version"] in {2, 3}
+            else None
+        ),
+        "base": (
+            v2_target_member(contract, target, "base")
+            if contract["schema_version"] in {2, 3}
+            else None
+        ),
     }
 
 
@@ -563,6 +740,9 @@ def main() -> int:
     materialize.add_argument("--contract", type=Path, required=True)
     materialize.add_argument("--catalog", type=Path, required=True)
     materialize.add_argument("--output", type=Path, required=True)
+    materialize.add_argument("--group-id")
+    matrix = commands.add_parser("matrix")
+    matrix.add_argument("--contract", type=Path, required=True)
     lock = commands.add_parser("verify-lock")
     lock.add_argument("--contract", type=Path, required=True)
     lock.add_argument("--lock", type=Path, required=True)
@@ -580,8 +760,14 @@ def main() -> int:
         elif args.command == "digest":
             print(canonical_sha256(contract))
         elif args.command == "materialize":
-            request = materialize_request(contract, load_object(args.catalog, "scenario catalog"))
+            request = materialize_request(
+                contract,
+                load_object(args.catalog, "scenario catalog"),
+                group_id=args.group_id,
+            )
             args.output.write_text(json.dumps(request, indent=2, sort_keys=True) + "\n")
+        elif args.command == "matrix":
+            print(canonical(campaign_matrix(contract)))
         elif args.command == "verify-lock":
             manifest = verify_lock(contract, args.lock)
             args.output.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")

--- a/.github/scripts/tests/test_harness_e2e_shadow_contract.py
+++ b/.github/scripts/tests/test_harness_e2e_shadow_contract.py
@@ -133,6 +133,65 @@ def manual_v2_catalog():
     }
 
 
+def campaign_v3_contract():
+    value = manual_v2_contract()
+    value["schema_version"] = 3
+    value["idempotency_key"] = f"rc:e2e:{'a' * 64}"
+    value["plan"]["revision"] = 3
+    value["plan"]["definition"] = {
+        "mode": "campaign",
+        "entrypoint": "e2e::run",
+        "label": "Daily campaign",
+        "lane": "daily",
+        "failurePolicy": "advisory",
+        "subject": {"provider": "deepseek", "model": "deepseek-v4-flash"},
+        "judge": {"provider": "zai", "model": "glm-5.3"},
+        "manifest": {"id": "daily", "sha256": f"sha256:{'3' * 64}"},
+        "scoring": {
+            "profile": "difficulty-weighted-v1",
+            "sha256": f"sha256:{'4' * 64}",
+        },
+        "catalog": {
+            "revision": "catalog-1",
+            "sha256": f"sha256:{'f' * 64}",
+            "seed": 4404,
+        },
+        "groups": [
+            {
+                "id": "daily-core",
+                "executionKind": "harness_turn",
+                "scenarios": ["direct_answer"],
+                "runs": 1,
+                "technicalRetries": 1,
+                "difficultyTier": "L4",
+                "difficultyWeight": 4,
+            },
+            {
+                "id": "weekly-fault-l2",
+                "executionKind": "fault_injection",
+                "scenarios": [],
+                "runs": 3,
+                "technicalRetries": 0,
+                "difficultyTier": "L2",
+                "difficultyWeight": 2,
+                "faultProfile": "weekly-l2-recovery",
+                "faultScenario": "stateful.2",
+                "soakMinutes": 60,
+            },
+        ],
+    }
+    value["runner"].update(
+        {
+            "revision": "e" * 40,
+            "catalog_sha256": f"sha256:{'f' * 64}",
+            "manifest_sha256": f"sha256:{'3' * 64}",
+            "scoring_profile_sha256": f"sha256:{'4' * 64}",
+            "assets_sha256": f"sha256:{'5' * 64}",
+        }
+    )
+    return value
+
+
 def manual_v2_contract_with_versions(versions: dict[str, str]):
     changed = manual_v2_contract()
     stack_digest = MODULE.canonical_sha256(versions)
@@ -213,6 +272,36 @@ class ShadowContractTest(unittest.TestCase):
         )
         self.assertEqual(request["run_contract"]["runner"]["version"], "0.1.0-experimental")
         self.assertEqual(request["run_contract"]["selected_cases"][0]["scenario_id"], "direct_answer")
+
+    def test_campaign_v3_keeps_legacy_contracts_and_materializes_one_group(self):
+        value = campaign_v3_contract()
+        MODULE.validate_contract(value)
+        request = MODULE.materialize_request(
+            value, manual_v2_catalog(), group_id="daily-core"
+        )
+        self.assertEqual(request["scenarios"], ["direct_answer"])
+        self.assertEqual(request["runs"], 1)
+        self.assertEqual(request["run_contract"]["plan"]["group_id"], "daily-core")
+        self.assertEqual(request["run_contract"]["mode"]["decision"], "observe_only")
+
+    def test_campaign_matrix_isolated_faults_on_the_trusted_runner(self):
+        matrix = MODULE.campaign_matrix(campaign_v3_contract())
+        self.assertEqual(len(matrix["include"]), 2)
+        self.assertEqual(matrix["include"][0]["runs_on"], ["ubuntu-latest"])
+        self.assertEqual(
+            matrix["include"][1]["runs_on"], ["self-hosted", "harness-e2e"]
+        )
+
+    def test_campaign_rejects_fault_retries_and_weight_drift(self):
+        retries = campaign_v3_contract()
+        retries["plan"]["definition"]["groups"][1]["technicalRetries"] = 1
+        with self.assertRaisesRegex(ValueError, "fault injection requires"):
+            MODULE.validate_contract(retries)
+
+        weight = campaign_v3_contract()
+        weight["plan"]["definition"]["groups"][0]["difficultyWeight"] = 3
+        with self.assertRaisesRegex(ValueError, "does not match L4"):
+            MODULE.validate_contract(weight)
 
     def test_rejects_a_manual_v2_contract_when_the_resolved_stack_digest_is_tampered(self):
         changed = manual_v2_contract()

--- a/.github/scripts/tests/test_release_workflows.py
+++ b/.github/scripts/tests/test_release_workflows.py
@@ -209,6 +209,29 @@ def test_every_dispatch_is_actor_gated_and_emits_factual_evidence() -> None:
         assert ("--mutating" in body) == (name in MUTATING), name
 
 
+def test_harness_campaign_isolates_groups_and_finalizes_partial_evidence() -> None:
+    value = workflow(WORKFLOWS / "harness-e2e-shadow.yml")
+    jobs = value["jobs"]
+    groups = jobs["groups"]
+    assert groups["strategy"]["fail-fast"] == "false"
+    assert groups["runs-on"] == "${{ matrix.runs_on }}"
+    assert "if: always()" in (WORKFLOWS / "harness-e2e-shadow.yml").read_text()
+    assert jobs["finalize"]["needs"] == ["prepare", "groups"]
+    body = (WORKFLOWS / "harness-e2e-shadow.yml").read_text()
+    assert "--aggregate-existing-root target/harness-e2e-campaign/groups" in body
+    assert "repository: iii-hq/harness-e2e" in body
+    assert "ref: ${{ needs.prepare.outputs.runner_revision }}" in body
+
+
+def test_harness_campaign_preserves_native_group_bytes() -> None:
+    script = (ROOT.parent / "harness/tests/e2e/run-shadow-control-ci.sh").read_text()
+    assert 'results_response="$artifact_dir/results-get.json"' in script
+    assert "for native_name in results.json manifest.json observation.json" in script
+    assert 'cp -- "$native_dir/$native_name" "$artifact_dir/$native_name"' in script
+    assert "expected_results_sha" in script
+    assert "expected_manifest_sha" in script
+
+
 def test_candidate_smoke_prepares_kvm_only_for_scrapling() -> None:
     steps = workflow(WORKFLOWS / "candidate-smoke.yml")["jobs"]["smoke"]["steps"]
     prepare = next(step for step in steps if step.get("name") == "Prepare KVM for Scrapling sandbox")

--- a/.github/workflows/harness-e2e-shadow.yml
+++ b/.github/workflows/harness-e2e-shadow.yml
@@ -76,12 +76,14 @@ jobs:
           schema_version=$(jq -er '.schema_version' target/harness-e2e-contract/execution-contract.json)
           runner_revision=$(jq -r '.runner.revision // ""' target/harness-e2e-contract/execution-contract.json)
           manifest_id=$(jq -r '.plan.definition.manifest.id // ""' target/harness-e2e-contract/execution-contract.json)
-          printf 'contract_sha256=%s\n' "$contract_sha256" >> "$GITHUB_OUTPUT"
-          printf 'matrix=%s\n' "$matrix" >> "$GITHUB_OUTPUT"
-          printf 'oidc_audience=%s\n' "$oidc_audience" >> "$GITHUB_OUTPUT"
-          printf 'runner_revision=%s\n' "$runner_revision" >> "$GITHUB_OUTPUT"
-          printf 'schema_version=%s\n' "$schema_version" >> "$GITHUB_OUTPUT"
-          printf 'manifest_id=%s\n' "$manifest_id" >> "$GITHUB_OUTPUT"
+          {
+            printf 'contract_sha256=%s\n' "$contract_sha256"
+            printf 'matrix=%s\n' "$matrix"
+            printf 'oidc_audience=%s\n' "$oidc_audience"
+            printf 'runner_revision=%s\n' "$runner_revision"
+            printf 'schema_version=%s\n' "$schema_version"
+            printf 'manifest_id=%s\n' "$manifest_id"
+          } >> "$GITHUB_OUTPUT"
           jq -e \
             --arg campaign '${{ inputs.campaign_id }}' \
             --arg execution '${{ inputs.execution_id }}' \

--- a/.github/workflows/harness-e2e-shadow.yml
+++ b/.github/workflows/harness-e2e-shadow.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       campaign_id:
-        description: Release Control shadow campaign UUID
+        description: Release Control campaign UUID
         required: true
         type: string
       execution_id:
@@ -13,7 +13,7 @@ on:
         required: true
         type: string
       attempt:
-        description: Explicit Release Control attempt
+        description: Explicit Release Control campaign attempt
         required: true
         type: number
       execution_contract:
@@ -27,17 +27,22 @@ permissions:
   id-token: write
 
 concurrency:
-  group: harness-e2e-shadow-${{ inputs.execution_id }}
+  group: harness-e2e-shadow-${{ inputs.execution_id }}-${{ inputs.attempt }}
   cancel-in-progress: false
 
 jobs:
-  observe:
-    name: Run observe-only plan
+  prepare:
+    name: Validate and admit campaign
     runs-on: ubuntu-latest
-    timeout-minutes: 210
+    timeout-minutes: 10
     environment: harness-e2e-trusted
-    env:
-      HARNESS_E2E_ARTIFACTS_DIR: ${{ github.workspace }}/target/harness-e2e-shadow
+    outputs:
+      contract_sha256: ${{ steps.contract.outputs.contract_sha256 }}
+      matrix: ${{ steps.contract.outputs.matrix }}
+      oidc_audience: ${{ steps.contract.outputs.oidc_audience }}
+      runner_revision: ${{ steps.contract.outputs.runner_revision }}
+      schema_version: ${{ steps.contract.outputs.schema_version }}
+      manifest_id: ${{ steps.contract.outputs.manifest_id }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -51,36 +56,40 @@ jobs:
           --operation-id '${{ inputs.campaign_id }}'
           --step-id '${{ inputs.execution_id }}'
 
-      - name: Prepare execution contract
+      - name: Prepare execution contract and group matrix
         id: contract
         env:
           EXECUTION_CONTRACT: ${{ inputs.execution_contract }}
         run: |
           set -euo pipefail
-          mkdir -p target/harness-e2e-shadow
-          printf '%s\n' "$EXECUTION_CONTRACT" > target/harness-e2e-shadow/execution-contract.json
+          mkdir -p target/harness-e2e-contract
+          printf '%s\n' "$EXECUTION_CONTRACT" > target/harness-e2e-contract/execution-contract.json
           python3 .github/scripts/harness_e2e_shadow_contract.py validate \
-            --contract target/harness-e2e-shadow/execution-contract.json >/dev/null
+            --contract target/harness-e2e-contract/execution-contract.json >/dev/null
           contract_sha256=$(python3 .github/scripts/harness_e2e_shadow_contract.py digest \
-            --contract target/harness-e2e-shadow/execution-contract.json)
+            --contract target/harness-e2e-contract/execution-contract.json)
+          matrix=$(python3 .github/scripts/harness_e2e_shadow_contract.py matrix \
+            --contract target/harness-e2e-contract/execution-contract.json)
           oidc_audience=$(jq -er \
-            'if .schema_version == 2 then .security.oidc_audience else "release-control-harness-e2e" end' \
-            target/harness-e2e-shadow/execution-contract.json)
+            'if .schema_version >= 2 then .security.oidc_audience else "release-control-harness-e2e" end' \
+            target/harness-e2e-contract/execution-contract.json)
+          schema_version=$(jq -er '.schema_version' target/harness-e2e-contract/execution-contract.json)
+          runner_revision=$(jq -r '.runner.revision // ""' target/harness-e2e-contract/execution-contract.json)
+          manifest_id=$(jq -r '.plan.definition.manifest.id // ""' target/harness-e2e-contract/execution-contract.json)
           printf 'contract_sha256=%s\n' "$contract_sha256" >> "$GITHUB_OUTPUT"
+          printf 'matrix=%s\n' "$matrix" >> "$GITHUB_OUTPUT"
           printf 'oidc_audience=%s\n' "$oidc_audience" >> "$GITHUB_OUTPUT"
+          printf 'runner_revision=%s\n' "$runner_revision" >> "$GITHUB_OUTPUT"
+          printf 'schema_version=%s\n' "$schema_version" >> "$GITHUB_OUTPUT"
+          printf 'manifest_id=%s\n' "$manifest_id" >> "$GITHUB_OUTPUT"
           jq -e \
             --arg campaign '${{ inputs.campaign_id }}' \
             --arg execution '${{ inputs.execution_id }}' \
             --argjson attempt '${{ inputs.attempt }}' \
             '.campaign_id == $campaign and .execution_id == $execution and .attempt == $attempt' \
-            target/harness-e2e-shadow/execution-contract.json >/dev/null
-
-      - name: Install stack verification tooling
-        run: python3 -m pip install --quiet pyyaml
+            target/harness-e2e-contract/execution-contract.json >/dev/null
 
       - name: Acquire single-use execution admission
-        id: admission
-        continue-on-error: true
         env:
           RELEASE_CONTROL_API_URL: ${{ vars.RELEASE_CONTROL_API_URL }}
           EXECUTION_CONTRACT_SHA256: ${{ steps.contract.outputs.contract_sha256 }}
@@ -103,12 +112,73 @@ jobs:
               --arg workflow_sha '${{ github.sha }}' \
               --arg execution_contract_sha256 "$EXECUTION_CONTRACT_SHA256" \
               '{campaign_id:$campaign_id,run_id:$run_id,run_attempt:$run_attempt,workflow_sha:$workflow_sha,execution_contract_sha256:$execution_contract_sha256}')")
-          printf '%s\n' "$response" > target/harness-e2e-shadow/admission.json
-          jq -e '.admitted == true' target/harness-e2e-shadow/admission.json >/dev/null
+          printf '%s\n' "$response" > target/harness-e2e-contract/admission.json
+          jq -e '.admitted == true' target/harness-e2e-contract/admission.json >/dev/null
 
-      - name: Run ephemeral E2E control plane
-        id: execute
-        if: steps.admission.outcome == 'success'
+      - uses: actions/upload-artifact@v6
+        with:
+          name: e2e-contract-${{ inputs.campaign_id }}-${{ inputs.execution_id }}-${{ inputs.attempt }}-gh-${{ github.run_attempt }}
+          path: target/harness-e2e-contract/
+          retention-days: 1
+          if-no-files-found: error
+
+  groups:
+    name: ${{ matrix.group_id }}
+    needs: prepare
+    runs-on: ${{ matrix.runs_on }}
+    timeout-minutes: 240
+    environment: harness-e2e-trusted
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+    env:
+      HARNESS_E2E_ARTIFACTS_DIR: ${{ github.workspace }}/target/harness-e2e-shadow
+      HARNESS_E2E_CAMPAIGN_GROUP_ID: ${{ matrix.group_id }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+
+      - uses: actions/download-artifact@v7
+        with:
+          name: e2e-contract-${{ inputs.campaign_id }}-${{ inputs.execution_id }}-${{ inputs.attempt }}-gh-${{ github.run_attempt }}
+          path: target/harness-e2e-contract
+
+      - name: Restore execution contract
+        run: |
+          set -euo pipefail
+          mkdir -p target/harness-e2e-shadow
+          cp target/harness-e2e-contract/execution-contract.json target/harness-e2e-shadow/execution-contract.json
+
+      - name: Check out exact Harness runner source for fault evaluation
+        if: matrix.execution_kind == 'fault_injection'
+        uses: actions/checkout@v5
+        with:
+          repository: iii-hq/harness-e2e
+          ref: ${{ needs.prepare.outputs.runner_revision }}
+          path: target/harness-source
+
+      - uses: dtolnay/rust-toolchain@1.97.1
+        if: matrix.execution_kind == 'fault_injection'
+
+      - uses: Swatinem/rust-cache@v2
+        if: matrix.execution_kind == 'fault_injection'
+        with:
+          workspaces: target/harness-source
+          key: harness-e2e-fault-${{ needs.prepare.outputs.runner_revision }}
+
+      - name: Build exact fault evaluator
+        if: matrix.execution_kind == 'fault_injection'
+        run: cargo build --locked --release --bin harness-e2e
+        working-directory: target/harness-source
+
+      - name: Install stack verification tooling
+        if: matrix.execution_kind != 'fault_injection'
+        run: python3 -m pip install --quiet pyyaml
+
+      - name: Execute common campaign group
+        id: common
+        if: matrix.execution_kind != 'fault_injection'
         continue-on-error: true
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -118,20 +188,20 @@ jobs:
           HARNESS_E2E_EXECUTION_CONTRACT: ${{ inputs.execution_contract }}
         run: harness/tests/e2e/run-shadow-control-ci.sh
 
-      - name: Record admission failure
-        if: steps.admission.outcome != 'success'
-        run: |
-          set -euo pipefail
-          mkdir -p target/harness-e2e-shadow
-          jq -n \
-            '{schema:"e2e-shadow-failure/v1",phase:"admission",outcome:"infra_failed",error:"execution admission was rejected"}' \
-            > target/harness-e2e-shadow/failure.json
+      - name: Execute protected fault campaign group
+        id: fault
+        if: matrix.execution_kind == 'fault_injection'
+        continue-on-error: true
+        env:
+          HARNESS_E2E_EXECUTION_CONTRACT: ${{ inputs.execution_contract }}
+          HARNESS_E2E_HARNESS_ROOT: ${{ github.workspace }}/target/harness-source
+        run: harness/tests/e2e/run-campaign-fault-ci.sh
 
-      - name: Package factual evidence
+      - name: Package factual group evidence
         if: always()
         env:
           WORKFLOW_IDENTITY: >-
-            {"repository":"${{ github.repository }}","workflow":"harness-e2e-shadow.yml","workflow_sha":"${{ github.sha }}","run_id":${{ github.run_id }},"run_attempt":${{ github.run_attempt }}}
+            {"repository":"${{ github.repository }}","workflow":"harness-e2e-shadow.yml","workflow_sha":"${{ github.sha }}","run_id":${{ github.run_id }},"run_attempt":${{ github.run_attempt }},"group_id":"${{ matrix.group_id }}","job":"${{ github.job }}"}
         run: |
           set -euo pipefail
           python3 .github/scripts/harness_e2e_shadow_contract.py package \
@@ -140,8 +210,17 @@ jobs:
             --workflow "$WORKFLOW_IDENTITY" \
             --output target/harness-e2e-shadow/bundle-manifest.json
 
-      - name: Upload observation bundle
-        if: always()
+      - name: Upload group observation bundle
+        if: always() && needs.prepare.outputs.schema_version == '3'
+        uses: actions/upload-artifact@v6
+        with:
+          name: e2e-observation-${{ inputs.campaign_id }}-${{ inputs.execution_id }}-${{ inputs.attempt }}-${{ matrix.group_id }}-gh-${{ github.run_attempt }}
+          path: target/harness-e2e-shadow/
+          retention-days: 90
+          if-no-files-found: error
+
+      - name: Upload legacy observation bundle
+        if: always() && needs.prepare.outputs.schema_version != '3'
         uses: actions/upload-artifact@v6
         with:
           name: e2e-observation-${{ inputs.campaign_id }}-${{ inputs.execution_id }}-${{ inputs.attempt }}-gh-${{ github.run_attempt }}
@@ -149,6 +228,70 @@ jobs:
           retention-days: 90
           if-no-files-found: error
 
-      - name: Preserve factual job conclusion
-        if: always() && (steps.admission.outcome != 'success' || steps.execute.outcome != 'success')
+      - name: Preserve factual group conclusion
+        if: always() && (steps.common.outcome == 'failure' || steps.fault.outcome == 'failure')
         run: exit 1
+
+  finalize:
+    name: Sign and aggregate campaign artifacts
+    if: always() && needs.prepare.result == 'success' && needs.prepare.outputs.schema_version == '3'
+    needs: [prepare, groups]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Check out exact Harness aggregator
+        uses: actions/checkout@v5
+        with:
+          repository: iii-hq/harness-e2e
+          ref: ${{ needs.prepare.outputs.runner_revision }}
+          path: target/harness-source
+
+      - uses: actions/download-artifact@v7
+        with:
+          name: e2e-contract-${{ inputs.campaign_id }}-${{ inputs.execution_id }}-${{ inputs.attempt }}-gh-${{ github.run_attempt }}
+          path: target/harness-e2e-campaign
+
+      - uses: actions/download-artifact@v7
+        with:
+          pattern: e2e-observation-${{ inputs.campaign_id }}-${{ inputs.execution_id }}-${{ inputs.attempt }}-*-gh-${{ github.run_attempt }}
+          path: target/downloaded-groups
+          merge-multiple: false
+
+      - name: Restore deterministic group paths
+        env:
+          EXECUTION_CONTRACT: ${{ inputs.execution_contract }}
+        run: |
+          set -euo pipefail
+          mkdir -p target/harness-e2e-campaign/groups
+          while IFS= read -r group; do
+            source="target/downloaded-groups/e2e-observation-${{ inputs.campaign_id }}-${{ inputs.execution_id }}-${{ inputs.attempt }}-${group}-gh-${{ github.run_attempt }}"
+            test -d "$source"
+            mv "$source" "target/harness-e2e-campaign/groups/$group"
+          done < <(jq -r '.plan.definition.groups[].id' <<<"$EXECUTION_CONTRACT")
+
+      - name: Aggregate with exact Harness scoring implementation
+        run: |
+          set -euo pipefail
+          python3 target/harness-source/scripts/run_e2e_campaign.py \
+            "target/harness-source/config/campaigns/${{ needs.prepare.outputs.manifest_id }}.json" \
+            --aggregate-existing-root target/harness-e2e-campaign/groups \
+            --execution-id '${{ inputs.execution_id }}' \
+            --summary target/harness-e2e-campaign/campaign-summary.json \
+            --bundle target/harness-e2e-campaign/campaign-bundle.json
+          python3 .github/scripts/harness_e2e_shadow_contract.py package \
+            --root target/harness-e2e-campaign \
+            --contract target/harness-e2e-campaign/execution-contract.json \
+            --workflow '{"repository":"${{ github.repository }}","workflow":"harness-e2e-shadow.yml","workflow_sha":"${{ github.sha }}","run_id":${{ github.run_id }},"run_attempt":${{ github.run_attempt }},"job":"finalize"}' \
+            --output target/harness-e2e-campaign/bundle-manifest.json
+
+      - name: Upload root observation bundle
+        uses: actions/upload-artifact@v6
+        with:
+          name: e2e-observation-${{ inputs.campaign_id }}-${{ inputs.execution_id }}-${{ inputs.attempt }}-gh-${{ github.run_attempt }}
+          path: target/harness-e2e-campaign/
+          retention-days: 90
+          if-no-files-found: error

--- a/harness/tests/e2e/README.md
+++ b/harness/tests/e2e/README.md
@@ -208,12 +208,19 @@ zero.
 | Deployment shadow observation | Successful Harness deployment | Plan-defined | Never blocks deployment or promotion |
 
 `harness-e2e-shadow.yml` is intentionally separate from the legacy validation
-matrix. It starts an isolated iii engine on a GitHub-hosted runner, installs the
-exact deployment stack, then installs the independent
-`harness-e2e@<plan-ref>` worker from Registry. The job materializes and invokes
-the local `e2e::*` control plane and uploads an
-`e2e-observation-bundle/v1`. Release Control admits the job through GitHub OIDC
-and ingests the Artifact; it does not host the E2E worker.
+matrix. It accepts the historical v1/v2 dispatch contracts and the campaign v3
+contract. A campaign expands to an isolated job per group with
+`fail-fast: false`: common groups start an ephemeral exact deployment stack,
+while fault-injection groups run on the protected trusted runner. Every job
+installs the exact immutable Harness runner, invokes the local `e2e::*` control
+plane, and uploads its native artifacts without rewriting their bytes. A final
+Harness job validates and signs the group outputs into the campaign root
+bundle. Release Control admits the workflow through GitHub OIDC and ingests the
+artifact; it does not host the E2E worker.
+
+Campaign and group identifiers are deterministic, while `run_attempt` remains
+the campaign attempt. This keeps retries correlated without merging attempts
+or turning partial infrastructure failures into product scores.
 
 Release Control owns the schedule, source/Registry choice, exact stack,
 profiles, selected and required scenarios, repetitions, subjects, judge and

--- a/harness/tests/e2e/run-campaign-fault-ci.sh
+++ b/harness/tests/e2e/run-campaign-fault-ci.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+: "${HARNESS_E2E_EXECUTION_CONTRACT:?HARNESS_E2E_EXECUTION_CONTRACT is required}"
+: "${HARNESS_E2E_CAMPAIGN_GROUP_ID:?HARNESS_E2E_CAMPAIGN_GROUP_ID is required}"
+: "${HARNESS_E2E_HARNESS_ROOT:?HARNESS_E2E_HARNESS_ROOT is required}"
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd -- "$script_dir/../../.." && pwd)
+contract_tool="$repo_root/.github/scripts/harness_e2e_shadow_contract.py"
+artifact_dir=${HARNESS_E2E_ARTIFACTS_DIR:-"$repo_root/target/harness-e2e-shadow"}
+supervisor=${HARNESS_E2E_FAULT_SUPERVISOR:-/opt/iii-harness-e2e/run-weekly-stress}
+e2e_bin="$HARNESS_E2E_HARNESS_ROOT/target/release/harness-e2e"
+contract_path="$artifact_dir/execution-contract.json"
+
+case "$artifact_dir" in
+  "$repo_root"/target/*) ;;
+  *) echo "HARNESS_E2E_ARTIFACTS_DIR must be below $repo_root/target" >&2; exit 2 ;;
+esac
+mkdir -p "$artifact_dir"
+printf '%s\n' "$HARNESS_E2E_EXECUTION_CONTRACT" >"$contract_path"
+python3 "$contract_tool" validate --contract "$contract_path" >/dev/null
+
+group=$(jq -ce --arg id "$HARNESS_E2E_CAMPAIGN_GROUP_ID" '
+  .plan.definition.groups
+  | map(select(.id == $id and .executionKind == "fault_injection"))
+  | if length == 1 then .[0] else error("fault group not found") end
+' "$contract_path")
+profile=$(jq -r '.faultProfile' <<<"$group")
+scenario=$(jq -r '.faultScenario' <<<"$group")
+runs=$(jq -r '.runs' <<<"$group")
+soak_minutes=$(jq -r '.soakMinutes' <<<"$group")
+profile_path="$HARNESS_E2E_HARNESS_ROOT/config/profiles/${profile}.json"
+plan="$artifact_dir/fault-plan.json"
+
+failure_phase=preflight
+failure_reason=""
+cleanup() {
+  local status=$?
+  trap - EXIT ERR
+  if ((status != 0)); then
+    [[ -n "$failure_reason" ]] || failure_reason="fault execution failed during $failure_phase"
+    jq -n --arg phase "$failure_phase" --arg error "$failure_reason" --argjson exit_code "$status" \
+      '{schema:"e2e-campaign-group-failure/v1",phase:$phase,outcome:"infra_failed",error:$error,exit_code:$exit_code}' \
+      >"$artifact_dir/failure.json"
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+trap 'failure_reason="command failed at line $LINENO"' ERR
+
+test -x "$supervisor"
+test -x "$e2e_bin"
+test -f "$profile_path"
+observed_revision=$(git -C "$HARNESS_E2E_HARNESS_ROOT" rev-parse HEAD)
+expected_revision=$(jq -r '.runner.revision' "$contract_path")
+[[ "$observed_revision" == "$expected_revision" ]]
+observed_version=$($e2e_bin --version | awk '{print $2}')
+expected_version=$(jq -r '.runner.registry_ref' "$contract_path")
+[[ "$observed_version" == "$expected_version" ]]
+manifest_id=$(jq -r '.plan.definition.manifest.id' "$contract_path")
+asset_validation=$(python3 "$HARNESS_E2E_HARNESS_ROOT/scripts/run_e2e_campaign.py" \
+  "$HARNESS_E2E_HARNESS_ROOT/config/campaigns/${manifest_id}.json" --validate-only)
+observed_manifest=$(jq -er '.manifest_sha256' <<<"$asset_validation")
+observed_scoring=$(jq -er '.scoring_profile_sha256' <<<"$asset_validation")
+expected_manifest=$(jq -r '.runner.manifest_sha256' "$contract_path")
+expected_scoring=$(jq -r '.runner.scoring_profile_sha256' "$contract_path")
+[[ "$observed_manifest" == "$expected_manifest" ]]
+[[ "$observed_scoring" == "$expected_scoring" ]]
+
+failure_phase=plan
+"$e2e_bin" fault-plan --profile "$profile_path" --output "$plan"
+
+failure_phase=execution
+deadline=$((SECONDS + soak_minutes * 60))
+iteration=0
+while ((iteration < runs || SECONDS < deadline)); do
+  iteration=$((iteration + 1))
+  output="$artifact_dir/run-${iteration}"
+  mkdir -p "$output"
+  "$supervisor" \
+    --e2e-bin "$e2e_bin" \
+    --profile "$profile_path" \
+    --plan "$plan" \
+    --scenario "$scenario" \
+    --iteration "$iteration" \
+    --output "$output"
+  evaluation=(
+    "$e2e_bin" fault-evaluate
+    --profile "$profile_path"
+    --plan "$plan"
+    --journal "$output/fault-journal.json"
+    --output "$output/fault-evaluation.json"
+  )
+  if [[ -e "$output/results" ]]; then
+    evaluation+=(--results "$output/results")
+  fi
+  "${evaluation[@]}"
+done
+
+failure_phase=complete

--- a/harness/tests/e2e/run-shadow-control-ci.sh
+++ b/harness/tests/e2e/run-shadow-control-ci.sh
@@ -25,7 +25,9 @@ printf '%s\n' "$HARNESS_E2E_EXECUTION_CONTRACT" >"$contract_path"
 python3 "$contract_tool" validate --contract "$contract_path" >/dev/null
 
 contract_schema=$(jq -r '.schema_version' "$contract_path")
-if [[ "$contract_schema" == 2 ]]; then
+exact_contract=false
+if [[ "$contract_schema" == 2 || "$contract_schema" == 3 ]]; then
+  exact_contract=true
   stack_versions=$(jq -c '.target.stack.resolved_versions' "$contract_path")
   stack_digest=$(jq -r '.target.stack.resolution_sha256' "$contract_path")
   runtime_versions=$(jq -c '.runtime.stack_versions' "$contract_path")
@@ -43,7 +45,15 @@ runner_worker=$(jq -r '.runner.registry_worker' "$contract_path")
 runner_ref=$(jq -r '.runner.registry_ref' "$contract_path")
 subject_provider=$(jq -r '.plan.definition.subject.provider' "$contract_path")
 judge_provider=$(jq -r '.plan.definition.judge.provider' "$contract_path")
-seed=$(jq -r '.plan.definition.seed' "$contract_path")
+campaign_group_id=${HARNESS_E2E_CAMPAIGN_GROUP_ID:-legacy}
+if [[ "$contract_schema" == 3 ]]; then
+  jq -e --arg group "$campaign_group_id" \
+    '.plan.definition.groups | any(.id == $group and .executionKind != "fault_injection")' \
+    "$contract_path" >/dev/null
+  seed=$(jq -r '.plan.definition.catalog.seed' "$contract_path")
+else
+  seed=$(jq -r '.plan.definition.seed' "$contract_path")
+fi
 
 run_root=$(mktemp -d "${TMPDIR:-/tmp}/harness-e2e-shadow.XXXXXX")
 project_dir="$run_root/project"
@@ -64,7 +74,8 @@ export HARNESS_E2E_STACK_VERSIONS="$stack_versions"
 export HARNESS_E2E_STACK_DIGEST="$stack_digest"
 export HARNESS_E2E_DATA_DIR="$run_root/e2e-data"
 export HARNESS_E2E_RUN_DIR="$project_dir"
-export HARNESS_E2E_LANE=release-control-shadow
+export HARNESS_E2E_LANE=$(jq -r '.plan.definition.lane' "$contract_path")
+export HARNESS_E2E_CAMPAIGN_GROUP="$campaign_group_id"
 
 iii_bin=""
 engine_pid=""
@@ -203,13 +214,13 @@ verify_target_harness_runtime() {
   fail "harness runtime version mismatch: expected $expected, observed ${observed:-unreported}"
 }
 
-if [[ "$contract_schema" == 2 ]]; then
+if [[ "$exact_contract" == true ]]; then
   log "Installing exact iii CLI $cli_version"
 else
   log "Installing iii CLI from $cli_channel"
 fi
 curl -fsSL --retry 3 --retry-all-errors --retry-delay 5 "$install_url" -o "$run_root/install.sh"
-if [[ "$contract_schema" == 2 ]]; then
+if [[ "$exact_contract" == true ]]; then
   VERSION="$cli_version" sh "$run_root/install.sh" 2>&1 | tee "$artifact_dir/logs/install.log"
 elif [[ "$cli_channel" == next ]]; then
   sh "$run_root/install.sh" --next 2>&1 | tee "$artifact_dir/logs/install.log"
@@ -219,7 +230,7 @@ fi
 iii_bin=$(command -v iii)
 observed_cli_version=$("$iii_bin" --version 2>&1)
 printf '%s\n' "$observed_cli_version" >"$artifact_dir/iii-version.txt"
-if [[ "$contract_schema" == 2 && "$observed_cli_version" != *"$cli_version"* ]]; then
+if [[ "$exact_contract" == true && "$observed_cli_version" != *"$cli_version"* ]]; then
   fail "iii CLI version mismatch: expected $cli_version, observed $observed_cli_version"
 fi
 export HARNESS_E2E_ENGINE_REVISION="$observed_cli_version"
@@ -231,7 +242,7 @@ engine_pid=$!
 wait_for_engine
 
 failure_phase=registry
-if [[ "$contract_schema" == 2 ]]; then
+if [[ "$exact_contract" == true ]]; then
   # The contract may distinguish runtime and target pins. Resolve their union
   # once before the runner and once after it, rather than waiting for every
   # individual worker to report ready in four serial loops.
@@ -255,7 +266,7 @@ else
   add_with_retry support "${support[@]}"
 fi
 
-if [[ "$contract_schema" != 2 ]]; then
+if [[ "$exact_contract" != true ]]; then
   while IFS=$'\t' read -r worker version; do
     log "Installing exact target stack: $worker@$version"
     # A shadow job always starts with a fresh project directory. Forcing an
@@ -272,7 +283,7 @@ add_with_retry runner "$runner_worker@$runner_ref" --force
 # exact pins without force: force restarts an already-correct target worker
 # while the engine's file watcher can revive its previous executable between
 # removal and download. The lock and runtime checks below remain fail-closed.
-if [[ "$contract_schema" == 2 ]]; then
+if [[ "$exact_contract" == true ]]; then
   install_exact_stack stack-repin "$exact_stack_versions" false
 else
   while IFS=$'\t' read -r worker version; do
@@ -281,7 +292,7 @@ else
 fi
 
 target_harness_version=$(jq -r '.target.version' "$contract_path")
-if [[ "$contract_schema" == 2 ]]; then
+if [[ "$exact_contract" == true ]]; then
   python3 "$contract_tool" verify-lock \
     --contract "$contract_path" \
     --lock "$project_dir/iii.lock" \
@@ -310,10 +321,15 @@ verify_target_harness_runtime
 failure_phase=materialization
 "$iii_bin" trigger e2e::scenarios-list --port "$engine_port" \
   --json "$(jq -cn --argjson seed "$seed" '{seed:$seed}')" >"$artifact_dir/catalog.json"
-python3 "$contract_tool" materialize \
-  --contract "$contract_path" \
-  --catalog "$artifact_dir/catalog.json" \
+materialize_args=(
+  --contract "$contract_path"
+  --catalog "$artifact_dir/catalog.json"
   --output "$artifact_dir/run-request.json"
+)
+if [[ "$contract_schema" == 3 ]]; then
+  materialize_args+=(--group-id "$campaign_group_id")
+fi
+python3 "$contract_tool" materialize "${materialize_args[@]}"
 
 failure_phase=execution
 timeout --signal=TERM --kill-after=30s "$admission_timeout_seconds" \
@@ -340,11 +356,36 @@ while true; do
 done
 
 failure_phase=results
+results_response="$artifact_dir/results.json"
+if [[ "$contract_schema" == 3 ]]; then
+  results_response="$artifact_dir/results-get.json"
+fi
 timeout --signal=TERM --kill-after=30s 120 \
   "$iii_bin" trigger e2e::results-get --port "$engine_port" \
   --json "$(jq -cn --arg execution_id "$remote_execution_id" '{execution_id:$execution_id}')" \
-  >"$artifact_dir/results.json"
-jq -e --arg id "$remote_execution_id" '.execution_id == $id' "$artifact_dir/results.json" >/dev/null
+  >"$results_response"
+jq -e --arg id "$remote_execution_id" '.execution_id == $id' "$results_response" >/dev/null
+
+if [[ "$contract_schema" == 3 ]]; then
+  # Preserve the exact Harness-authored bytes. The API envelope is retained as
+  # results-get.json for transport evidence, but it is never used to rebuild
+  # results.json, manifest.json, or observation.json.
+  native_result_path=$(jq -er '.result_path | select(type == "string" and length > 0)' "$results_response")
+  case "$native_result_path" in
+    /*|*".."*) fail "unsafe native result path: $native_result_path" ;;
+  esac
+  native_dir="$HARNESS_E2E_DATA_DIR/$(dirname -- "$native_result_path")"
+  for native_name in results.json manifest.json observation.json; do
+    test -f "$native_dir/$native_name"
+    cp -- "$native_dir/$native_name" "$artifact_dir/$native_name"
+  done
+  expected_results_sha=$(jq -er '.observation.evidence.results_sha256' "$results_response")
+  expected_manifest_sha=$(jq -er '.observation.evidence.manifest_sha256' "$results_response")
+  observed_results_sha="sha256:$(sha256sum "$artifact_dir/results.json" | cut -d ' ' -f1)"
+  observed_manifest_sha="sha256:$(sha256sum "$artifact_dir/manifest.json" | cut -d ' ' -f1)"
+  [[ "$observed_results_sha" == "$expected_results_sha" ]]
+  [[ "$observed_manifest_sha" == "$expected_manifest_sha" ]]
+fi
 
 # This proves the archive contract while the runner is alive. GitHub Artifact,
 # not this ephemeral local storage, is the D0 retention boundary.


### PR DESCRIPTION
## Summary

- add the campaign v3 dispatch contract while preserving legacy v1/v2 executions
- expand one campaign into isolated group jobs with `fail-fast: false`
- route common groups to exact ephemeral stacks and fault groups to the protected trusted runner
- preserve native `results.json`, `manifest.json`, and `observation.json` bytes and digests
- aggregate partial group outcomes in a final exact Harness runner job

## Validation

- 229 workflow/script tests passed
- 3 shell subtests passed
- shell syntax, workflow YAML, and diff checks passed

## Dependency

Depends on iii-hq/harness-e2e#24. This is the second PR in the Harness -> Workers -> Release Control rollout.