### PR TITLE
(MOT-4533) feat(browser): a new session pulls the browser page into the workspace

### DIFF
--- a/browser/oracle/manifest.json
+++ b/browser/oracle/manifest.json
@@ -1,8 +1,8 @@
 {
   "format": 1,
   "source": {
-    "version": "0.2.7",
-    "sha256": "a9ffef811b02bdaa27c83fb8a5bdff7196adfc73a22827532282ff42851cb081",
+    "version": "0.2.8",
+    "sha256": "70cb988ef589429d0f6137a7884dd9eb4ee12446cb711e69cc808ae0950c5f6b",
     "files": [
       {
         "path": "scrapling/src/__init__.py",
@@ -41,8 +41,8 @@
       },
       {
         "path": "scrapling/src/schemas.py",
-        "size": 19648,
-        "sha256": "623202d3bdb1fe6b9894688d12ba073af00759f14b58468c00f8d3b943fcc2d9"
+        "size": 19877,
+        "sha256": "277c462dd70065eb443926a811243e3a3f658636274a20db8dc9c487823afe2b"
       },
       {
         "path": "scrapling/src/sessions.py",

--- a/browser/oracle/manifest.json
+++ b/browser/oracle/manifest.json
@@ -2,7 +2,7 @@
   "format": 1,
   "source": {
     "version": "0.2.8",
-    "sha256": "70cb988ef589429d0f6137a7884dd9eb4ee12446cb711e69cc808ae0950c5f6b",
+    "sha256": "adc5b130e5b492fa8f35fe191f537ca9a566bb9010182d4438435bad24fe1205",
     "files": [
       {
         "path": "scrapling/src/__init__.py",
@@ -41,8 +41,8 @@
       },
       {
         "path": "scrapling/src/schemas.py",
-        "size": 19877,
-        "sha256": "277c462dd70065eb443926a811243e3a3f658636274a20db8dc9c487823afe2b"
+        "size": 19985,
+        "sha256": "b84a9cab3eaba28ec48c36ec5759abfad2d6ce215cf203591106548f6cb07b58"
       },
       {
         "path": "scrapling/src/sessions.py",

--- a/browser/src/scrapling/inject_guidance.rs
+++ b/browser/src/scrapling/inject_guidance.rs
@@ -12,6 +12,14 @@ pub const GUIDANCE_HOOK_DESC: &str =
     "Internal: appends browser::* scraping and HTML parsing guidance to the agent system prompt.";
 
 pub const GUIDANCE: &str = "\
+## Showing a page vs scraping one (browser::*)
+To OPEN or SHOW a page — anything the user should watch, a local app to \
+demo, a page to click or screenshot live — use the interactive sessions: \
+`browser::sessions::start` with the url, then `browser::navigate`, \
+`browser::snapshot`, `browser::act`, and `browser::screenshot`. Those \
+sessions render in a real Chromium and appear live in the console's \
+browser page. The scraping surface below fetches content and renders \
+nothing the user can see — never use it to \"open\" something for them.
 ## Scraping and HTML parsing (browser::*)
 Start with `browser::fetch` for static web pages, RSS/Atom feeds, and APIs; \
 its `urls` input fetches concurrently. Do not refetch successful entries, and \
@@ -87,7 +95,7 @@ mod tests {
     fn nonempty_base_appends_guidance() {
         let v = serde_json::to_value(mutations_for("BASE")).unwrap();
         let s = v["mutations"]["system_prompt"].as_str().unwrap();
-        assert!(s.starts_with("BASE\n\n## Scraping and HTML parsing"));
+        assert!(s.starts_with("BASE\n\n## Showing a page vs scraping one"));
     }
 
     /// The guidance is what routes agents to these functions, so it must not

--- a/browser/src/scrapling/schemas.rs
+++ b/browser/src/scrapling/schemas.rs
@@ -694,13 +694,13 @@ pub fn catalog() -> Vec<FunctionSpec> {
         },
         FunctionSpec {
             function_id: "browser::session-open",
-            description: "Open a persistent HTTP/browser session; returns a session_id that reuses cookies + state.",
+            description: "Open a persistent scraping session (HTTP or headless fetcher) whose session_id reuses cookies and state across fetches. Renders nothing the user can see; to open a page in the visible browser use browser::sessions::start.",
             request: session_open_request(),
             response: session_open_response(),
         },
         FunctionSpec {
             function_id: "browser::session-fetch",
-            description: "Fetch a URL on an open session (reuses its cookies/browser); same page/extraction output.",
+            description: "Fetch a URL on an open scraping session (reuses its cookies/state); returns page content, shows nothing. For a page the user should see, use browser::sessions::start + browser::navigate.",
             request: session_fetch_request(),
             response: fetch_response(),
         },

--- a/browser/tests/e2e/workers/harness/src/cases-hardening.ts
+++ b/browser/tests/e2e/workers/harness/src/cases-hardening.ts
@@ -415,7 +415,7 @@ export const HARDENING_CASES: TestCase[] = [
       const hooked = await call('browser::inject-guidance', { generate: { system_prompt: 'BASE' } })
       expect(
         typeof hooked.mutations?.system_prompt === 'string' &&
-          hooked.mutations.system_prompt.startsWith('BASE\n\n## Scraping and HTML parsing (browser::*)'),
+          hooked.mutations.system_prompt.startsWith('BASE\n\n## Showing a page vs scraping one (browser::*)'),
         `guidance hook did not append: ${JSON.stringify(hooked)}`,
       )
       expectEqual(

--- a/browser/tests/golden/schemas/browser.session-fetch.json
+++ b/browser/tests/golden/schemas/browser.session-fetch.json
@@ -1,6 +1,6 @@
 {
   "function_id": "browser::session-fetch",
-  "description": "Fetch a URL on an open session (reuses its cookies/browser); same page/extraction output.",
+  "description": "Fetch a URL on an open scraping session (reuses its cookies/state); returns page content, shows nothing. For a page the user should see, use browser::sessions::start + browser::navigate.",
   "request_schema": {
     "type": "object",
     "properties": {

--- a/browser/tests/golden/schemas/browser.session-open.json
+++ b/browser/tests/golden/schemas/browser.session-open.json
@@ -1,6 +1,6 @@
 {
   "function_id": "browser::session-open",
-  "description": "Open a persistent HTTP/browser session; returns a session_id that reuses cookies + state.",
+  "description": "Open a persistent scraping session (HTTP or headless fetcher) whose session_id reuses cookies and state across fetches. Renders nothing the user can see; to open a page in the visible browser use browser::sessions::start.",
   "request_schema": {
     "type": "object",
     "properties": {

--- a/browser/ui/package.json
+++ b/browser/ui/package.json
@@ -14,8 +14,10 @@
   },
   "devDependencies": {
     "@types/react": "^19.2.14",
+    "@types/react-dom": "19.2.3",
     "esbuild": "^0.25.0",
     "react": "^19.2.6",
+    "react-dom": "19.2.7",
     "typescript": "^5.9.2",
     "vitest": "^4.1.6"
   }

--- a/browser/ui/page.tsx
+++ b/browser/ui/page.tsx
@@ -25,6 +25,7 @@ import {
   createBrowserScreenshotRenderer,
 } from './src/function-trigger-message'
 import { createScraplingRenderer } from './src/function-trigger-message/scrapling'
+import { shouldOpenBrowserSession } from './src/lib/session-open'
 import { BrowserPage } from './src/page'
 import { registerBrowserPalette } from './src/page/palette'
 
@@ -45,4 +46,36 @@ export default function setup(host: Host) {
   host.functionTriggers.register(createBrowserScreenshotRenderer())
   host.functionTriggers.register(createScraplingRenderer(host))
   host.functionTriggers.register(createBrowserRenderer(host))
+
+  // A session an agent (or anyone) starts pulls the browser page into the
+  // workspace — the old always-visible-page behaviour, restated for
+  // workspaces: opened once, deduped to the tab already showing it, and the
+  // new session lands selected through the panelContext channel. Sessions
+  // pointed at the console itself are tooling and stay quiet.
+  const autoOpenFnId = 'browser-ui::session-auto-open'
+  try {
+    host.iii.on<{ session_id?: string; url?: string }>(
+      autoOpenFnId,
+      (event) => {
+        if (!shouldOpenBrowserSession(event?.url, window.location.origin)) {
+          return
+        }
+        host.panels?.open({
+          pageId: 'browser',
+          context:
+            typeof event?.session_id === 'string' && event.session_id
+              ? { sessionId: event.session_id }
+              : undefined,
+        })
+      },
+    )
+    host.iii.registerTrigger({
+      type: 'browser::session-started',
+      function_id: `${autoOpenFnId}::${host.iii.browserId}`,
+      config: {},
+    })
+  } catch {
+    // Worker restarting or trigger type not yet up; the page still opens
+    // by hand and the next reload rebinds.
+  }
 }

--- a/browser/ui/src/function-trigger-message/open-in-browser.tsx
+++ b/browser/ui/src/function-trigger-message/open-in-browser.tsx
@@ -1,0 +1,33 @@
+import type { Host } from '@iii-dev/console-ui'
+import { useState } from 'react'
+
+/**
+ * "Open in browser" on a scrape result, the way the shell offers "View
+ * file": one click starts an interactive session at the URL, and the
+ * session-started binding pulls the browser page into the workspace with
+ * that session selected.
+ */
+export function OpenInBrowser({ host, url }: { host: Host; url: string }) {
+  const [state, setState] = useState<'idle' | 'opening' | 'failed'>('idle')
+  return (
+    <button
+      type="button"
+      className="br-ui-open-in-browser"
+      disabled={state === 'opening'}
+      title={
+        state === 'failed'
+          ? 'could not start a session; try again'
+          : `open ${url} in the browser page`
+      }
+      onClick={() => {
+        setState('opening')
+        host.iii
+          .trigger('browser::sessions::start', { url })
+          .then(() => setState('idle'))
+          .catch(() => setState('failed'))
+      }}
+    >
+      {state === 'opening' ? 'opening…' : 'open in browser'}
+    </button>
+  )
+}

--- a/browser/ui/src/function-trigger-message/open-in-browser.tsx
+++ b/browser/ui/src/function-trigger-message/open-in-browser.tsx
@@ -1,4 +1,5 @@
 import type { Host } from '@iii-dev/console-ui'
+import { AppWindow } from 'lucide-react'
 import { useState } from 'react'
 
 /**
@@ -14,10 +15,11 @@ export function OpenInBrowser({ host, url }: { host: Host; url: string }) {
       type="button"
       className="br-ui-open-in-browser"
       disabled={state === 'opening'}
+      aria-label={`Open ${url} in the browser page`}
       title={
         state === 'failed'
-          ? 'could not start a session; try again'
-          : `open ${url} in the browser page`
+          ? 'Could not start a session; try again'
+          : `Open ${url} in the browser page`
       }
       onClick={() => {
         setState('opening')
@@ -27,7 +29,8 @@ export function OpenInBrowser({ host, url }: { host: Host; url: string }) {
           .catch(() => setState('failed'))
       }}
     >
-      {state === 'opening' ? 'opening…' : 'open in browser'}
+      <AppWindow aria-hidden />
+      <span>{state === 'opening' ? 'Opening…' : 'Open in browser'}</span>
     </button>
   )
 }

--- a/browser/ui/src/function-trigger-message/open-in-browser.tsx
+++ b/browser/ui/src/function-trigger-message/open-in-browser.tsx
@@ -1,5 +1,5 @@
 import type { Host } from '@iii-dev/console-ui'
-import { AppWindow } from 'lucide-react'
+import { ExternalLink } from '../lib/icons'
 import { useState } from 'react'
 
 /**
@@ -29,7 +29,7 @@ export function OpenInBrowser({ host, url }: { host: Host; url: string }) {
           .catch(() => setState('failed'))
       }}
     >
-      <AppWindow aria-hidden />
+      <ExternalLink aria-hidden />
       <span>{state === 'opening' ? 'Opening…' : 'Open in browser'}</span>
     </button>
   )

--- a/browser/ui/src/function-trigger-message/scrapling/FetchView.tsx
+++ b/browser/ui/src/function-trigger-message/scrapling/FetchView.tsx
@@ -1,3 +1,5 @@
+import type { Host } from '@iii-dev/console-ui'
+import { OpenInBrowser } from '../open-in-browser'
 import { JsonHighlight } from '@iii-dev/console-ui'
 import { cn } from '../../lib/cn'
 import {
@@ -22,6 +24,7 @@ const MAX_TARGET_LINES = 5
 const HTML_PREVIEW_CHARS = 1500
 
 interface FetchViewProps {
+  host?: Host
   functionId: string
   input: unknown
   output: unknown
@@ -35,6 +38,7 @@ export function FetchView({
   input,
   output,
   running,
+  host,
 }: FetchViewProps) {
   const req = safeParseRequest(fetchRequestSchema, input)
   if (!req) return null
@@ -46,7 +50,7 @@ export function FetchView({
           <StatusPill label="fetching…" variant="default" />
           <OptionChips functionId={functionId} req={req} />
         </MetaRow>
-        <TargetLines urls={targetUrls(req)} />
+        <TargetLines urls={targetUrls(req)} host={host} />
         <div className="br-ui-scrape-running">
           · waiting for page…
         </div>
@@ -145,13 +149,14 @@ function OptionChips({
   )
 }
 
-function TargetLines({ urls }: { urls: string[] }) {
+function TargetLines({ urls, host }: { urls: string[]; host?: Host }) {
   return (
     <>
       {urls.slice(0, MAX_TARGET_LINES).map((url, i) => (
         // biome-ignore lint/suspicious/noArrayIndexKey: static wire snapshot; rows never reorder and urls may repeat
         <ActionLine key={`${i}:${url}`} symbol="→" tone="ink">
           <span className="br-ui-scrape-break">{url}</span>
+          {host ? <OpenInBrowser host={host} url={url} /> : null}
         </ActionLine>
       ))}
       {urls.length > MAX_TARGET_LINES ? (

--- a/browser/ui/src/function-trigger-message/scrapling/FetchView.tsx
+++ b/browser/ui/src/function-trigger-message/scrapling/FetchView.tsx
@@ -66,7 +66,9 @@ export function FetchView({
       <BulkPane functionId={functionId} req={req} results={result.results} />
     )
   }
-  return <SinglePane functionId={functionId} req={req} page={result} />
+  return (
+    <SinglePane functionId={functionId} req={req} page={result} host={host} />
+  )
 }
 
 /** Compact read-only summary shown while the call sits in the approval gate. */
@@ -174,10 +176,12 @@ function SinglePane({
   functionId,
   req,
   page,
+  host,
 }: {
   functionId: string
   req: FetchRequest
   page: PageResult
+  host?: Host
 }) {
   const status = page.status ?? null
   const contentType = headerValue(page.headers, 'content-type')
@@ -198,6 +202,9 @@ function SinglePane({
       </MetaRow>
       <ActionLine symbol="→" tone="ink">
         <span className="br-ui-scrape-break">{page.url || req.url || ''}</span>
+        {host && (page.url || req.url) ? (
+          <OpenInBrowser host={host} url={page.url || req.url || ''} />
+        ) : null}
       </ActionLine>
       {page.extracted ? <Extracted extracted={page.extracted} /> : null}
       {page.content != null ? (

--- a/browser/ui/src/function-trigger-message/scrapling/SessionViews.tsx
+++ b/browser/ui/src/function-trigger-message/scrapling/SessionViews.tsx
@@ -1,3 +1,5 @@
+import type { Host } from '@iii-dev/console-ui'
+import { OpenInBrowser } from '../open-in-browser'
 import { JsonHighlight } from '@iii-dev/console-ui'
 import {
   ActionLine,
@@ -138,10 +140,12 @@ export function SessionFetchView({
   input,
   output,
   running,
+  host,
 }: {
   input: unknown
   output: unknown
   running?: boolean
+  host?: Host
 }) {
   const header = fetchHeader(input)
   if (!header) return null
@@ -184,6 +188,9 @@ export function SessionFetchView({
       </MetaRow>
       <ActionLine symbol="→" tone="ink">
         <span className="br-ui-scrape-break">{page.url || url || ''}</span>
+        {host && (page.url || url) ? (
+          <OpenInBrowser host={host} url={page.url || url || ''} />
+        ) : null}
       </ActionLine>
       {page.extracted ? (
         <div>

--- a/browser/ui/src/function-trigger-message/scrapling/index.test.tsx
+++ b/browser/ui/src/function-trigger-message/scrapling/index.test.tsx
@@ -24,6 +24,23 @@ describe('scraping renderer', () => {
     expect(renderer.isMatch('browser::screenshot')).toBe(false)
   })
 
+  it('offers open-in-browser on a fetched url', async () => {
+    const { renderToStaticMarkup } = await import('react-dom/server')
+    const withHost = {
+      iii: { trigger: () => Promise.resolve({}) },
+    } as unknown as Host
+    const renderer = createScraplingRenderer(withHost)
+    const done = {
+      functionId: 'browser::fetch',
+      input: { url: 'https://example.com' },
+      output: { status: 200, url: 'https://example.com', content: 'hi' },
+      running: false,
+    } as unknown as FunctionTriggerMessage
+    const html = renderToStaticMarkup(<>{renderer.tryRender?.(done)}</>)
+    expect(html).toContain('Open in browser')
+    expect(html).toContain('br-ui-open-in-browser')
+  })
+
   it('renders approval previews and parse results', () => {
     const renderer = createScraplingRenderer(host)
     const preview = {

--- a/browser/ui/src/function-trigger-message/scrapling/index.tsx
+++ b/browser/ui/src/function-trigger-message/scrapling/index.tsx
@@ -59,7 +59,10 @@ function redactProxyValues(
   }
 }
 
-function tryRender(message: FunctionTriggerMessage): React.ReactNode | null {
+function tryRender(
+  message: FunctionTriggerMessage,
+  host?: Host,
+): React.ReactNode | null {
   if (!isScraplingFunction(message.functionId) || message.pendingApproval) {
     return null
   }
@@ -81,6 +84,7 @@ function tryRender(message: FunctionTriggerMessage): React.ReactNode | null {
       input,
       output,
       running,
+      host,
     })
   }
   if (ELEMENT_SEARCH_FUNCTION_IDS.has(message.functionId)) {
@@ -114,7 +118,7 @@ function tryRender(message: FunctionTriggerMessage): React.ReactNode | null {
     case 'browser::session-open':
       return SessionOpenView({ input, output, running })
     case 'browser::session-fetch':
-      return SessionFetchView({ input, output, running })
+      return SessionFetchView({ input, output, running, host })
     case 'browser::session-close':
       return SessionCloseView({ input, output, running })
     case 'browser::session-list':
@@ -152,13 +156,14 @@ function tryRenderPreview(
 }
 
 export function createScraplingRenderer(
-  _host: Host,
+  host: Host,
 ): FunctionTriggerRenderer {
+  const render = (message: FunctionTriggerMessage) => tryRender(message, host)
   return {
     id: 'browser/page.js#scraping-calls',
     isMatch: isScraplingFunction,
-    tryRender,
-    tryRenderRunning: tryRender,
+    tryRender: render,
+    tryRenderRunning: render,
     tryRenderPreview,
     FunctionIdLabel,
     redactRaw: redactProxyValues,

--- a/browser/ui/src/lib/session-open.test.ts
+++ b/browser/ui/src/lib/session-open.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { shouldOpenBrowserSession } from './session-open'
+
+const CONSOLE = 'http://127.0.0.1:3113'
+
+describe('shouldOpenBrowserSession', () => {
+  it('opens for an outside page', () => {
+    expect(shouldOpenBrowserSession('https://iii.dev/docs', CONSOLE)).toBe(true)
+    expect(
+      shouldOpenBrowserSession('file:///tmp/demo/index.html', CONSOLE),
+    ).toBe(true)
+  })
+
+  it('stays quiet for sessions pointed at the console itself', () => {
+    expect(shouldOpenBrowserSession('http://127.0.0.1:3113/', CONSOLE)).toBe(
+      false,
+    )
+    expect(
+      shouldOpenBrowserSession('http://127.0.0.1:3113/#/workers', CONSOLE),
+    ).toBe(false)
+  })
+
+  it('stays quiet without a url, opens on an unparsable one', () => {
+    expect(shouldOpenBrowserSession(undefined, CONSOLE)).toBe(false)
+    expect(shouldOpenBrowserSession('not a url', CONSOLE)).toBe(true)
+  })
+})

--- a/browser/ui/src/lib/session-open.ts
+++ b/browser/ui/src/lib/session-open.ts
@@ -1,0 +1,17 @@
+/**
+ * Whether a freshly started browser session should pull the browser page
+ * into the workspace. Sessions pointed at the console itself are tooling
+ * (tests, self-inspection) — surfacing those would flip the user's
+ * workspace under them for nothing they asked to watch.
+ */
+export function shouldOpenBrowserSession(
+  url: string | undefined,
+  consoleOrigin: string,
+): boolean {
+  if (!url) return false
+  try {
+    return new URL(url).origin !== consoleOrigin
+  } catch {
+    return true
+  }
+}

--- a/browser/ui/styles.css
+++ b/browser/ui/styles.css
@@ -3004,3 +3004,25 @@
     max-height: 160px;
   }
 }
+
+/* open-in-browser action on scrape url lines */
+[data-iii-ui="browser"] .br-ui-open-in-browser {
+  margin-left: 8px;
+  padding: 1px 8px;
+  border: 1px solid var(--color-rule);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--color-ink-faint);
+  font: inherit;
+  font-size: 11px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+[data-iii-ui="browser"] .br-ui-open-in-browser:hover {
+  color: var(--color-ink);
+  border-color: var(--color-ink-faint);
+}
+[data-iii-ui="browser"] .br-ui-open-in-browser:disabled {
+  opacity: 0.6;
+  cursor: default;
+}

--- a/browser/ui/styles.css
+++ b/browser/ui/styles.css
@@ -3005,18 +3005,26 @@
   }
 }
 
-/* open-in-browser action on scrape url lines */
+/* open-in-browser action on scrape url lines — the shell's "View file"
+   anatomy: icon + sans label on a quiet bordered pill */
 [data-iii-ui="browser"] .br-ui-open-in-browser {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   margin-left: 8px;
   padding: 1px 8px;
   border: 1px solid var(--color-rule);
   border-radius: 999px;
   background: transparent;
   color: var(--color-ink-faint);
-  font: inherit;
+  font-family: var(--font-sans, inherit);
   font-size: 11px;
   cursor: pointer;
   white-space: nowrap;
+}
+[data-iii-ui="browser"] .br-ui-open-in-browser svg {
+  width: 16px;
+  height: 16px;
 }
 [data-iii-ui="browser"] .br-ui-open-in-browser:hover {
   color: var(--color-ink);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,12 +48,18 @@ importers:
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.17
+      '@types/react-dom':
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.17)
       esbuild:
         specifier: ^0.25.0
         version: 0.25.12
       react:
         specifier: ^19.2.6
         version: 19.2.7
+      react-dom:
+        specifier: 19.2.7
+        version: 19.2.7(react@19.2.7)
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
@@ -6373,9 +6379,9 @@ snapshots:
       '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.7)
       '@storybook/csf-plugin': 10.5.3(storybook@10.5.3(@types/react@19.2.17)(react@19.2.7))(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0))
       '@storybook/icons': 2.1.0(react@19.2.7)
-      '@storybook/react-dom-shim': 10.5.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.5.3(@types/react@19.2.17)(react@19.2.7))
+      '@storybook/react-dom-shim': 10.5.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(storybook@10.5.3(@types/react@19.2.17)(react@19.2.7))
       react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react-dom: 19.2.8(react@19.2.7)
       storybook: 10.5.3(@types/react@19.2.17)(react@19.2.7)
       ts-dedent: 2.3.0
     optionalDependencies:
@@ -6415,6 +6421,15 @@ snapshots:
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
+      storybook: 10.5.3(@types/react@19.2.17)(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@storybook/react-dom-shim@10.5.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(storybook@10.5.3(@types/react@19.2.17)(react@19.2.7))':
+    dependencies:
+      react: 19.2.7
+      react-dom: 19.2.8(react@19.2.7)
       storybook: 10.5.3(@types/react@19.2.17)(react@19.2.7)
     optionalDependencies:
       '@types/react': 19.2.17
@@ -8317,6 +8332,11 @@ snapshots:
       - supports-color
 
   react-dom@19.2.7(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      scheduler: 0.27.0
+
+  react-dom@19.2.8(react@19.2.7):
     dependencies:
       react: 19.2.7
       scheduler: 0.27.0

--- a/scrapling/src/schemas.py
+++ b/scrapling/src/schemas.py
@@ -542,14 +542,22 @@ FUNCTIONS: list[dict[str, Any]] = [
     {
         "id": "scrapling::session-open",
         "handler": "session_open",
-        "description": "Open a persistent scraping session (HTTP or headless fetcher) whose session_id reuses cookies and state across fetches. Renders nothing the user can see; to open a page in the visible browser use browser::sessions::start.",
+        "description": (
+            "Open a persistent scraping session (HTTP or headless fetcher) whose session_id reuses "
+            "cookies and state across fetches. Renders nothing the user can see; to open a page in "
+            "the visible browser use browser::sessions::start."
+        ),
         "request": _SESSION_OPEN_REQUEST,
         "response": _SESSION_OPEN_RESPONSE,
     },
     {
         "id": "scrapling::session-fetch",
         "handler": "session_fetch",
-        "description": "Fetch a URL on an open scraping session (reuses its cookies/state); returns page content, shows nothing. For a page the user should see, use browser::sessions::start + browser::navigate.",
+        "description": (
+            "Fetch a URL on an open scraping session (reuses its cookies/state); returns page "
+            "content, shows nothing. For a page the user should see, use browser::sessions::start "
+            "+ browser::navigate."
+        ),
         "request": _SESSION_FETCH_REQUEST,
         "response": _FETCH_RESPONSE,
     },

--- a/scrapling/src/schemas.py
+++ b/scrapling/src/schemas.py
@@ -542,14 +542,14 @@ FUNCTIONS: list[dict[str, Any]] = [
     {
         "id": "scrapling::session-open",
         "handler": "session_open",
-        "description": "Open a persistent HTTP/browser session; returns a session_id that reuses cookies + state.",
+        "description": "Open a persistent scraping session (HTTP or headless fetcher) whose session_id reuses cookies and state across fetches. Renders nothing the user can see; to open a page in the visible browser use browser::sessions::start.",
         "request": _SESSION_OPEN_REQUEST,
         "response": _SESSION_OPEN_RESPONSE,
     },
     {
         "id": "scrapling::session-fetch",
         "handler": "session_fetch",
-        "description": "Fetch a URL on an open session (reuses its cookies/browser); same page/extraction output.",
+        "description": "Fetch a URL on an open scraping session (reuses its cookies/state); returns page content, shows nothing. For a page the user should see, use browser::sessions::start + browser::navigate.",
         "request": _SESSION_FETCH_REQUEST,
         "response": _FETCH_RESPONSE,
     },


### PR DESCRIPTION
## What

An agent starting a browser session used to be visible immediately: the old
console kept the browser page ever-present, so new sessions simply appeared.
The workspace redesign made pages explicit attachments, and nothing was left
to bring the page in — an agent could browse an entire site with the user
staring at a chat pane, wondering where the browser went.

The browser worker's injectable UI now closes that loop itself, with no
console or harness involvement: `setup(host)` binds
`browser::session-started`, and a new session pulls the browser page into
the workspace through the existing `host.panels.open` bridge — opened once,
deduped to the tab already showing it — with the session landing selected
through the page's established `panelContext` channel.

One guard: sessions whose URL points at the console's own origin are
tooling (tests, self-inspection) and stay quiet, so automation never flips
a workspace under the user. The rule lives in a small pure helper with its
own tests; the binding registration fails open when the worker is
restarting, matching the page's other lifecycle bindings.

## How verified

- browser/ui: tsc clean, build passes, 30 tests including three new ones
  pinning the origin rule.
- Live on a rig: a wire-started session at an outside URL opens the browser
  page in the active workspace with the session selected; a session pointed
  at the console does nothing; the browser page's own session rail shows
  both regardless.

Refs MOT-4533.
