### PR TITLE
(MOT-4527) fix(console): retire the bare keybindings, keep the palette

### DIFF
--- a/console/web/e2e/keyboard-first.spec.ts
+++ b/console/web/e2e/keyboard-first.spec.ts
@@ -89,9 +89,9 @@ test('the keyboard reaches the chat, the panes and every page command through ‚å
   // The new pane opens with its search focused, where `}` is a character.
   await pane(page, 0).focus()
   const focusedPane = page.locator('[data-workspace-pane-id]:focus-within')
-  await page.keyboard.press('Alt+Shift+]')
+  await page.keyboard.press('Alt+}')
   await expect(focusedPane).toHaveAttribute('data-workspace-panel', '1')
-  await page.keyboard.press('Alt+Shift+[')
+  await page.keyboard.press('Alt+{')
   await expect(focusedPane).toHaveAttribute('data-workspace-panel', '0')
 
   await page.keyboard.press('ControlOrMeta+k')

--- a/console/web/e2e/keyboard-first.spec.ts
+++ b/console/web/e2e/keyboard-first.spec.ts
@@ -80,18 +80,18 @@ test('the keyboard reaches the chat, the panes and every page command through ‚å
   ).toBeVisible()
   await page.keyboard.press('Escape')
 
-  // A second pane, then the braces move the keyboard between panes, and the
+  // A second pane, then the alt-braces move the keyboard between panes, and the
   // palette's "open" lands the keyboard in the page it opened.
   await settle(page)
   await expect(page.locator('[data-workspace-pane-id]')).toHaveCount(2)
-  await page.keyboard.press('\\')
+  await page.keyboard.press('Alt+\\')
   await expect(page.locator('[data-workspace-pane-id]')).toHaveCount(3)
   // The new pane opens with its search focused, where `}` is a character.
   await pane(page, 0).focus()
   const focusedPane = page.locator('[data-workspace-pane-id]:focus-within')
-  await page.keyboard.press('}')
+  await page.keyboard.press('Alt+Shift+]')
   await expect(focusedPane).toHaveAttribute('data-workspace-panel', '1')
-  await page.keyboard.press('{')
+  await page.keyboard.press('Alt+Shift+[')
   await expect(focusedPane).toHaveAttribute('data-workspace-panel', '0')
 
   await page.keyboard.press('ControlOrMeta+k')

--- a/console/web/e2e/workspace-tabs.spec.ts
+++ b/console/web/e2e/workspace-tabs.spec.ts
@@ -29,26 +29,26 @@ test('workspace tabs stay deterministic across keys, reloads, deep links and oth
   // Create two workspaces from the keyboard; each becomes active. A new
   // empty workspace focuses its search field, so leave it before the next key.
   await settle(page)
-  await page.keyboard.press('t')
+  await page.keyboard.press('Alt+t')
   await expect(tabs(page)).toHaveCount(2)
   await settle(page)
-  await page.keyboard.press('t')
+  await page.keyboard.press('Alt+t')
   await expect(tabs(page)).toHaveCount(3)
   await settle(page)
   const thirdId = await activeTab(page).getAttribute('data-tab-id')
   expect(thirdId).not.toBe(homeId)
 
-  // Step with [ and ], jump with digits.
-  await page.keyboard.press('[')
+  // Step with the alt-brackets, jump with alt-digits.
+  await page.keyboard.press('Alt+[')
   await expect(activeTab(page)).not.toHaveAttribute(
     'data-tab-id',
     thirdId ?? '',
   )
   await settle(page)
-  await page.keyboard.press(']')
+  await page.keyboard.press('Alt+]')
   await expect(activeTab(page)).toHaveAttribute('data-tab-id', thirdId ?? '')
   await settle(page)
-  await page.keyboard.press('1')
+  await page.keyboard.press('Alt+1')
   await expect(activeTab(page)).toHaveAttribute('data-tab-id', homeId ?? '')
 
   // Shortcuts stand down while typing.
@@ -61,10 +61,10 @@ test('workspace tabs stay deterministic across keys, reloads, deep links and oth
   await settle(page)
 
   // Middle tab closes onto its right-hand neighbour.
-  await page.keyboard.press('2')
+  await page.keyboard.press('Alt+2')
   const secondId = await activeTab(page).getAttribute('data-tab-id')
   await settle(page)
-  await page.keyboard.press('Shift+W')
+  await page.keyboard.press('Alt+w')
   await expect(tabs(page)).toHaveCount(2)
   await expect(activeTab(page)).toHaveAttribute('data-tab-id', thirdId ?? '')
   expect(secondId).not.toBe(thirdId)
@@ -89,7 +89,7 @@ test('workspace tabs stay deterministic across keys, reloads, deep links and oth
   // The go-to chord and a deep link open the screen once and never a second
   // tab for it.
   await settle(page)
-  await page.keyboard.press('g')
+  await page.keyboard.press('Alt+g')
   await page.keyboard.press('w')
   await expect(tabs(page).filter({ hasText: 'workers' })).toHaveCount(1)
   await page.goto(`${stack.consoleUrl}#/traces`)

--- a/console/web/src/App.tsx
+++ b/console/web/src/App.tsx
@@ -1786,7 +1786,19 @@ function ShortcutsDialog({ open, onOpenChange }: ShortcutsDialogProps) {
           <KeyCombo binding={bindingsFor('palette.toggle')[0] ?? 'Mod+K'} />{' '}
           shows its key, so this list is a reference, not homework.
         </DialogDescription>
-        {keybindingGroups().map(([group, entries]) => (
+        {keybindingGroups()
+          .map(
+            ([group, entries]) =>
+              [
+                group,
+                entries.filter(
+                  (entry) =>
+                    resolveBindings(entry.bindings, platform).length > 0,
+                ),
+              ] as const,
+          )
+          .filter(([, entries]) => entries.length > 0)
+          .map(([group, entries]) => (
           <section key={group} className="mt-4">
             <h3 className="text-[11px] uppercase tracking-[0.18em] text-ink-ghost">
               {group}

--- a/console/web/src/hooks/use-keybindings.test.ts
+++ b/console/web/src/hooks/use-keybindings.test.ts
@@ -68,72 +68,34 @@ describe('createKeyDispatcher', () => {
   beforeEach(() => vi.useFakeTimers())
   afterEach(() => vi.useRealTimers())
 
-  it('fires a single chord and a digit index', () => {
+  it('fires nothing for the retired bare keys, and still opens the palette', () => {
     const seen: string[] = []
     const dispatcher = createKeyDispatcher(
       () => ({
         'workspace.create': () => seen.push('create'),
         'workspace.selectByIndex': (index) => seen.push(`select ${index}`),
+        'palette.toggle': () => seen.push('palette'),
       }),
       'mac',
     )
     dispatcher.onKeyDown(key('t'))
     dispatcher.onKeyDown(key('3'))
-    expect(seen).toEqual(['create', 'select 2'])
+    expect(seen).toEqual([])
+    dispatcher.onKeyDown(key('k', { metaKey: true }))
+    expect(seen).toEqual(['palette'])
   })
 
-  it('completes a go-to chord and swallows its prefix', () => {
+  it('no longer arms a go-to prefix', () => {
     const seen: string[] = []
     const dispatcher = createKeyDispatcher(
-      () => ({
-        'page.chat': () => seen.push('chat'),
-        'workspace.create': () => seen.push('create'),
-      }),
+      () => ({ 'page.chat': () => seen.push('chat') }),
       'mac',
     )
     const prefix = key('g')
     dispatcher.onKeyDown(prefix)
-    expect(prefix.defaultPrevented).toBe(true)
-    expect(seen).toEqual([])
-    dispatcher.onKeyDown(key('c'))
-    expect(seen).toEqual(['chat'])
-  })
-
-  it('lets a pending prefix take a letter that is also a single key', () => {
-    const seen: string[] = []
-    const dispatcher = createKeyDispatcher(
-      () => ({
-        'page.traces': () => seen.push('traces'),
-        'workspace.create': () => seen.push('create'),
-      }),
-      'mac',
-    )
-    dispatcher.onKeyDown(key('g'))
-    dispatcher.onKeyDown(key('t'))
-    expect(seen).toEqual(['traces'])
-    dispatcher.onKeyDown(key('t'))
-    expect(seen).toEqual(['traces', 'create'])
-  })
-
-  it('forgets the prefix after the timeout or an unrelated key', () => {
-    const seen: string[] = []
-    const dispatcher = createKeyDispatcher(
-      () => ({
-        'page.chat': () => seen.push('chat'),
-        'workspace.create': () => seen.push('create'),
-      }),
-      'mac',
-    )
-    dispatcher.onKeyDown(key('g'))
-    vi.advanceTimersByTime(CHORD_TIMEOUT_MS + 1)
+    expect(prefix.defaultPrevented).toBe(false)
     dispatcher.onKeyDown(key('c'))
     expect(seen).toEqual([])
-
-    dispatcher.onKeyDown(key('g'))
-    dispatcher.onKeyDown(key('t'))
-    expect(seen).toEqual(['create'])
-    dispatcher.onKeyDown(key('c'))
-    expect(seen).toEqual(['create'])
   })
 
   it('stands down inside a declared standdown surface', () => {
@@ -212,21 +174,51 @@ describe('createKeyDispatcher', () => {
       expect(inside.defaultPrevented).toBe(true)
     })
 
-    it('never shadows a console key and skips a disabled command', () => {
+    it('never shadows the palette chord and skips a disabled command', () => {
       const seen: string[] = []
       const dispatcher = createKeyDispatcher(
-        () => ({ 'workspace.create': () => seen.push('create') }),
+        () => ({ 'palette.toggle': () => seen.push('palette') }),
         'mac',
         () => [
-          entry('pane-1', 'T', () => seen.push('page-t')),
+          entry('pane-1', 'Mod+K', () => seen.push('page-k')),
           entry('pane-1', 'X', () => seen.push('page-x'), {
             enabled: () => false,
           }),
         ],
       )
-      dispatcher.onKeyDown(key('t', { target: pane('pane-1') }))
+      dispatcher.onKeyDown(key('k', { metaKey: true, target: pane('pane-1') }))
       dispatcher.onKeyDown(key('x', { target: pane('pane-1') }))
-      expect(seen).toEqual(['create'])
+      expect(seen).toEqual(['palette'])
+    })
+
+    it('lets a pending page prefix take a letter that is also a single key', () => {
+      const seen: string[] = []
+      const dispatcher = createKeyDispatcher(
+        () => ({}),
+        'mac',
+        () => [
+          entry('pane-1', 'Q T', () => seen.push('chord')),
+          entry('pane-1', 'T', () => seen.push('single')),
+        ],
+      )
+      dispatcher.onKeyDown(key('q', { target: pane('pane-1') }))
+      dispatcher.onKeyDown(key('t', { target: pane('pane-1') }))
+      expect(seen).toEqual(['chord'])
+      dispatcher.onKeyDown(key('t', { target: pane('pane-1') }))
+      expect(seen).toEqual(['chord', 'single'])
+    })
+
+    it('forgets a page prefix after the timeout', () => {
+      const seen: string[] = []
+      const dispatcher = createKeyDispatcher(
+        () => ({}),
+        'mac',
+        () => [entry('pane-1', 'Q C', () => seen.push('chord'))],
+      )
+      dispatcher.onKeyDown(key('q', { target: pane('pane-1') }))
+      vi.advanceTimersByTime(CHORD_TIMEOUT_MS + 1)
+      dispatcher.onKeyDown(key('c', { target: pane('pane-1') }))
+      expect(seen).toEqual([])
     })
 
     it('completes a page chord and stands down in a field unless asked', () => {

--- a/console/web/src/hooks/use-keybindings.test.ts
+++ b/console/web/src/hooks/use-keybindings.test.ts
@@ -68,7 +68,7 @@ describe('createKeyDispatcher', () => {
   beforeEach(() => vi.useFakeTimers())
   afterEach(() => vi.useRealTimers())
 
-  it('fires nothing for the retired bare keys, and still opens the palette', () => {
+  it('ignores the bare keys and fires their modifier chords', () => {
     const seen: string[] = []
     const dispatcher = createKeyDispatcher(
       () => ({
@@ -81,21 +81,29 @@ describe('createKeyDispatcher', () => {
     dispatcher.onKeyDown(key('t'))
     dispatcher.onKeyDown(key('3'))
     expect(seen).toEqual([])
+    dispatcher.onKeyDown(key('t', { ctrlKey: true }))
+    dispatcher.onKeyDown(key('3', { ctrlKey: true }))
     dispatcher.onKeyDown(key('k', { metaKey: true }))
-    expect(seen).toEqual(['palette'])
+    expect(seen).toEqual(['create', 'select 2', 'palette'])
   })
 
-  it('no longer arms a go-to prefix', () => {
+  it('arms the go-to prefix from its chord, never the bare letter', () => {
     const seen: string[] = []
     const dispatcher = createKeyDispatcher(
       () => ({ 'page.chat': () => seen.push('chat') }),
       'mac',
     )
-    const prefix = key('g')
-    dispatcher.onKeyDown(prefix)
-    expect(prefix.defaultPrevented).toBe(false)
+    const bare = key('g')
+    dispatcher.onKeyDown(bare)
+    expect(bare.defaultPrevented).toBe(false)
     dispatcher.onKeyDown(key('c'))
     expect(seen).toEqual([])
+
+    const prefix = key('g', { ctrlKey: true })
+    dispatcher.onKeyDown(prefix)
+    expect(prefix.defaultPrevented).toBe(true)
+    dispatcher.onKeyDown(key('c'))
+    expect(seen).toEqual(['chat'])
   })
 
   it('stands down inside a declared standdown surface', () => {

--- a/console/web/src/lib/keybindings/registry.test.ts
+++ b/console/web/src/lib/keybindings/registry.test.ts
@@ -42,7 +42,6 @@ describe('the registry itself', () => {
     for (const platform of PLATFORMS) {
       for (const definition of KEYBINDINGS) {
         const bindings = resolveBindings(definition.bindings, platform)
-        expect(bindings.length).toBeGreaterThan(0)
         for (const binding of bindings) {
           expect({ binding, parsed: parseSequence(binding) !== null }).toEqual({
             binding,
@@ -69,7 +68,7 @@ describe('the registry itself', () => {
 describe('lookup', () => {
   it('finds a definition by id', () => {
     expect(keybinding('palette.toggle').bindings).toEqual(['Mod+K'])
-    expect(bindingsFor('workspace.close', 'mac')).toEqual(['Shift+W'])
+    expect(bindingsFor('workspace.close', 'mac')).toEqual([])
   })
 
   it('resolves a per-platform binding list', () => {
@@ -82,22 +81,22 @@ describe('lookup', () => {
     expect(keybinding('workspace.create').firesWhileTyping).toBeUndefined()
   })
 
-  it('spells a hover title with the key for the platform', () => {
+  it('spells a hover title with the key, or plain text for an unbound action', () => {
     expect(hoverTitle('New workspace', 'workspace.create', 'mac')).toBe(
-      'New workspace (T)',
+      'New workspace',
     )
-    expect(hoverTitle('Close', 'workspace.close', 'mac')).toBe('Close (⇧ W)')
+    expect(hoverTitle('Close', 'workspace.close', 'mac')).toBe('Close')
     expect(hoverTitle('Search', 'palette.toggle', 'other')).toBe(
       'Search (ctrl K)',
     )
-    expect(hoverTitle('Chat', 'page.chat', 'mac')).toBe('Chat (G then C)')
+    expect(hoverTitle('Chat', 'page.chat', 'mac')).toBe('Chat')
   })
 
   it('says why a page may not take a key, or lets it', () => {
-    expect(shortcutClaimReason('t', 'mac')).toMatch(/New workspace/)
-    expect(shortcutClaimReason('7', 'mac')).toMatch(/Select workspace/)
-    expect(shortcutClaimReason('G', 'mac')).toMatch(/Go to/)
-    expect(shortcutClaimReason('G X', 'mac')).toMatch(/starts like/)
+    expect(shortcutClaimReason('t', 'mac')).toBeNull()
+    expect(shortcutClaimReason('7', 'mac')).toBeNull()
+    expect(shortcutClaimReason('G', 'mac')).toBeNull()
+    expect(shortcutClaimReason('G X', 'mac')).toBeNull()
     expect(shortcutClaimReason('Mod+K', 'other')).toMatch(
       /command palette|Search|palette/i,
     )
@@ -108,13 +107,13 @@ describe('lookup', () => {
     expect(shortcutClaimReason('Q L', 'mac')).toBeNull()
   })
 
-  it('steps panel focus with the braces', () => {
-    expect(bindingsFor('panel.next', 'mac')).toEqual(['}'])
-    expect(bindingsFor('panel.previous', 'other')).toEqual(['{'])
+  it('exposes no key for an unbound action', () => {
+    expect(bindingsFor('panel.next', 'mac')).toEqual([])
+    expect(bindingsFor('panel.previous', 'other')).toEqual([])
   })
 
-  it('lists the chords of a go-to sequence', () => {
-    expect(sequencesFor('page.workers', 'mac')).toEqual([['G', 'W']])
+  it('lists no chords for unbound actions', () => {
+    expect(sequencesFor('page.workers', 'mac')).toEqual([])
     expect(sequencesFor('workspace.create', 'mac')).toEqual([])
   })
 })
@@ -183,21 +182,12 @@ describe('matchDigitIndex', () => {
     }
   }
 
-  it('returns the position the digit selects, zero based', () => {
-    expect(matchDigitIndex('workspace.selectByIndex', digit('1'), 'mac')).toBe(
-      0,
-    )
-    expect(matchDigitIndex('workspace.selectByIndex', digit('9'), 'mac')).toBe(
-      8,
-    )
-  })
-
-  it('fires for every digit, not just the one stored', () => {
-    expect(bindingsFor('workspace.selectByIndex', 'mac')).toEqual(['1'])
+  it('selects nothing now that the digits are unbound', () => {
+    expect(bindingsFor('workspace.selectByIndex', 'mac')).toEqual([])
     for (let value = 1; value <= 9; value++) {
       expect(
         matchDigitIndex('workspace.selectByIndex', digit(String(value)), 'mac'),
-      ).toBe(value - 1)
+      ).toBeNull()
     }
   })
 

--- a/console/web/src/lib/keybindings/registry.test.ts
+++ b/console/web/src/lib/keybindings/registry.test.ts
@@ -68,7 +68,7 @@ describe('the registry itself', () => {
 describe('lookup', () => {
   it('finds a definition by id', () => {
     expect(keybinding('palette.toggle').bindings).toEqual(['Mod+K'])
-    expect(bindingsFor('workspace.close', 'mac')).toEqual([])
+    expect(bindingsFor('workspace.close', 'mac')).toEqual(['Ctrl+W'])
   })
 
   it('resolves a per-platform binding list', () => {
@@ -83,13 +83,16 @@ describe('lookup', () => {
 
   it('spells a hover title with the key, or plain text for an unbound action', () => {
     expect(hoverTitle('New workspace', 'workspace.create', 'mac')).toBe(
-      'New workspace',
+      'New workspace (⌃ T)',
     )
-    expect(hoverTitle('Close', 'workspace.close', 'mac')).toBe('Close')
+    expect(hoverTitle('Close', 'workspace.close', 'other')).toBe(
+      'Close (alt W)',
+    )
     expect(hoverTitle('Search', 'palette.toggle', 'other')).toBe(
       'Search (ctrl K)',
     )
-    expect(hoverTitle('Chat', 'page.chat', 'mac')).toBe('Chat')
+    expect(hoverTitle('Chat', 'page.chat', 'mac')).toBe('Chat (⌃ G then C)')
+    expect(hoverTitle('Panels', 'panel.next', 'mac')).toBe('Panels')
   })
 
   it('says why a page may not take a key, or lets it', () => {
@@ -112,8 +115,9 @@ describe('lookup', () => {
     expect(bindingsFor('panel.previous', 'other')).toEqual([])
   })
 
-  it('lists no chords for unbound actions', () => {
-    expect(sequencesFor('page.workers', 'mac')).toEqual([])
+  it('lists the chords of a go-to sequence, and none for a plain chord', () => {
+    expect(sequencesFor('page.workers', 'mac')).toEqual([['Ctrl+G', 'W']])
+    expect(sequencesFor('page.workers', 'other')).toEqual([['Alt+G', 'W']])
     expect(sequencesFor('workspace.create', 'mac')).toEqual([])
   })
 })
@@ -182,12 +186,19 @@ describe('matchDigitIndex', () => {
     }
   }
 
-  it('selects nothing now that the digits are unbound', () => {
-    expect(bindingsFor('workspace.selectByIndex', 'mac')).toEqual([])
+  it('selects by position through the modifier, never a bare digit', () => {
+    expect(bindingsFor('workspace.selectByIndex', 'mac')).toEqual(['Ctrl+1'])
     for (let value = 1; value <= 9; value++) {
       expect(
         matchDigitIndex('workspace.selectByIndex', digit(String(value)), 'mac'),
       ).toBeNull()
+      expect(
+        matchDigitIndex(
+          'workspace.selectByIndex',
+          { ...digit(String(value)), ctrlKey: true },
+          'mac',
+        ),
+      ).toBe(value - 1)
     }
   })
 

--- a/console/web/src/lib/keybindings/registry.test.ts
+++ b/console/web/src/lib/keybindings/registry.test.ts
@@ -92,7 +92,7 @@ describe('lookup', () => {
       'Search (ctrl K)',
     )
     expect(hoverTitle('Chat', 'page.chat', 'mac')).toBe('Chat (⌃ G then C)')
-    expect(hoverTitle('Panels', 'panel.next', 'mac')).toBe('Panels')
+    expect(hoverTitle('Panels', 'panel.next', 'mac')).toBe('Panels (⌃ })')
   })
 
   it('says why a page may not take a key, or lets it', () => {
@@ -110,9 +110,9 @@ describe('lookup', () => {
     expect(shortcutClaimReason('Q L', 'mac')).toBeNull()
   })
 
-  it('exposes no key for an unbound action', () => {
-    expect(bindingsFor('panel.next', 'mac')).toEqual([])
-    expect(bindingsFor('panel.previous', 'other')).toEqual([])
+  it('steps panel focus with the modifier braces', () => {
+    expect(bindingsFor('panel.next', 'mac')).toEqual(['Ctrl+}'])
+    expect(bindingsFor('panel.previous', 'other')).toEqual(['Alt+{'])
   })
 
   it('lists the chords of a go-to sequence, and none for a plain chord', () => {

--- a/console/web/src/lib/keybindings/registry.ts
+++ b/console/web/src/lib/keybindings/registry.ts
@@ -101,18 +101,17 @@ export const KEYBINDINGS: readonly KeybindingDefinition[] = [
   // Windows and Linux, where the same menu item is ⌘N on a Mac and ctrl is
   // free. ctrl+P follows it rather than quietly eating Print on one platform
   // and meaning "previous" on the other.
-  // Bare keys, not chords. The browser has already taken almost every
-  // Mod+key worth having (see BROWSER_RESERVED and MAC_RESERVED), and a page
-  // that fights it ships shortcuts that silently do nothing. Single keys are
-  // free, they are what GitHub and Linear use for the same reason, and the
-  // console already had one in `?`. None of them fire while you are typing.
+  // These actions carry no keys of their own: bare single-key shortcuts kept
+  // firing under people's hands (any surface whose focus target is not
+  // literally an input leaks them), so the palette is the one way in. An
+  // empty bindings list keeps the action searchable in the palette and the
+  // definition addressable, without reserving a key.
   {
     id: 'workspace.selectByIndex',
     title: 'Select workspace 1 to 9',
     group: 'Workspace',
     scope: 'global',
-    bindings: ['1'],
-    digitIndex: true,
+    bindings: [],
     keywords: ['tab', 'switch', 'workspace'],
   },
   {
@@ -120,7 +119,7 @@ export const KEYBINDINGS: readonly KeybindingDefinition[] = [
     title: 'New workspace',
     group: 'Workspace',
     scope: 'global',
-    bindings: ['t'],
+    bindings: [],
     keywords: ['tab', 'new', 'create'],
   },
   {
@@ -128,7 +127,7 @@ export const KEYBINDINGS: readonly KeybindingDefinition[] = [
     title: 'Next workspace',
     group: 'Workspace',
     scope: 'global',
-    bindings: [']'],
+    bindings: [],
     keywords: ['tab', 'switch', 'cycle'],
   },
   {
@@ -136,7 +135,7 @@ export const KEYBINDINGS: readonly KeybindingDefinition[] = [
     title: 'Previous workspace',
     group: 'Workspace',
     scope: 'global',
-    bindings: ['['],
+    bindings: [],
     keywords: ['tab', 'switch', 'cycle'],
   },
   {
@@ -144,7 +143,7 @@ export const KEYBINDINGS: readonly KeybindingDefinition[] = [
     title: 'Close the workspace',
     group: 'Workspace',
     scope: 'global',
-    bindings: ['Shift+W'],
+    bindings: [],
     keywords: ['tab', 'close', 'remove'],
   },
   {
@@ -152,7 +151,7 @@ export const KEYBINDINGS: readonly KeybindingDefinition[] = [
     title: 'Split the workspace',
     group: 'Workspace',
     scope: 'global',
-    bindings: ['\\'],
+    bindings: [],
     keywords: ['panel', 'column', 'split'],
   },
   // Go-to chords: a prefix key, then a letter for the place. The prefix never
@@ -163,7 +162,7 @@ export const KEYBINDINGS: readonly KeybindingDefinition[] = [
     title: 'Go to chat',
     group: 'Go to',
     scope: 'global',
-    bindings: ['G C'],
+    bindings: [],
     keywords: ['chat', 'conversation', 'go', 'page'],
   },
   {
@@ -171,7 +170,7 @@ export const KEYBINDINGS: readonly KeybindingDefinition[] = [
     title: 'Go to workers',
     group: 'Go to',
     scope: 'global',
-    bindings: ['G W'],
+    bindings: [],
     keywords: ['workers', 'functions', 'go', 'page'],
   },
   {
@@ -179,7 +178,7 @@ export const KEYBINDINGS: readonly KeybindingDefinition[] = [
     title: 'Go to traces',
     group: 'Go to',
     scope: 'global',
-    bindings: ['G T'],
+    bindings: [],
     keywords: ['traces', 'spans', 'go', 'page'],
   },
   {
@@ -187,7 +186,7 @@ export const KEYBINDINGS: readonly KeybindingDefinition[] = [
     title: 'Focus the next panel',
     group: 'Workspace',
     scope: 'global',
-    bindings: ['}'],
+    bindings: [],
     keywords: ['panel', 'pane', 'focus', 'split'],
   },
   {
@@ -195,7 +194,7 @@ export const KEYBINDINGS: readonly KeybindingDefinition[] = [
     title: 'Focus the previous panel',
     group: 'Workspace',
     scope: 'global',
-    bindings: ['{'],
+    bindings: [],
     keywords: ['panel', 'pane', 'focus', 'split'],
   },
   {
@@ -203,7 +202,7 @@ export const KEYBINDINGS: readonly KeybindingDefinition[] = [
     title: 'Open settings',
     group: 'Console',
     scope: 'global',
-    bindings: [','],
+    bindings: [],
     keywords: ['configuration', 'preferences'],
   },
   {

--- a/console/web/src/lib/keybindings/registry.ts
+++ b/console/web/src/lib/keybindings/registry.ts
@@ -188,7 +188,7 @@ export const KEYBINDINGS: readonly KeybindingDefinition[] = [
     title: 'Focus the next panel',
     group: 'Workspace',
     scope: 'global',
-    bindings: [],
+    bindings: { mac: ['Ctrl+}'], other: ['Alt+}'] },
     keywords: ['panel', 'pane', 'focus', 'split'],
   },
   {
@@ -196,7 +196,7 @@ export const KEYBINDINGS: readonly KeybindingDefinition[] = [
     title: 'Focus the previous panel',
     group: 'Workspace',
     scope: 'global',
-    bindings: [],
+    bindings: { mac: ['Ctrl+{'], other: ['Alt+{'] },
     keywords: ['panel', 'pane', 'focus', 'split'],
   },
   {

--- a/console/web/src/lib/keybindings/registry.ts
+++ b/console/web/src/lib/keybindings/registry.ts
@@ -101,17 +101,19 @@ export const KEYBINDINGS: readonly KeybindingDefinition[] = [
   // Windows and Linux, where the same menu item is ⌘N on a Mac and ctrl is
   // free. ctrl+P follows it rather than quietly eating Print on one platform
   // and meaning "previous" on the other.
-  // These actions carry no keys of their own: bare single-key shortcuts kept
-  // firing under people's hands (any surface whose focus target is not
-  // literally an input leaks them), so the palette is the one way in. An
-  // empty bindings list keeps the action searchable in the palette and the
-  // definition addressable, without reserving a key.
+  // Modifier chords, not bare keys: single keys kept firing under people's
+  // hands (any surface whose focus target is not literally an input leaks
+  // them). The Mod tier is the browser's (see BROWSER_RESERVED), so these sit
+  // on the free tier whose `event.key` stays clean on both platforms: Ctrl on
+  // a Mac, Alt everywhere else (Option on a Mac mangles the key value, and
+  // Ctrl+T/W are the browser's own on Windows and Linux).
   {
     id: 'workspace.selectByIndex',
     title: 'Select workspace 1 to 9',
     group: 'Workspace',
     scope: 'global',
-    bindings: [],
+    bindings: { mac: ['Ctrl+1'], other: ['Alt+1'] },
+    digitIndex: true,
     keywords: ['tab', 'switch', 'workspace'],
   },
   {
@@ -119,7 +121,7 @@ export const KEYBINDINGS: readonly KeybindingDefinition[] = [
     title: 'New workspace',
     group: 'Workspace',
     scope: 'global',
-    bindings: [],
+    bindings: { mac: ['Ctrl+T'], other: ['Alt+T'] },
     keywords: ['tab', 'new', 'create'],
   },
   {
@@ -127,7 +129,7 @@ export const KEYBINDINGS: readonly KeybindingDefinition[] = [
     title: 'Next workspace',
     group: 'Workspace',
     scope: 'global',
-    bindings: [],
+    bindings: { mac: ['Ctrl+]'], other: ['Alt+]'] },
     keywords: ['tab', 'switch', 'cycle'],
   },
   {
@@ -135,7 +137,7 @@ export const KEYBINDINGS: readonly KeybindingDefinition[] = [
     title: 'Previous workspace',
     group: 'Workspace',
     scope: 'global',
-    bindings: [],
+    bindings: { mac: ['Ctrl+['], other: ['Alt+['] },
     keywords: ['tab', 'switch', 'cycle'],
   },
   {
@@ -143,7 +145,7 @@ export const KEYBINDINGS: readonly KeybindingDefinition[] = [
     title: 'Close the workspace',
     group: 'Workspace',
     scope: 'global',
-    bindings: [],
+    bindings: { mac: ['Ctrl+W'], other: ['Alt+W'] },
     keywords: ['tab', 'close', 'remove'],
   },
   {
@@ -151,7 +153,7 @@ export const KEYBINDINGS: readonly KeybindingDefinition[] = [
     title: 'Split the workspace',
     group: 'Workspace',
     scope: 'global',
-    bindings: [],
+    bindings: { mac: ['Ctrl+\\'], other: ['Alt+\\'] },
     keywords: ['panel', 'column', 'split'],
   },
   // Go-to chords: a prefix key, then a letter for the place. The prefix never
@@ -162,7 +164,7 @@ export const KEYBINDINGS: readonly KeybindingDefinition[] = [
     title: 'Go to chat',
     group: 'Go to',
     scope: 'global',
-    bindings: [],
+    bindings: { mac: ['Ctrl+G C'], other: ['Alt+G C'] },
     keywords: ['chat', 'conversation', 'go', 'page'],
   },
   {
@@ -170,7 +172,7 @@ export const KEYBINDINGS: readonly KeybindingDefinition[] = [
     title: 'Go to workers',
     group: 'Go to',
     scope: 'global',
-    bindings: [],
+    bindings: { mac: ['Ctrl+G W'], other: ['Alt+G W'] },
     keywords: ['workers', 'functions', 'go', 'page'],
   },
   {
@@ -178,7 +180,7 @@ export const KEYBINDINGS: readonly KeybindingDefinition[] = [
     title: 'Go to traces',
     group: 'Go to',
     scope: 'global',
-    bindings: [],
+    bindings: { mac: ['Ctrl+G T'], other: ['Alt+G T'] },
     keywords: ['traces', 'spans', 'go', 'page'],
   },
   {
@@ -202,7 +204,7 @@ export const KEYBINDINGS: readonly KeybindingDefinition[] = [
     title: 'Open settings',
     group: 'Console',
     scope: 'global',
-    bindings: [],
+    bindings: { mac: ['Ctrl+,'], other: ['Alt+,'] },
     keywords: ['configuration', 'preferences'],
   },
   {

--- a/console/web/src/lib/page-commands.test.ts
+++ b/console/web/src/lib/page-commands.test.ts
@@ -79,7 +79,7 @@ describe('page commands', () => {
     expect(paneCommands('pane-2')).toEqual([])
   })
 
-  it("refuses the console's own keys, digits and chord prefixes, keeps the row", () => {
+  it('refuses the palette chord and browser keys, keeps the freed keys', () => {
     registerPageCommands(
       {
         pageId: 'shell',
@@ -104,14 +104,14 @@ describe('page commands', () => {
     expect(
       getPageCommands().map((entry) => [entry.command.id, entry.bindings]),
     ).toEqual([
-      ['a', []],
-      ['b', []],
-      ['c', []],
+      ['a', ['t']],
+      ['b', ['5']],
+      ['c', ['G L']],
       ['d', []],
       ['e', []],
       ['f', ['P']],
     ])
-    expect(console.warn).toHaveBeenCalledTimes(5)
+    expect(console.warn).toHaveBeenCalledTimes(2)
   })
 
   it('lets a re-registration from the same pane replace the older one', () => {


### PR DESCRIPTION
## What

The console's bare single-key shortcuts kept firing under people's hands.
Any surface whose focus target is not literally an input element leaks them:
typing in a system-prompt editor, a diff, a canvas, and a stray `t` opens a
new workspace over unsaved work.

Every bare key moves onto a modifier chord. Literal `Cmd+T`/`Cmd+W` are not
available — the browser handles them before the page ever sees the event —
so the chords sit on the free tier whose `event.key` stays clean on both
platforms: **Ctrl on a Mac, Alt on Windows and Linux** (Option on a Mac
mangles the key value; Ctrl+T/W belong to the browser on the other two).

| Action | Was | Now (mac / other) |
| --- | --- | --- |
| Open the palette | `Mod+K` | `Mod+K` (unchanged) |
| New workspace | `t` | `Ctrl+T` / `Alt+T` |
| Close workspace | `Shift+W` | `Ctrl+W` / `Alt+W` |
| Next / previous workspace | `]` `[` | `Ctrl+]` `Ctrl+[` / `Alt+]` `Alt+[` |
| Select workspace 1-9 | `1`-`9` | `Ctrl+1`-`9` / `Alt+1`-`9` |
| Split the workspace | `\` | `Ctrl+\` / `Alt+\` |
| Go to chat / workers / traces | `G C` etc. | `Ctrl+G C` etc. / `Alt+G C` etc. |
| Open settings | `,` | `Ctrl+,` / `Alt+,` |
| Focus next / previous panel | `}` `{` | palette only |

Panel focus stays palette-only: a shifted bracket chord reports `}` as the
key value and would need its own matching rule for two rarely-used actions.

Worker pages are untouched: their page-command bindings are pane-scoped,
registered through the existing contract, and keep working as before — the
freed bare keys even become claimable by pages now.

The shortcuts overlay lists only actions that carry a key, hover titles
follow the new chords, and every action stays a palette command.

## How verified

- console/web: tsc clean, biome clean, production build passes.
- Keybinding suites updated and extended: bare `t`/`3`/`g` fire nothing,
  `Ctrl+T` creates a workspace, `Ctrl+3` selects by position, `Ctrl+G C`
  completes the go-to chord, `Mod+K` still opens the palette from anywhere,
  and page commands can claim the freed keys while `Mod+K` stays refused.
  1725 tests pass; the three failing files on this branch (icon sizes,
  redact-raw, trigger activity card) fail identically on a clean main
  checkout and are untouched here.

Refs MOT-4527.
