### PR TITLE
(MOT-4527) fix(console,iii-directory): editor surfaces stand down, discard asks in-app

### DIFF
--- a/console/web/src/components/ui/CodeEditor.tsx
+++ b/console/web/src/components/ui/CodeEditor.tsx
@@ -332,6 +332,9 @@ export const CodeEditor = React.forwardRef<CodeEditorHandle, CodeEditorProps>(
           disabled && 'pointer-events-none opacity-40',
           className,
         )}
+        // Monaco's gutters, widgets and dead space are focus targets that are
+        // not inputs; every keystroke inside the editor is content.
+        data-keybindings-standdown=""
         onKeyDown={onKeyDown}
         onMouseDown={(e) => {
           // A caller-set min-height can leave dead space under the last

--- a/console/web/src/components/ui/FileDiff.tsx
+++ b/console/web/src/components/ui/FileDiff.tsx
@@ -145,6 +145,9 @@ export function FileDiff({
       edit={editing}
       editorOptions={editing ? editorOptions : undefined}
       className={cn('[--diffs-font-family:var(--font-code)]', className)}
+      // Read-mode diff text takes clicks and selection without input focus;
+      // a bare shortcut must not fire from inside it.
+      data-keybindings-standdown=""
       options={{
         diffStyle,
         overflow,

--- a/iii-directory/ui/src/page/browser.tsx
+++ b/iii-directory/ui/src/page/browser.tsx
@@ -308,8 +308,10 @@ export function CollectionBrowser({
   // A dirty draft asks in the console's own dialog, never window.confirm:
   // the native box blocks the whole tab and cannot say what is at stake
   // when the draft is a new, unnamed entry.
-  const [pendingDiscard, setPendingDiscard] = useState<{
-    label: string
+  const [pendingConfirm, setPendingConfirm] = useState<{
+    title: string
+    description: string
+    confirmLabel: string
     proceed: () => void
   } | null>(null)
   const guardDirty = useCallback((proceed: () => void) => {
@@ -317,8 +319,11 @@ export function CollectionBrowser({
       proceed()
       return
     }
-    setPendingDiscard({
-      label: selectedRef.current ?? 'this new entry',
+    const label = selectedRef.current ?? 'this new entry'
+    setPendingConfirm({
+      title: 'Discard unsaved changes?',
+      description: `The unsaved changes to ${label} will be lost.`,
+      confirmLabel: 'Discard',
       proceed,
     })
   }, [])
@@ -535,15 +540,17 @@ export function CollectionBrowser({
   const remove = useCallback(() => {
     if (readOnly || !adapter.remove || !loaded || creating || saving || deleting) return
     const key = loaded.key
-    const dirtyNote = dirty ? '\n\nYour unsaved changes will also be lost.' : ''
-    if (
-      !window.confirm(
-        `Delete ${adapter.noun} “${key}”? This removes its file and cannot be undone.${dirtyNote}`,
-      )
-    ) {
-      return
-    }
+    const dirtyNote = dirty ? ' Your unsaved changes will also be lost.' : ''
+    setPendingConfirm({
+      title: `Delete ${adapter.noun} “${key}”?`,
+      description: `This removes its file and cannot be undone.${dirtyNote}`,
+      confirmLabel: 'Delete',
+      proceed: () => removeNow(key),
+    })
+  }, [adapter, loaded, creating, saving, deleting, readOnly, dirty])
 
+  const removeNow = useCallback((key: string) => {
+    if (!adapter.remove) return
     setDeleting(true)
     setDeleteError(null)
     setSaveError(null)
@@ -583,16 +590,17 @@ export function CollectionBrowser({
 
   // Narrow-mode drill-out: back to the list, guarding an unsaved draft.
   const goBack = () => {
-    if (dirty && !window.confirm('Discard unsaved changes?')) return
-    removeStored(`${storageKey}:draft`)
-    setSelected(null)
-    setCreating(false)
-    setLoaded(null)
-    setDraft('')
-    setLoadError(null)
-    setSaveError(null)
-    setDeleteError(null)
-    setStaleOnDisk(false)
+    guardDirty(() => {
+      removeStored(`${storageKey}:draft`)
+      setSelected(null)
+      setCreating(false)
+      setLoaded(null)
+      setDraft('')
+      setLoadError(null)
+      setSaveError(null)
+      setDeleteError(null)
+      setStaleOnDisk(false)
+    })
   }
 
   // The collection's primary verbs, for the palette and for the keyboard
@@ -752,20 +760,16 @@ export function CollectionBrowser({
       onKeyDown={onRootKeyDown}
     >
       <ConfirmDialog
-        open={pendingDiscard !== null}
+        open={pendingConfirm !== null}
         onOpenChange={(next) => {
-          if (!next) setPendingDiscard(null)
+          if (!next) setPendingConfirm(null)
         }}
-        title="Discard unsaved changes?"
-        description={
-          pendingDiscard
-            ? `The unsaved changes to ${pendingDiscard.label} will be lost.`
-            : undefined
-        }
-        confirmLabel="Discard"
+        title={pendingConfirm?.title ?? ''}
+        description={pendingConfirm?.description}
+        confirmLabel={pendingConfirm?.confirmLabel}
         onConfirm={() => {
-          pendingDiscard?.proceed()
-          setPendingDiscard(null)
+          pendingConfirm?.proceed()
+          setPendingConfirm(null)
         }}
       />
       {showSide ? (

--- a/iii-directory/ui/src/page/browser.tsx
+++ b/iii-directory/ui/src/page/browser.tsx
@@ -27,6 +27,7 @@
 import {
   Button,
   CodeEditor,
+  ConfirmDialog,
   type Host,
   Input,
   MarkdownPreview,
@@ -304,6 +305,23 @@ export function CollectionBrowser({
 
   const dirtyRef = useRef(dirty)
   dirtyRef.current = dirty
+  // A dirty draft asks in the console's own dialog, never window.confirm:
+  // the native box blocks the whole tab and cannot say what is at stake
+  // when the draft is a new, unnamed entry.
+  const [pendingDiscard, setPendingDiscard] = useState<{
+    label: string
+    proceed: () => void
+  } | null>(null)
+  const guardDirty = useCallback((proceed: () => void) => {
+    if (!dirtyRef.current) {
+      proceed()
+      return
+    }
+    setPendingDiscard({
+      label: selectedRef.current ?? 'this new entry',
+      proceed,
+    })
+  }, [])
   const selectedRef = useRef(selected)
   selectedRef.current = selected
   const creatingRef = useRef(creating)
@@ -345,43 +363,42 @@ export function CollectionBrowser({
 
   const open = useCallback(
     (key: string, opts?: { reload?: boolean }) => {
-      if (!opts?.reload) {
-        // Re-clicking the open entry must not clobber the draft; switching
-        // away from an unsaved draft asks first.
-        if (key === selectedRef.current) return
-        if (
-          dirtyRef.current &&
-          !window.confirm(`Discard unsaved changes to ${selectedRef.current}?`)
-        ) {
-          return
-        }
-      }
       // Discard confirmed (or a reload): the persisted draft dies now, not
       // when the load lands — an unmount in between must not resurrect it.
-      removeStored(`${storageKey}:draft`)
-      setSelected(key)
-      setCreating(false)
-      setLoaded(null)
-      setDraft('')
-      setLoadError(null)
-      setSaveError(null)
-      setDeleteError(null)
-      setStaleOnDisk(false)
-      adapter
-        .load(host, key)
-        .then((content) => {
-          // Stale async result: the user opened another entry (or drilled
-          // out) while this load was in flight — applying it would show A's
-          // content under B's title and risk saving it there.
-          if (selectedRef.current !== key) return
-          setLoaded({ key, content })
-          setDraft(content)
-        })
-        .catch((e) => {
-          if (selectedRef.current === key) setLoadError(String(e))
-        })
+      const proceed = () => {
+        removeStored(`${storageKey}:draft`)
+        setSelected(key)
+        setCreating(false)
+        setLoaded(null)
+        setDraft('')
+        setLoadError(null)
+        setSaveError(null)
+        setDeleteError(null)
+        setStaleOnDisk(false)
+        adapter
+          .load(host, key)
+          .then((content) => {
+            // Stale async result: the user opened another entry (or drilled
+            // out) while this load was in flight — applying it would show A's
+            // content under B's title and risk saving it there.
+            if (selectedRef.current !== key) return
+            setLoaded({ key, content })
+            setDraft(content)
+          })
+          .catch((e) => {
+            if (selectedRef.current === key) setLoadError(String(e))
+          })
+      }
+      if (opts?.reload) {
+        proceed()
+        return
+      }
+      // Re-clicking the open entry must not clobber the draft; switching
+      // away from an unsaved draft asks first.
+      if (key === selectedRef.current) return
+      guardDirty(proceed)
     },
-    [host, adapter, storageKey],
+    [host, adapter, storageKey, guardDirty],
   )
 
   const appliedOpenRef = useRef(0)
@@ -395,22 +412,18 @@ export function CollectionBrowser({
       template, so the scaffold already counts as unsaved work and ⌘S/save is
       live immediately. */
   const startCreate = useCallback(() => {
-    if (
-      dirtyRef.current &&
-      !window.confirm(`Discard unsaved changes to ${selectedRef.current}?`)
-    ) {
-      return
-    }
-    removeStored(`${storageKey}:draft`)
-    setCreating(true)
-    setSelected(null)
-    setLoaded({ key: '', content: '' })
-    setDraft(NEW_TEMPLATE)
-    setLoadError(null)
-    setSaveError(null)
-    setDeleteError(null)
-    setStaleOnDisk(false)
-  }, [storageKey])
+    guardDirty(() => {
+      removeStored(`${storageKey}:draft`)
+      setCreating(true)
+      setSelected(null)
+      setLoaded({ key: '', content: '' })
+      setDraft(NEW_TEMPLATE)
+      setLoadError(null)
+      setSaveError(null)
+      setDeleteError(null)
+      setStaleOnDisk(false)
+    })
+  }, [storageKey, guardDirty])
 
   // External change (download / update from anywhere): refresh the list;
   // reload the open entry only when the editor has no unsaved edits.
@@ -738,6 +751,23 @@ export function CollectionBrowser({
       ref={rootRef}
       onKeyDown={onRootKeyDown}
     >
+      <ConfirmDialog
+        open={pendingDiscard !== null}
+        onOpenChange={(next) => {
+          if (!next) setPendingDiscard(null)
+        }}
+        title="Discard unsaved changes?"
+        description={
+          pendingDiscard
+            ? `The unsaved changes to ${pendingDiscard.label} will be lost.`
+            : undefined
+        }
+        confirmLabel="Discard"
+        onConfirm={() => {
+          pendingDiscard?.proceed()
+          setPendingDiscard(null)
+        }}
+      />
       {showSide ? (
         <PageSidebar
           label={`${adapter.noun} list`}


### PR DESCRIPTION
## What

A sweep of every worker UI for the keystroke-leak class behind the recent
shortcut reports found the same shape in ten workers: a page registers
single-key page commands, and its editor or diff surface hands the dispatcher
a non-input focus target, so a bare key typed mid-thought fires a command.
Fifteen pages mount the shared `CodeEditor`; none but the shell declared a
standdown surface.

Two component-level fixes close the class everywhere at once:

- **`CodeEditor` declares `data-keybindings-standdown` on its root.** Monaco's
  gutters, widgets and dead space are focus targets that are not inputs;
  every keystroke inside the editor now counts as typing for every consumer —
  console pages and all injectable worker UIs — including future ones.
- **`FileDiff` declares it too.** Read-mode diff text takes clicks and
  selection without input focus; it was the original report's surface.

And the dialog those reports surfaced alongside:

- **The directory browser's discard prompt was `window.confirm`,** blocking
  the tab and printing "Discard unsaved changes to null?" when the draft was
  a new, unnamed entry. It now asks through the console's `ConfirmDialog`,
  names the entry (or "this new entry"), and the switch-away and
  start-create paths share one guard.

## How verified

- console/web: tsc clean, biome clean, build passes, 65 ui-component tests.
- iii-directory/ui: build passes, 31 tests.
- The standdown contract itself is pinned by the existing dispatcher test
  ("stands down inside a declared standdown surface").

Refs MOT-4527.
