### PR TITLE
docs: iii is a language agnostic runtime, not a worker mesh

### DIFF
--- a/claude-code/src/iii-prompt.ts
+++ b/claude-code/src/iii-prompt.ts
@@ -9,7 +9,8 @@
 
 export const III_CONTEXT_PROMPT = `# iii runtime
 
-This machine runs an iii engine: a WebSocket-routed worker mesh whose single engine process
+This machine runs an iii engine. iii is a language agnostic runtime where services, agents, and
+tools are composed of the same things: workers, triggers, and functions. The single engine process
 holds a live registry of every connected worker, every function those workers expose, and every
 trigger bound to them. Every call routes worker -> engine -> worker, so the language, runtime,
 and location of a worker are invisible to its callers. The function id is the ONLY contract

--- a/codex/src/iii_prompt.rs
+++ b/codex/src/iii_prompt.rs
@@ -6,7 +6,8 @@
 
 pub const III_CONTEXT_PROMPT: &str = r#"# iii runtime
 
-This machine runs an iii engine: a WebSocket-routed worker mesh whose single engine process
+This machine runs an iii engine. iii is a language agnostic runtime where services, agents, and
+tools are composed of the same things: workers, triggers, and functions. The single engine process
 holds a live registry of every connected worker, every function those workers expose, and every
 trigger bound to them. Every call routes worker -> engine -> worker, so the language, runtime,
 and location of a worker are invisible to its callers. The function id is the ONLY contract

--- a/console/web/src/stories/fixtures/coder-fixtures.ts
+++ b/console/web/src/stories/fixtures/coder-fixtures.ts
@@ -52,17 +52,17 @@ iii.registerFunction(
 const III_SKILL_MD = `---
 name: iii
 description: >-
-  WebSocket-routed worker mesh — the engine's Function/Trigger/Worker model and
-  the iii-sdk surface for authoring them.
+  Language agnostic runtime where services, agents, and tools are composed of
+  the same things: workers, triggers, and functions.
 ---
 
 # iii
 
-iii is a WebSocket-routed worker mesh. One engine process (default port \`49134\`)
-holds a live registry of every connected worker, every function those workers
-expose, and every trigger bound to them. Workers are independent OS processes
-that open a WebSocket to the engine and register **Functions** (\`service::name\`
-handlers) and **Triggers** (the events that invoke those Functions).
+iii is a language agnostic runtime where services, agents, and tools are composed of the same things:
+workers, triggers, and functions. One engine process (default port \`49134\`) holds a live registry
+of every connected worker, every function those workers expose, and every trigger bound to them.
+Workers are independent OS processes that open a WebSocket to the engine and register **Functions**
+(\`service::name\` handlers) and **Triggers** (the events that invoke those Functions).
 
 \`\`\`ts
 import { registerWorker } from 'iii-sdk'

--- a/console/web/src/stories/fixtures/workflow-fixtures.ts
+++ b/console/web/src/stories/fixtures/workflow-fixtures.ts
@@ -129,7 +129,7 @@ Armin Ronacher's "The Coming Loop" names something a lot of us have felt and
 mostly tried not to think about. You start an agent loop, it runs, code appears,
 tests pass — and somewhere in the middle of that you stop being the author.
 
-I work on iii, a worker mesh, and I want to make a specific, scoped claim: iii
+I work on iii, a language agnostic runtime, and I want to make a specific, scoped claim: iii
 is a partial answer to Ronacher's problem. A real one, but narrow.
 
 ## Enumerable is not comprehensible

--- a/devin/README.md
+++ b/devin/README.md
@@ -115,7 +115,7 @@ Because the CLI agent runs locally with the iii runtime context, a plain questio
 iii trigger devin::run --json '{"prompt":"What workers are connected to this iii engine and what does each do?","cwd":"/tmp"}' | jq -r '.result'
 ```
 
-![Devin answering a plain question by discovering the live iii mesh through the iii CLI](https://raw.githubusercontent.com/iii-hq/workers/main/devin/assets/iii-discovery.png)
+![Devin answering a plain question by discovering the live iii runtime through the iii CLI](https://raw.githubusercontent.com/iii-hq/workers/main/devin/assets/iii-discovery.png)
 
 Or ask it to map the whole engine by capability area, and it groups what it finds itself:
 

--- a/devin/README.md
+++ b/devin/README.md
@@ -115,7 +115,7 @@ Because the CLI agent runs locally with the iii runtime context, a plain questio
 iii trigger devin::run --json '{"prompt":"What workers are connected to this iii engine and what does each do?","cwd":"/tmp"}' | jq -r '.result'
 ```
 
-![Devin answering a plain question by discovering the live iii runtime through the iii CLI](https://raw.githubusercontent.com/iii-hq/workers/main/devin/assets/iii-discovery.png)
+![Devin answering a plain question by discovering the live iii worker functionality through the iii CLI](https://raw.githubusercontent.com/iii-hq/workers/main/devin/assets/iii-discovery.png)
 
 Or ask it to map the whole engine by capability area, and it groups what it finds itself:
 

--- a/devin/skills/SKILL.md
+++ b/devin/skills/SKILL.md
@@ -36,7 +36,7 @@ Devin itself, add another iii worker to the bus instead of bolting it on.
 - Delegate a coding task to the local agent in a chosen directory: `devin::run`
   with `prompt` and `cwd`; follow `devin::events` / `agent::events`; interrupt
   with `devin::stop`.
-- Have Devin operate your iii runtime: with `iii_context` on (default), ask a plain
+- Have Devin operate your iii workers: with `iii_context` on (default), ask a plain
   question ("what workers are connected and what does each do?") and Devin
   discovers and calls engine functions itself through the iii CLI.
 - Delegate a whole task to Devin's cloud agent ("open a PR that adds X"):

--- a/devin/skills/SKILL.md
+++ b/devin/skills/SKILL.md
@@ -2,7 +2,7 @@
 name: devin
 description: >-
   Drive Devin over the iii bus. Run the local Devin CLI agent (SWE-1.6) with the
-  iii runtime context so it discovers and operates your mesh, or start and steer
+  iii runtime context so it discovers and operates your workers, or start and steer
   autonomous Devin cloud sessions through the REST API, with a passthrough to any
   Devin v1/v3 endpoint.
 ---
@@ -36,7 +36,7 @@ Devin itself, add another iii worker to the bus instead of bolting it on.
 - Delegate a coding task to the local agent in a chosen directory: `devin::run`
   with `prompt` and `cwd`; follow `devin::events` / `agent::events`; interrupt
   with `devin::stop`.
-- Have Devin operate your iii mesh: with `iii_context` on (default), ask a plain
+- Have Devin operate your iii runtime: with `iii_context` on (default), ask a plain
   question ("what workers are connected and what does each do?") and Devin
   discovers and calls engine functions itself through the iii CLI.
 - Delegate a whole task to Devin's cloud agent ("open a PR that adds X"):

--- a/devin/src/iii_prompt.rs
+++ b/devin/src/iii_prompt.rs
@@ -5,7 +5,8 @@
 
 pub const III_CONTEXT_PROMPT: &str = r#"# iii runtime
 
-This machine runs an iii engine: a WebSocket-routed worker mesh whose single engine process
+This machine runs an iii engine. iii is a language agnostic runtime where services, agents, and
+tools are composed of the same things: workers, triggers, and functions. The single engine process
 holds a live registry of every connected worker, every function those workers expose, and every
 trigger bound to them. Every call routes worker -> engine -> worker, so the language, runtime,
 and location of a worker are invisible to its callers. The function id is the ONLY contract

--- a/grok/README.md
+++ b/grok/README.md
@@ -122,7 +122,7 @@ iii trigger grok::run --timeout-ms 300000 \
   --json '{"prompt":"List every worker connected to this engine and what each one does.","cwd":"/tmp"}'
 ```
 
-With the context on, Grok reaches for `iii trigger engine::workers::list` itself and reports the live runtime — every worker and what it does — instead of guessing from `ps` and config files:
+With the context on, Grok reaches for `iii trigger engine::workers::list` itself and reports the live iii worker functionality — every worker and what it does — instead of guessing from `ps` and config files:
 
 ![Grok answering a live-system question by querying the engine through the iii CLI](https://raw.githubusercontent.com/iii-hq/workers/main/grok/assets/iii-context.png)
 

--- a/grok/README.md
+++ b/grok/README.md
@@ -122,7 +122,7 @@ iii trigger grok::run --timeout-ms 300000 \
   --json '{"prompt":"List every worker connected to this engine and what each one does.","cwd":"/tmp"}'
 ```
 
-With the context on, Grok reaches for `iii trigger engine::workers::list` itself and reports the live mesh — every worker and what it does — instead of guessing from `ps` and config files:
+With the context on, Grok reaches for `iii trigger engine::workers::list` itself and reports the live runtime — every worker and what it does — instead of guessing from `ps` and config files:
 
 ![Grok answering a live-system question by querying the engine through the iii CLI](https://raw.githubusercontent.com/iii-hq/workers/main/grok/assets/iii-context.png)
 

--- a/grok/src/iii_prompt.rs
+++ b/grok/src/iii_prompt.rs
@@ -5,7 +5,8 @@
 
 pub const III_CONTEXT_PROMPT: &str = r#"# iii runtime
 
-This machine runs an iii engine: a WebSocket-routed worker mesh whose single engine process
+This machine runs an iii engine. iii is a language agnostic runtime where services, agents, and
+tools are composed of the same things: workers, triggers, and functions. The single engine process
 holds a live registry of every connected worker, every function those workers expose, and every
 trigger bound to them. Every call routes worker -> engine -> worker, so the language, runtime,
 and location of a worker are invisible to its callers. The function id is the ONLY contract

--- a/harness/README.md
+++ b/harness/README.md
@@ -90,10 +90,12 @@ workers from the local source tree with `iii compose`.
 
 ## Working with iii
 
-iii is a WebSocket-routed worker mesh. One engine holds a live registry of every
-connected worker, their functions, and the triggers bound to them. Calls route
-worker to engine to worker, so the language, runtime, and location of a worker
-are invisible; the function id is the only contract.
+iii is a language agnostic runtime where services, agents, and tools are
+composed of the same things: workers, triggers, and functions. One engine
+holds a live registry of every connected worker, their functions, and the
+triggers bound to them. Calls route worker to engine to worker, so the
+language, runtime, and location of a worker are invisible; the function id is
+the only contract.
 
 **1. Discover what is already there (the engine is the source of truth)**
 - `engine::functions::list` — every function across all workers (filter with `prefix` / `search` / `worker`)

--- a/harness/prompts/default.txt
+++ b/harness/prompts/default.txt
@@ -6,13 +6,15 @@ three arguments: `function` (the function id, like `engine::functions::list`), `
 OBJECT with the function's arguments). Everything you do happens through `agent_trigger`.
 Never use a function id from memory.
 
-iii is a mesh of workers connected to one engine. Each worker registers functions. A function
-id looks like `worker::name`. Every call goes through the engine: worker → engine → worker.
-Workers never talk to each other directly. The function id is the only contract. A function is
-callable the moment its worker connects; workers registering the same id load-balance; worker
-restarts are invisible to callers. Triggers make functions run when events fire, and
-`engine::register_trigger` binds them: if you want something to happen on an event or after
-this reply ends, register a trigger; do not poll, and do not keep a turn alive to wait.
+iii is a language agnostic runtime where services, agents, and tools are composed of the same
+things: workers, triggers, and functions. Workers connect to one engine. Each worker registers
+functions. A function id looks like `worker::name`. Every call goes through the engine:
+worker → engine → worker. Workers never talk to each other directly.
+The function id is the only contract. A function is callable the moment its worker connects;
+workers registering the same id load-balance; worker restarts are invisible to callers.
+Triggers make functions run when events fire, and `engine::register_trigger` binds them: if
+you want something to happen on an event or after this reply ends,
+register a trigger; do not poll, and do not keep a turn alive to wait.
 
 # System rules
 

--- a/harness/src/bindings/store.rs
+++ b/harness/src/bindings/store.rs
@@ -1,7 +1,7 @@
 //! Durable binding storage, in the state worker under `harness_binding`.
 //!
 //! No in-memory cache, deliberately. Workers registering the same id
-//! load-balance, so two harness instances can serve the same mesh; a cached
+//! load-balance, so two harness instances can serve the same engine; a cached
 //! "still live" binding in instance B after instance A retired it would
 //! double-fire a `once`. The store IS the authority, and every fire pays one
 //! private state read for it — the same round trip the fire already makes to

--- a/harness/src/prompt/tests.rs
+++ b/harness/src/prompt/tests.rs
@@ -170,7 +170,7 @@ fn fn_pill_syntax() {
 }
 
 #[test]
-fn mesh_model() {
+fn runtime_model() {
     let out = default_prompt();
     assert!(out.contains("worker → engine → worker"));
     assert!(out.contains("Workers never talk to each other directly"));

--- a/hermes/src/iii_prompt.py
+++ b/hermes/src/iii_prompt.py
@@ -8,7 +8,8 @@ session and skipped on resume (already in the conversation history).
 
 III_CONTEXT_PROMPT = """# iii runtime
 
-This machine runs an iii engine: a WebSocket-routed worker mesh whose single engine process
+This machine runs an iii engine. iii is a language agnostic runtime where services, agents, and
+tools are composed of the same things: workers, triggers, and functions. The single engine process
 holds a live registry of every connected worker, every function those workers expose, and every
 trigger bound to them. Every call routes worker -> engine -> worker, so the language, runtime,
 and location of a worker are invisible to its callers. The function id is the ONLY contract

--- a/iii-directory/tests/e2e/run-tests.sh
+++ b/iii-directory/tests/e2e/run-tests.sh
@@ -155,7 +155,8 @@ out=$(trig directory::skills::get id=shell/index)
 has  "get shell/index -> LOCAL override body wins"               "$out" "LOCAL OVERRIDE"
 out=$(trig directory::skills::get id=iii/index)
 jtrue "get iii/index resolves (real SKILL.md alias), bare id"    "$out" '.id == "iii"'
-has  "get iii/index -> real iii body content"                    "$out" "worker mesh"
+has   "get iii/index -> real iii body content (registerWorker)"   "$out" "registerWorker"
+hasnt "get iii/index -> body says runtime, NOT \"mesh\""          "$out" "mesh"
 
 # the `iii` worker ships skills/SKILL.md → flattened on disk to iii/SKILL.md and
 # served under the `iii/index` id via the singular SKILL.md alias. Prove every
@@ -165,8 +166,8 @@ out=$(trig directory::skills::get id=iii)
 jtrue "get id=iii (bare name) -> resolves, returns bare id"      "$out" '.id == "iii"'
 jtrue "get id=iii -> title falls back to body H1 (\"iii\")"       "$out" '.title == "iii"'
 jtrue "get id=iii -> type is null (SKILL.md omits frontmatter type)" "$out" '.type == null'
-has   "get id=iii -> real SKILL.md body (\"worker mesh\")"        "$out" "worker mesh"
 has   "get id=iii -> real SKILL.md body (registerWorker snippet)" "$out" "registerWorker"
+hasnt "get id=iii -> body says runtime, NOT \"mesh\""            "$out" "mesh"
 iii_bare_body=$(printf '%s' "$out" | jq -r '.body')
 out=$(trig directory::skills::get id=iii/SKILL.md)
 jtrue "get id=iii/SKILL.md (explicit filename) -> bare iii"      "$out" '.id == "iii"'
@@ -185,7 +186,8 @@ fi
 [ ! -e "$GLOBAL/iii/index.md" ] && ok "on-disk: iii/index served from SKILL.md (no iii/index.md file)" || no "on-disk: iii/index served from SKILL.md (no iii/index.md file)"
 # the SKILL.md frontmatter description surfaces in list rows (get output has none)
 out=$(trig directory::skills::list --json '{}')
-jtrue "list: iii row carries the SKILL.md frontmatter description" "$out" '([.skills[]|select(.id=="iii")|.description][0] // "") | contains("WebSocket-routed worker mesh")'
+jtrue "list: iii row carries the SKILL.md frontmatter description" "$out" '([.skills[]|select(.id=="iii")|.description][0] // "") | length > 0'
+jtrue "list: iii description says runtime, NOT \"mesh\""           "$out" '([.skills[]|select(.id=="iii")|.description][0] // "") | ascii_downcase | contains("mesh") | not'
 
 out=$(trig directory::skills::get id=database/iii-database/query)
 jtrue "get database/iii-database/query -> real deep skill title" "$out" '.title == "Run a read-only SQL query and return rows"'

--- a/opencode/src/iii-prompt.ts
+++ b/opencode/src/iii-prompt.ts
@@ -9,7 +9,8 @@
 
 export const III_CONTEXT_PROMPT = `# iii runtime
 
-This machine runs an iii engine: a WebSocket-routed worker mesh whose single engine process
+This machine runs an iii engine. iii is a language agnostic runtime where services, agents, and
+tools are composed of the same things: workers, triggers, and functions. The single engine process
 holds a live registry of every connected worker, every function those workers expose, and every
 trigger bound to them. Every call routes worker -> engine -> worker, so the language, runtime,
 and location of a worker are invisible to its callers. The function id is the ONLY contract

--- a/pi/src/iii-prompt.ts
+++ b/pi/src/iii-prompt.ts
@@ -9,7 +9,8 @@
 
 export const III_CONTEXT_PROMPT = `# iii runtime
 
-This machine runs an iii engine: a WebSocket-routed worker mesh whose single engine process
+This machine runs an iii engine. iii is a language agnostic runtime where services, agents, and
+tools are composed of the same things: workers, triggers, and functions. The single engine process
 holds a live registry of every connected worker, every function those workers expose, and every
 trigger bound to them. Every call routes worker -> engine -> worker, so the language, runtime,
 and location of a worker are invisible to its callers. The function id is the ONLY contract


### PR DESCRIPTION
## What

Every place in this repo that described iii as a "mesh" now uses the canonical framing:

> iii is a language agnostic runtime where services, agents, and tools are composed of the same things: workers, triggers, and functions.

19 of 22 `mesh` hits are gone; the 3 that remain are negative assertions that guard against the word coming back.

## Where

| Area | Change |
| --- | --- |
| `claude-code`, `codex`, `devin`, `grok`, `hermes`, `opencode`, `pi` `iii_prompt` | The shared `# iii runtime` context block opens with the new sentence |
| `harness/prompts/default.txt`, `harness/README.md` | Same sentence, rewrapped |
| `console/web/src/stories/fixtures/*` | Storybook `iii` skill fixture and blog-post fixture |
| `devin/skills/SKILL.md`, `devin/README.md`, `grok/README.md` | Inline paraphrase: "your workers", "the live runtime" |
| `harness/src/bindings/store.rs` | Comment: "serve the same mesh" -> "serve the same engine" |
| `harness/src/prompt/tests.rs` | `mesh_model` test renamed `runtime_model` |

## Note: the iii-directory e2e suite is red on purpose

`iii-directory/tests/e2e/run-tests.sh` had three assertions pinned to the literal words `worker mesh` in the **upstream** `iii` SKILL.md, which the suite downloads from the registry at run time. That document is not in this repo, so this PR cannot update it.

Rather than delete the assertions, they are flipped to guard the new wording:

- body canary is now `registerWorker` (real content, phrasing independent)
- `hasnt ... "mesh"` on the `id=iii` and `id=iii/index` bodies
- the list row description must be non-empty **and** must not contain `mesh`

**These three assertions fail until the upstream `iii` SKILL.md ships the new wording.** That is the intended signal: the suite now fails loudly while the canonical description is stale, instead of passing on the description we are removing.

## Verification

- `cargo test --lib prompt::` in `harness`: 43 passed. The rewrap in `default.txt` keeps every substring those tests assert on unbroken.
- `cargo check` clean for `codex`, `devin`, `grok`.
- `bash -n run-tests.sh` clean.
- The `coder-fixtures.ts` skill excerpt keeps its 42-line length, so the `numberWindow(III_SKILL_MD, 26, 33)` and `(1, 6)` ranges still frame the same content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)