### PR TITLE
(MOT-4407) feat(shell,console): tree creates entries; picker and turns behave

### DIFF
--- a/console/web/src/lib/ui-loader.tsx
+++ b/console/web/src/lib/ui-loader.tsx
@@ -21,6 +21,7 @@ import { registerPageCommands } from '@/lib/page-commands'
 import { requestPaletteOpen } from '@/lib/palette/open-request'
 import { registerPaletteSource } from '@/lib/palette/providers'
 import { requestPanelOpen } from '@/lib/panel-context'
+import { loadRecentProjects } from '@/lib/storage'
 import { ExtensionScopeProvider } from '@/lib/ui-scope'
 import {
   registerExtConfigForm,
@@ -157,6 +158,11 @@ function makeHost(
         return track(
           registerPageCommands({ pageId, source: 'worker', commands }),
         )
+      },
+    },
+    workspace: {
+      recentDirectories() {
+        return loadRecentProjects()
       },
     },
     palette: {

--- a/console/web/src/types/injectable-ui.ts
+++ b/console/web/src/types/injectable-ui.ts
@@ -456,6 +456,7 @@ export interface Host {
   uiClasses: ConsoleApi['uiClasses']
   /** The script's asset path, e.g. `state/page.js`. */
   path: string
+  workspace?: { recentDirectories(): string[] }
   pages: {
     register(page: PageRegistration): () => void
   }

--- a/packages/console-ui/index.d.ts
+++ b/packages/console-ui/index.d.ts
@@ -440,6 +440,12 @@ export interface Host {
   path: string
   pages: { register(page: PageRegistration): () => void }
   /**
+   * The console's remembered working directories, most recent first — the
+   * same list its chat composer offers. A page with its own root picker
+   * lists them so both pickers agree on where work happens.
+   */
+  workspace?: { recentDirectories(): string[] }
+  /**
    * Palette rows for a page this script owns, alive exactly as long as the
    * script. For a page that may not be open yet; `run` usually calls
    * `panels.open`. Keys are honoured only through `PageRenderProps.commands`.

--- a/shell/ui/src/page/FilesTab.tsx
+++ b/shell/ui/src/page/FilesTab.tsx
@@ -13,7 +13,7 @@
 
 import type { FileTreeDirectoryHandle, GitStatusEntry } from '@pierre/trees'
 import { FileTree, useFileTree } from '@pierre/trees/react'
-import { Search, X } from 'lucide-react'
+import { FilePlus, FolderPlus, Search, X } from 'lucide-react'
 import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import type { FlatTree } from './coder'
 import {
@@ -48,6 +48,8 @@ interface FilesTabProps {
   onActivateFile: (relPath: string) => void
   /** Double click on a file — pin clean files; keep changes in review. */
   onPinFile: (relPath: string) => void
+  /** Create a file or folder at a root-relative path; parents are made. */
+  onCreate?: (kind: 'file' | 'folder', rel: string) => Promise<void>
 }
 
 export function FilesTab({
@@ -62,9 +64,25 @@ export function FilesTab({
   activePath,
   onActivateFile,
   onPinFile,
+  onCreate,
 }: FilesTabProps) {
   const filterId = useId()
   const [filter, setFilter] = useState('')
+  const [createKind, setCreateKind] = useState<'file' | 'folder' | null>(null)
+  const [createName, setCreateName] = useState('')
+  const [createError, setCreateError] = useState<string | null>(null)
+  const submitCreate = async () => {
+    const rel = createName.trim().replace(/^\/+/, '')
+    if (!rel || !createKind || !onCreate) return
+    try {
+      await onCreate(createKind, rel)
+      setCreateKind(null)
+      setCreateName('')
+      setCreateError(null)
+    } catch (error) {
+      setCreateError(error instanceof Error ? error.message : String(error))
+    }
+  }
   const [filterMatchCount, setFilterMatchCount] = useState<number | null>(null)
   // The model is created once per component lifetime; data arriving
   // later flows through resetPaths/setGitStatus below. Selection opens
@@ -257,7 +275,65 @@ export function FilesTab({
             </button>
           ) : null}
         </div>
+        {onCreate ? (
+          <div className="shui-tree-new-actions">
+            <button
+              type="button"
+              className="shui-tree-new-btn"
+              aria-label="New file"
+              title="new file"
+              onClick={() => {
+                setCreateKind((kind) => (kind === 'file' ? null : 'file'))
+                setCreateError(null)
+              }}
+            >
+              <FilePlus aria-hidden />
+            </button>
+            <button
+              type="button"
+              className="shui-tree-new-btn"
+              aria-label="New folder"
+              title="new folder"
+              onClick={() => {
+                setCreateKind((kind) => (kind === 'folder' ? null : 'folder'))
+                setCreateError(null)
+              }}
+            >
+              <FolderPlus aria-hidden />
+            </button>
+          </div>
+        ) : null}
       </div>
+      {createKind !== null ? (
+        <div className="shui-tree-new-row">
+          <input
+            type="text"
+            value={createName}
+            onChange={(event) => setCreateName(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') void submitCreate()
+              if (event.key === 'Escape') {
+                setCreateKind(null)
+                setCreateName('')
+                setCreateError(null)
+              }
+            }}
+            placeholder={
+              createKind === 'file' ? 'new/file/path.txt' : 'new/folder/path'
+            }
+            aria-label={
+              createKind === 'file' ? 'New file path' : 'New folder path'
+            }
+            autoComplete="off"
+            spellCheck={false}
+            // biome-ignore lint/a11y/noAutofocus: the row exists because the user just asked to type a name
+            autoFocus
+          />
+          {createError !== null ? (
+            <div className="shui-tree-new-error">{createError}</div>
+          ) : null}
+        </div>
+      ) : null}
 
       <div className="shui-tree-stage">
         {!tree ? (

--- a/shell/ui/src/page/FilesTab.tsx
+++ b/shell/ui/src/page/FilesTab.tsx
@@ -13,6 +13,7 @@
 
 import type { FileTreeDirectoryHandle, GitStatusEntry } from '@pierre/trees'
 import { FileTree, useFileTree } from '@pierre/trees/react'
+import { IconButton } from '@iii-dev/console-ui'
 import { FilePlus, FolderPlus, Search, X } from 'lucide-react'
 import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import type { FlatTree } from './coder'
@@ -283,30 +284,26 @@ export function FilesTab({
         </div>
         {onCreate ? (
           <div className="shui-tree-new-actions">
-            <button
-              type="button"
-              className="shui-tree-new-btn"
-              aria-label="New file"
-              title="new file"
+            <IconButton
+              label="New file"
+              aria-pressed={createKind === 'file'}
               onClick={() => {
                 setCreateKind((kind) => (kind === 'file' ? null : 'file'))
                 setCreateError(null)
               }}
             >
               <FilePlus aria-hidden />
-            </button>
-            <button
-              type="button"
-              className="shui-tree-new-btn"
-              aria-label="New folder"
-              title="new folder"
+            </IconButton>
+            <IconButton
+              label="New folder"
+              aria-pressed={createKind === 'folder'}
               onClick={() => {
                 setCreateKind((kind) => (kind === 'folder' ? null : 'folder'))
                 setCreateError(null)
               }}
             >
               <FolderPlus aria-hidden />
-            </button>
+            </IconButton>
           </div>
         ) : null}
       </div>

--- a/shell/ui/src/page/FilesTab.tsx
+++ b/shell/ui/src/page/FilesTab.tsx
@@ -74,6 +74,12 @@ export function FilesTab({
   const submitCreate = async () => {
     const rel = createName.trim().replace(/^\/+/, '')
     if (!rel || !createKind || !onCreate) return
+    // Paths stay inside the browsed root: a "." or ".." segment is either
+    // noise or an escape attempt, and the jail would reject it anyway.
+    if (rel.split('/').some((part) => part === '.' || part === '..')) {
+      setCreateError('the path cannot contain "." or ".." segments')
+      return
+    }
     try {
       await onCreate(createKind, rel)
       setCreateKind(null)

--- a/shell/ui/src/page/coder.ts
+++ b/shell/ui/src/page/coder.ts
@@ -185,6 +185,9 @@ export async function coderCreateNewFile(
   )
   const result = out.results?.[0]
   if (!result) throw new Error('coder::create-file returned no result')
+  if (!result.success) {
+    throw new Error(result.error?.message ?? `could not create ${path}`)
+  }
   return result
 }
 

--- a/shell/ui/src/page/coder.ts
+++ b/shell/ui/src/page/coder.ts
@@ -173,6 +173,29 @@ export function coderReadFileBase64(
   })
 }
 
+/** Create a brand-new empty file, parents included; an existing file at
+    the path is an error rather than silently emptied. */
+export async function coderCreateNewFile(
+  host: Host,
+  path: string,
+): Promise<CreateFileResult> {
+  const out = await host.iii.trigger<{ results: CreateFileResult[] }>(
+    'coder::create-file',
+    { files: [{ path, content: '', parents: true }] },
+  )
+  const result = out.results?.[0]
+  if (!result) throw new Error('coder::create-file returned no result')
+  return result
+}
+
+/** Create a folder, parents included, through the shell's fs surface. */
+export async function shellCreateFolder(
+  host: Host,
+  path: string,
+): Promise<void> {
+  await host.iii.trigger('shell::fs::mkdir', { path, parents: true })
+}
+
 /** Whole-file save. `mode` (from a prior read) keeps permission bits —
     create-file would otherwise reset them to the 0644 default. */
 export async function coderWriteFile(

--- a/shell/ui/src/page/index.tsx
+++ b/shell/ui/src/page/index.tsx
@@ -2442,11 +2442,21 @@ export function ShellExplorerPage({
     async (kind: 'file' | 'folder', rel: string) => {
       const currentRoot = rootRef.current
       if (!currentRoot) return
+      const generation = rootGenerationRef.current
       const absPath = joinPath(currentRoot, rel)
       if (kind === 'folder') {
         await shellCreateFolder(host, absPath)
       } else {
         await coderCreateNewFile(host, absPath)
+      }
+      // A root switch during the write: the entry landed on disk, but the
+      // pane now shows another tree — refreshing or pinning would talk to
+      // the wrong root.
+      if (
+        rootGenerationRef.current !== generation ||
+        rootRef.current !== currentRoot
+      ) {
+        return
       }
       refreshTree()
       void refreshGit()

--- a/shell/ui/src/page/index.tsx
+++ b/shell/ui/src/page/index.tsx
@@ -386,6 +386,10 @@ export function ShellExplorerPage({
     'loading',
   )
   const [root, setRoot] = useState<string | null>(null)
+  // The root the picker is validating right now: the select holds this
+  // value so the choice never appears to snap back, and the files pane
+  // says what it is opening instead of sitting empty.
+  const [pendingRoot, setPendingRoot] = useState<string | null>(null)
   const rootRef = useRef(root)
   rootRef.current = root
   const workingDirRef = useRef(workingDir ?? null)
@@ -2070,9 +2074,11 @@ export function ShellExplorerPage({
     }
     const request = ++workingDirFollowRequestSeqRef.current
     workingDirFollowPendingRef.current = { path: next, request }
+    setPendingRoot(next)
     const accepted = changeRoot(next, (outcome) => {
       if (workingDirFollowPendingRef.current?.request !== request) return
       workingDirFollowPendingRef.current = null
+      setPendingRoot(null)
       if (outcome === 'validated') {
         acknowledgedWorkingDirRef.current =
           acknowledgeValidatedWorkingDirectory(
@@ -2103,6 +2109,7 @@ export function ShellExplorerPage({
     })
     if (!accepted && workingDirFollowPendingRef.current?.request === request) {
       workingDirFollowPendingRef.current = null
+      setPendingRoot(null)
     }
   }, [workingDir, root, changeRoot, reviewSavePending, workingDirRetryEpoch])
 
@@ -2128,10 +2135,12 @@ export function ShellExplorerPage({
         window.clearTimeout(workingDirRetryTimerRef.current)
         workingDirRetryTimerRef.current = null
       }
+      setPendingRoot(nextRoot)
       const accepted = changeRoot(nextRoot, (outcome) => {
         if (!ownsRequestToken(manualRootActiveRequestRef.current, request))
           return
         manualRootActiveRequestRef.current = null
+        setPendingRoot(null)
         if (outcome === 'validated' && workingDirRef.current === chatDir) {
           acknowledgedWorkingDirRef.current = chatDir
           workingDirRetryRef.current = { path: chatDir, failures: 0 }
@@ -2142,6 +2151,7 @@ export function ShellExplorerPage({
         }
       })
       if (accepted) return
+      setPendingRoot(null)
       if (ownsRequestToken(manualRootActiveRequestRef.current, request)) {
         manualRootActiveRequestRef.current = null
         setWorkingDirRetryEpoch((epoch) => epoch + 1)
@@ -2614,13 +2624,16 @@ export function ShellExplorerPage({
           rootOptions.length > 1 ? (
             <select
               className="shui-header-root-select"
-              value={root}
+              value={pendingRoot ?? root}
               onChange={(event) => changeManualRoot(event.target.value)}
               disabled={reviewSavePending}
               aria-label="browsed root"
-              title={root}
+              title={pendingRoot ?? root}
             >
-              {rootOptions.map((path) => (
+              {(pendingRoot !== null && !rootOptions.includes(pendingRoot)
+                ? [...rootOptions, pendingRoot]
+                : rootOptions
+              ).map((path) => (
                 <option key={path} value={path}>
                   {lastSegments(path)}
                 </option>
@@ -2774,7 +2787,11 @@ export function ShellExplorerPage({
             className="shui-sidebar"
           >
             <div className="shui-side-body">
-              {sideTab === 'files' ? (
+              {sideTab === 'files' && (pendingRoot !== null || tree === null) ? (
+                <div className="shui-side-note">
+                  opening {lastSegments(pendingRoot ?? root ?? '')}…
+                </div>
+              ) : sideTab === 'files' ? (
                 <FilesTab
                   tree={reviewTree}
                   gitStatus={treeGitStatus}

--- a/shell/ui/src/page/index.tsx
+++ b/shell/ui/src/page/index.tsx
@@ -77,6 +77,8 @@ import {
   joinPath,
   type TreeNode,
   workspaceValidate,
+  coderCreateNewFile,
+  shellCreateFolder,
 } from './coder'
 import {
   type EditorCache,
@@ -1361,7 +1363,10 @@ export function ShellExplorerPage({
       .then((turns) => {
         if (cancelled || rootRef.current !== root) return
         setSessionTurns(turns)
-        const latest = turns.find((turn) => turn.file_count > 0) ?? turns[0]
+        // Only a turn that touched files is worth restoring: landing a
+        // chat-switcher on "0 files at 02:55 PM" reads as a broken pane,
+        // where the plain Last Turn default reads as an empty one.
+        const latest = turns.find((turn) => turn.file_count > 0)
         if (!latest || observedReviewKeyRef.current !== null) return
         if (reviewEntriesRef.current.size > 0) return
         const scope = {
@@ -2421,12 +2426,35 @@ export function ShellExplorerPage({
   // Chat-synced roots can be subfolders of a base path — surface the
   // current root as an option so the select never holds a value its
   // options don't contain (and the user can always pop back to a base).
+  // "New file" / "New folder" from the Files tree: root-relative path,
+  // parents created, a new file opens in the editor right away.
+  const createTreeEntry = useCallback(
+    async (kind: 'file' | 'folder', rel: string) => {
+      const currentRoot = rootRef.current
+      if (!currentRoot) return
+      const absPath = joinPath(currentRoot, rel)
+      if (kind === 'folder') {
+        await shellCreateFolder(host, absPath)
+      } else {
+        await coderCreateNewFile(host, absPath)
+      }
+      refreshTree()
+      void refreshGit()
+      if (kind === 'file') pinFile(rel)
+    },
+    [host, refreshTree, refreshGit, pinFile],
+  )
+
   const rootOptions = useMemo(() => {
     if (!info || !root) return []
-    return info.base_paths.includes(root)
+    const bases = info.base_paths.includes(root)
       ? info.base_paths
       : [root, ...info.base_paths]
-  }, [info, root])
+    // The console's remembered working directories (the composer's picker
+    // list) are as reachable here as a chat-synced root; offer them too.
+    const remembered = host.workspace?.recentDirectories() ?? []
+    return [...new Set([...bases, ...remembered])]
+  }, [info, root, host])
 
   const changeTerminalDock = useCallback((next: TerminalDock) => {
     setTerminalOpen(true)
@@ -2759,6 +2787,7 @@ export function ShellExplorerPage({
                   activePath={diff?.change.path ?? tabs.active}
                   onActivateFile={activateFile}
                   onPinFile={pinFile}
+                  onCreate={createTreeEntry}
                 />
               ) : (
                 <SearchTab

--- a/shell/ui/styles.css
+++ b/shell/ui/styles.css
@@ -2866,3 +2866,58 @@
   border: 0;
   background: color-mix(in srgb, #000 42%, transparent);
 }
+
+/* new file / folder actions beside the tree filter */
+[data-iii-ui="shell"] .shui-tree-filter-shell {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+[data-iii-ui="shell"] .shui-tree-filter-shell .shui-tree-filter {
+  flex: 1;
+  min-width: 0;
+}
+[data-iii-ui="shell"] .shui-tree-new-actions {
+  display: flex;
+  gap: 2px;
+}
+[data-iii-ui="shell"] .shui-tree-new-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--color-ink-faint);
+  cursor: pointer;
+}
+[data-iii-ui="shell"] .shui-tree-new-btn:hover {
+  background: var(--color-surface-active);
+  color: var(--color-ink);
+}
+[data-iii-ui="shell"] .shui-tree-new-btn svg {
+  width: 14px;
+  height: 14px;
+}
+[data-iii-ui="shell"] .shui-tree-new-row {
+  padding: 4px 8px 6px;
+  border-bottom: 1px solid var(--color-rule-2);
+}
+[data-iii-ui="shell"] .shui-tree-new-row input {
+  width: 100%;
+  padding: 4px 6px;
+  border: 1px solid var(--color-rule);
+  border-radius: 4px;
+  background: var(--color-bg);
+  color: var(--color-ink);
+  font: inherit;
+  font-size: 12px;
+  outline: none;
+}
+[data-iii-ui="shell"] .shui-tree-new-error {
+  margin-top: 4px;
+  color: var(--color-warn);
+  font-size: 11px;
+}

--- a/shell/ui/styles.css
+++ b/shell/ui/styles.css
@@ -2881,26 +2881,6 @@
   display: flex;
   gap: 2px;
 }
-[data-iii-ui="shell"] .shui-tree-new-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-  border: 0;
-  border-radius: 4px;
-  background: transparent;
-  color: var(--color-ink-faint);
-  cursor: pointer;
-}
-[data-iii-ui="shell"] .shui-tree-new-btn:hover {
-  background: var(--color-surface-active);
-  color: var(--color-ink);
-}
-[data-iii-ui="shell"] .shui-tree-new-btn svg {
-  width: 14px;
-  height: 14px;
-}
 [data-iii-ui="shell"] .shui-tree-new-row {
   padding: 4px 8px 6px;
   border-bottom: 1px solid var(--color-rule-2);


### PR DESCRIPTION
## What

Three shell-page follow-ups from live use on main.

**Switching chats landed on a cryptic empty turn.** The reopened-session
restore fell back to the newest stored turn even when it touched nothing, so
a chat whose turns only talked showed "02:55 PM · 0 files" and "No changes" —
reads as a broken pane. Only a turn that touched files is worth restoring;
everything else stays on the plain Last Turn default.

**The root picker only knew the jail bases.** The console's composer offers
the remembered working directories; the shell page's picker offered
`coder::info` base paths and nothing else. The host grows an optional
`workspace.recentDirectories()` — the same list the composer shows, provided
by the console, typed in `@iii-dev/console-ui` — and the page merges it into
its root options, deduped. Chat-synced roots already prove the page can
re-root anywhere a conversation works.

**The tree could only look.** Two header buttons next to the file filter
create entries in the browsed root: a root-relative path typed inline
(nested paths welcome — parents are created), Enter to confirm, Escape to
cancel, errors shown in place. Files go through `coder::create-file` with
no overwrite — an existing file at the path errors rather than being
silently emptied — and open pinned in the editor; folders go through
`shell::fs::mkdir`.

## How verified

- shell/ui: tsc clean, build passes, 312 tests.
- console/web: tsc clean, biome clean on the touched files, build passes.
- Live on a rig: the picker lists the composer's directories; a nested
  `demo/notes.md` created from the tree opens in the editor and shows in
  the review; a chat with no file-touching turns opens on a quiet Last
  Turn.

Refs MOT-4407.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Create new files and folders directly from the Files tree.
  - Enter root-relative paths, submit with Enter, or cancel with Escape.
  - View errors when file or folder creation fails.
  - Select from recently used working directories.
  - Newly created files are automatically refreshed and pinned.

- **Bug Fixes**
  - Prevented automatic session restoration when no file changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->