### PR TITLE
(MOT-4533) feat(browser): chat screenshots open full screen on click

### DIFF
--- a/browser/ui/package.json
+++ b/browser/ui/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@iii-dev/console-ui": "workspace:*",
-    "react-dom": "^19.2.8",
+    "react-dom": "^19.2.7",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/browser/ui/package.json
+++ b/browser/ui/package.json
@@ -10,10 +10,12 @@
   },
   "dependencies": {
     "@iii-dev/console-ui": "workspace:*",
+    "react-dom": "^19.2.8",
     "zod": "^4.0.0"
   },
   "devDependencies": {
     "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
     "esbuild": "^0.25.0",
     "react": "^19.2.6",
     "typescript": "^5.9.2",

--- a/browser/ui/src/function-trigger-message/index.tsx
+++ b/browser/ui/src/function-trigger-message/index.tsx
@@ -37,6 +37,7 @@ import {
   StylesWriteView,
 } from './BrowserViews'
 import { decodeBrowserResult } from './parsers'
+import { ZoomableImage } from '../lib/image-zoom'
 
 /** The injected page's route — where "open in browser tab" navigates. */
 const BROWSER_PAGE_HASH = '#/ext/browser'
@@ -71,7 +72,7 @@ function ScreenshotBody({ output }: { output: unknown }) {
   if (!screenshot?.dataUrl) return null
   return (
     <div className="br-ui-shot">
-      <img
+      <ZoomableImage
         src={screenshot.dataUrl}
         alt={`capture of ${screenshot.url}`}
         className="br-ui-shot-img"

--- a/browser/ui/src/function-trigger-message/scrapling/ScreenshotView.tsx
+++ b/browser/ui/src/function-trigger-message/scrapling/ScreenshotView.tsx
@@ -10,6 +10,7 @@ import {
   screenshotRequestSchema,
   screenshotResponseSchema,
 } from './parsers'
+import { ZoomableImage } from '../../lib/image-zoom'
 
 interface ScreenshotViewProps {
   input: unknown
@@ -76,11 +77,10 @@ export function ScreenshotView({
       </ActionLine>
       <div className="br-ui-scrape-gallery">
         {images.map((b, i) => (
-          <img
+          <ZoomableImage
             key={i}
             src={`data:${b.mime || mime};base64,${b.data}`}
             alt={caption || `screenshot of ${url || 'page'}`}
-            loading="lazy"
             className="br-ui-scrape-image"
           />
         ))}

--- a/browser/ui/src/lib/image-zoom.test.tsx
+++ b/browser/ui/src/lib/image-zoom.test.tsx
@@ -1,0 +1,19 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { ZoomableImage } from './image-zoom'
+
+describe('ZoomableImage', () => {
+  it('renders the thumbnail as a pressable image, closed by default', () => {
+    const html = renderToStaticMarkup(
+      <ZoomableImage
+        src="data:image/png;base64,AAAA"
+        alt="capture of example.com"
+        className="br-ui-shot-img"
+      />,
+    )
+    expect(html).toContain('role="button"')
+    expect(html).toContain('tabindex="0"')
+    expect(html).toContain('capture of example.com')
+    expect(html).not.toContain('zoom-out')
+  })
+})

--- a/browser/ui/src/lib/image-zoom.tsx
+++ b/browser/ui/src/lib/image-zoom.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+/** The overlay rides a portal to `document.body`, outside the injectable
+    UI's style scope, so it is styled inline rather than from styles.css. */
+const OVERLAY_STYLE: React.CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  zIndex: 2147483000,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  background: 'rgba(8, 8, 8, 0.88)',
+  cursor: 'zoom-out',
+}
+
+const IMAGE_STYLE: React.CSSProperties = {
+  maxWidth: '95vw',
+  maxHeight: '95vh',
+  objectFit: 'contain',
+  boxShadow: '0 8px 40px rgba(0, 0, 0, 0.6)',
+}
+
+/**
+ * A chat screenshot that opens full screen on click and closes on a click
+ * or Escape. Escape is caught in the capture phase and stopped, so closing
+ * the image never also closes a dialog behind it or reaches a shortcut.
+ */
+export function ZoomableImage({
+  src,
+  alt,
+  className,
+}: {
+  src: string
+  alt: string
+  className?: string
+}) {
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    if (!open) return
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return
+      event.stopPropagation()
+      event.preventDefault()
+      setOpen(false)
+    }
+    window.addEventListener('keydown', onKeyDown, true)
+    return () => window.removeEventListener('keydown', onKeyDown, true)
+  }, [open])
+
+  return (
+    <>
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: Enter is covered below */}
+      <img
+        src={src}
+        alt={alt}
+        className={className}
+        loading="lazy"
+        role="button"
+        tabIndex={0}
+        onClick={() => setOpen(true)}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter') setOpen(true)
+        }}
+      />
+      {open
+        ? createPortal(
+            <div
+              style={OVERLAY_STYLE}
+              data-keybindings-standdown=""
+              onClick={() => setOpen(false)}
+              role="presentation"
+            >
+              <img src={src} alt={alt} style={IMAGE_STYLE} />
+            </div>,
+            document.body,
+          )
+        : null}
+    </>
+  )
+}

--- a/browser/ui/styles.css
+++ b/browser/ui/styles.css
@@ -2224,6 +2224,7 @@
   border: 1px solid var(--color-rule-2);
   background: var(--color-paper-2);
   object-fit: contain;
+  cursor: zoom-in;
 }
 [data-iii-ui="browser"] .br-ui-scrape-num {
   font-variant-numeric: tabular-nums;
@@ -2400,6 +2401,7 @@
   max-width: 100%;
   max-height: 320px;
   border: 1px solid var(--color-rule);
+  cursor: zoom-in;
 }
 
 /* --- infra error view ------------------------------------------------ */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@iii-dev/console-ui':
         specifier: workspace:*
         version: link:../../packages/console-ui
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
       zod:
         specifier: ^4.0.0
         version: 4.4.3
@@ -48,6 +51,9 @@ importers:
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
       esbuild:
         specifier: ^0.25.0
         version: 0.25.12
@@ -6373,9 +6379,9 @@ snapshots:
       '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.7)
       '@storybook/csf-plugin': 10.5.3(storybook@10.5.3(@types/react@19.2.17)(react@19.2.7))(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0))
       '@storybook/icons': 2.1.0(react@19.2.7)
-      '@storybook/react-dom-shim': 10.5.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.5.3(@types/react@19.2.17)(react@19.2.7))
+      '@storybook/react-dom-shim': 10.5.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(storybook@10.5.3(@types/react@19.2.17)(react@19.2.7))
       react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react-dom: 19.2.8(react@19.2.7)
       storybook: 10.5.3(@types/react@19.2.17)(react@19.2.7)
       ts-dedent: 2.3.0
     optionalDependencies:
@@ -6415,6 +6421,15 @@ snapshots:
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
+      storybook: 10.5.3(@types/react@19.2.17)(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@storybook/react-dom-shim@10.5.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(storybook@10.5.3(@types/react@19.2.17)(react@19.2.7))':
+    dependencies:
+      react: 19.2.7
+      react-dom: 19.2.8(react@19.2.7)
       storybook: 10.5.3(@types/react@19.2.17)(react@19.2.7)
     optionalDependencies:
       '@types/react': 19.2.17
@@ -8317,6 +8332,11 @@ snapshots:
       - supports-color
 
   react-dom@19.2.7(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      scheduler: 0.27.0
+
+  react-dom@19.2.8(react@19.2.7):
     dependencies:
       react: 19.2.7
       scheduler: 0.27.0


### PR DESCRIPTION
## What

A screenshot in the chat transcript was a dead `<img>`: `browser::screenshot`
results and the scrapling screenshot gallery rendered inline at 320px with no
way to see them at full size.

Both now render through a small `ZoomableImage`: click (or focus + Enter)
opens the capture full screen, click anywhere or Escape closes it. The
overlay rides a portal to `document.body` — outside the injectable UI's
style scope, so it is styled inline — and Escape is caught in the capture
phase and stopped, so closing the image never also closes a dialog behind it
or reaches a console shortcut. The overlay declares
`data-keybindings-standdown` and the thumbnails advertise themselves with
`cursor: zoom-in`.

`react-dom` joins the package's dependencies (pinned to the workspace react
version), matching the other injectable UIs; the build already externalized
it.

## How verified

- browser/ui: tsc clean, build passes, 28 tests (new: the thumbnail renders
  as a pressable image and the overlay stays closed by default).
- On a rig, the console's served browser bundle carries the wired component
  (`zoom-in` on the thumbnail, the portal overlay, the standdown marker);
  the full click path is unit-covered rather than driven end to end.

Refs MOT-4533.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added click-to-zoom functionality for screenshots and scraped images.
  * Open images in a full-screen view and close them by clicking or pressing Escape.
  * Images can also be activated using the Enter key.

* **Style**
  * Added a zoom-in cursor to indicate images are interactive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->