### PR TITLE
(MOT-4572) fix: stabilize the prompt-cache prefix and shrink contract context

### DIFF
--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -47,7 +47,11 @@ import { syncEditorWorkspace } from '@/lib/editor-sync'
 import { expandFileMentions, parseFileMentions } from '@/lib/file-mentions'
 import { formatStopReason } from '@/lib/format-stop-reason'
 import { newMessageId } from '@/lib/session-id'
-import { expandSlashInvocation, slashChip } from '@/lib/slash-commands'
+import {
+  expandSlashInvocation,
+  loadedSkillIds,
+  slashChip,
+} from '@/lib/slash-commands'
 import { useExtSessionChips, useExtSessionTurnSummaries } from '@/lib/ui-slots'
 import { fetchDefaultWorkingDir, validateWorkspaceDir } from '@/lib/working-dir'
 import {
@@ -620,7 +624,10 @@ export function ChatView({
         // the body the queued message already carried with no explanation.
         const slashExpansion =
           backend.id === 'real'
-            ? await expandSlashInvocation(payload.text.trim())
+            ? await expandSlashInvocation(
+                payload.text.trim(),
+                loadedSkillIds(messagesRef.current),
+              )
             : null
         if (slashExpansion?.status === 'attached') {
           attachedBlocks = [...(attachedBlocks ?? []), slashExpansion.block]
@@ -1296,7 +1303,12 @@ export function ChatView({
       // Prose that merely starts with a slash never resolves (the expander
       // is gated on the palette's fetched entries).
       const slashExpansion =
-        backend.id === 'real' ? await expandSlashInvocation(trimmed) : null
+        backend.id === 'real'
+          ? await expandSlashInvocation(
+              trimmed,
+              loadedSkillIds(messagesRef.current),
+            )
+          : null
       if (slashExpansion?.status === 'attached') {
         attachedBlocks = [...(attachedBlocks ?? []), slashExpansion.block]
         // The body travels as a block, never as visible text — show the same

--- a/console/web/src/lib/slash-commands.test.ts
+++ b/console/web/src/lib/slash-commands.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   expandSlashInvocation,
   fuzzyFilterSlash,
+  loadedSkillIds,
   mergeSlashEntries,
   parseSlashBlockHeader,
   parseSlashInvocation,
@@ -127,6 +128,58 @@ describe('expandSlashInvocation gate', () => {
     expect(await expandSlashInvocation('/compact now')).toBeNull()
     expect(await expandSlashInvocation('/skill:coder/index go')).toBeNull()
     setDynamicSlashEntries(null)
+  })
+
+  /* The dedupe branch also returns before any client is touched. */
+  it('an already-loaded skill expands to a pointer without a refetch', async () => {
+    setDynamicSlashEntries([
+      { command: '/skill:coder/index', description: 'coder', kind: 'skill' },
+    ])
+    const result = await expandSlashInvocation(
+      '/skill:coder/index go',
+      new Set(['coder/index']),
+    )
+    expect(result?.status).toBe('attached')
+    if (result?.status !== 'attached') throw new Error('unreachable')
+    expect(result.block).toContain('already loaded')
+    expect(result.block.length).toBeLessThan(200)
+    // The pointer still collapses to the same chip on hydration.
+    expect(parseSlashBlockHeader(result.block)).toEqual({
+      kind: 'skill',
+      id: 'coder/index',
+    })
+    setDynamicSlashEntries(null)
+  })
+})
+
+describe('loadedSkillIds', () => {
+  const skillMsg = {
+    role: 'user',
+    attachments: [slashChip({ kind: 'skill', id: 'coder/index' }, 7)],
+  }
+
+  it('collects skill chips from prior messages', () => {
+    expect(loadedSkillIds([skillMsg]).has('coder/index')).toBe(true)
+  })
+
+  it('a compaction marker resets what counts as loaded', () => {
+    expect(
+      loadedSkillIds([skillMsg, { role: 'system', kind: 'compaction' }]).size,
+    ).toBe(0)
+  })
+
+  it('prompt chips and plain attachments never count', () => {
+    expect(
+      loadedSkillIds([
+        {
+          role: 'user',
+          attachments: [
+            slashChip({ kind: 'prompt', name: 'review-pr' }, 7),
+            { name: 'a.pdf', type: 'application/pdf' },
+          ],
+        },
+      ]).size,
+    ).toBe(0)
   })
 })
 

--- a/console/web/src/lib/slash-commands.ts
+++ b/console/web/src/lib/slash-commands.ts
@@ -131,18 +131,56 @@ export type SlashExpansion =
   | { status: 'failed'; command: string }
 
 /**
+ * Skill ids whose full body already rides in this conversation's context:
+ * skill chips on messages after the last compaction marker. Compaction
+ * summarises the earlier block away, so it stops counting as loaded.
+ */
+export function loadedSkillIds(
+  messages: ReadonlyArray<{
+    role: string
+    kind?: string
+    attachments?: ReadonlyArray<{ name: string; type: string }>
+  }>,
+): ReadonlySet<string> {
+  const ids = new Set<string>()
+  for (const m of messages) {
+    if (m.role === 'system' && m.kind === 'compaction') {
+      ids.clear()
+      continue
+    }
+    for (const a of m.attachments ?? []) {
+      if (a.type === 'text/x-skill' && a.name.startsWith('/skill:'))
+        ids.add(a.name.slice('/skill:'.length))
+    }
+  }
+  return ids
+}
+
+/**
  * Shared submit-time expansion for the fresh-send and queued-edit paths: a
  * leading palette-known `/name` / `/skill:<id>` resolves its body into an
  * attachment block; `failed` means the caller should warn and send the text
  * as typed; null means the text is not an invocation (or not palette-known).
+ *
+ * A skill in `loaded` (see `loadedSkillIds`) expands to a short pointer
+ * instead of refetching the body — the full block is already in context, so
+ * a repeat invocation shouldn't cost another copy of it.
  */
 export async function expandSlashInvocation(
   text: string,
+  loaded?: ReadonlySet<string>,
 ): Promise<SlashExpansion | null> {
   const inv = parseSlashInvocation(text)
   if (!inv) return null
   const command = invocationCommand(inv)
   if (!dynamicSlashEntries?.some((e) => e.command === command)) return null
+  if (inv.kind === 'skill' && loaded?.has(inv.id)) {
+    return {
+      status: 'attached',
+      block: `<skill id="${inv.id}">\nThis skill was already loaded by an earlier message in this conversation. Follow that skill block directly; do not reload it.\n</skill>`,
+      inv,
+    }
+  }
   try {
     const client = await getIiiClient()
     const body =

--- a/harness/src/deferred.rs
+++ b/harness/src/deferred.rs
@@ -628,7 +628,7 @@ mod tests {
 
         let (second, updates) =
             crate::trigger::prepare_info_result("held-2", &arguments, &data, &ledger, true);
-        assert_eq!(second.content, data.content, "a sibling result stays full");
+        assert_eq!(second.content, first.content, "a sibling result stays full");
         apply_deferred_contract_updates_after_append(&mut ledger, "held-2", updates);
 
         crate::trigger::retain_visible_contract_sources(
@@ -655,7 +655,19 @@ mod tests {
             )]
         );
         assert!(updates.is_empty());
-        assert_eq!(first.content, data.content);
+        assert_eq!(
+            first.content,
+            crate::trigger::prepare_info_result(
+                "probe",
+                &arguments,
+                &data,
+                &Default::default(),
+                true
+            )
+            .0
+            .content,
+            "the first result is the full (response-schema-stripped) rendering"
+        );
     }
 
     #[test]

--- a/harness/src/discovery.rs
+++ b/harness/src/discovery.rs
@@ -86,26 +86,17 @@ fn fingerprint_of(functions: &[FunctionDescriptor]) -> u64 {
 }
 
 /// Swap the snapshot under the write lock, bumping the generation only when the
-/// incoming set's fingerprint differs from the current one.
+/// incoming set's fingerprint differs from the current one. Availability events
+/// with a byte-identical set deliberately do NOT bump: the generation feeds the
+/// registry-changed notice and the discovery hint, and a no-op bump invalidates
+/// the provider's prompt-cache prefix for nothing. A response-schema-only
+/// change is fingerprint-invisible and goes un-noticed until a list-visible
+/// field moves — the schema-aware `functions_hash` named at the safety-reload
+/// ponytail comment is the real fix for that.
 pub async fn apply(cell: &FunctionsCell, functions: Vec<FunctionDescriptor>) {
-    apply_inner(cell, functions, false).await;
-}
-
-/// Explicit availability events advance the generation even when list-visible
-/// fields stayed equal: the event may represent a response-schema-only change
-/// that native invocation descriptors do not carry.
-async fn apply_on_availability_event(cell: &FunctionsCell, functions: Vec<FunctionDescriptor>) {
-    apply_inner(cell, functions, true).await;
-}
-
-async fn apply_inner(
-    cell: &FunctionsCell,
-    functions: Vec<FunctionDescriptor>,
-    force_generation: bool,
-) {
     let fingerprint = fingerprint_of(&functions);
     let mut guard = cell.write().await;
-    if !force_generation && fingerprint == guard.fingerprint {
+    if fingerprint == guard.fingerprint {
         return;
     }
     let generation = guard.generation + 1;
@@ -204,21 +195,12 @@ async fn hydrate(
 
 /// Fetch the authoritative registry, hydrate schemas, and swap the snapshot;
 /// returns the count.
-async fn reload(
-    iii: &Arc<IIIClient>,
-    cell: &FunctionsCell,
-    timeout_ms: u64,
-    availability_event: bool,
-) -> usize {
+async fn reload(iii: &Arc<IIIClient>, cell: &FunctionsCell, timeout_ms: u64) -> usize {
     let engine = EngineClient::new(iii.clone(), timeout_ms);
     let functions = engine.functions_list().await;
     let functions = hydrate(&engine, cell, functions).await;
     let count = functions.len();
-    if availability_event {
-        apply_on_availability_event(cell, functions).await;
-    } else {
-        apply(cell, functions).await;
-    }
+    apply(cell, functions).await;
     count
 }
 
@@ -265,7 +247,7 @@ pub fn register_functions_trigger(iii: &Arc<IIIClient>, cell: FunctionsCell, tim
         ticker.tick().await; // consume the immediate first tick
         loop {
             ticker.tick().await;
-            let count = reload(&reload_iii, &reload_cell, timeout_ms, false).await;
+            let count = reload(&reload_iii, &reload_cell, timeout_ms).await;
             tracing::debug!(count, "function-registry cache safety-reloaded");
         }
     });
@@ -277,7 +259,7 @@ pub fn register_functions_trigger(iii: &Arc<IIIClient>, cell: FunctionsCell, tim
             let engine = engine.clone();
             let cell = cell.clone();
             async move {
-                let count = reload(&engine, &cell, timeout_ms, true).await;
+                let count = reload(&engine, &cell, timeout_ms).await;
                 tracing::debug!(count, "function-registry cache refreshed");
                 Ok::<OnFunctionsChangeResponse, Error>(OnFunctionsChangeResponse { ok: true })
             }
@@ -361,14 +343,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn explicit_availability_event_bumps_generation_for_unchanged_list_shape() {
+    async fn availability_event_with_identical_set_does_not_bump_generation() {
+        // A no-op bump would fire the registry-changed notice and re-arm the
+        // discovery hint, invalidating the provider prompt-cache for nothing.
         let cell = new_cell();
         let fns = vec![desc("a::b", Some(json!({ "type": "object" })))];
         apply(&cell, fns.clone()).await;
 
-        apply_on_availability_event(&cell, fns).await;
+        apply(&cell, fns).await;
 
-        assert_eq!(cell.read().await.generation, 2);
+        assert_eq!(cell.read().await.generation, 1);
     }
 
     #[test]

--- a/harness/src/discovery.rs
+++ b/harness/src/discovery.rs
@@ -343,9 +343,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn availability_event_with_identical_set_does_not_bump_generation() {
-        // A no-op bump would fire the registry-changed notice and re-arm the
-        // discovery hint, invalidating the provider prompt-cache for nothing.
+    async fn re_applying_an_identical_set_does_not_bump_generation() {
+        // Availability events now route through this same `apply` (the forced
+        // bump was removed), so this covers that path too. A no-op bump would
+        // fire the registry-changed notice and re-arm the discovery hint,
+        // invalidating the provider prompt-cache for nothing.
         let cell = new_cell();
         let fns = vec![desc("a::b", Some(json!({ "type": "object" })))];
         apply(&cell, fns.clone()).await;

--- a/harness/src/functions/send.rs
+++ b/harness/src/functions/send.rs
@@ -264,6 +264,9 @@ async fn start_with_delivery_lock(
     if let (true, Some(prev)) = (inherits_prompt, prev.as_ref()) {
         inherit_prior_system_prompt(&mut options, &prev.options);
     }
+    if let Some(prev) = prev.as_ref() {
+        inherit_prior_filesystem_root(&mut options, &prev.options);
+    }
     prepare_skill_context(
         deps,
         &mut options,
@@ -895,6 +898,26 @@ fn prompt_fields_omitted(opts: Option<&SendOptions>) -> bool {
 fn inherit_prior_system_prompt(options: &mut TurnOptions, prev: &TurnOptions) {
     options.system_prompt = prev.system_prompt.clone();
     options.skills_prompt = prev.skills_prompt.clone();
+}
+
+/// A send whose metadata does not name the `fs_scope` key inherits the prior
+/// turn's working directory — the same omitted-field rule as model, prompt,
+/// and policy. The working-dir line in the system prompt must not flip when a
+/// client omits `fs_scope` on a later send (it invalidates the provider's
+/// prompt-cache prefix). An explicit `fs_scope` — even an empty `{}` — is an
+/// intentional clear and blocks inheritance.
+fn inherit_prior_filesystem_root(options: &mut TurnOptions, prev: &TurnOptions) {
+    let names_fs_scope = options
+        .metadata
+        .as_ref()
+        .and_then(Value::as_object)
+        .is_some_and(|m| m.contains_key(crate::types::turn::FS_SCOPE_KEY));
+    if names_fs_scope {
+        return;
+    }
+    if let Some(root) = prev.filesystem_root() {
+        options.set_filesystem_root(root);
+    }
 }
 
 /// Default a BRAND-NEW session's working directory (MOT-3897): when the very
@@ -1915,6 +1938,53 @@ mod tests {
         apply_default_filesystem_root(&mut opts, true, None);
         assert_eq!(opts.filesystem_root(), None);
         assert!(opts.metadata.is_none());
+    }
+
+    #[test]
+    fn omitted_fs_scope_inherits_prior_root() {
+        let mut prev = bare_options();
+        prev.set_filesystem_root("/work/project");
+
+        let mut opts = bare_options();
+        inherit_prior_filesystem_root(&mut opts, &prev);
+        assert_eq!(opts.filesystem_root(), Some("/work/project"));
+    }
+
+    #[test]
+    fn inheritance_preserves_unrelated_metadata_keys() {
+        let mut prev = bare_options();
+        prev.set_filesystem_root("/work/project");
+
+        let mut opts = bare_options();
+        opts.metadata = Some(serde_json::json!({ "session_id": "s_1" }));
+        inherit_prior_filesystem_root(&mut opts, &prev);
+        assert_eq!(opts.filesystem_root(), Some("/work/project"));
+        assert_eq!(
+            opts.metadata.as_ref().unwrap().get("session_id"),
+            Some(&serde_json::json!("s_1"))
+        );
+    }
+
+    #[test]
+    fn explicit_empty_fs_scope_clears_instead_of_inheriting() {
+        let mut prev = bare_options();
+        prev.set_filesystem_root("/work/project");
+
+        let mut opts = bare_options();
+        opts.metadata = Some(serde_json::json!({ "fs_scope": {} }));
+        inherit_prior_filesystem_root(&mut opts, &prev);
+        assert_eq!(opts.filesystem_root(), None);
+    }
+
+    #[test]
+    fn explicit_root_wins_over_inheritance() {
+        let mut prev = bare_options();
+        prev.set_filesystem_root("/work/project");
+
+        let mut opts = bare_options();
+        opts.metadata = Some(serde_json::json!({ "fs_scope": { "root": "/picked" } }));
+        inherit_prior_filesystem_root(&mut opts, &prev);
+        assert_eq!(opts.filesystem_root(), Some("/picked"));
     }
 
     #[test]

--- a/harness/src/functions/send.rs
+++ b/harness/src/functions/send.rs
@@ -264,9 +264,6 @@ async fn start_with_delivery_lock(
     if let (true, Some(prev)) = (inherits_prompt, prev.as_ref()) {
         inherit_prior_system_prompt(&mut options, &prev.options);
     }
-    if let Some(prev) = prev.as_ref() {
-        inherit_prior_filesystem_root(&mut options, &prev.options);
-    }
     prepare_skill_context(
         deps,
         &mut options,
@@ -906,6 +903,11 @@ fn inherit_prior_system_prompt(options: &mut TurnOptions, prev: &TurnOptions) {
 /// client omits `fs_scope` on a later send (it invalidates the provider's
 /// prompt-cache prefix). An explicit `fs_scope` — even an empty `{}` — is an
 /// intentional clear and blocks inheritance.
+///
+/// Called from `seed_new` only, with the freshest prior record read under the
+/// delivery guard: an inherited root must never travel into the active-turn
+/// merge path, where `refresh_filesystem_root_from` would let a stale
+/// inherited value overwrite a root the running turn just changed.
 fn inherit_prior_filesystem_root(options: &mut TurnOptions, prev: &TurnOptions) {
     let names_fs_scope = options
         .metadata
@@ -1074,11 +1076,14 @@ pub(crate) async fn seed_new(
     deps: &Deps,
     cfg: &WorkerConfig,
     session_id: &str,
-    options: TurnOptions,
+    mut options: TurnOptions,
     prior: Option<&TurnRecord>,
     message_preview: Option<String>,
     lineage: &TurnLineage,
 ) -> Result<StartOutcome, HarnessError> {
+    if let Some(prior) = prior {
+        inherit_prior_filesystem_root(&mut options, &prior.options);
+    }
     let turn_id = ids::new_turn_id();
     let now = AgentMessage::now_ms();
     let functions_generation = prior.and_then(|record| record.functions_generation);

--- a/harness/src/functions/system_prompt.rs
+++ b/harness/src/functions/system_prompt.rs
@@ -37,7 +37,6 @@ pub enum SystemPromptPartKind {
     Selected,
     Skills,
     Runtime,
-    RegistryNotice,
     Injected,
 }
 
@@ -96,13 +95,6 @@ pub async fn handle(
     };
     let runtime =
         crate::turn_loop::runtime_context_aid(&req.session_id, filesystem_root.as_deref(), policy);
-    let registry_notice = match record.as_ref() {
-        Some(record) => crate::turn_loop::registry_notice(
-            record.functions_generation,
-            deps.functions().await.generation,
-        ),
-        None => None,
-    };
     let skills = record
         .as_ref()
         .and_then(|record| record.options.skill_context.as_ref())
@@ -129,7 +121,6 @@ pub async fn handle(
             req.selected_prompt,
             skills,
             runtime,
-            registry_notice,
             injections,
         ),
     })
@@ -159,7 +150,6 @@ fn build_parts(
     selected: Option<SelectedSystemPrompt>,
     skills: Option<String>,
     runtime: String,
-    registry_notice: Option<String>,
     injections: Vec<SystemPromptPart>,
 ) -> Vec<SystemPromptPart> {
     let selected = selected.filter(|prompt| !prompt.body.is_empty());
@@ -198,13 +188,6 @@ fn build_parts(
         name: None,
         body: runtime,
     });
-    if let Some(body) = registry_notice {
-        parts.push(SystemPromptPart {
-            kind: SystemPromptPartKind::RegistryNotice,
-            name: None,
-            body,
-        });
-    }
     parts.extend(injections);
     parts
 }
@@ -239,7 +222,6 @@ mod tests {
             }),
             Some("skill index".into()),
             "session context".into(),
-            None,
             vec![SystemPromptPart {
                 kind: SystemPromptPartKind::Injected,
                 name: Some("fp".into()),
@@ -272,7 +254,6 @@ mod tests {
             }),
             None,
             "session context".into(),
-            None,
             Vec::new(),
         );
         assert_eq!(parts.len(), 2);
@@ -290,7 +271,6 @@ mod tests {
             None,
             None,
             "session context".into(),
-            None,
             Vec::new(),
         );
         assert_eq!(parts[0].kind, SystemPromptPartKind::BuiltIn);
@@ -304,7 +284,6 @@ mod tests {
             None,
             None,
             "session context".into(),
-            None,
             Vec::new(),
         );
         assert_eq!(parts.len(), 1);

--- a/harness/src/trigger.rs
+++ b/harness/src/trigger.rs
@@ -196,8 +196,23 @@ pub(crate) fn prepare_info_result(
         }
     }
 
+    // Response-side schemas carry no calling contract — the model reads
+    // results, it never constructs them — and they are ~40% of a typical
+    // contract's bytes. Strip them from the model-visible copy only; the raw
+    // contract stays in `details`, and the ledger digest is taken over the
+    // raw contract, so unchanged-detection is unaffected.
+    let mut stripped = false;
+    match display.get_mut("functions").and_then(Value::as_array_mut) {
+        Some(items) => {
+            for item in items {
+                stripped |= strip_response_schemas(item);
+            }
+        }
+        None => stripped |= strip_response_schemas(&mut display),
+    }
+
     let mut prepared = data.clone();
-    if compacted {
+    if compacted || stripped {
         prepared.content = normalize(&display).0;
     }
     let Some(source_content_digest) = digest_content(&prepared.content) else {
@@ -218,6 +233,19 @@ pub(crate) fn prepare_info_result(
         })
         .collect();
     (prepared, updates)
+}
+
+/// Drop the response-side schema keys from one model-visible contract item.
+/// A dedupe marker or error item has none of these — the call is a no-op.
+fn strip_response_schemas(item: &mut Value) -> bool {
+    let Some(object) = item.as_object_mut() else {
+        return false;
+    };
+    let mut stripped = false;
+    for key in ["response_schema", "response_format"] {
+        stripped |= object.remove(key).is_some();
+    }
+    stripped
 }
 
 fn valid_contract_id(value: &Value) -> Option<&str> {
@@ -596,6 +624,79 @@ mod tests {
         assert!(!arguments_degraded(&json!({ "path": "/tmp" })));
     }
 
+    /// The model-visible rendering of a full contract result: `details`
+    /// minus the response-side schema keys prepare_info_result strips.
+    fn stripped_content(details: &Value) -> Vec<ContentBlock> {
+        let mut display = details.clone();
+        match display.get_mut("functions").and_then(Value::as_array_mut) {
+            Some(items) => {
+                for item in items {
+                    strip_response_schemas(item);
+                }
+            }
+            None => {
+                strip_response_schemas(&mut display);
+            }
+        }
+        normalize(&display).0
+    }
+
+    #[test]
+    fn response_schemas_are_stripped_from_the_model_visible_copy_only() {
+        let details = json!({ "functions": [{
+            "function_id": "worker::function",
+            "description": "Does work",
+            "request_schema": { "type": "object" },
+            "response_schema": { "type": "object" },
+            "response_format": { "type": "object" }
+        }]});
+        let data = ResultData {
+            content: normalize(&details).0,
+            is_error: false,
+            details: details.clone(),
+        };
+        let (prepared, updates) = prepare_info_result(
+            "call_1",
+            &json!({ "function_ids": ["worker::function"] }),
+            &data,
+            &BTreeMap::new(),
+            true,
+        );
+        let rendered: Value =
+            serde_json::from_str(&ContentBlock::join_text(&prepared.content)).unwrap();
+        assert!(rendered["functions"][0].get("response_schema").is_none());
+        assert!(rendered["functions"][0].get("response_format").is_none());
+        assert_eq!(
+            rendered["functions"][0]["request_schema"],
+            json!({ "type": "object" })
+        );
+        assert_eq!(prepared.details, details, "raw contract stays in details");
+        // The ledger digest is over the RAW contract, so a repeat fetch of the
+        // same contract still dedupes to a marker — the stripped transcript
+        // copy is what the visibility check digests.
+        let mut ledger: BTreeMap<_, _> = updates.into_iter().collect();
+        let source = json!({
+            "role": "function_result",
+            "function_call_id": "call_1",
+            "function_id": "engine::functions::info",
+            "content": serde_json::to_value(&prepared.content).unwrap()
+        });
+        retain_visible_contract_sources(&mut ledger, &[source]);
+        let (second, _) = prepare_info_result(
+            "call_2",
+            &json!({ "function_ids": ["worker::function"] }),
+            &data,
+            &ledger,
+            true,
+        );
+        let rendered: Value =
+            serde_json::from_str(&ContentBlock::join_text(&second.content)).unwrap();
+        assert_eq!(
+            rendered["functions"][0]["contract_status"],
+            "unchanged_in_context"
+        );
+    }
+
     #[test]
     fn unchanged_info_contract_reuses_an_exact_model_visible_source() {
         let details = json!({
@@ -619,8 +720,9 @@ mod tests {
             true,
         );
         assert_eq!(
-            first.content, data.content,
-            "the first full result is retained"
+            first.content,
+            stripped_content(&data.details),
+            "the first result keeps everything but response schemas"
         );
         ledger.extend(updates);
 
@@ -734,13 +836,13 @@ mod tests {
         assert!(ledger.is_empty(), "the exact last result must match");
 
         let (without_source, updates) = prepare_info_result("repeat", &args, &data, &ledger, true);
-        assert_eq!(without_source.content, data.content);
+        assert_eq!(without_source.content, stripped_content(&data.details));
         assert_eq!(updates.len(), 1, "the new full result becomes the source");
 
         let same_call_ledger: BTreeMap<_, _> = updates.into_iter().collect();
         let (same_call, updates) =
             prepare_info_result("repeat", &args, &data, &same_call_ledger, true);
-        assert_eq!(same_call.content, data.content);
+        assert_eq!(same_call.content, stripped_content(&data.details));
         assert!(updates.is_empty(), "a call id cannot source itself");
 
         let (hook_mutated, updates) =
@@ -760,7 +862,8 @@ mod tests {
         };
         let (prepared, updates) =
             prepare_info_result("changed", &args, &changed, &same_call_ledger, true);
-        assert_eq!(prepared, changed);
+        assert_eq!(prepared.content, stripped_content(&changed.details));
+        assert_eq!(prepared.details, changed.details);
         assert_eq!(updates.len(), 1, "a changed contract stays full");
 
         let error = ResultData {
@@ -803,7 +906,8 @@ mod tests {
             true,
         );
 
-        assert_eq!(prepared, data);
+        assert_eq!(prepared.content, stripped_content(&data.details));
+        assert_eq!(prepared.details, data.details);
         assert!(updates.is_empty());
     }
 
@@ -857,7 +961,14 @@ mod tests {
         let rendered: Value = serde_json::from_str(&ContentBlock::join_text(&prepared.content))
             .expect("prepared batch content is JSON");
 
-        assert_eq!(rendered["functions"][0], details["functions"][0]);
+        assert_eq!(
+            rendered["functions"][0],
+            json!({
+                "function_id": "worker::bad",
+                "request_schema": { "type": 42 }
+            }),
+            "malformed entry stays full, minus the stripped response schema"
+        );
         assert_eq!(
             rendered["functions"][1],
             json!({
@@ -907,7 +1018,8 @@ mod tests {
             true,
         );
 
-        assert_eq!(prepared, data);
+        assert_eq!(prepared.content, stripped_content(&data.details));
+        assert_eq!(prepared.details, data.details);
         assert!(updates.is_empty());
     }
 
@@ -1098,7 +1210,8 @@ mod tests {
             &BTreeMap::new(),
             true,
         );
-        assert_eq!(prepared, data);
+        assert_eq!(prepared.content, stripped_content(&data.details));
+        assert_eq!(prepared.details, data.details);
         assert!(updates.is_empty());
     }
 

--- a/harness/src/turn_loop.rs
+++ b/harness/src/turn_loop.rs
@@ -497,16 +497,15 @@ pub async fn run_step(
     // Build every deterministic model-facing input before context assembly.
     // Registry-change notice: if the function registry changed since this
     // session last acknowledged its generation, tell the model its cached
-    // contracts may be stale. First sighting stamps silently.
+    // contracts may be stale. First sighting stamps silently. The notice rides
+    // as a tail message, never a system-prompt mutation: the system prompt is
+    // the provider's first input item, and a one-shot append-then-remove there
+    // invalidates the whole prompt-cache prefix twice per event.
     let current_generation = functions.generation;
-    let mut assembly_system_prompt =
+    let assembly_system_prompt =
         with_runtime_context(record.options.system_prompt.clone(), &record);
-    if let Some(notice) = registry_notice(record.functions_generation, current_generation) {
-        assembly_system_prompt = Some(match assembly_system_prompt.take() {
-            Some(prompt) if !prompt.is_empty() => format!("{prompt}\n\n{notice}"),
-            _ => notice,
-        });
-    }
+    let registry_notice_message =
+        registry_notice(record.functions_generation, current_generation).map(notice_message);
     record.functions_generation = Some(current_generation);
 
     // Resolve the output-contract strategy and build the invocation surface:
@@ -632,8 +631,12 @@ pub async fn run_step(
                 .await;
             }
         };
-        let hook_appended = !appended.is_empty();
+        // The notice lands after the hooks ran (they must not read it as the
+        // newest user message) and before their appends (hook messages stay
+        // last, closest to the decision point).
+        let hook_appended = !appended.is_empty() || registry_notice_message.is_some();
         let mut gen_messages = assembled.messages.clone();
+        gen_messages.extend(registry_notice_message.iter().cloned());
         gen_messages.extend(appended);
 
         // Post-assembly invariant guard: providers reject a context where an
@@ -3016,9 +3019,20 @@ fn patch_orphaned_calls(messages: &mut Vec<Value>) -> usize {
     patched
 }
 
-/// The single-line notice appended to the system prompt when the registry
+/// The single-line notice delivered as a tail message when the registry
 /// changed under a session that had already acknowledged an earlier generation.
 const REGISTRY_CHANGED_NOTICE: &str = "NOTE: the function registry changed during this conversation. Function contracts fetched earlier may be stale — re-fetch the contracts you rely on (engine::functions::info) before calling those functions again.";
+
+/// Wrap the notice as an ephemeral tail user message for the generate request.
+/// `timestamp` is mandatory — the router's message types have no serde default
+/// for it — and never reaches the provider wire.
+fn notice_message(text: String) -> Value {
+    json!({
+        "role": "user",
+        "content": [{ "type": "text", "text": text }],
+        "timestamp": AgentMessage::now_ms(),
+    })
+}
 
 /// Decide the registry-change notice for a step. `None` when the record already
 /// matches the live generation, or is being stamped for the first time; `Some`
@@ -3277,7 +3291,7 @@ mod tests {
 
         let (second, updates) =
             crate::trigger::prepare_info_result("call-2", &arguments, &data, &ledger, true);
-        assert_eq!(second.content, data.content, "a sibling result stays full");
+        assert_eq!(second.content, first.content, "a sibling result stays full");
         crate::trigger::apply_contract_updates_after_append(&mut ledger, "call-2", updates);
 
         crate::trigger::retain_visible_contract_sources(
@@ -3304,7 +3318,19 @@ mod tests {
             )]
         );
         assert!(updates.is_empty());
-        assert_eq!(first.content, data.content);
+        assert_eq!(
+            first.content,
+            crate::trigger::prepare_info_result(
+                "probe",
+                &arguments,
+                &data,
+                &Default::default(),
+                true
+            )
+            .0
+            .content,
+            "the first result is the full (response-schema-stripped) rendering"
+        );
     }
 
     #[test]
@@ -3646,6 +3672,17 @@ mod tests {
         assert!(super::registry_notice(Some(7), 7).is_none());
         // Registry moved on: notice fires.
         assert!(super::registry_notice(Some(6), 7).is_some());
+    }
+
+    #[test]
+    fn notice_message_is_a_timestamped_tail_user_message() {
+        let msg = super::notice_message(super::REGISTRY_CHANGED_NOTICE.to_string());
+        assert_eq!(msg["role"], "user");
+        assert_eq!(msg["content"][0]["type"], "text");
+        assert_eq!(msg["content"][0]["text"], super::REGISTRY_CHANGED_NOTICE);
+        // The router's message types have no serde default for `timestamp`;
+        // omitting it fails deserialization at the router boundary.
+        assert!(msg["timestamp"].is_i64());
     }
 
     #[test]

--- a/harness/tests/golden/schemas/harness.system-prompt.get.json
+++ b/harness/tests/golden/schemas/harness.system-prompt.get.json
@@ -133,7 +133,6 @@
           "selected",
           "skills",
           "runtime",
-          "registry_notice",
           "injected"
         ],
         "type": "string"

--- a/harness/tests/integration/src/scenarios/function_contract_reuse.rs
+++ b/harness/tests/integration/src/scenarios/function_contract_reuse.rs
@@ -9,7 +9,10 @@ use super::ScenarioDriver;
 use crate::fixtures::ScenarioFixture;
 
 const INFO: &str = "engine::functions::info";
-const FULL_CONTRACT: &str = r#"{"description":"Record one integration fixture value.","function_id":"{{run_id}}::record","registered_triggers":[],"request_schema":{"properties":{"value":{"type":"string"}},"required":["value"],"type":"object"},"response_schema":{"$schema":"http://json-schema.org/draft-07/schema#","const":{"content":[{"text":"recorded","type":"text"}],"is_error":false}},"worker_name":"integration-probe"}"#;
+// The MODEL-VISIBLE first result: the raw engine contract minus the
+// response-side schema keys prepare_info_result strips (the raw contract,
+// response_schema included, stays in `details`).
+const FULL_CONTRACT: &str = r#"{"description":"Record one integration fixture value.","function_id":"{{run_id}}::record","registered_triggers":[],"request_schema":{"properties":{"value":{"type":"string"}},"required":["value"],"type":"object"},"worker_name":"integration-probe"}"#;
 
 pub(super) fn scenario() -> ScenarioFixture {
     const ID: &str = "INT-025";
@@ -147,7 +150,9 @@ mod tests {
             serde_json::to_string(&fixture.script.generations[1].match_.messages).unwrap();
         assert!(first_gate.contains("\"content\""), "{first_gate}");
         assert!(first_gate.contains("request_schema"), "{first_gate}");
-        assert!(first_gate.contains("response_schema"), "{first_gate}");
+        // Response-side schemas are stripped from the model-visible copy
+        // (they stay in `details`), so the gate must not expect them.
+        assert!(!first_gate.contains("response_schema"), "{first_gate}");
 
         let gate = serde_json::to_string(&fixture.script.generations[2].match_.messages).unwrap();
         assert!(gate.contains("call-info-2"), "{gate}");

--- a/harness/tests/integration/src/scenarios/wake_expiry_notice.rs
+++ b/harness/tests/integration/src/scenarios/wake_expiry_notice.rs
@@ -134,7 +134,10 @@ pub(super) fn scenario() -> ScenarioFixture {
     // unregister is a registry change; the staleness notice now rides as an
     // ephemeral TAIL user message (never a system-prompt mutation — that
     // invalidated the provider's prompt-cache prefix), so the prompt keeps
-    // the stable sha and the notice is pinned as the final message.
+    // the stable sha. Advisory tail messages are invisible to matchers (the
+    // scripted router strips them — their timing is stack noise elsewhere),
+    // so the notice delivery is asserted over the raw router evidence in
+    // verify instead of a message gate here.
     .generation(
         Generation::new(3)
             .expect(
@@ -147,10 +150,6 @@ pub(super) fn scenario() -> ScenarioFixture {
                         json!({ "role": "function_result" }),
                         json!({ "role": "assistant" }),
                         json!({ "role": "user" }),
-                        json!({ "role": "user", "content": [{
-                            "type": "text",
-                            "text": "NOTE: the function registry changed during this conversation. Function contracts fetched earlier may be stale — re-fetch the contracts you rely on (engine::functions::info) before calling those functions again."
-                        }] }),
                     ])
                     .tools_exact_after_controls([REGISTER], [record.tool()]),
             )
@@ -158,6 +157,31 @@ pub(super) fn scenario() -> ScenarioFixture {
     )
     .verify(|run| {
         run.expect_assistant_texts(["armed and parked", "expiry noted"])?;
+
+        // The registry-changed notice reached the provider on the woken turn
+        // as a raw tail user message (matchers never see advisories; the raw
+        // router evidence keeps them).
+        let notice_delivered = run
+            .router_evidence
+            .get("calls")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(|call| call.get("request")?.get("messages")?.as_array())
+            .flatten()
+            .any(|message| {
+                message
+                    .get("content")
+                    .and_then(Value::as_array)
+                    .and_then(|blocks| blocks.first())
+                    .and_then(|block| block.get("text"))
+                    .and_then(Value::as_str)
+                    .is_some_and(|text| text.starts_with("NOTE: the function registry changed"))
+            });
+        anyhow::ensure!(
+            notice_delivered,
+            "the registry-changed notice must reach the provider as a tail message"
+        );
 
         // Exactly one notification, and it must carry everything the woken
         // session needs to act without a lookup: the watch, the zero-fire

--- a/harness/tests/integration/src/scenarios/wake_expiry_notice.rs
+++ b/harness/tests/integration/src/scenarios/wake_expiry_notice.rs
@@ -130,22 +130,27 @@ pub(super) fn scenario() -> ScenarioFixture {
             .respond(Response::text("armed and parked", 10, 2)),
     )
     // The expiry-woken turn: a fresh externally initiated turn carrying the
-    // wake-lost notification as its user message. Its prompt is NOT the arm
-    // turn's — the sweep's engine-side unregister is a registry change, so
-    // the staleness notice deterministically joins the prompt; pin the notice
-    // instead of the sha (same drift INT-008 handles).
+    // wake-lost notification as its user message. The sweep's engine-side
+    // unregister is a registry change; the staleness notice now rides as an
+    // ephemeral TAIL user message (never a system-prompt mutation — that
+    // invalidated the provider's prompt-cache prefix), so the prompt keeps
+    // the stable sha and the notice is pinned as the final message.
     .generation(
         Generation::new(3)
             .expect(
                 Request::new()
                     .turn_request_step(0)
-                    .system_prompt_regex("registry changed during this conversation")
+                    .system_prompt_sha256("{{system_prompt_sha256}}")
                     .messages_subset([
                         json!({ "role": "user" }),
                         json!({ "role": "assistant" }),
                         json!({ "role": "function_result" }),
                         json!({ "role": "assistant" }),
                         json!({ "role": "user" }),
+                        json!({ "role": "user", "content": [{
+                            "type": "text",
+                            "text": "NOTE: the function registry changed during this conversation. Function contracts fetched earlier may be stale — re-fetch the contracts you rely on (engine::functions::info) before calling those functions again."
+                        }] }),
                     ])
                     .tools_exact_after_controls([REGISTER], [record.tool()]),
             )

--- a/harness/tests/integration/src/scripted_router.rs
+++ b/harness/tests/integration/src/scripted_router.rs
@@ -450,30 +450,37 @@ async fn wait_for_gate_state(
     }
 }
 
-/// Drop iii-directory's `<discovery_assist>` hint messages from the MATCHED
-/// view of a request. The hint is an ephemeral tail user message whose
-/// presence depends on the booted stack (inject_hint config, worker count,
-/// per-turn gates), so no fixture can pin it deterministically — exactly as
-/// before, when it was an unpinned system-prompt mutation. Only the matched
-/// copy is filtered; call evidence keeps the raw request. The registry-changed
-/// notice is NOT filtered: it is deterministic within a scenario's script and
-/// INT-017 pins it as a message.
-fn without_discovery_hints(input: &Value) -> Value {
+/// Drop the harness's ephemeral advisory tail messages from the MATCHED view
+/// of a request: iii-directory's `<discovery_assist>` hint and the harness
+/// registry-changed notice. Both ride as tail user messages whose presence
+/// depends on the booted stack (inject_hint config, worker count, per-turn
+/// gates, registration timing while the stack settles), so no fixture can pin
+/// them deterministically — exactly as before, when they were unpinned
+/// system-prompt mutations. Only the matched copy is filtered; call evidence
+/// keeps the raw request, so a scenario that asserts an advisory was
+/// delivered does it over `router_evidence` (INT-017 does).
+fn without_advisory_tail_messages(input: &Value) -> Value {
     let mut matched = input.clone();
     if let Some(messages) = matched.get_mut("messages").and_then(Value::as_array_mut) {
-        messages.retain(|message| {
-            let is_hint = message.get("role").and_then(Value::as_str) == Some("user")
-                && message
-                    .get("content")
-                    .and_then(Value::as_array)
-                    .and_then(|blocks| blocks.first())
-                    .and_then(|block| block.get("text"))
-                    .and_then(Value::as_str)
-                    .is_some_and(|text| text.starts_with("<discovery_assist"));
-            !is_hint
-        });
+        messages.retain(|message| !is_advisory_message(message));
     }
     matched
+}
+
+/// True for the hint / registry-notice user messages the harness appends per
+/// generation (never persisted to the transcript).
+pub fn is_advisory_message(message: &Value) -> bool {
+    message.get("role").and_then(Value::as_str) == Some("user")
+        && message
+            .get("content")
+            .and_then(Value::as_array)
+            .and_then(|blocks| blocks.first())
+            .and_then(|block| block.get("text"))
+            .and_then(Value::as_str)
+            .is_some_and(|text| {
+                text.starts_with("<discovery_assist")
+                    || text.starts_with("NOTE: the function registry changed")
+            })
 }
 
 async fn chat(
@@ -482,7 +489,7 @@ async fn chat(
     client: Arc<IIIClient>,
     input: Value,
 ) -> Result<Value, Error> {
-    let matched_input = without_discovery_hints(&input);
+    let matched_input = without_advisory_tail_messages(&input);
     // Match under the lock; stream outside it.
     let (generation, writer_ref, request_id) = {
         let mut state = state.lock().expect("router state");
@@ -850,27 +857,29 @@ mod tests {
     }
 
     #[test]
-    fn discovery_hint_messages_are_invisible_to_matchers() {
+    fn advisory_tail_messages_are_invisible_to_matchers() {
         let input = serde_json::json!({ "messages": [
             { "role": "user", "content": [{ "type": "text", "text": "do the task" }] },
             { "role": "user", "content": [{ "type": "text",
                 "text": "<discovery_assist functions_generation=3>\nBefore calling..." }] },
             { "role": "user", "content": [{ "type": "text",
                 "text": "NOTE: the function registry changed during this conversation. ..." }] },
+            // A user message merely QUOTING an advisory mid-text stays.
+            { "role": "user", "content": [{ "type": "text",
+                "text": "what does NOTE: the function registry changed mean?" }] },
         ]});
-        let matched = super::without_discovery_hints(&input);
+        let matched = super::without_advisory_tail_messages(&input);
         let texts: Vec<&str> = matched["messages"]
             .as_array()
             .unwrap()
             .iter()
             .map(|m| m["content"][0]["text"].as_str().unwrap())
             .collect();
-        // The hint is stripped; the user message and the (deterministic,
-        // INT-017-pinned) registry notice stay.
+        // Both advisories are stripped; real user messages stay.
         assert_eq!(texts.len(), 2);
         assert!(texts[0].starts_with("do the task"));
-        assert!(texts[1].starts_with("NOTE: the function registry changed"));
-        // The raw input is untouched.
-        assert_eq!(input["messages"].as_array().unwrap().len(), 3);
+        assert!(texts[1].starts_with("what does NOTE:"));
+        // The raw input is untouched (call evidence keeps advisories).
+        assert_eq!(input["messages"].as_array().unwrap().len(), 4);
     }
 }

--- a/harness/tests/integration/src/scripted_router.rs
+++ b/harness/tests/integration/src/scripted_router.rs
@@ -450,12 +450,39 @@ async fn wait_for_gate_state(
     }
 }
 
+/// Drop iii-directory's `<discovery_assist>` hint messages from the MATCHED
+/// view of a request. The hint is an ephemeral tail user message whose
+/// presence depends on the booted stack (inject_hint config, worker count,
+/// per-turn gates), so no fixture can pin it deterministically — exactly as
+/// before, when it was an unpinned system-prompt mutation. Only the matched
+/// copy is filtered; call evidence keeps the raw request. The registry-changed
+/// notice is NOT filtered: it is deterministic within a scenario's script and
+/// INT-017 pins it as a message.
+fn without_discovery_hints(input: &Value) -> Value {
+    let mut matched = input.clone();
+    if let Some(messages) = matched.get_mut("messages").and_then(Value::as_array_mut) {
+        messages.retain(|message| {
+            let is_hint = message.get("role").and_then(Value::as_str) == Some("user")
+                && message
+                    .get("content")
+                    .and_then(Value::as_array)
+                    .and_then(|blocks| blocks.first())
+                    .and_then(|block| block.get("text"))
+                    .and_then(Value::as_str)
+                    .is_some_and(|text| text.starts_with("<discovery_assist"));
+            !is_hint
+        });
+    }
+    matched
+}
+
 async fn chat(
     state: Arc<Mutex<State>>,
     address: String,
     client: Arc<IIIClient>,
     input: Value,
 ) -> Result<Value, Error> {
+    let matched_input = without_discovery_hints(&input);
     // Match under the lock; stream outside it.
     let (generation, writer_ref, request_id) = {
         let mut state = state.lock().expect("router state");
@@ -496,7 +523,7 @@ async fn chat(
                 .match_
                 .fields()
                 .iter()
-                .map(|(field, matcher)| evaluate(field, matcher, input.get(*field)))
+                .map(|(field, matcher)| evaluate(field, matcher, matched_input.get(*field)))
                 .collect();
             if field_results.iter().all(|result| result.passed) {
                 selected = Some((index, generation, field_results));
@@ -820,5 +847,30 @@ mod tests {
             .await
             .expect("gate release should wake the router")
             .expect("router gate task should finish");
+    }
+
+    #[test]
+    fn discovery_hint_messages_are_invisible_to_matchers() {
+        let input = serde_json::json!({ "messages": [
+            { "role": "user", "content": [{ "type": "text", "text": "do the task" }] },
+            { "role": "user", "content": [{ "type": "text",
+                "text": "<discovery_assist functions_generation=3>\nBefore calling..." }] },
+            { "role": "user", "content": [{ "type": "text",
+                "text": "NOTE: the function registry changed during this conversation. ..." }] },
+        ]});
+        let matched = super::without_discovery_hints(&input);
+        let texts: Vec<&str> = matched["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|m| m["content"][0]["text"].as_str().unwrap())
+            .collect();
+        // The hint is stripped; the user message and the (deterministic,
+        // INT-017-pinned) registry notice stay.
+        assert_eq!(texts.len(), 2);
+        assert!(texts[0].starts_with("do the task"));
+        assert!(texts[1].starts_with("NOTE: the function registry changed"));
+        // The raw input is untouched.
+        assert_eq!(input["messages"].as_array().unwrap().len(), 3);
     }
 }

--- a/iii-directory/src/hook.rs
+++ b/iii-directory/src/hook.rs
@@ -1,7 +1,8 @@
 //! `directory::pre-generate` — the conditional search hint. One short
 //! standing instruction pointing the model at `directory::search_functions`,
-//! injected at most once per turn and only when discovery is plausibly
-//! needed. Moved from the reflex spike's `search` selector branch; measured
+//! appended as the generation's final message at most once per turn and only
+//! when discovery is plausibly needed. Moved from the reflex spike's `search`
+//! selector branch; measured
 //! there: an unconditional per-generation hint *induces* redundant discovery
 //! on guided tasks (double discovery, up to +110% tokens), so every gate
 //! below earns its place.
@@ -90,7 +91,12 @@ pub enum ExposeKind {
 
 #[derive(Debug, Clone, serde::Serialize, schemars::JsonSchema)]
 pub struct PreGenerateMutations {
-    pub system_prompt: String,
+    /// Ephemeral tail messages for this generation only. The hint rides here
+    /// rather than as a system-prompt mutation: the system prompt is the
+    /// provider's first input item, and a once-per-turn append there
+    /// invalidated the entire prompt-cache prefix twice per turn.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub append_messages: Vec<Value>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, schemars::JsonSchema)]
@@ -284,14 +290,22 @@ Before calling any task function whose ID has not already been verified in this 
     )
 }
 
-/// The conditional hint block appended to the system prompt.
-fn hint_prompt(system_prompt: &str, functions_generation: u64, expose: ExposeKind) -> String {
-    let hint = hint_block(functions_generation, expose);
-    if system_prompt.is_empty() {
-        hint
-    } else {
-        format!("{system_prompt}\n\n{hint}")
-    }
+/// The hint as an ephemeral tail user message. `timestamp` is mandatory —
+/// the router's message types have no serde default for it — and never
+/// reaches the provider wire.
+fn hint_message(functions_generation: u64, expose: ExposeKind) -> Value {
+    serde_json::json!({
+        "role": "user",
+        "content": [{ "type": "text", "text": hint_block(functions_generation, expose) }],
+        "timestamp": now_ms(),
+    })
+}
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
 }
 
 #[derive(Debug, Clone, Default, serde::Deserialize, schemars::JsonSchema)]
@@ -320,7 +334,9 @@ pub fn hint_preview() -> HintPreviewResponse {
 pub async fn pre_generate(deps: &Deps, request: PreGenerateHookRequest) -> PreGenerateHookResponse {
     let config = deps.config.load_full();
     let GeneratePayload {
-        system_prompt,
+        // Wire compat: the harness always sends it; the hint no longer
+        // mutates it (see PreGenerateMutations).
+        system_prompt: _,
         messages,
         functions_generation,
         tools,
@@ -400,7 +416,7 @@ pub async fn pre_generate(deps: &Deps, request: PreGenerateHookRequest) -> PreGe
     PreGenerateHookResponse {
         decision: "continue".to_string(),
         mutations: Some(PreGenerateMutations {
-            system_prompt: hint_prompt(&system_prompt, functions_generation, expose),
+            append_messages: vec![hint_message(functions_generation, expose)],
         }),
         annotations: annotation(DiscoveryPassV1 {
             outcome: DiscoveryOutcome::HintInjected,
@@ -475,6 +491,21 @@ mod tests {
         assert_eq!(response.annotations.directory.data.reason, Some(reason));
     }
 
+    /// The hint must be exactly one appended user message with one text
+    /// block and a timestamp (the router's message types have no serde
+    /// default for it). Returns the hint text for content assertions.
+    fn hint_text(response: &PreGenerateHookResponse) -> String {
+        let appended = &response.mutations.as_ref().unwrap().append_messages;
+        assert_eq!(appended.len(), 1, "exactly one appended hint message");
+        let message = &appended[0];
+        assert_eq!(message["role"], "user");
+        assert!(message["timestamp"].is_i64());
+        let blocks = message["content"].as_array().unwrap();
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0]["type"], "text");
+        blocks[0]["text"].as_str().unwrap().to_string()
+    }
+
     #[tokio::test]
     async fn injects_the_hint_when_every_gate_clears() {
         let deps = deps();
@@ -483,8 +514,8 @@ mod tests {
             response.annotations.directory.data.outcome,
             DiscoveryOutcome::HintInjected
         );
-        let prompt = &response.mutations.as_ref().unwrap().system_prompt;
-        assert!(prompt.starts_with("base discovery prompt\n\n<discovery_assist"));
+        let prompt = hint_text(&response);
+        assert!(prompt.starts_with("<discovery_assist"));
         assert!(prompt.contains("call directory::search_functions ONCE"));
         assert!(prompt
             .contains("Before calling any task function whose ID has not already been verified"));
@@ -534,8 +565,10 @@ mod tests {
             response.annotations.directory.data.outcome,
             DiscoveryOutcome::HintInjected
         );
-        let prompt = &response.mutations.as_ref().unwrap().system_prompt;
-        assert!(prompt.contains("payload `{\"id\":\"<exact id>\"}`"));
+        // The hint rides as an appended message, so the system prompt (and the
+        // pre-verified guidance it carries) is untouched by construction; the
+        // hint's own carve-out for pre-verified calls must still be present.
+        let prompt = hint_text(&response);
         assert!(prompt.contains("A call marked pre-verified by a Harness runtime block or update"));
         assert!(prompt.contains("do not search for it or fetch its contract"));
         assert!(prompt
@@ -549,7 +582,7 @@ mod tests {
         let mut request = request_for("find the stars", wide_tools());
         request.generate.expose = ExposeKind::Native;
         let response = pre_generate(&deps, request).await;
-        let prompt = &response.mutations.as_ref().unwrap().system_prompt;
+        let prompt = hint_text(&response);
         assert!(prompt.contains("required `capabilities` request field"));
         assert!(!prompt.contains("agent_trigger"));
     }

--- a/iii-directory/tests/golden/schemas/directory.pre-generate.json
+++ b/iii-directory/tests/golden/schemas/directory.pre-generate.json
@@ -202,12 +202,14 @@
       },
       "PreGenerateMutations": {
         "properties": {
-          "system_prompt": {
-            "type": "string"
+          "append_messages": {
+            "description": "Ephemeral tail messages for this generation only. The hint rides here rather than as a system-prompt mutation: the system prompt is the provider's first input item, and a once-per-turn append there invalidated the entire prompt-cache prefix twice per turn.",
+            "items": true,
+            "type": "array"
           }
         },
         "required": [
-          "system_prompt"
+          "append_messages"
         ],
         "type": "object"
       }


### PR DESCRIPTION
## Problem

OpenAI prompt caching never hit across turns — `cache_read: 0` at every turn boundary in live codex sessions (even 13s apart), so the full ~29k-token context was re-billed at 100% input price every turn. The cache key/affinity plumbing was fine and the codex provider is byte-deterministic; the assembled request itself was not byte-stable. The system prompt ships as the provider's **first input item**, so any change to it invalidates the entire prefix.

Root causes, confirmed by a byte-level diff of real captured request bodies (`traces.sqlite3`) plus code trace:

1. **`<discovery_assist>` hint** (iii-directory pre-generate hook): appended to the system prompt on step 0 of every turn, dropped on steps 1+ — two full-prefix invalidations per turn, every turn.
2. **Registry-changed notice** (harness): same add-then-remove on the system prompt, with generation bumps firing even for byte-identical function sets.
3. **`Your working directory is {dir}.`** flipped whenever a send omitted `fs_scope` (per-turn option, no inheritance) — trace-proven divergence at byte 23060.

Two context-size issues found while measuring composition:

4. The console re-attached the full skill body on every `/skill:` invocation (3 identical copies in one session).
5. `engine::functions::info` carried `response_schema`/`response_format` to the model — ~41% of contract bytes the model never needs to call a function.

## Fix

- Hint and notice ride as **ephemeral tail messages** (`mutations.append_messages` — existing hook contract, memory worker precedent). Only the tail diverges when they appear; the once-per-turn semantics are unchanged.
- `apply()` bumps the functions generation **only on fingerprint change**.
- `fs_scope` **inherits** from the prior turn like model/prompt/policy; explicit `fs_scope: {}` still clears.
- The console sends a short **pointer block** when the same skill block already rides in the transcript (reset at compaction markers).
- `prepare_info_result` **strips response schemas** from the model-visible copy; the raw contract stays in `details` and ledger digests stay over raw, so `unchanged_in_context` dedupe is unaffected.

## Live verification (dev stack, codex)

| Measurement | Before | After |
|---|---|---|
| Turn-boundary `cache_read` | 0, always | 19,968 of ~20.2k |
| Step after hint appears/disappears | 0 | 18,944 |
| Repeat `/skill:` send | ~2.6k tok re-attached, full-price re-read | **180 tok in**, 8,192 cached |
| 3-contract `functions::info` | 28,088 ch | 16,538 ch |
| Repeat contract fetch (same or later turn) | 28,088 ch | 421 ch (markers) |

A/B side-finding: `gpt-5.6-luna`'s fleet evicts its prompt cache within ~4 min idle while `gpt-5.4-mini` retains it (same build, same shape, ~235s gap) — provider-side, out of scope.

## Tests

harness 423 lib tests (6 fixture updates + 1 new strip test), iii-directory 376 `--lib` + schema goldens, console 18 vitest + tsc + biome. Both golden diffs are exactly the mutations-shape change and the `RegistryNotice` enum-variant removal.

Known trade-off: a response-schema-only registry change is fingerprint-invisible and no longer produces a staleness notice; the engine-side schema-aware `functions_hash` (already named at the safety-reload ponytail comment) is the real fix for that.

https://linear.app/motia/issue/MOT-4572

https://claude.ai/code/session_01C27p7LmUtAFpYE3cddH7kA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Slash commands recognize skills already loaded in a conversation, avoiding repeated content retrieval.
  - Discovery hints and registry updates appear as timestamped, temporary conversation messages.

- **Improvements**
  - Model-facing function information omits response-schema details while retaining underlying contracts.
  - System prompt previews are simplified by removing registry notices.
  - Function discovery reloads are handled more consistently.

- **Bug Fixes**
  - Preserved explicit filesystem-scope settings, including intentional clearing or replacement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->