### PR TITLE
(MOT-4527) feat(console): the bare palette navigates; prefixes reach everything else

### DIFF
--- a/console/web/e2e/keyboard-first.spec.ts
+++ b/console/web/e2e/keyboard-first.spec.ts
@@ -53,7 +53,7 @@ test('the keyboard reaches the chat, the panes and every page command through âŒ
   // The palette lists the chat's commands under its name, with their keys.
   await page.keyboard.press('ControlOrMeta+k')
   const palette = page.getByRole('dialog')
-  await palette.getByRole('textbox').fill('focus the composer')
+  await palette.getByRole('textbox').fill('>focus the composer')
   const row = palette.getByRole('button', { name: /Chat: Focus the composer/ })
   await expect(row).toBeVisible()
   await expect(row.locator('kbd')).toHaveText('I')

--- a/console/web/src/components/CommandPalette.tsx
+++ b/console/web/src/components/CommandPalette.tsx
@@ -110,7 +110,7 @@ const EMPTY_SOURCES: readonly RegisteredPaletteSource[] = []
 function placeholderFor(prefix: string | null): string {
   if (prefix === '#') return 'File name…'
   if (prefix !== null) return 'Command…'
-  return 'Search, or type > for commands, # for files, @ for chats…'
+  return 'Go to a page, workspace or chat — > commands, # files, @ chats…'
 }
 
 function emptyText(
@@ -356,12 +356,14 @@ export function CommandPalette({
     ],
     [localEntries, engineEntries, sourceEntries, parsed],
   )
+  // Recents recall whatever was last chosen — a command included — even
+  // though the bare palette only searches navigation.
   const recentRows = useMemo(
     () =>
       parsed.text === '' && parsed.prefix === null && filter === 'all'
-        ? recentOf(results, recents)
+        ? recentOf([...localEntries, ...engineEntries], recents)
         : [],
-    [results, recents, parsed, filter],
+    [localEntries, engineEntries, recents, parsed, filter],
   )
   const groups = useMemo(
     () => groupEntries(results, recentRows),

--- a/console/web/src/components/workspace/use-screen-options.ts
+++ b/console/web/src/components/workspace/use-screen-options.ts
@@ -55,8 +55,8 @@ const EXT_PAGE_PRESENTATION: Readonly<Record<string, PagePresentation>> = {
   },
   directory: {
     icon: FolderTree,
-    description: 'Project files and directories.',
-    keywords: ['files', 'folders'],
+    description: 'Skills, prompts and system prompts.',
+    keywords: ['skills', 'prompts', 'system', 'system-prompts'],
   },
   editor: {
     icon: Code,

--- a/console/web/src/lib/palette/providers.test.ts
+++ b/console/web/src/lib/palette/providers.test.ts
@@ -6,7 +6,7 @@ import {
   searchPaletteSources,
 } from './providers'
 import { loadRecents, recentOf, recordRecent } from './recents'
-import { groupEntries, parseQuery, scoreEntry } from './sources'
+import { DEFAULT_KINDS, groupEntries, parseQuery, scoreEntry } from './sources'
 
 const noop = () => {}
 
@@ -28,10 +28,10 @@ describe('parseQuery', () => {
     expect(parseQuery('@standup', 'all').kinds).toEqual(new Set(['chat']))
   })
 
-  it('otherwise keeps the chip filter', () => {
+  it('otherwise searches navigation, or the chip filter', () => {
     expect(parseQuery(' open file ', 'all')).toEqual({
       prefix: null,
-      kinds: null,
+      kinds: new Set(DEFAULT_KINDS),
       text: 'open file',
     })
     expect(parseQuery('x', 'worker').kinds).toEqual(new Set(['worker']))

--- a/console/web/src/lib/palette/providers.test.ts
+++ b/console/web/src/lib/palette/providers.test.ts
@@ -102,6 +102,25 @@ describe('palette sources', () => {
     ])
   })
 
+  it("reaches a source through its own prefix even outside the mode's kinds", async () => {
+    registerPaletteSource('database', {
+      id: 'tables',
+      title: 'Tables',
+      kind: 'item',
+      prefix: '#',
+      search: async () => [{ id: 't', title: 'users', run: () => {} }],
+    })
+    const rows = await searchPaletteSources(getPaletteSources(), {
+      text: 'us',
+      prefix: '#',
+      kinds: new Set(['file']),
+      workingDir: null,
+      conversationId: null,
+      signal: new AbortController().signal,
+    })
+    expect(rows.map((entry) => entry.title)).toEqual(['users'])
+  })
+
   it('skips a source outside the mode and one that throws', async () => {
     registerPaletteSource('shell', files(['src/main.rs']))
     registerPaletteSource('other', {

--- a/console/web/src/lib/palette/providers.ts
+++ b/console/web/src/lib/palette/providers.ts
@@ -90,8 +90,11 @@ export async function searchPaletteSources(
   input: SourceSearchInput,
 ): Promise<PaletteEntry[]> {
   const asked = sources.filter(({ source }) => {
-    if (input.kinds && !input.kinds.has(source.kind)) return false
+    // A source's own prefix always reaches it, whatever kinds the mode
+    // carries: the bare palette only navigates, so a prefix (or a filter
+    // chip) is how a tables- or files-source gets asked at all.
     if (input.prefix !== null && input.prefix === source.prefix) return true
+    if (input.kinds && !input.kinds.has(source.kind)) return false
     return input.text.length >= (source.minQuery ?? 1)
   })
   // A source that ignores its abort signal must not hold the whole answer

--- a/console/web/src/lib/palette/sources.ts
+++ b/console/web/src/lib/palette/sources.ts
@@ -34,6 +34,19 @@ export type PaletteGroup = PaletteKind | 'recent'
  * and `/` commands, `#` files, `@` chats. The rest of the query is the
  * search text.
  */
+/**
+ * The bare palette is a navigator: it opens pages, workspaces and chats, and
+ * jumps to a worker's view. Commands, actions, functions and files answer
+ * only behind their prefix (or an explicit filter chip), so typing a page's
+ * name is never buried under everything that mentions it.
+ */
+export const DEFAULT_KINDS: readonly PaletteKind[] = [
+  'page',
+  'workspace',
+  'chat',
+  'worker',
+]
+
 export const PREFIX_MODES: Record<string, readonly PaletteKind[]> = {
   '>': ['command', 'action'],
   '/': ['command', 'action'],
@@ -58,7 +71,7 @@ export function parseQuery(
   }
   return {
     prefix: null,
-    kinds: filter === 'all' ? null : new Set([filter]),
+    kinds: filter === 'all' ? new Set(DEFAULT_KINDS) : new Set([filter]),
     text: raw.trim(),
   }
 }
@@ -287,14 +300,14 @@ export const KIND_LABEL: Record<PaletteGroup, string> = {
 
 /** Group in a fixed order so the list does not reshuffle as scores change. */
 export const KIND_ORDER: PaletteKind[] = [
+  'page',
+  'workspace',
+  'chat',
+  'worker',
   'file',
   'command',
   'action',
-  'workspace',
-  'page',
-  'chat',
   'item',
-  'worker',
   'function',
 ]
 

--- a/docs/sops/injectable-console-ui.md
+++ b/docs/sops/injectable-console-ui.md
@@ -486,19 +486,22 @@ function Page({ commands }: PageRenderProps) {
 ```
 
 Keys a page may take: anything the console does not already use. The
-console's own keys (`1`–`9`, `t`, `[`, `]`, `Shift+W`, `\`, `,`, `{`, `}`,
-`Mod+K`), the prefix of any go-to chord (`G`) and the chords the browser owns
-(`Mod+W`, `Mod+T`, `Mod+1`…) are refused at registration with a
-`console.warn`; the row stays, without a key. Single letters and chords
-(`Q L`) are fine; the typing guard keeps them out of fields unless the
-command says `firesWhileTyping`, and a field can hand specific commands back
-with `data-keybindings-allow="<pageId>.<id>"`.
+console keeps `Mod+K` and its modifier chords (Ctrl on a Mac, Alt elsewhere:
+`Ctrl+T`, `Ctrl+W`, `Ctrl+[`/`]`, `Ctrl+{`/`}`, `Ctrl+1`-`9`, `Ctrl+\`,
+`Ctrl+,`, and the `Ctrl+G` go-to prefix), and the browser owns its own
+(`Mod+W`, `Mod+T`, `Mod+1`…); those are refused at registration with a
+`console.warn` and the row stays, without a key. Bare single letters, digits
+and chords (`Q L`) are the page's to take; the typing guard keeps them out
+of fields unless the command says `firesWhileTyping`, a
+`data-keybindings-standdown` surface swallows them entirely, and a field can
+hand specific commands back with `data-keybindings-allow="<pageId>.<id>"`.
 
 Focus follows the keyboard: opening a page from `⌘K`, a go-to chord or
 `host.panels.open` moves focus into its pane — the first `[data-autofocus]`
 element inside it, else the pane root — so the next keystroke is already
 the page's. Mark the element a page wants focused on arrival with
-`data-autofocus`. `{` / `}` step focus across panes.
+`data-autofocus`. `Ctrl+{` / `Ctrl+}` (mac; `Alt+` elsewhere) step focus
+across panes.
 
 **`host.palette.registerSource(source)`** — a live source: rows computed per
 query by the worker, the way an editor's quick open lists files as you type.
@@ -524,7 +527,10 @@ host.palette?.registerSource({
 })
 ```
 
-The palette asks every source that fits the mode, debounced, and drops an
+The bare palette is a navigator — no prefix searches only pages,
+workspaces, chats and workers — so a source whose kind is `item` or `file`
+is asked under its prefix or the matching filter chip, never from the bare
+query. The palette asks every source that fits, debounced, and drops an
 answer to a query it has moved past (`signal`). A source that throws
 contributes nothing; the others still answer. Rows open the page with a
 context the page already understands through `panelContext`.

--- a/docs/sops/injectable-console-ui.md
+++ b/docs/sops/injectable-console-ui.md
@@ -452,8 +452,8 @@ the console's.
 The dispatcher already yields to a caret in an `input`, `textarea`, `select`,
 or contentEditable node. Anything else that consumes raw keystrokes — a code
 editor's gutters and widgets, a read-mode diff, a drawing surface — gives the
-dispatcher a plain element as the event target, and a bare binding like `t`
-(new workspace) fires mid-thought. Declare the surface:
+dispatcher a plain element as the event target, and a bare page binding
+(a `t`, a digit) fires mid-thought. Declare the surface:
 
 ```tsx
 <div className="my-editor-body" data-keybindings-standdown="">…</div>


### PR DESCRIPTION
## What

⌘K mixed everything it knew into one list: typing a page's name surfaced
every command, action and function that mentioned it, and the Pages group
sat far down the reading order. Typing "shell" should open the shell page,
not present a million things that merely involve the shell.

The bare palette is now a navigator. With no prefix it searches only the
things you go to — pages, workspaces, chats, and workers (their view on the
workers page) — grouped in that order, so a page's name is its top hit.

The prefix modes are the ones the palette has had all along, unchanged —
they just become the only way to the non-navigation kinds instead of a
shortcut past the pile:

- `>` or `/` — commands and actions
- `#` — files
- `@` — chats
- the filter chips — any single kind, functions included

Two consequences handled with it:

- A live palette source whose kind is not navigation (a tables source, a
  files source) would have been unreachable: the kind gate ran before the
  source's own prefix was consulted. The gates now check the prefix first —
  a source's prefix always reaches it, the bare mode still never asks it —
  with a test pinning the order.
- The injectable-console-ui SOP still described the retired bare-key world
  ("the console's own keys: 1-9, t, [, ] …"). Its claims section, the
  pane-focus keys and the palette-source contract now match the shipped
  behaviour.

The placeholder teaches the split ("Go to a page, workspace or chat — >
commands, # files, @ chats…"), and the empty query's Recent rows still
recall whatever was last chosen — a command included — since recents are
memory, not search.

## How verified

- console/web: tsc clean, biome clean, build passes; palette suites green
  (23 palette tests including the new gate-order pin; the two failing files
  on this branch fail identically on a clean main checkout and are
  untouched).
- Live on a rig: "shell" puts the shell page first with no command rows;
  ">" still reaches page commands; the e2e keyboard-first flow follows the
  new contract.

Refs MOT-4527.
