### PR TITLE
(MOT-4577) feat(console): refine chat start and waiting states

### DIFF
--- a/console/web/src/components/chat/ChatSettingsSheet.tsx
+++ b/console/web/src/components/chat/ChatSettingsSheet.tsx
@@ -146,7 +146,7 @@ export function ChatSettingsSheet({
 
   return (
     <BottomSheet open={open} onOpenChange={handleOpenChange}>
-      <BottomSheetContent className="mx-auto max-w-[460px] sm:hidden">
+      <BottomSheetContent className="mx-auto max-w-[460px]">
         {navigation.page === 'settings' ? (
           <SheetPage
             title="Chat settings"

--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -200,7 +200,7 @@ export function ChatView({
 }: ChatViewProps) {
   const [isStreaming, setIsStreaming] = useState(false)
   // Pre-content phase of this tab's in-flight send, for the thinking
-  // shimmer's detail line: submit → harness::send ack → turn-started.
+  // waiting indicator detail: submit → harness::send ack → turn-started.
   // Null once content streams (or for turns this tab didn't start).
   const [turnPhase, setTurnPhase] = useState<
     'sending' | 'accepted' | 'merged' | 'started' | null
@@ -218,8 +218,7 @@ export function ChatView({
   )
   /* Lives on the conversation record, not in local state: the interactive
      picker is on the new-session screen, so a reset on a tab switch (ChatPanel
-     keys this view by conversation id) would be invisible — no control is left
-     in the composer to show or restore it. */
+     keys this view by conversation id) would be invisible. */
   const effectiveSystemPrompt =
     conversation.systemPrompt ?? DEFAULT_SYSTEM_PROMPT_STATE
   const abortRef = useRef<AbortController | null>(null)
@@ -912,8 +911,8 @@ export function ChatView({
   ])
 
   // The stack's default folder, resolved once (cached page-wide): pre-fills
-  // fresh drafts below and feeds the picker's pinned "default" row so the
-  // launch folder stays selectable after a chat re-scopes elsewhere.
+  // fresh drafts below and keeps the launch folder selectable after a chat
+  // re-scopes elsewhere.
   const [defaultWorkingDir, setDefaultWorkingDir] = useState<string | null>(
     null,
   )
@@ -1635,7 +1634,7 @@ export function ChatView({
               break
             }
             case 'turn-status': {
-              // `queued` renders in the queued-messages strip, not the shimmer.
+              // `queued` renders in the queued-messages strip, not the waiting indicator.
               setTurnPhase(event.phase === 'queued' ? null : event.phase)
               break
             }
@@ -1684,7 +1683,7 @@ export function ChatView({
         if (!isAbortError(err)) {
           console.warn('[chat] stream errored', err)
           // A dead send must never be silent: without this notice the user
-          // sees only their message and an eternal shimmer.
+          // sees only their message and an eternal waiting indicator.
           const detail = err instanceof Error ? err.message : String(err)
           const noticeContent = `send failed — ${detail}`
           const notice: SystemMessage = {
@@ -1775,7 +1774,7 @@ export function ChatView({
   }, [isStreaming, conversation.status])
 
   // Covers the gap between submit / fcall-end and the next streamed content,
-  // where the assistant/thought shimmer hasn't yet rendered.
+  // where the assistant/thought output hasn't yet rendered.
   const isThinking =
     streamingIndicator &&
     (() => {
@@ -1793,7 +1792,7 @@ export function ChatView({
       return false
     })()
 
-  // Pre-content phase text for the shimmer. Only trusted while the transcript
+  // Pre-content phase text for the waiting indicator. Only trusted while the transcript
   // still ends at the user's message — on the real backend content arrives via
   // session events (not stream events), so once anything streamed the phase is
   // stale and mid-turn gaps fall back to the model line instead.
@@ -2217,6 +2216,15 @@ export function ChatView({
         onManageFilesystemAccess={handleManageFilesystemAccess}
         onConfigureProvider={handleOpenModelPicker}
         workingDir={conversation.workingDir ?? null}
+        onWorkingDirChange={
+          workingDirEnabled ? handleWorkingDirChange : undefined
+        }
+        defaultWorkingDir={defaultWorkingDir}
+        worktreePicker={
+          worktreeEnabled
+            ? { enabled: true, onPick: handlePickWorktree }
+            : undefined
+        }
         triggersById={triggersById}
       />
       <LiveRegion announcement={announcer.announcement} />

--- a/console/web/src/components/chat/ContextUsage.tsx
+++ b/console/web/src/components/chat/ContextUsage.tsx
@@ -104,7 +104,7 @@ export function ContextUsage({ messages, contextWindow }: ContextUsageProps) {
         <div
           role="dialog"
           aria-label="context details"
-          className="absolute top-full right-0 z-50 mt-1 w-64 rounded-md border border-rule-2 bg-panel-raised p-3 font-sans text-sm normal-case tracking-normal text-ink shadow-floating"
+          className="absolute top-full right-0 z-50 mt-1 w-64 rounded-md border border-rule-2 bg-panel-raised p-3 font-sans text-sm whitespace-normal normal-case tracking-normal text-ink shadow-floating"
         >
           <div className="flex items-baseline justify-between gap-3">
             <span className="font-medium">Context</span>

--- a/console/web/src/components/chat/DirectoryPicker.tsx
+++ b/console/web/src/components/chat/DirectoryPicker.tsx
@@ -1,3 +1,4 @@
+import * as PopoverPrimitive from '@radix-ui/react-popover'
 import {
   AlertCircle,
   ArrowLeft,
@@ -13,17 +14,19 @@ import {
 } from 'lucide-react'
 import {
   type ReactNode,
+  type RefObject,
   useCallback,
   useEffect,
   useMemo,
   useRef,
   useState,
 } from 'react'
-import { createPortal } from 'react-dom'
+import { BottomSheet, BottomSheetContent } from '@/components/ui/BottomSheet'
 import { StatusDot } from '@/components/ui/StatusDot'
 import { useMediaQuery } from '@/hooks/use-media-query'
 import { getIiiClient } from '@/lib/iii-client'
 import { loadRecentProjects, removeRecentProject } from '@/lib/storage'
+import { PortalScope } from '@/lib/ui-scope'
 import { cn } from '@/lib/utils'
 import {
   errMsg,
@@ -77,15 +80,19 @@ interface DirectoryPickerProps {
    */
   externalError?: string | null
   /**
-   * The stack's default working directory (harness launch folder). Pinned
-   * at the top of the projects view with a "default" tag: unlike recents it
-   * is never forgettable and survives re-scoping away, so the launch folder
-   * stays one click away. Deduped against the recents list.
+   * The stack's default working directory (harness launch folder). Pinned at
+   * the top of the projects view: unlike recents it is never forgettable and
+   * survives re-scoping away, so the launch folder stays one click away.
+   * Deduped against the recents list.
    */
   defaultDir?: string | null
   /** Show the worktrees tab next to directory browsing. */
   worktrees?: WorktreePickerOptions
   className?: string
+  /** Compact text-only trigger used when the picker is part of a sentence. */
+  triggerAppearance?: 'default' | 'inline'
+  /** Trigger copy while no directory has been resolved yet. */
+  emptyLabel?: string
   /** Render only the picker content inside an existing sheet page. */
   presentation?: 'trigger' | 'embedded'
   /** Called after an embedded picker accepts a directory. */
@@ -112,11 +119,6 @@ function basename(p: string): string {
   return parts.length ? parts[parts.length - 1] : p
 }
 
-function parentDisplay(p: string): string {
-  const idx = p.replace(/\/+$/, '').lastIndexOf('/')
-  return idx <= 0 ? '/' : p.slice(0, idx)
-}
-
 function parentOf(p: string): string {
   const trimmed = p.replace(/\/+$/, '')
   const idx = trimmed.lastIndexOf('/')
@@ -141,9 +143,12 @@ export function DirectoryPicker({
   defaultDir,
   worktrees,
   className,
+  triggerAppearance = 'default',
+  emptyLabel = 'Choose directory',
   presentation = 'trigger',
   onSelect,
 }: DirectoryPickerProps) {
+  const embedded = presentation === 'embedded'
   const [open, setOpen] = useState(false)
   const [view, setView] = useState<'projects' | 'browse' | 'worktrees'>(
     'projects',
@@ -162,33 +167,8 @@ export function DirectoryPicker({
   const [wtRows, setWtRows] = useState<WorktreeInfo[]>([])
   const [wtLoading, setWtLoading] = useState(false)
   const [wtError, setWtError] = useState<string | null>(null)
-  const containerRef = useRef<HTMLDivElement>(null)
-  const panelRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
   const mobileSheet = useMediaQuery('(max-width: 767px)')
-  const embedded = presentation === 'embedded'
-
-  // Close on outside click / Escape.
-  useEffect(() => {
-    if (!open || embedded) return
-    const onDocClick = (e: MouseEvent) => {
-      const target = e.target as Node
-      if (
-        !containerRef.current?.contains(target) &&
-        !panelRef.current?.contains(target)
-      ) {
-        setOpen(false)
-      }
-    }
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setOpen(false)
-    }
-    document.addEventListener('mousedown', onDocClick)
-    document.addEventListener('keydown', onKey)
-    return () => {
-      document.removeEventListener('mousedown', onDocClick)
-      document.removeEventListener('keydown', onKey)
-    }
-  }, [open, embedded])
 
   const openPanel = useCallback(() => {
     setProjects(loadRecentProjects())
@@ -438,7 +418,7 @@ export function DirectoryPicker({
     else if (view === 'browse') void jumpTo(query)
   }
 
-  const label = value ? basename(value) : 'Choose directory'
+  const label = value ? basename(value) : emptyLabel
 
   if (locked && !embedded) {
     return (
@@ -457,7 +437,6 @@ export function DirectoryPicker({
 
   return (
     <div
-      ref={containerRef}
       className={cn(
         embedded
           ? 'flex h-full min-h-0 w-full flex-col'
@@ -467,546 +446,526 @@ export function DirectoryPicker({
     >
       {!embedded ? (
         <button
+          ref={triggerRef}
           type="button"
           disabled={disabled}
-          aria-label="working directory"
+          aria-label={
+            triggerAppearance === 'inline'
+              ? `select project folder, current folder: ${label}`
+              : 'working directory'
+          }
           aria-haspopup="dialog"
           aria-expanded={open}
           title={value ?? 'choose a working directory'}
           onClick={() => (open ? setOpen(false) : openPanel())}
           className={cn(
-            'inline-flex h-12 min-w-0 items-center gap-2 rounded-sm border border-transparent bg-transparent px-3 font-sans text-base text-ink-faint hover:bg-surface-hover hover:text-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus sm:h-9 sm:text-[13px]',
+            triggerAppearance === 'inline'
+              ? 'relative inline-flex min-w-0 h-6.5 items-baseline border-dashed border-b border-ink-faint/50 px-0.5 font-sans font-medium text-ink hover:border-ink hover:text-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus disabled:opacity-50'
+              : 'inline-flex h-12 min-w-0 items-center gap-2 rounded-sm border border-transparent bg-transparent px-3 font-sans text-base text-ink-faint hover:border-ink hover:bg-surface-hover hover:text-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus disabled:opacity-50 sm:h-9 sm:text-[13px]',
             externalError ? 'text-warn' : value ? 'text-ink' : 'text-ink-faint',
-            'hover:border-ink hover:text-ink disabled:opacity-50',
           )}
         >
-          <Folder aria-hidden className="size-4 shrink-0" />
-          <span className="min-w-0 max-w-[160px] truncate">{label}</span>
+          {triggerAppearance === 'default' ? (
+            <Folder aria-hidden className="size-4 shrink-0" />
+          ) : null}
+          <span className="min-w-0 max-w-[18rem] truncate">{label}</span>
+          {triggerAppearance === 'inline' ? (
+            <span
+              className="pointer-events-none absolute top-1/2 left-1/2 size-[max(100%,3rem)] -translate-1/2 pointer-fine:hidden"
+              aria-hidden="true"
+            />
+          ) : null}
         </button>
       ) : null}
 
-      {embedded || open ? (
-        <DirectoryPickerPortal enabled={!embedded && mobileSheet}>
-          {!embedded ? (
+      <DirectoryPickerSurface
+        open={open}
+        embedded={embedded}
+        mobileSheet={mobileSheet}
+        onOpenChange={setOpen}
+        triggerRef={triggerRef}
+        alignToInlineTrigger={triggerAppearance === 'inline'}
+      >
+        {/* section tabs (only with the worktree worker present) */}
+        {worktrees?.enabled ? (
+          <div
+            role="tablist"
+            className="mx-4 mb-3 flex shrink-0 gap-1 rounded-md bg-surface p-1 font-sans text-base md:mx-0 md:mb-1 md:text-[12px]"
+          >
             <button
               type="button"
-              aria-label="close project picker"
-              onClick={() => setOpen(false)}
-              className="fixed inset-0 z-40 bg-black/55 md:hidden"
-            />
-          ) : null}
-          {/* biome-ignore lint/a11y/useAriaPropsSupportedByRole: role is always group or dialog, both support an accessible name. */}
+              role="tab"
+              aria-selected={view !== 'worktrees'}
+              onClick={() => {
+                setView('projects')
+                setProjects(loadRecentProjects())
+                setQuery('')
+                setError(null)
+              }}
+              className={cn(
+                'min-h-12 flex-1 rounded-sm px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus md:min-h-8 md:py-1.5',
+                view !== 'worktrees'
+                  ? 'bg-panel-raised text-ink ring-1 ring-edge'
+                  : 'text-ink-faint hover:bg-surface-hover hover:text-ink',
+              )}
+            >
+              directories
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={view === 'worktrees'}
+              onClick={() => void enterWorktrees()}
+              className={cn(
+                'min-h-12 flex-1 rounded-sm px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus md:min-h-8 md:py-1.5',
+                view === 'worktrees'
+                  ? 'bg-panel-raised text-ink ring-1 ring-edge'
+                  : 'text-ink-faint hover:bg-surface-hover hover:text-ink',
+              )}
+            >
+              worktrees
+            </button>
+          </div>
+        ) : null}
+
+        {/* search */}
+        <div className="mx-4 mb-3 flex min-h-12 shrink-0 items-center gap-2 rounded-md bg-surface px-3 py-2 focus-within:ring-2 focus-within:ring-rule-focus md:mx-0 md:mb-1 md:min-h-8 md:px-2.5 md:py-1">
+          <Search className="size-4 shrink-0 text-ink-ghost" aria-hidden />
+          <input
+            // biome-ignore lint/a11y/noAutofocus: desktop popovers keep keyboard-first filtering; mobile avoids opening the keyboard on entry
+            autoFocus={!mobileSheet}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={onSearchKey}
+            placeholder={
+              view === 'projects'
+                ? 'Search projects or paste a path…'
+                : view === 'worktrees'
+                  ? 'Filter worktrees…'
+                  : 'Filter this folder or paste a path…'
+            }
+            aria-label="search directories"
+            name="directory-search"
+            className="min-w-0 flex-1 bg-transparent text-base text-ink placeholder:text-ink-ghost focus:outline-none md:text-[12px]"
+          />
+        </div>
+
+        {/* validation/error (shown in the projects view; browse has its own) */}
+        {view !== 'browse' && error ? (
+          <div className="mx-4 mb-2 flex items-start gap-2 rounded-md bg-warn-muted px-3 py-2 font-sans text-base text-warn md:mx-0 md:text-[11px]">
+            <AlertCircle className="size-4 shrink-0" aria-hidden />
+            <span>{error}</span>
+          </div>
+        ) : null}
+
+        {/* body */}
+        {view === 'worktrees' ? (
           <div
-            ref={panelRef}
-            role={embedded ? 'group' : 'dialog'}
-            aria-label="select working directory"
             className={cn(
-              embedded
-                ? 'flex min-h-0 flex-1 flex-col overflow-hidden bg-transparent'
-                : 'fixed inset-x-3 bottom-3 z-50 max-h-[calc(100dvh-1.5rem)] overscroll-contain overflow-y-auto rounded-lg border border-edge bg-panel-raised pb-[max(0.75rem,env(safe-area-inset-bottom))] shadow-floating md:absolute md:inset-x-auto md:right-0 md:bottom-full md:left-auto md:z-30 md:mb-2 md:max-h-none md:w-[420px] md:overflow-visible md:rounded-lg md:p-2',
+              'space-y-1 overflow-y-auto px-4 pb-2 md:px-0',
+              embedded ? 'min-h-0 flex-1' : 'max-h-[220px]',
             )}
           >
-            {!embedded ? (
-              <div className="sticky top-0 z-10 bg-panel-raised px-4 pb-3 md:hidden">
-                <div
-                  className="flex h-6 items-center justify-center"
+            {wtLoading ? (
+              <div className="rounded-md bg-surface px-3 py-4 font-sans text-base text-ink-faint md:text-[11px]">
+                Loading worktrees…
+              </div>
+            ) : wtError ? (
+              <div className="flex items-start gap-2 rounded-md bg-warn-muted px-3 py-3 font-sans text-base text-warn md:text-[11px]">
+                <AlertCircle className="size-4 shrink-0" aria-hidden />
+                <span>{wtError}</span>
+              </div>
+            ) : filteredWorktrees.length > 0 ? (
+              filteredWorktrees.map((wt) => {
+                const tone = lifecycleTone(wt.lifecycle)
+                const { dirty, ahead } = worktreeIndicators(wt.status)
+                const orphaned = wt.lifecycle === 'orphaned'
+                const landing = wt.lifecycle === 'landing'
+                return (
+                  <button
+                    key={wt.worktree_id}
+                    type="button"
+                    disabled={orphaned || landing}
+                    onClick={() => pickWorktree(wt)}
+                    title={
+                      orphaned
+                        ? `${wt.path} — directory is missing`
+                        : landing
+                          ? `${wt.path} — land in progress; not retargetable`
+                          : `${wt.path} — claim and use this worktree`
+                    }
+                    className="flex min-h-14 w-full items-center gap-3 rounded-md px-3 py-2.5 text-left hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus disabled:opacity-50 md:min-h-9 md:gap-2 md:py-1.5"
+                  >
+                    <GitBranch
+                      className="size-4 shrink-0 text-ink-faint"
+                      aria-hidden
+                    />
+                    <span className="flex min-w-0 flex-1 items-center gap-1.5 font-sans text-base md:text-[12px]">
+                      <span className="truncate text-ink">{wt.branch}</span>
+                      <span className="shrink-0 rounded-sm bg-surface px-1.5 py-0.5 font-mono text-[10px] text-ink-ghost tabular-nums">
+                        {shortWorktreeId(wt.worktree_id)}
+                      </span>
+                      {dirty ? (
+                        <span
+                          className="shrink-0 text-warn"
+                          title="uncommitted changes"
+                        >
+                          *
+                        </span>
+                      ) : null}
+                      {ahead > 0 ? (
+                        <span
+                          className="shrink-0 text-[10px] text-ink-faint tabular-nums"
+                          title={`${ahead} commit(s) ahead of base`}
+                        >
+                          +{ahead}
+                        </span>
+                      ) : null}
+                    </span>
+                    <span className="flex shrink-0 items-center gap-1.5 font-sans text-sm md:text-[10px]">
+                      {wt.session_id ? (
+                        <span
+                          className="max-w-[80px] truncate text-ink-ghost"
+                          title={`claimed by ${wt.session_id}`}
+                        >
+                          {wt.session_id}
+                        </span>
+                      ) : null}
+                      {wt.lifecycle !== 'active' ? (
+                        <span
+                          className={cn(
+                            'flex items-center gap-1',
+                            lifecycleToneClass[tone],
+                          )}
+                        >
+                          <StatusDot
+                            tone={tone}
+                            pulse={wt.lifecycle === 'landing'}
+                          />
+                          {wt.lifecycle}
+                        </span>
+                      ) : null}
+                    </span>
+                  </button>
+                )
+              })
+            ) : (
+              <div className="rounded-md bg-surface px-3 py-4 font-sans text-base text-ink-faint md:text-[11px]">
+                {q
+                  ? 'No matching worktrees.'
+                  : 'No managed worktrees yet. Create one with worktree::create.'}
+              </div>
+            )}
+          </div>
+        ) : view === 'projects' ? (
+          <div
+            className={cn(
+              'space-y-1 overflow-y-auto px-4 pb-2 md:px-0',
+              embedded ? 'min-h-0 flex-1' : 'max-h-[220px]',
+            )}
+          >
+            {isAbsPath(query) ? (
+              <button
+                type="button"
+                disabled={validating !== null}
+                onClick={() => void validateAndSelect(query)}
+                className="flex min-h-14 w-full items-center gap-3 rounded-md bg-accent-muted px-3 py-2.5 text-left font-sans text-base text-accent hover:bg-surface-selected focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus disabled:opacity-50 md:min-h-9 md:gap-2 md:py-1.5 md:text-[12px]"
+              >
+                <CornerDownLeft className="size-4 shrink-0" aria-hidden />
+                <span className="truncate font-mono">Use {query.trim()}</span>
+              </button>
+            ) : null}
+
+            {showDefaultRow || filteredProjects.length > 0 ? (
+              <p className="px-1 pt-2 pb-1 font-sans text-base font-medium text-ink-faint md:pt-1 md:text-[11px]">
+                Current and recent
+              </p>
+            ) : null}
+
+            {showDefaultRow && defaultDir ? (
+              <button
+                type="button"
+                disabled={validating !== null}
+                onClick={() => void validateAndSelect(defaultDir)}
+                aria-current={defaultDir === value ? 'true' : undefined}
+                className={cn(
+                  'flex min-h-14 w-full items-center gap-3 rounded-md px-3 py-2.5 text-left hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus disabled:opacity-50 md:min-h-9 md:gap-2 md:py-1.5',
+                  defaultDir === value && 'bg-surface-selected',
+                )}
+                title={`${defaultDir} — the folder the stack was started from`}
+              >
+                <Folder
+                  className={cn(
+                    'size-4 shrink-0',
+                    defaultDir === value ? 'text-ink' : 'text-ink-faint',
+                  )}
                   aria-hidden
+                />
+                <span className="min-w-0 flex-1 truncate font-sans text-base font-medium text-ink md:text-[12px]">
+                  {basename(defaultDir)}
+                </span>
+                {defaultDir === value ? (
+                  <Check className="size-4 shrink-0 text-ink" aria-hidden />
+                ) : null}
+              </button>
+            ) : null}
+
+            {filteredProjects.map((p) => {
+              const isSelected = p === value
+              return (
+                <div
+                  key={p}
+                  className={cn(
+                    'group flex items-center gap-1 rounded-md pr-1 hover:bg-surface-hover',
+                    isSelected && 'bg-surface-selected',
+                  )}
                 >
-                  <span className="h-1 w-10 rounded-full bg-ink-ghost/60" />
-                </div>
-                <div className="flex min-h-12 items-center justify-between gap-3">
-                  <div>
-                    <h2 className="font-sans text-lg font-semibold text-ink">
-                      Working directory
-                    </h2>
-                    <p className="font-sans text-base text-ink-faint">
-                      {worktrees?.enabled
-                        ? 'Choose a recent project, folder, or managed worktree.'
-                        : 'Choose a recent project or browse folders.'}
-                    </p>
-                  </div>
                   <button
                     type="button"
-                    onClick={() => setOpen(false)}
-                    aria-label="close project picker"
-                    className="flex size-12 shrink-0 items-center justify-center rounded-sm text-ink-faint hover:bg-surface-hover hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus"
+                    disabled={validating !== null}
+                    onClick={() => void validateAndSelect(p)}
+                    aria-current={isSelected ? 'true' : undefined}
+                    className="flex min-h-14 min-w-0 flex-1 items-center gap-3 rounded-md px-3 py-2.5 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus disabled:opacity-50 md:min-h-9 md:gap-2 md:py-1.5"
+                    title={p}
                   >
-                    <X className="size-5" aria-hidden />
+                    <Folder
+                      className={cn(
+                        'size-4 shrink-0',
+                        isSelected ? 'text-ink' : 'text-ink-faint',
+                      )}
+                      aria-hidden
+                    />
+                    <span className="min-w-0 flex-1 truncate font-sans text-base font-medium text-ink md:text-[12px]">
+                      {basename(p)}
+                    </span>
                   </button>
+                  <button
+                    type="button"
+                    aria-label={`forget ${p}`}
+                    title="forget this project"
+                    onClick={() => forget(p)}
+                    className="relative flex size-12 shrink-0 items-center justify-center rounded-sm text-ink-ghost hover:bg-surface-hover hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus md:size-8 md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100"
+                  >
+                    <span
+                      className="pointer-events-none absolute top-1/2 left-1/2 size-[max(100%,3rem)] -translate-1/2 pointer-fine:hidden"
+                      aria-hidden="true"
+                    />
+                    <X className="size-4 shrink-0 md:size-4" aria-hidden />
+                  </button>
+                  {isSelected ? (
+                    <span className="flex size-12 shrink-0 items-center justify-center md:size-8">
+                      <Check className="size-4 shrink-0 text-ink" aria-hidden />
+                    </span>
+                  ) : null}
                 </div>
+              )
+            })}
+
+            {filteredProjects.length === 0 &&
+            !showDefaultRow &&
+            !isAbsPath(query) ? (
+              <div className="rounded-md bg-surface px-3 py-4 font-sans text-base text-ink-faint md:text-[11px]">
+                {projects.length === 0
+                  ? 'No recent projects yet.'
+                  : 'No matching projects.'}{' '}
+                Browse to add one.
               </div>
             ) : null}
 
-            {/* section tabs (only with the worktree worker present) */}
-            {worktrees?.enabled ? (
-              <div
-                role="tablist"
-                className="mx-4 mb-3 flex shrink-0 gap-1 rounded-md bg-surface p-1 font-sans text-base md:mx-0 md:mb-2 md:text-[12px]"
+            <div className="pt-2">
+              <button
+                type="button"
+                onClick={() => void enterBrowse()}
+                className="flex min-h-14 w-full items-center gap-3 rounded-md bg-surface px-3 py-2.5 text-left font-sans text-base font-medium text-ink-faint hover:bg-surface-hover hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus md:min-h-9 md:gap-2 md:py-1.5 md:text-[12px]"
               >
+                <FolderPlus className="size-4 shrink-0" aria-hidden />
+                Browse folders
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className={cn(embedded && 'flex min-h-0 flex-1 flex-col')}>
+            {/* browse header */}
+            <div className="mx-4 mb-2 flex min-h-14 shrink-0 items-center justify-between gap-2 rounded-md bg-surface p-1 md:mx-0 md:min-h-10">
+              <div className="flex min-w-0 flex-1 items-center gap-1 font-sans text-base text-ink-faint md:text-[11px]">
                 <button
                   type="button"
-                  role="tab"
-                  aria-selected={view !== 'worktrees'}
+                  aria-label="back to projects"
                   onClick={() => {
                     setView('projects')
                     setProjects(loadRecentProjects())
                     setQuery('')
                     setError(null)
                   }}
-                  className={cn(
-                    'min-h-12 flex-1 rounded-sm px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus md:min-h-8 md:py-1.5',
-                    view !== 'worktrees'
-                      ? 'bg-panel-raised text-ink ring-1 ring-edge'
-                      : 'text-ink-faint hover:bg-surface-hover hover:text-ink',
-                  )}
+                  className="relative flex size-12 shrink-0 items-center justify-center rounded-sm text-ink-faint hover:bg-surface-hover hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus md:size-8"
                 >
-                  directories
+                  <ArrowLeft className="size-4 shrink-0" aria-hidden />
                 </button>
+                {path ? (
+                  <button
+                    type="button"
+                    aria-label="up one level"
+                    onClick={goUp}
+                    className="relative flex size-12 shrink-0 items-center justify-center rounded-sm text-ink-faint hover:bg-surface-hover hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus md:size-8"
+                  >
+                    <ChevronUp className="size-4 shrink-0" aria-hidden />
+                  </button>
+                ) : null}
+                <span className="truncate font-mono">{path ?? 'roots'}</span>
+              </div>
+              {path ? (
                 <button
                   type="button"
-                  role="tab"
-                  aria-selected={view === 'worktrees'}
-                  onClick={() => void enterWorktrees()}
-                  className={cn(
-                    'min-h-12 flex-1 rounded-sm px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus md:min-h-8 md:py-1.5',
-                    view === 'worktrees'
-                      ? 'bg-panel-raised text-ink ring-1 ring-edge'
-                      : 'text-ink-faint hover:bg-surface-hover hover:text-ink',
-                  )}
+                  disabled={validating !== null}
+                  onClick={() => void validateAndSelect(path)}
+                  className="inline-flex min-h-12 shrink-0 items-center gap-1.5 rounded-sm bg-accent py-2 pr-3 pl-2 font-sans text-base font-medium whitespace-nowrap text-accent-fg hover:bg-accent-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rule-focus disabled:opacity-50 md:min-h-8 md:text-[11px]"
                 >
-                  worktrees
+                  <Check className="size-4 shrink-0" aria-hidden />
+                  Use folder
                 </button>
-              </div>
-            ) : null}
-
-            {/* search */}
-            <div className="mx-4 mb-3 flex min-h-12 shrink-0 items-center gap-2 rounded-md bg-surface px-3 py-2 focus-within:ring-2 focus-within:ring-rule-focus md:mx-0 md:mb-2 md:min-h-9 md:px-2.5 md:py-1.5">
-              <Search className="size-4 shrink-0 text-ink-ghost" aria-hidden />
-              <input
-                // biome-ignore lint/a11y/noAutofocus: desktop popovers keep keyboard-first filtering; mobile avoids opening the keyboard on entry
-                autoFocus={!mobileSheet}
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                onKeyDown={onSearchKey}
-                placeholder={
-                  view === 'projects'
-                    ? 'Search projects or paste a path…'
-                    : view === 'worktrees'
-                      ? 'Filter worktrees…'
-                      : 'Filter this folder or paste a path…'
-                }
-                aria-label="search directories"
-                name="directory-search"
-                className="min-w-0 flex-1 bg-transparent text-base text-ink placeholder:text-ink-ghost focus:outline-none md:text-[12px]"
-              />
+              ) : null}
             </div>
 
-            {/* validation/error (shown in the projects view; browse has its own) */}
-            {view !== 'browse' && error ? (
-              <div className="mx-4 mb-2 flex items-start gap-2 rounded-md bg-warn-muted px-3 py-2 font-sans text-base text-warn md:mx-0 md:text-[11px]">
-                <AlertCircle className="size-4 shrink-0" aria-hidden />
-                <span>{error}</span>
-              </div>
-            ) : null}
+            <div
+              className={cn(
+                'space-y-1 overflow-y-auto px-4 pb-2 md:px-0',
+                embedded ? 'min-h-0 flex-1' : 'max-h-[220px]',
+              )}
+            >
+              {isAbsPath(query) ? (
+                <button
+                  type="button"
+                  onClick={() => void jumpTo(query)}
+                  className="flex min-h-14 w-full items-center gap-3 rounded-md bg-accent-muted px-3 py-2.5 text-left font-sans text-base text-accent hover:bg-surface-selected focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus md:min-h-10 md:gap-2 md:py-2 md:text-[12px]"
+                >
+                  <CornerDownLeft className="size-4 shrink-0" aria-hidden />
+                  <span className="truncate font-mono">
+                    Go to {query.trim()}
+                  </span>
+                </button>
+              ) : null}
 
-            {/* body */}
-            {view === 'worktrees' ? (
-              <div
-                className={cn(
-                  'space-y-1 overflow-y-auto px-4 pb-2 md:px-0',
-                  embedded ? 'min-h-0 flex-1' : 'max-h-[280px]',
-                )}
-              >
-                {wtLoading ? (
-                  <div className="rounded-md bg-surface px-3 py-4 font-sans text-base text-ink-faint md:text-[11px]">
-                    Loading worktrees…
-                  </div>
-                ) : wtError ? (
-                  <div className="flex items-start gap-2 rounded-md bg-warn-muted px-3 py-3 font-sans text-base text-warn md:text-[11px]">
-                    <AlertCircle className="size-4 shrink-0" aria-hidden />
-                    <span>{wtError}</span>
-                  </div>
-                ) : filteredWorktrees.length > 0 ? (
-                  filteredWorktrees.map((wt) => {
-                    const tone = lifecycleTone(wt.lifecycle)
-                    const { dirty, ahead } = worktreeIndicators(wt.status)
-                    const orphaned = wt.lifecycle === 'orphaned'
-                    const landing = wt.lifecycle === 'landing'
-                    return (
-                      <button
-                        key={wt.worktree_id}
-                        type="button"
-                        disabled={orphaned || landing}
-                        onClick={() => pickWorktree(wt)}
-                        title={
-                          orphaned
-                            ? `${wt.path} — directory is missing`
-                            : landing
-                              ? `${wt.path} — land in progress; not retargetable`
-                              : `${wt.path} — claim and use this worktree`
-                        }
-                        className="flex min-h-14 w-full items-start gap-3 rounded-md px-3 py-2.5 text-left hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus disabled:opacity-50 md:min-h-10 md:gap-2 md:py-2"
-                      >
-                        <GitBranch
-                          className="size-4 shrink-0 text-ink-faint"
-                          aria-hidden
-                        />
-                        <span className="flex min-w-0 flex-1 flex-col">
-                          <span className="flex min-w-0 items-center gap-1.5 font-sans text-base md:text-[12px]">
-                            <span className="truncate text-ink">
-                              {wt.branch}
-                            </span>
-                            <span className="shrink-0 rounded-sm bg-surface px-1.5 py-0.5 font-mono text-[10px] text-ink-ghost tabular-nums">
-                              {shortWorktreeId(wt.worktree_id)}
-                            </span>
-                            {dirty ? (
-                              <span
-                                className="shrink-0 text-warn"
-                                title="uncommitted changes"
-                              >
-                                *
-                              </span>
-                            ) : null}
-                            {ahead > 0 ? (
-                              <span
-                                className="shrink-0 text-[10px] text-ink-faint tabular-nums"
-                                title={`${ahead} commit(s) ahead of base`}
-                              >
-                                +{ahead}
-                              </span>
-                            ) : null}
-                          </span>
-                          <span className="truncate font-mono text-sm text-ink-ghost md:text-[10px]">
-                            {wt.path}
-                          </span>
-                        </span>
-                        <span className="flex shrink-0 items-center gap-1.5 font-sans text-sm md:text-[10px]">
-                          {wt.session_id ? (
-                            <span
-                              className="max-w-[80px] truncate text-ink-ghost"
-                              title={`claimed by ${wt.session_id}`}
-                            >
-                              {wt.session_id}
-                            </span>
-                          ) : null}
-                          {wt.lifecycle !== 'active' ? (
-                            <span
-                              className={cn(
-                                'flex items-center gap-1',
-                                lifecycleToneClass[tone],
-                              )}
-                            >
-                              <StatusDot
-                                tone={tone}
-                                pulse={wt.lifecycle === 'landing'}
-                              />
-                              {wt.lifecycle}
-                            </span>
-                          ) : null}
-                        </span>
-                      </button>
-                    )
-                  })
-                ) : (
-                  <div className="rounded-md bg-surface px-3 py-4 font-sans text-base text-ink-faint md:text-[11px]">
-                    {q
-                      ? 'No matching worktrees.'
-                      : 'No managed worktrees yet. Create one with worktree::create.'}
-                  </div>
-                )}
-              </div>
-            ) : view === 'projects' ? (
-              <div
-                className={cn(
-                  'space-y-1 overflow-y-auto px-4 pb-2 md:px-0',
-                  embedded ? 'min-h-0 flex-1' : 'max-h-[280px]',
-                )}
-              >
-                {isAbsPath(query) ? (
+              {loading ? (
+                <div className="rounded-md bg-surface px-3 py-4 font-sans text-base text-ink-faint md:text-[11px]">
+                  Loading folders…
+                </div>
+              ) : error ? (
+                <div className="flex items-start gap-2 rounded-md bg-warn-muted px-3 py-3 font-sans text-base text-warn md:text-[11px]">
+                  <AlertCircle className="size-4 shrink-0" aria-hidden />
+                  <span>{error}</span>
+                </div>
+              ) : path === null ? (
+                // roots list (only when multiple roots)
+                (roots ?? []).map((r) => (
                   <button
+                    key={r}
                     type="button"
-                    disabled={validating !== null}
-                    onClick={() => void validateAndSelect(query)}
-                    className="flex min-h-14 w-full items-center gap-3 rounded-md bg-accent-muted px-3 py-2.5 text-left font-sans text-base text-accent hover:bg-surface-selected focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus disabled:opacity-50 md:min-h-10 md:gap-2 md:py-2 md:text-[12px]"
+                    onClick={() => enterRoot(r)}
+                    className="flex min-h-14 w-full items-center gap-3 rounded-md px-3 py-2.5 text-left font-sans text-base text-ink hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus md:min-h-10 md:gap-2 md:py-2 md:text-[12px]"
                   >
-                    <CornerDownLeft className="size-4 shrink-0" aria-hidden />
-                    <span className="truncate font-mono">
-                      Use {query.trim()}
-                    </span>
-                  </button>
-                ) : null}
-
-                {showDefaultRow || filteredProjects.length > 0 ? (
-                  <p className="px-1 pt-2 pb-1 font-sans text-base font-medium text-ink-faint md:text-[11px]">
-                    Current and recent
-                  </p>
-                ) : null}
-
-                {showDefaultRow && defaultDir ? (
-                  <button
-                    type="button"
-                    disabled={validating !== null}
-                    onClick={() => void validateAndSelect(defaultDir)}
-                    aria-current={defaultDir === value ? 'true' : undefined}
-                    className={cn(
-                      'flex min-h-14 w-full items-center gap-3 rounded-md px-3 py-2.5 text-left hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus disabled:opacity-50 md:min-h-10 md:gap-2 md:py-2',
-                      defaultDir === value && 'bg-surface-selected',
-                    )}
-                    title={`${defaultDir} — the folder the stack was started from`}
-                  >
-                    <Folder
-                      className={cn(
-                        'size-4 shrink-0',
-                        defaultDir === value ? 'text-ink' : 'text-ink-faint',
-                      )}
+                    <FolderOpen
+                      className="size-4 shrink-0 text-ink-faint"
                       aria-hidden
                     />
-                    <span className="flex min-w-0 flex-1 flex-col">
-                      <span
-                        className={cn(
-                          'truncate font-sans text-base font-medium md:text-[12px]',
-                          'text-ink',
-                        )}
-                      >
-                        {basename(defaultDir)}
-                      </span>
-                      <span className="truncate font-mono text-sm text-ink-ghost md:text-[10px]">
-                        {parentDisplay(defaultDir)}
-                      </span>
-                    </span>
-                    <span className="shrink-0 rounded-sm bg-surface-active px-1.5 py-0.5 font-sans text-sm text-ink-faint md:text-[9px]">
-                      default
-                    </span>
-                    {defaultDir === value ? (
-                      <Check className="size-4 shrink-0 text-ink" aria-hidden />
-                    ) : null}
+                    <span className="truncate font-mono">{r}</span>
                   </button>
-                ) : null}
-
-                {filteredProjects.map((p) => {
-                  const isSelected = p === value
-                  return (
-                    <div
-                      key={p}
-                      className={cn(
-                        'group flex items-center gap-1 rounded-md pr-1 hover:bg-surface-hover',
-                        isSelected && 'bg-surface-selected',
-                      )}
-                    >
-                      <button
-                        type="button"
-                        disabled={validating !== null}
-                        onClick={() => void validateAndSelect(p)}
-                        aria-current={isSelected ? 'true' : undefined}
-                        className="flex min-h-14 min-w-0 flex-1 items-center gap-3 rounded-md px-3 py-2.5 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus disabled:opacity-50 md:min-h-10 md:gap-2 md:py-2"
-                        title={p}
-                      >
-                        <Folder
-                          className={cn(
-                            'size-4 shrink-0',
-                            isSelected ? 'text-ink' : 'text-ink-faint',
-                          )}
-                          aria-hidden
-                        />
-                        <span className="flex min-w-0 flex-1 flex-col">
-                          <span
-                            className={cn(
-                              'truncate font-sans text-base font-medium md:text-[12px]',
-                              'text-ink',
-                            )}
-                          >
-                            {basename(p)}
-                          </span>
-                          <span className="truncate font-mono text-sm text-ink-ghost md:text-[10px]">
-                            {parentDisplay(p)}
-                          </span>
-                        </span>
-                        {isSelected ? (
-                          <Check
-                            className="size-4 shrink-0 text-ink"
-                            aria-hidden
-                          />
-                        ) : null}
-                      </button>
-                      <button
-                        type="button"
-                        aria-label={`forget ${p}`}
-                        title="forget this project"
-                        onClick={() => forget(p)}
-                        className="relative flex size-12 shrink-0 items-center justify-center rounded-sm text-ink-ghost hover:bg-surface-hover hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus md:size-8 md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100"
-                      >
-                        <span
-                          className="pointer-events-none absolute top-1/2 left-1/2 size-[max(100%,3rem)] -translate-1/2 pointer-fine:hidden"
-                          aria-hidden="true"
-                        />
-                        <X className="size-4 shrink-0 md:size-4" aria-hidden />
-                      </button>
-                    </div>
-                  )
-                })}
-
-                {filteredProjects.length === 0 &&
-                !showDefaultRow &&
-                !isAbsPath(query) ? (
-                  <div className="rounded-md bg-surface px-3 py-4 font-sans text-base text-ink-faint md:text-[11px]">
-                    {projects.length === 0
-                      ? 'No recent projects yet.'
-                      : 'No matching projects.'}{' '}
-                    Browse to add one.
-                  </div>
-                ) : null}
-
-                <div className="pt-2">
+                ))
+              ) : filteredDirs.length > 0 ? (
+                filteredDirs.map((d) => (
                   <button
+                    key={d}
                     type="button"
-                    onClick={() => void enterBrowse()}
-                    className="flex min-h-14 w-full items-center gap-3 rounded-md bg-surface px-3 py-2.5 text-left font-sans text-base font-medium text-ink-faint hover:bg-surface-hover hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus md:min-h-10 md:gap-2 md:py-2 md:text-[12px]"
+                    onClick={() => enterDir(d)}
+                    className="flex min-h-14 w-full items-center gap-3 rounded-md px-3 py-2.5 text-left font-sans text-base text-ink hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus md:min-h-10 md:gap-2 md:py-2 md:text-[12px]"
                   >
-                    <FolderPlus className="size-4 shrink-0" aria-hidden />
-                    Browse folders
+                    <Folder
+                      className="size-4 shrink-0 text-ink-faint"
+                      aria-hidden
+                    />
+                    <span className="truncate font-mono">{basename(d)}</span>
                   </button>
+                ))
+              ) : (
+                <div className="rounded-md bg-surface px-3 py-4 font-sans text-base text-ink-faint md:text-[11px]">
+                  {q
+                    ? 'No matching subfolders.'
+                    : 'No subfolders. You can use this folder.'}
                 </div>
-              </div>
-            ) : (
-              <div className={cn(embedded && 'flex min-h-0 flex-1 flex-col')}>
-                {/* browse header */}
-                <div className="mx-4 mb-2 flex min-h-14 shrink-0 items-center justify-between gap-2 rounded-md bg-surface p-1 md:mx-0 md:min-h-10">
-                  <div className="flex min-w-0 flex-1 items-center gap-1 font-sans text-base text-ink-faint md:text-[11px]">
-                    <button
-                      type="button"
-                      aria-label="back to projects"
-                      onClick={() => {
-                        setView('projects')
-                        setProjects(loadRecentProjects())
-                        setQuery('')
-                        setError(null)
-                      }}
-                      className="relative flex size-12 shrink-0 items-center justify-center rounded-sm text-ink-faint hover:bg-surface-hover hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus md:size-8"
-                    >
-                      <ArrowLeft className="size-4 shrink-0" aria-hidden />
-                    </button>
-                    {path ? (
-                      <button
-                        type="button"
-                        aria-label="up one level"
-                        onClick={goUp}
-                        className="relative flex size-12 shrink-0 items-center justify-center rounded-sm text-ink-faint hover:bg-surface-hover hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus md:size-8"
-                      >
-                        <ChevronUp className="size-4 shrink-0" aria-hidden />
-                      </button>
-                    ) : null}
-                    <span className="truncate font-mono">
-                      {path ?? 'roots'}
-                    </span>
-                  </div>
-                  {path ? (
-                    <button
-                      type="button"
-                      disabled={validating !== null}
-                      onClick={() => void validateAndSelect(path)}
-                      className="inline-flex min-h-12 shrink-0 items-center gap-1.5 rounded-sm bg-accent py-2 pr-3 pl-2 font-sans text-base font-medium whitespace-nowrap text-accent-fg hover:bg-accent-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rule-focus disabled:opacity-50 md:min-h-8 md:text-[11px]"
-                    >
-                      <Check className="size-4 shrink-0" aria-hidden />
-                      Use folder
-                    </button>
-                  ) : null}
-                </div>
-
-                <div
-                  className={cn(
-                    'space-y-1 overflow-y-auto px-4 pb-2 md:px-0',
-                    embedded ? 'min-h-0 flex-1' : 'max-h-[260px]',
-                  )}
-                >
-                  {isAbsPath(query) ? (
-                    <button
-                      type="button"
-                      onClick={() => void jumpTo(query)}
-                      className="flex min-h-14 w-full items-center gap-3 rounded-md bg-accent-muted px-3 py-2.5 text-left font-sans text-base text-accent hover:bg-surface-selected focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus md:min-h-10 md:gap-2 md:py-2 md:text-[12px]"
-                    >
-                      <CornerDownLeft className="size-4 shrink-0" aria-hidden />
-                      <span className="truncate font-mono">
-                        Go to {query.trim()}
-                      </span>
-                    </button>
-                  ) : null}
-
-                  {loading ? (
-                    <div className="rounded-md bg-surface px-3 py-4 font-sans text-base text-ink-faint md:text-[11px]">
-                      Loading folders…
-                    </div>
-                  ) : error ? (
-                    <div className="flex items-start gap-2 rounded-md bg-warn-muted px-3 py-3 font-sans text-base text-warn md:text-[11px]">
-                      <AlertCircle className="size-4 shrink-0" aria-hidden />
-                      <span>{error}</span>
-                    </div>
-                  ) : path === null ? (
-                    // roots list (only when multiple roots)
-                    (roots ?? []).map((r) => (
-                      <button
-                        key={r}
-                        type="button"
-                        onClick={() => enterRoot(r)}
-                        className="flex min-h-14 w-full items-center gap-3 rounded-md px-3 py-2.5 text-left font-sans text-base text-ink hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus md:min-h-10 md:gap-2 md:py-2 md:text-[12px]"
-                      >
-                        <FolderOpen
-                          className="size-4 shrink-0 text-ink-faint"
-                          aria-hidden
-                        />
-                        <span className="truncate font-mono">{r}</span>
-                      </button>
-                    ))
-                  ) : filteredDirs.length > 0 ? (
-                    filteredDirs.map((d) => (
-                      <button
-                        key={d}
-                        type="button"
-                        onClick={() => enterDir(d)}
-                        className="flex min-h-14 w-full items-center gap-3 rounded-md px-3 py-2.5 text-left font-sans text-base text-ink hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus md:min-h-10 md:gap-2 md:py-2 md:text-[12px]"
-                      >
-                        <Folder
-                          className="size-4 shrink-0 text-ink-faint"
-                          aria-hidden
-                        />
-                        <span className="truncate font-mono">
-                          {basename(d)}
-                        </span>
-                      </button>
-                    ))
-                  ) : (
-                    <div className="rounded-md bg-surface px-3 py-4 font-sans text-base text-ink-faint md:text-[11px]">
-                      {q
-                        ? 'No matching subfolders.'
-                        : 'No subfolders. You can use this folder.'}
-                    </div>
-                  )}
-                </div>
-              </div>
-            )}
-
-            {/* Static discoverability footnote — same line in both views, per
-              the filesystem-access spec §6: sets expectations before the first
-              grant prompt ever fires. */}
-            <div className="shrink-0 px-4 pt-2 md:px-0 md:pt-1">
-              <div className="rounded-md bg-surface px-3 py-2 font-sans text-base text-pretty text-ink-faint md:font-mono md:text-[10px]">
-                The agent can use the chosen folder freely. It asks before
-                accessing anything outside it.
-              </div>
+              )}
             </div>
           </div>
-        </DirectoryPickerPortal>
-      ) : null}
+        )}
+      </DirectoryPickerSurface>
     </div>
   )
 }
 
-function DirectoryPickerPortal({
-  enabled,
+function DirectoryPickerSurface({
+  open,
+  embedded,
+  mobileSheet,
+  onOpenChange,
+  triggerRef,
+  alignToInlineTrigger,
   children,
 }: {
-  enabled: boolean
+  open: boolean
+  embedded: boolean
+  mobileSheet: boolean
+  onOpenChange: (open: boolean) => void
+  triggerRef: RefObject<HTMLButtonElement | null>
+  alignToInlineTrigger: boolean
   children: ReactNode
 }) {
-  if (!enabled || typeof document === 'undefined') return children
-  return createPortal(children, document.body)
+  if (embedded) {
+    return (
+      // biome-ignore lint/a11y/useSemanticElements: this flex surface owns scroll layout and cannot use fieldset's rendering semantics
+      <div
+        role="group"
+        aria-label="select working directory"
+        className="flex min-h-0 flex-1 flex-col overflow-hidden bg-transparent"
+      >
+        {children}
+      </div>
+    )
+  }
+
+  if (mobileSheet) {
+    return (
+      <BottomSheet open={open} onOpenChange={onOpenChange}>
+        <BottomSheetContent
+          heading="Working directory"
+          closeLabel="Close project picker"
+        >
+          <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+            {children}
+          </div>
+        </BottomSheetContent>
+      </BottomSheet>
+    )
+  }
+
+  return (
+    <PopoverPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <PopoverPrimitive.Anchor
+        virtualRef={triggerRef as RefObject<HTMLButtonElement>}
+      />
+      <PopoverPrimitive.Portal>
+        <PortalScope>
+          <PopoverPrimitive.Content
+            side="top"
+            align={alignToInlineTrigger ? 'center' : 'end'}
+            sideOffset={8}
+            collisionPadding={12}
+            sticky="always"
+            role="dialog"
+            aria-label="select working directory"
+            className="iii-ui-motion-dropdown z-50 max-h-[var(--radix-popover-content-available-height)] w-[min(360px,calc(100vw-24px))] overflow-y-auto overscroll-contain rounded-lg border border-edge bg-panel-raised p-1.5 shadow-floating"
+          >
+            {children}
+          </PopoverPrimitive.Content>
+        </PortalScope>
+      </PopoverPrimitive.Portal>
+    </PopoverPrimitive.Root>
+  )
 }

--- a/console/web/src/components/chat/EmptyState.stories.tsx
+++ b/console/web/src/components/chat/EmptyState.stories.tsx
@@ -1,8 +1,13 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import { useState } from 'react'
 import { fn } from 'storybook/test'
 import type { InstallStage } from '@/hooks/use-harness-status'
-import { EmptyState } from './EmptyState'
-import { DEFAULT_SYSTEM_PROMPT_STATE } from './system-prompt-selection'
+import { EmptyState, type EmptyStateProps } from './EmptyState'
+import {
+  DEFAULT_SYSTEM_PROMPT_STATE,
+  type SkillSelection,
+  type SystemPromptState,
+} from './system-prompt-selection'
 
 /** Mid-download progress for the live install console. */
 const installingStages: InstallStage[] = [
@@ -47,24 +52,63 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
+function ConfiguredReadyStory(args: EmptyStateProps) {
+  const [systemPrompt, setSystemPrompt] = useState<SystemPromptState>(
+    args.systemPrompt ?? DEFAULT_SYSTEM_PROMPT_STATE,
+  )
+  const [skills, setSkills] = useState<SkillSelection>(args.skills)
+
+  return (
+    <EmptyState
+      {...args}
+      systemPrompt={systemPrompt}
+      onSystemPromptChange={setSystemPrompt}
+      skills={skills}
+      onSkillsChange={setSkills}
+    />
+  )
+}
+
 export const Ready: Story = {
   name: 'ready (harness + provider)',
   args: {
     variant: 'ready',
+    workingDir: '/Users/sergio/Documents/workspaces/iii/workers',
+    defaultWorkingDir: '/Users/sergio/Documents/workspaces/iii/workers',
+    onWorkingDirChange: fn(),
     systemPrompt: DEFAULT_SYSTEM_PROMPT_STATE,
     onSystemPromptChange: fn(),
+    onSkillsChange: fn(),
   },
 }
 
-export const ReadyWithNamedPrompt: Story = {
-  name: 'ready (agent selected)',
+export const ReadyConfigured: Story = {
+  name: 'ready (prompt + selected skills)',
+  render: (args) => <ConfiguredReadyStory {...args} />,
   args: {
     variant: 'ready',
+    workingDir: '/Users/sergio/Documents/workspaces/iii/workers',
+    defaultWorkingDir: '/Users/sergio/Documents/workspaces/iii/workers',
+    onWorkingDirChange: fn(),
     systemPrompt: {
       ...DEFAULT_SYSTEM_PROMPT_STATE,
-      choice: { named: 'agent:tech-leader' },
+      choice: { named: 'reviewer' },
     },
     onSystemPromptChange: fn(),
+    skills: ['design', 'linear-workflow', 'canonicalize-tailwind'],
+    onSkillsChange: fn(),
+  },
+}
+
+export const ReadyWithoutProject: Story = {
+  name: 'ready (project loading)',
+  args: {
+    variant: 'ready',
+    workingDir: null,
+    onWorkingDirChange: fn(),
+    systemPrompt: DEFAULT_SYSTEM_PROMPT_STATE,
+    onSystemPromptChange: fn(),
+    onSkillsChange: fn(),
   },
 }
 

--- a/console/web/src/components/chat/EmptyState.test.tsx
+++ b/console/web/src/components/chat/EmptyState.test.tsx
@@ -1,12 +1,46 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
 import { EmptyState } from './EmptyState'
+import { DEFAULT_SYSTEM_PROMPT_STATE } from './system-prompt-selection'
 
 describe('EmptyState', () => {
   it('shrinks and scrolls while keeping short content centered', () => {
-    const html = renderToStaticMarkup(<EmptyState variant="ready" />)
+    const html = renderToStaticMarkup(
+      <EmptyState variant="ready" workingDir="/workspace/console" />,
+    )
 
     expect(html).toContain('min-h-0 overflow-y-auto')
     expect(html).toContain('my-auto')
+    expect(html).toContain('size-16')
+    expect(html).toContain('What should we build in')
+    expect(html).toContain('console')
+  })
+
+  it('keeps session prompt and selected skills compact beneath the question', () => {
+    const html = renderToStaticMarkup(
+      <EmptyState
+        variant="ready"
+        workingDir="/workspace/console"
+        onWorkingDirChange={() => {}}
+        systemPrompt={{
+          ...DEFAULT_SYSTEM_PROMPT_STATE,
+          choice: { named: 'reviewer' },
+        }}
+        onSystemPromptChange={() => {}}
+        skills={['design', 'linear-workflow']}
+        onSkillsChange={() => {}}
+      />,
+    )
+
+    expect(html).toContain('aria-label="session setup"')
+    expect(html).toContain('System prompt')
+    expect(html).toContain('reviewer')
+    expect(html).toContain('items-baseline')
+    expect(html).not.toContain('Extending')
+    expect(html).not.toContain('Overriding')
+    expect(html).toContain('border-dashed')
+    expect(html).toContain('Add skills')
+    expect(html).toContain('remove design from this session')
+    expect(html).toContain('remove linear-workflow from this session')
   })
 })

--- a/console/web/src/components/chat/EmptyState.tsx
+++ b/console/web/src/components/chat/EmptyState.tsx
@@ -1,12 +1,19 @@
-import { FunctionMentionPill } from '@/components/chat/lexical/FunctionMentionNode'
+import { X } from 'lucide-react'
 import { CopyCommandButton } from '@/components/chat/sandbox/terminal/CopyCommandButton'
 import { Terminal } from '@/components/chat/sandbox/terminal/Terminal'
 import { Button } from '@/components/ui/Button'
+import { Wordmark } from '@/components/ui/Wordmark'
 import type { InstallStage } from '@/hooks/use-harness-status'
 import { normalizeErrorMessage } from '@/lib/providers'
 import { cn } from '@/lib/utils'
-import { AgentPicker } from './AgentPicker'
-import type { SystemPromptState } from './system-prompt-selection'
+import { DirectoryPicker, type WorktreePickerOptions } from './DirectoryPicker'
+import { SessionAddonsPicker } from './SessionAddonsPicker'
+import { SystemPromptPicker } from './SystemPromptPicker'
+import {
+  type SkillSelection,
+  type SystemPromptState,
+  toggleSkillSelection,
+} from './system-prompt-selection'
 
 /**
  * The chat empty state, as a small set of presentational variants:
@@ -43,16 +50,21 @@ export interface EmptyStateProps {
   onRetryInstall?: () => void
   /** `no-provider` CTA (opens the model/provider picker). */
   onConfigureProvider?: () => void
-  /**
-   * `ready` system-prompt control. This screen is where the choice is made —
-   * once the chat has messages the composer only shows it read-only. Omitted
-   * (e.g. Storybook without a provider) renders no control at all.
-   */
+  /** `ready` project context and shared directory-picker behavior. */
+  workingDir?: string | null
+  onWorkingDirChange?: (next: string) => void
+  workingDirError?: string | null
+  defaultWorkingDir?: string | null
+  worktreePicker?: WorktreePickerOptions
+  /** Session instructions selected before the first message. */
   systemPrompt?: SystemPromptState
   onSystemPromptChange?: (next: SystemPromptState) => void
+  /** Exact model-invocable skill IDs curated for this session. */
+  skills?: SkillSelection
+  onSkillsChange?: (next: SkillSelection) => void
 }
 
-const HARNESS_INSTALL_COMMAND = 'iii worker add harness'
+const HARNESS_INSTALL_COMMAND = 'iii trigger compose::add worker=harness'
 
 const HEADING_CLASS =
   'text-balance font-sans text-3xl font-semibold tracking-tight text-ink'
@@ -66,12 +78,18 @@ export function EmptyState({
   onInstallHarness,
   onRetryInstall,
   onConfigureProvider,
+  workingDir,
+  onWorkingDirChange,
+  workingDirError,
+  defaultWorkingDir,
+  worktreePicker,
   systemPrompt,
   onSystemPromptChange,
+  skills,
+  onSkillsChange,
 }: EmptyStateProps) {
   const emptyPad = density === 'dock' ? 'px-3 sm:px-4' : 'px-3 sm:px-6 lg:px-9'
-  const eyebrow =
-    variant === 'ready' || variant === 'no-provider' ? 'new session' : 'setup'
+  const eyebrow = variant === 'no-provider' ? 'New session' : 'Setup'
 
   return (
     <div
@@ -80,17 +98,29 @@ export function EmptyState({
         emptyPad,
       )}
     >
-      <div className="my-auto flex w-full max-w-[520px] flex-col gap-6 py-6">
-        <div className="font-sans text-base font-medium text-ink-faint sm:text-sm">
-          {eyebrow === 'new session' ? 'New session' : 'Setup'}
-        </div>
-
+      <div
+        className={cn(
+          'my-auto flex w-full max-w-[520px] flex-col py-6',
+          variant === 'ready' ? 'items-center gap-5 text-center' : 'gap-6',
+        )}
+      >
         {variant === 'ready' ? (
           <ReadyBody
+            workingDir={workingDir}
+            onWorkingDirChange={onWorkingDirChange}
+            workingDirError={workingDirError}
+            defaultWorkingDir={defaultWorkingDir}
+            worktreePicker={worktreePicker}
             systemPrompt={systemPrompt}
             onSystemPromptChange={onSystemPromptChange}
+            skills={skills}
+            onSkillsChange={onSkillsChange}
           />
-        ) : null}
+        ) : (
+          <div className="font-sans text-base font-medium text-ink-faint sm:text-sm">
+            {eyebrow}
+          </div>
+        )}
         {variant === 'no-provider' ? (
           <NoProviderBody onConfigureProvider={onConfigureProvider} />
         ) : null}
@@ -112,80 +142,133 @@ export function EmptyState({
 
 /* ---------------- ready (welcome hero) ---------------- */
 
-const EXPLORE_FUNCTIONS = [
-  { id: 'engine::functions::list', hint: 'see all callable functions' },
-  { id: 'engine::workers::list', hint: 'check connected workers' },
-  { id: 'engine::triggers::list', hint: 'discover trigger types' },
-] as const
-
 function ReadyBody({
+  workingDir,
+  onWorkingDirChange,
+  workingDirError,
+  defaultWorkingDir,
+  worktreePicker,
   systemPrompt,
   onSystemPromptChange,
+  skills,
+  onSkillsChange,
 }: {
+  workingDir?: string | null
+  onWorkingDirChange?: (next: string) => void
+  workingDirError?: string | null
+  defaultWorkingDir?: string | null
+  worktreePicker?: WorktreePickerOptions
   systemPrompt?: SystemPromptState
   onSystemPromptChange?: (next: SystemPromptState) => void
+  skills?: SkillSelection
+  onSkillsChange?: (next: SkillSelection) => void
 }) {
+  const projectName = workingDir
+    ? (workingDir.split('/').filter(Boolean).at(-1) ?? workingDir)
+    : 'a project'
+
   return (
     <>
-      <h1 className={HEADING_CLASS}>Welcome to iii</h1>
-      <div className="flex flex-col gap-2">
-        <p className={BODY_CLASS}>
-          You're in an agent-oriented workspace where you can leverage the power
-          of a full-featured agentic system:
-        </p>
-        <ul className="flex flex-col gap-1 font-sans text-base/7 text-ink-faint">
-          <li>· trigger functions via the function registry</li>
-          <li>· spawn sub-agents for parallel/async work</li>
-          <li>· register triggers for callbacks &amp; automation</li>
-          <li>· query state and subscribe to events</li>
-        </ul>
+      <Wordmark appearance="inset" />
+      <div className="flex max-w-full flex-col items-center gap-2.5">
+        <div className="max-w-full font-sans text-xl font-medium text-ink-faint sm:text-lg">
+          What should we build in{' '}
+          {onWorkingDirChange ? (
+            <DirectoryPicker
+              value={workingDir ?? null}
+              onChange={onWorkingDirChange}
+              externalError={workingDirError}
+              defaultDir={defaultWorkingDir}
+              worktrees={worktreePicker}
+              triggerAppearance="inline"
+              emptyLabel="a project"
+              className="max-w-[min(18rem,70vw)] align-baseline"
+            />
+          ) : (
+            <span className="font-medium text-ink">{projectName}</span>
+          )}
+          {'?'}
+        </div>
+        {systemPrompt && onSystemPromptChange ? (
+          <SessionSetupControls
+            systemPrompt={systemPrompt}
+            onSystemPromptChange={onSystemPromptChange}
+            skills={skills}
+            onSkillsChange={onSkillsChange}
+          />
+        ) : null}
       </div>
-      <div className="flex flex-col gap-2">
-        <p className={BODY_CLASS}>Start by exploring what's available:</p>
-        <ul className="flex flex-col gap-1.5 font-sans text-base/7 text-ink-faint">
-          {EXPLORE_FUNCTIONS.map(({ id, hint }) => (
-            <li key={id}>
-              <FunctionMentionPill functionId={id} /> — {hint}
+    </>
+  )
+}
+
+function SessionSetupControls({
+  systemPrompt,
+  onSystemPromptChange,
+  skills,
+  onSkillsChange,
+}: {
+  systemPrompt: SystemPromptState
+  onSystemPromptChange: (next: SystemPromptState) => void
+  skills?: SkillSelection
+  onSkillsChange?: (next: SkillSelection) => void
+}) {
+  return (
+    <section
+      aria-label="session setup"
+      className="flex max-w-full flex-col items-center gap-2"
+    >
+      <div className="flex max-w-full min-w-0 items-baseline justify-center gap-1.5 font-sans text-base text-ink-faint sm:text-sm">
+        <span>System prompt</span>
+        <SystemPromptPicker
+          value={systemPrompt}
+          onChange={onSystemPromptChange}
+          allowCustom={false}
+          appearance="inline"
+          className="max-w-48"
+        />
+      </div>
+
+      {onSkillsChange ? (
+        <div className="flex justify-center font-sans text-base text-ink-faint sm:text-sm">
+          <SessionAddonsPicker
+            value={skills}
+            onChange={onSkillsChange}
+            appearance="inline"
+          />
+        </div>
+      ) : null}
+
+      {skills?.length && onSkillsChange ? (
+        <ul
+          // biome-ignore lint/a11y/noRedundantRoles: keep list semantics when CSS resets remove markers.
+          role="list"
+          aria-label="skills selected for this session"
+          className="flex max-w-full flex-wrap justify-center gap-1.5"
+        >
+          {skills.map((skill) => (
+            <li key={skill} className="min-w-0 max-w-full">
+              <button
+                type="button"
+                aria-label={`remove ${skill} from this session`}
+                title={`Remove ${skill}`}
+                onClick={() =>
+                  onSkillsChange(toggleSkillSelection(skills, skill))
+                }
+                className="relative inline-flex h-9 max-w-full items-center gap-1 rounded-full bg-surface py-1 pr-2 pl-3 font-sans text-base font-medium text-ink-faint hover:bg-surface-hover hover:text-ink focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rule-focus sm:h-7 sm:text-[0.8125rem]"
+              >
+                <span className="truncate">{skill}</span>
+                <X className="size-4 shrink-0 text-ink-faint/80" aria-hidden />
+                <span
+                  className="pointer-events-none absolute top-1/2 left-1/2 size-[max(100%,3rem)] -translate-1/2 pointer-fine:hidden"
+                  aria-hidden="true"
+                />
+              </button>
             </li>
           ))}
         </ul>
-      </div>
-      <p className={BODY_CLASS}>
-        need help? ask away. the agent will discover apis on the fly and show
-        you what's possible.
-      </p>
-      {/* Last, after the orientation arc: a compact preflight closest to the
-          composer that starts and locks the session. */}
-      {systemPrompt && onSystemPromptChange ? (
-        <section
-          aria-labelledby="session-agent"
-          className="rounded-sm bg-surface p-4 flex flex-col gap-3"
-        >
-          <div className="flex flex-col gap-1">
-            <h2
-              id="session-agent"
-              className="font-sans text-base font-semibold text-ink sm:text-sm"
-            >
-              Agent
-            </h2>
-            <p className="font-sans text-base/6 text-ink-faint sm:text-sm/6">
-              Choose who the agent is in this session.
-            </p>
-          </div>
-          <AgentPicker
-            value={systemPrompt}
-            onChange={onSystemPromptChange}
-            className="min-w-0"
-          />
-          <p className="font-sans text-base/6 text-ink-faint sm:text-sm/5">
-            {systemPrompt.choice === 'default'
-              ? "Default uses the provider's built-in prompt"
-              : "The agent's instructions and skill selection apply to this session"}
-            {' · Locked after your first message'}
-          </p>
-        </section>
       ) : null}
-    </>
+    </section>
   )
 }
 
@@ -291,7 +374,7 @@ function InstallingBody({
 
 /**
  * Live install console — `Terminal` chrome over the streamed `worker`
- * lifecycle stages, framed as the equivalent `iii worker add harness` run.
+ * lifecycle stages, framed as the equivalent `iii trigger compose::add worker=harness` run.
  */
 function InstallConsole({
   stages,

--- a/console/web/src/components/chat/MessageList.test.tsx
+++ b/console/web/src/components/chat/MessageList.test.tsx
@@ -4,6 +4,7 @@ import type {
   AssistantMessage,
   FunctionTriggerMessage,
   Message,
+  UserMessage,
 } from '@/types/chat'
 import { MessageList } from './MessageList'
 
@@ -86,5 +87,25 @@ describe('MessageList function-trigger groups', () => {
     expect(html).toContain('aria-label="action required for shell::run"')
     expect(html).toContain('tabindex="-1"')
     expect(html).toContain('data-approval-actions=""')
+  })
+
+  it('renders the branded waiting indicator while the model is pending', () => {
+    const user: UserMessage = {
+      id: 'user-1',
+      role: 'user',
+      content: 'Build the feature.',
+      createdAt: 0,
+    }
+    const html = renderToStaticMarkup(
+      <MessageList
+        messages={[user]}
+        isThinking
+        thinkingDetail="dispatching model"
+      />,
+    )
+
+    expect(html).toContain('data-model-waiting=""')
+    expect(html).toContain('aria-label="dispatching model"')
+    expect(html.match(/model-waiting-wordmark-segment/g)).toHaveLength(3)
   })
 })

--- a/console/web/src/components/chat/MessageList.tsx
+++ b/console/web/src/components/chat/MessageList.tsx
@@ -13,7 +13,6 @@ import {
   type WheelEvent,
 } from 'react'
 import { resultEnvelope } from '@/components/function-trigger/FunctionTriggerCard'
-import { imageZoomTarget } from './image-zoom-target'
 import {
   rawRedactor,
   useFunctionTriggerRenderers,
@@ -45,11 +44,15 @@ import {
 } from '@/lib/sessions/entry-mapper'
 import { cn } from '@/lib/utils'
 import type { Message as MessageType } from '@/types/chat'
+import type { WorktreePickerOptions } from './DirectoryPicker'
 import { EmptyState, type EmptyStateProps } from './EmptyState'
 import { functionTriggerGroups } from './function-trigger-groups'
+import { imageZoomTarget } from './image-zoom-target'
 import { Message, type SpawnTaskContext } from './Message'
+import { ModelWaitingIndicator } from './ModelWaitingIndicator'
 import {
   DEFAULT_SYSTEM_PROMPT_STATE,
+  type SkillSelection,
   type SystemPromptState,
 } from './system-prompt-selection'
 import {
@@ -69,11 +72,11 @@ interface MessageListProps {
    * so opening a chat never glides through a partial history.
    */
   transcriptHydrated?: boolean
-  /** Show "thinking…" shimmer at the bottom while the agent is between
-      visible outputs (after submit, or between fcall-end and the next
-      turn's first token). */
+  /** Show the model-waiting indicator at the bottom while the agent is
+      between visible outputs (after submit, or between fcall-end and the
+      next turn's first token). */
   isThinking?: boolean
-  /** Under-the-hood context shown as the waiting shimmer (e.g. "dispatching
+  /** Under-the-hood context shown in the waiting indicator (e.g. "dispatching
       zai::glm-5.2" or the session's status_reason). Falls back to "thinking…"
       when absent. */
   thinkingDetail?: string
@@ -103,6 +106,10 @@ interface MessageListProps {
   /** Current child-session identity shown by direct spawn seed messages. */
   spawnContext?: SpawnTaskContext
   workingDir?: string | null
+  onWorkingDirChange?: (next: string) => void
+  workingDirError?: string | null
+  defaultWorkingDir?: string | null
+  worktreePicker?: WorktreePickerOptions
   /**
    * Render every function-call card (and group) already expanded. Off in the
    * product, where a turn's calls collapse to one line each; on for showcase
@@ -286,6 +293,10 @@ export function MessageList({
   onConfigureProvider,
   spawnContext,
   workingDir,
+  onWorkingDirChange,
+  workingDirError,
+  defaultWorkingDir,
+  worktreePicker,
   defaultOpenCalls,
   triggersById,
 }: MessageListProps) {
@@ -446,7 +457,7 @@ export function MessageList({
   ])
 
   /* Content height can change without a messages identity change: markdown
-     wraps, images load, results expand, the shimmer mounts, or the pane
+     wraps, images load, results expand, the waiting indicator mounts, or the pane
      resizes. Observe both the content and viewport, coalescing all of it into
      the single follow loop. A paused reader is never moved. */
   useEffect(() => {
@@ -586,7 +597,15 @@ export function MessageList({
 
   if (messages.length === 0 && !header) {
     return (
-      <EmptyState {...resolveEmptyState(ctx, density, onConfigureProvider)} />
+      <EmptyState
+        {...resolveEmptyState(ctx, density, onConfigureProvider, {
+          workingDir,
+          onWorkingDirChange,
+          workingDirError,
+          defaultWorkingDir,
+          worktreePicker,
+        })}
+      />
     )
   }
 
@@ -694,11 +713,7 @@ export function MessageList({
               </div>
             )
           })}
-          {isThinking ? (
-            <div className="font-mono text-[13px] italic thinking-shimmer text-ink-faint">
-              {thinkingDetail ?? 'thinking…'}
-            </div>
-          ) : null}
+          {isThinking ? <ModelWaitingIndicator label={thinkingDetail} /> : null}
         </div>
       </section>
       {tailState === 'paused' ? (
@@ -855,8 +870,16 @@ function resolveEmptyState(
   ctx: ChatCtx,
   density: 'route' | 'dock',
   onConfigureProvider?: () => void,
+  directory?: Pick<
+    EmptyStateProps,
+    | 'workingDir'
+    | 'onWorkingDirChange'
+    | 'workingDirError'
+    | 'defaultWorkingDir'
+    | 'worktreePicker'
+  >,
 ): EmptyStateProps {
-  if (!ctx) return { variant: 'ready', density }
+  if (!ctx) return { variant: 'ready', density, ...directory }
 
   const { harnessStatus, modelOptions, catalogLoading, active } = ctx
   const base: EmptyStateProps = {
@@ -867,13 +890,15 @@ function resolveEmptyState(
     onInstallHarness: harnessStatus.install,
     onRetryInstall: harnessStatus.retry,
     onConfigureProvider,
-    /* The system prompt is chosen here and nowhere else. It persists on the
-       conversation record, so it survives this view being keyed away and
-       back on a chat-tab switch. */
     systemPrompt: active?.systemPrompt ?? DEFAULT_SYSTEM_PROMPT_STATE,
     onSystemPromptChange: active
       ? (next: SystemPromptState) => ctx.setSystemPrompt(active.id, next)
       : undefined,
+    skills: active?.skills,
+    onSkillsChange: active
+      ? (next: SkillSelection) => ctx.setSkills(active.id, next)
+      : undefined,
+    ...directory,
   }
 
   if (harnessStatus.error) return { ...base, variant: 'install-failed' }

--- a/console/web/src/components/chat/ModePicker.tsx
+++ b/console/web/src/components/chat/ModePicker.tsx
@@ -60,9 +60,7 @@ export function ModePicker({ value, onChange, className }: ModePickerProps) {
           position="popper"
           sideOffset={4}
           className={cn(
-            'z-50 min-w-[var(--radix-select-trigger-width)] overflow-hidden rounded-md border border-rule-2 bg-panel-raised font-sans text-base text-ink shadow-floating sm:text-[13px]',
-            'data-[state=open]:animate-in data-[state=closed]:animate-out',
-            'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+            'iii-ui-motion-dropdown z-50 min-w-[var(--radix-select-trigger-width)] overflow-hidden rounded-md border border-rule-2 bg-panel-raised font-sans text-base text-ink shadow-floating sm:text-[13px]',
           )}
         >
           <SelectPrimitive.Viewport className="p-1">

--- a/console/web/src/components/chat/ModelPicker.tsx
+++ b/console/web/src/components/chat/ModelPicker.tsx
@@ -8,6 +8,8 @@ import {
   RefreshCw,
 } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { BottomSheet, BottomSheetContent } from '@/components/ui/BottomSheet'
+import { useMediaQuery } from '@/hooks/use-media-query'
 import { useConversationsCtxOptional } from '@/lib/conversations-context'
 import { cn } from '@/lib/utils'
 import { useUnsavedGuard } from '@/pages/Configuration/tabs/WorkersTab/useUnsavedGuard'
@@ -31,6 +33,7 @@ const DEFAULT_EFFORT: ReasoningEffortOption = {
 }
 
 const FILTER_KEYS = ['ArrowDown', 'ArrowUp', 'Home', 'End', 'Enter', 'Escape']
+const MODEL_PICKER_PAGE_TRANSITION_MS = 250
 
 interface ModelPickerProps {
   value: ModelId | null
@@ -49,7 +52,7 @@ interface ModelPickerProps {
 interface PickerSubpageHeaderProps {
   title: string
   description: string
-  onBack: () => void
+  onBack?: () => void
 }
 
 function PickerSubpageHeader({
@@ -59,19 +62,21 @@ function PickerSubpageHeader({
 }: PickerSubpageHeaderProps) {
   return (
     <div className="flex shrink-0 items-start gap-2 px-4 py-3 pr-12">
-      <button
-        type="button"
-        aria-label="back to models"
-        onClick={onBack}
-        className="relative flex size-8 shrink-0 items-center justify-center rounded-sm text-ink-faint hover:bg-surface-hover hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus"
-      >
-        <span
-          className="pointer-events-none absolute top-1/2 left-1/2 size-[max(100%,3rem)] -translate-1/2 pointer-fine:hidden"
-          aria-hidden="true"
-        />
-        <ArrowLeft className="size-4 shrink-0" aria-hidden />
-      </button>
-      <div className="min-w-0 flex-1 pt-0.5">
+      {onBack ? (
+        <button
+          type="button"
+          aria-label="back to models"
+          onClick={onBack}
+          className="relative flex size-8 shrink-0 items-center justify-center rounded-sm text-ink-faint hover:bg-surface-hover hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus"
+        >
+          <span
+            className="pointer-events-none absolute top-1/2 left-1/2 size-[max(100%,3rem)] -translate-1/2 pointer-fine:hidden"
+            aria-hidden="true"
+          />
+          <ArrowLeft className="size-4 shrink-0" aria-hidden />
+        </button>
+      ) : null}
+      <div className={cn('min-w-0 flex-1', onBack && 'pt-0.5')}>
         <h2 className="font-sans text-lg font-semibold text-ink">{title}</h2>
         <p className="font-sans text-sm text-pretty text-ink-faint">
           {description}
@@ -133,12 +138,15 @@ export function ModelPicker({
   className,
 }: ModelPickerProps) {
   const ctx = useConversationsCtxOptional()
+  const mobileSheet = useMediaQuery('(max-width: 767px)')
   const [open, setOpen] = useState(false)
   const triggerRef = useRef<HTMLButtonElement>(null)
   const consumedOpenRequestRef = useRef(openRequest)
   const [configurationProvider, setConfigurationProvider] = useState<
     string | null
   >(null)
+  const [renderedConfigurationProvider, setRenderedConfigurationProvider] =
+    useState<string | null>(null)
   const [reasoningOpen, setReasoningOpen] = useState(false)
   const configurationGuard = useUnsavedGuard()
 
@@ -175,6 +183,22 @@ export function ModelPicker({
     if (pickerDisabled && open) setOpen(false)
   }, [pickerDisabled, open])
 
+  useEffect(() => {
+    if (configurationProvider !== null) return
+    if (renderedConfigurationProvider === null) return
+    const timeout = window.setTimeout(
+      () => setRenderedConfigurationProvider(null),
+      MODEL_PICKER_PAGE_TRANSITION_MS,
+    )
+    return () => window.clearTimeout(timeout)
+  }, [configurationProvider, renderedConfigurationProvider])
+
+  const activePage = configurationProvider
+    ? 'provider'
+    : reasoningOpen
+      ? 'reasoning'
+      : 'models'
+
   function handleOpenChange(nextOpen: boolean) {
     if (nextOpen) {
       setOpen(true)
@@ -187,117 +211,179 @@ export function ModelPicker({
     })
   }
 
+  const sheetHeading =
+    activePage === 'models'
+      ? 'Model'
+      : activePage === 'reasoning'
+        ? 'Reasoning effort'
+        : renderedConfigurationProvider
+          ? (formatProviderLabel(renderedConfigurationProvider) ??
+            renderedConfigurationProvider)
+          : 'Provider configuration'
+
+  const pickerTrigger = (
+    <button
+      ref={triggerRef}
+      type="button"
+      aria-label={
+        loading
+          ? 'model (loading catalog)'
+          : selected
+            ? `model: ${selected.label}, reasoning effort: ${thinkingLevel}`
+            : 'model'
+      }
+      aria-busy={loading || undefined}
+      aria-haspopup={mobileSheet ? 'dialog' : 'menu'}
+      aria-expanded={open}
+      data-state={open ? 'open' : 'closed'}
+      disabled={pickerDisabled}
+      onClick={mobileSheet ? () => handleOpenChange(!open) : undefined}
+      className={cn(
+        'flex h-12 min-w-0 flex-1 items-center justify-between gap-x-2 rounded-sm border border-transparent bg-transparent px-3 font-sans text-base text-ink-faint hover:bg-surface-hover hover:text-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus data-[state=open]:bg-surface data-[state=open]:text-ink sm:h-9 sm:text-[13px]',
+        pickerDisabled && 'pointer-events-none opacity-40',
+      )}
+    >
+      <span className="flex min-w-0 flex-1 items-baseline gap-1.5 overflow-hidden whitespace-nowrap text-left">
+        <span
+          className={cn(
+            'min-w-0 flex-1 truncate',
+            !selected && 'text-ink-faint',
+          )}
+        >
+          {selected?.label ?? (loading ? 'Loading…' : 'No models')}
+        </span>
+        {selectedEfforts.length > 1 && thinkingLevel !== 'default' ? (
+          <span className="shrink-0 text-[11px] text-ink-faint">
+            · {thinkingLevel}
+          </span>
+        ) : null}
+      </span>
+      {open ? (
+        <ChevronUp size={16} aria-hidden />
+      ) : (
+        <ChevronDown size={16} aria-hidden />
+      )}
+    </button>
+  )
+
+  const pickerPages = (
+    <div className="relative min-h-0 flex-1 overflow-hidden">
+      <div
+        data-active={activePage === 'models'}
+        aria-hidden={activePage !== 'models'}
+        inert={activePage !== 'models'}
+        className={cn(
+          'iii-ui-motion-picker-page absolute inset-0 flex min-h-0 flex-col [--picker-page-offset:calc(var(--distance-base)*-1)]',
+          !mobileSheet && 'pt-4',
+        )}
+      >
+        <ModelPickerPanel
+          value={value}
+          options={options}
+          thinkingLevel={thinkingLevel}
+          onChange={onChange}
+          onThinkingLevelChange={onThinkingLevelChange}
+          onConfigureProvider={(providerId) => {
+            setReasoningOpen(false)
+            setRenderedConfigurationProvider(providerId)
+            setConfigurationProvider(providerId)
+          }}
+          onOpenReasoning={() => setReasoningOpen(true)}
+          disabled={disabled}
+          loading={loading}
+          contentClassName="space-y-4 px-3 pb-3"
+          autoFocusFilter={!mobileSheet}
+        />
+      </div>
+
+      <div
+        data-active={activePage === 'reasoning'}
+        aria-hidden={activePage !== 'reasoning'}
+        inert={activePage !== 'reasoning'}
+        className="iii-ui-motion-picker-page absolute inset-0 flex min-h-0 flex-col [--picker-page-offset:var(--distance-base)]"
+      >
+        <PickerSubpageHeader
+          title="Reasoning effort"
+          description="Choose how much reasoning this model should use."
+          onBack={() => setReasoningOpen(false)}
+        />
+        <div className="min-h-0 flex-1 overflow-y-auto px-3 pb-3">
+          <ReasoningEffortPanel
+            model={selected}
+            value={thinkingLevel}
+            onChange={(next) => {
+              onThinkingLevelChange(next)
+              setReasoningOpen(false)
+            }}
+            disabled={disabled}
+          />
+        </div>
+      </div>
+
+      <div
+        data-active={activePage === 'provider'}
+        aria-hidden={activePage !== 'provider'}
+        inert={activePage !== 'provider'}
+        className="iii-ui-motion-picker-page absolute inset-0 flex min-h-0 flex-col [--picker-page-offset:var(--distance-base)]"
+      >
+        {renderedConfigurationProvider ? (
+          <>
+            <PickerSubpageHeader
+              title={
+                formatProviderLabel(renderedConfigurationProvider) ??
+                renderedConfigurationProvider
+              }
+              description="Credentials and provider-specific settings."
+              onBack={() =>
+                configurationGuard.tryNavigate(() =>
+                  setConfigurationProvider(null),
+                )
+              }
+            />
+            <ProviderConfigurationPanel
+              providerId={renderedConfigurationProvider}
+              onDirtyChange={configurationGuard.setDirty}
+            />
+          </>
+        ) : null}
+      </div>
+    </div>
+  )
+
   return (
     <span className={cn('flex min-w-0 items-center gap-1', className)}>
-      <DropdownMenuPrimitive.Root open={open} onOpenChange={handleOpenChange}>
-        <DropdownMenuPrimitive.Trigger asChild disabled={pickerDisabled}>
-          <button
-            ref={triggerRef}
-            type="button"
-            aria-label={
-              loading
-                ? 'model (loading catalog)'
-                : selected
-                  ? `model: ${selected.label}, reasoning effort: ${thinkingLevel}`
-                  : 'model'
-            }
-            aria-busy={loading || undefined}
-            className={cn(
-              'flex h-12 min-w-0 flex-1 items-center justify-between gap-x-2 rounded-sm border border-transparent bg-transparent px-3 font-sans text-base text-ink-faint hover:bg-surface-hover hover:text-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus data-[state=open]:bg-surface data-[state=open]:text-ink sm:h-9 sm:text-[13px]',
-              pickerDisabled && 'pointer-events-none opacity-40',
-            )}
-          >
-            <span className="flex min-w-0 flex-1 items-baseline gap-1.5 overflow-hidden whitespace-nowrap text-left">
-              <span
-                className={cn(
-                  'min-w-0 flex-1 truncate',
-                  !selected && 'text-ink-faint',
-                )}
-              >
-                {selected?.label ?? (loading ? 'Loading…' : 'No models')}
-              </span>
-              {selectedEfforts.length > 1 && thinkingLevel !== 'default' ? (
-                <span className="shrink-0 text-[11px] text-ink-faint">
-                  · {thinkingLevel}
-                </span>
-              ) : null}
-            </span>
-            {open ? (
-              <ChevronUp size={16} aria-hidden />
-            ) : (
-              <ChevronDown size={16} aria-hidden />
-            )}
-          </button>
-        </DropdownMenuPrimitive.Trigger>
+      {mobileSheet ? (
+        <>
+          {pickerTrigger}
+          <BottomSheet open={open} onOpenChange={handleOpenChange}>
+            <BottomSheetContent
+              heading={sheetHeading}
+              headerClassName={activePage === 'models' ? undefined : 'sr-only'}
+              closeLabel="Close model picker"
+              className="h-[min(82dvh,720px)]"
+            >
+              {pickerPages}
+            </BottomSheetContent>
+          </BottomSheet>
+        </>
+      ) : (
+        <DropdownMenuPrimitive.Root open={open} onOpenChange={handleOpenChange}>
+          <DropdownMenuPrimitive.Trigger asChild disabled={pickerDisabled}>
+            {pickerTrigger}
+          </DropdownMenuPrimitive.Trigger>
 
-        <DropdownMenuPrimitive.Portal>
-          <DropdownMenuPrimitive.Content
-            sideOffset={4}
-            align="start"
-            collisionPadding={12}
-            className="z-50 flex h-[min(72vh,720px)] w-[min(480px,calc(100vw-24px))] flex-col overflow-hidden rounded-lg border border-edge bg-panel-raised text-ink shadow-floating"
-          >
-            {configurationProvider ? (
-              <div className="flex min-h-0 flex-1 flex-col">
-                <PickerSubpageHeader
-                  title={
-                    formatProviderLabel(configurationProvider) ??
-                    configurationProvider
-                  }
-                  description="Credentials and provider-specific settings."
-                  onBack={() =>
-                    configurationGuard.tryNavigate(() =>
-                      setConfigurationProvider(null),
-                    )
-                  }
-                />
-                <ProviderConfigurationPanel
-                  providerId={configurationProvider}
-                  onDirtyChange={configurationGuard.setDirty}
-                />
-              </div>
-            ) : reasoningOpen ? (
-              <div className="flex min-h-0 flex-1 flex-col">
-                <PickerSubpageHeader
-                  title="Reasoning effort"
-                  description="Choose how much reasoning this model should use."
-                  onBack={() => setReasoningOpen(false)}
-                />
-                <div className="min-h-0 flex-1 overflow-y-auto px-3 pb-3">
-                  <ReasoningEffortPanel
-                    model={selected}
-                    value={thinkingLevel}
-                    onChange={(next) => {
-                      onThinkingLevelChange(next)
-                      setReasoningOpen(false)
-                    }}
-                    disabled={disabled}
-                  />
-                </div>
-              </div>
-            ) : (
-              <div className="flex min-h-0 flex-1 flex-col pt-4">
-                <ModelPickerPanel
-                  value={value}
-                  options={options}
-                  thinkingLevel={thinkingLevel}
-                  onChange={onChange}
-                  onThinkingLevelChange={onThinkingLevelChange}
-                  onConfigureProvider={(providerId) => {
-                    setReasoningOpen(false)
-                    setConfigurationProvider(providerId)
-                  }}
-                  onOpenReasoning={() => setReasoningOpen(true)}
-                  disabled={disabled}
-                  loading={loading}
-                  contentClassName="space-y-4 px-3 pb-3"
-                  autoFocusFilter
-                />
-              </div>
-            )}
-          </DropdownMenuPrimitive.Content>
-        </DropdownMenuPrimitive.Portal>
-      </DropdownMenuPrimitive.Root>
+          <DropdownMenuPrimitive.Portal>
+            <DropdownMenuPrimitive.Content
+              sideOffset={4}
+              align="start"
+              collisionPadding={12}
+              className="iii-ui-motion-dropdown z-50 flex h-[min(72vh,720px)] w-[min(480px,calc(100vw-24px))] flex-col overflow-hidden rounded-lg border border-edge bg-panel-raised text-ink shadow-floating"
+            >
+              {pickerPages}
+            </DropdownMenuPrimitive.Content>
+          </DropdownMenuPrimitive.Portal>
+        </DropdownMenuPrimitive.Root>
+      )}
 
       {ctx && showRefresh ? (
         <button

--- a/console/web/src/components/chat/ModelWaitingIndicator.stories.tsx
+++ b/console/web/src/components/chat/ModelWaitingIndicator.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { ModelWaitingIndicator } from './ModelWaitingIndicator'
+
+const meta = {
+  title: 'Chat/ModelWaitingIndicator',
+  component: ModelWaitingIndicator,
+  args: {
+    label: 'dispatching anthropic::claude-sonnet-4-5',
+  },
+  parameters: { layout: 'padded' },
+} satisfies Meta<typeof ModelWaitingIndicator>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const Narrow: Story = {
+  decorators: [
+    (Story) => (
+      <div className="w-64">
+        <Story />
+      </div>
+    ),
+  ],
+}

--- a/console/web/src/components/chat/ModelWaitingIndicator.test.tsx
+++ b/console/web/src/components/chat/ModelWaitingIndicator.test.tsx
@@ -1,0 +1,24 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import {
+  formatModelWaitElapsed,
+  ModelWaitingIndicator,
+} from './ModelWaitingIndicator'
+
+describe('ModelWaitingIndicator', () => {
+  it('renders the animated wordmark as a named live status', () => {
+    const html = renderToStaticMarkup(
+      <ModelWaitingIndicator label="dispatching model" />,
+    )
+
+    expect(html).toContain('role="status"')
+    expect(html).toContain('aria-label="dispatching model"')
+    expect(html.match(/model-waiting-wordmark-segment/g)).toHaveLength(3)
+    expect(html).toContain('0.0s')
+  })
+
+  it('formats elapsed seconds and minutes', () => {
+    expect(formatModelWaitElapsed(12_345)).toBe('12.3s')
+    expect(formatModelWaitElapsed(61_250)).toBe('1m 1.2s')
+  })
+})

--- a/console/web/src/components/chat/ModelWaitingIndicator.tsx
+++ b/console/web/src/components/chat/ModelWaitingIndicator.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react'
+import { Wordmark } from '@/components/ui/Wordmark'
+
+export function formatModelWaitElapsed(elapsedMs: number): string {
+  const totalSeconds = Math.floor(elapsedMs / 100) / 10
+  if (totalSeconds < 60) return `${totalSeconds.toFixed(1)}s`
+  return `${Math.floor(totalSeconds / 60)}m ${(totalSeconds % 60).toFixed(1)}s`
+}
+
+function useModelWaitElapsed(): string {
+  const [elapsedMs, setElapsedMs] = useState(0)
+
+  useEffect(() => {
+    const startedAt = performance.now()
+    const timer = window.setInterval(() => {
+      setElapsedMs(performance.now() - startedAt)
+    }, 100)
+
+    return () => window.clearInterval(timer)
+  }, [])
+
+  return formatModelWaitElapsed(elapsedMs)
+}
+
+export function ModelWaitingIndicator({
+  label = 'thinking…',
+}: {
+  label?: string
+}) {
+  const elapsed = useModelWaitElapsed()
+  const resolvedLabel = label.trim() || 'thinking…'
+
+  return (
+    <div
+      role="status"
+      aria-label={resolvedLabel}
+      data-model-waiting=""
+      className="flex max-w-full min-w-0 items-center gap-2.5"
+    >
+      <Wordmark appearance="loading" className="size-4" />
+      <div
+        aria-hidden="true"
+        className="thinking-shimmer min-w-0 truncate font-sans text-base font-medium sm:text-[0.8125rem]"
+      >
+        {resolvedLabel}
+      </div>
+      <div
+        aria-hidden="true"
+        className="min-w-[7ch] shrink-0 text-right font-mono text-base text-ink-ghost tabular-nums sm:text-[0.75rem]"
+      >
+        {elapsed}
+      </div>
+    </div>
+  )
+}

--- a/console/web/src/components/chat/SessionAddonsPicker.test.ts
+++ b/console/web/src/components/chat/SessionAddonsPicker.test.ts
@@ -1,6 +1,11 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it, vi } from 'vitest'
 import type { IiiClient } from '@/lib/iii-client'
-import { loadSessionSkills } from './SessionAddonsPicker'
+import {
+  loadSessionSkills,
+  SessionAddonsPickerPanel,
+} from './SessionAddonsPicker'
 
 describe('session skill picker', () => {
   it('loads list metadata only and omits skills disabled for model invocation', async () => {
@@ -37,5 +42,29 @@ describe('session skill picker', () => {
       { include_description: true },
       { timeoutMs: 10_000 },
     )
+  })
+
+  it('keeps selected skill checks at the end of mobile sheet rows', () => {
+    const html = renderToStaticMarkup(
+      createElement(SessionAddonsPickerPanel, {
+        value: ['review'],
+        entries: [
+          { name: 'review', description: 'Review changes' },
+          { name: 'design', description: 'Design interfaces' },
+        ],
+        onClear: () => {},
+        onToggle: () => {},
+      }),
+    )
+
+    const selectedRow = html.slice(html.indexOf('Review changes'))
+    expect(html).toContain('aria-pressed="true"')
+    expect(selectedRow.indexOf('Review changes')).toBeLessThan(
+      selectedRow.indexOf('lucide-check'),
+    )
+    expect(html).toContain(
+      'min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto',
+    )
+    expect(html).toContain('w-full min-w-0 max-w-full')
   })
 })

--- a/console/web/src/components/chat/SessionAddonsPicker.tsx
+++ b/console/web/src/components/chat/SessionAddonsPicker.tsx
@@ -1,5 +1,6 @@
 import { Blocks, Check, ChevronDown } from 'lucide-react'
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { BottomSheet, BottomSheetContent } from '@/components/ui/BottomSheet'
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -7,6 +8,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/DropdownMenu'
+import { useMediaQuery } from '@/hooks/use-media-query'
 import { listSkills } from '@/lib/backend/directory-prompts'
 import type { IiiClient } from '@/lib/iii-client'
 import { getIiiClient } from '@/lib/iii-client'
@@ -27,20 +29,108 @@ export async function loadSessionSkills(client: IiiClient) {
   )
 }
 
+interface SessionAddonsPickerPanelProps {
+  value: SkillSelection
+  entries: { name: string; description: string }[] | null
+  disabled?: boolean
+  onClear: () => void
+  onToggle: (name: string) => void
+}
+
+/** Multi-select skill list used by the mobile sheet. */
+export function SessionAddonsPickerPanel({
+  value,
+  entries,
+  disabled,
+  onClear,
+  onToggle,
+}: SessionAddonsPickerPanelProps) {
+  const selected = new Set(value ?? [])
+  return (
+    <div className="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto px-3 pb-1">
+      <fieldset
+        disabled={disabled}
+        className="w-full min-w-0 max-w-full divide-y divide-edge overflow-hidden rounded-lg bg-surface ring-1 ring-inset ring-edge"
+      >
+        <legend className="sr-only">Session skills</legend>
+        <button
+          type="button"
+          aria-pressed={selected.size === 0}
+          disabled={disabled}
+          onClick={onClear}
+          className={cn(
+            'flex min-h-14 w-full min-w-0 items-center gap-3 px-3 py-2 text-left font-sans text-base text-ink hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-rule-focus disabled:pointer-events-none disabled:opacity-40',
+            selected.size === 0 && 'bg-surface-selected',
+          )}
+        >
+          <span className="min-w-0 flex-1 font-medium">All skills</span>
+          {selected.size === 0 ? (
+            <Check className="size-5 shrink-0 text-ink" aria-hidden />
+          ) : null}
+        </button>
+
+        {entries === null ? (
+          <div className="px-3 py-3 font-sans text-sm text-ink-faint">
+            Loading skills…
+          </div>
+        ) : entries.length === 0 ? (
+          <div className="px-3 py-3 font-sans text-sm text-ink-faint">
+            No skills available
+          </div>
+        ) : (
+          entries.map((entry) => {
+            const checked = selected.has(entry.name)
+            return (
+              <button
+                key={entry.name}
+                type="button"
+                aria-pressed={checked}
+                disabled={disabled}
+                onClick={() => onToggle(entry.name)}
+                className={cn(
+                  'flex min-h-14 w-full min-w-0 items-center gap-3 px-3 py-2 text-left font-sans text-base text-ink hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-rule-focus disabled:pointer-events-none disabled:opacity-40',
+                  checked && 'bg-surface-selected',
+                )}
+              >
+                <span className="flex min-w-0 flex-1 flex-col overflow-hidden">
+                  <span className="truncate font-medium">{entry.name}</span>
+                  {entry.description ? (
+                    <span className="truncate text-sm leading-relaxed text-ink-faint">
+                      {entry.description}
+                    </span>
+                  ) : null}
+                </span>
+                {checked ? (
+                  <Check className="size-5 shrink-0 text-ink" aria-hidden />
+                ) : null}
+              </button>
+            )
+          })
+        )}
+      </fieldset>
+    </div>
+  )
+}
+
 export function SessionAddonsPicker({
   value,
   onChange,
   disabled,
+  appearance = 'default',
   className,
 }: {
   value: SkillSelection
   onChange: (next: SkillSelection) => void
   disabled?: boolean
+  /** Text-only action used by the compact empty-state session controls. */
+  appearance?: 'default' | 'inline'
   className?: string
 }) {
+  const [open, setOpen] = useState(false)
   const [entries, setEntries] = useState<
     { name: string; description: string }[] | null
   >(null)
+  const mobileSheet = useMediaQuery('(max-width: 767px)')
 
   /* Radix keeps the menu open across toggles, so update the ref immediately
      rather than waiting for the parent render between adjacent clicks. */
@@ -49,8 +139,9 @@ export function SessionAddonsPicker({
 
   /* Fetch on EVERY open, SystemPromptPicker-style: keep the last list while
      loading, degrade to an empty list when the directory worker is absent. */
-  const handleOpenChange = useCallback(async (open: boolean) => {
-    if (!open) return
+  const handleOpenChange = useCallback(async (nextOpen: boolean) => {
+    setOpen(nextOpen)
+    if (!nextOpen) return
     try {
       const client = await getIiiClient()
       setEntries(
@@ -63,6 +154,10 @@ export function SessionAddonsPicker({
       setEntries((prev) => prev ?? [])
     }
   }, [])
+
+  useEffect(() => {
+    if (disabled && open) setOpen(false)
+  }, [disabled, open])
 
   const isChecked = useCallback(
     (name: string) => value?.includes(name) ?? false,
@@ -80,24 +175,84 @@ export function SessionAddonsPicker({
 
   const count = value?.length ?? 0
 
-  return (
-    <DropdownMenu onOpenChange={handleOpenChange}>
-      <DropdownMenuTrigger
-        aria-label="session skills"
-        disabled={disabled}
-        className={cn(
-          'inline-flex w-full items-center justify-between gap-x-2 rounded-sm border border-transparent bg-bg px-3 h-9 text-ink font-sans text-[13px] hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus data-[state=open]:bg-surface-active transition-colors',
-          disabled && 'opacity-40 pointer-events-none',
-          className,
-        )}
-      >
-        <span className="inline-flex items-center gap-2 min-w-0">
-          <Blocks size={16} className="text-ink-faint" aria-hidden />
+  const triggerClassName = cn(
+    appearance === 'inline'
+      ? 'relative inline-flex min-h-5.5 min-w-0 items-center border-dashed border-b border-ink-faint/50 px-0.5 font-sans text-base font-medium text-ink hover:border-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus data-[state=open]:border-ink sm:text-[0.8125rem]'
+      : 'inline-flex h-9 w-full items-center justify-between gap-x-2 rounded-sm border border-transparent bg-bg px-3 font-sans text-[0.8125rem] text-ink transition-colors hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus data-[state=open]:bg-surface-active',
+    disabled && 'pointer-events-none opacity-40',
+    className,
+  )
+
+  const triggerContent =
+    appearance === 'inline' ? (
+      <>
+        <span>Add skills</span>
+        <span
+          className="pointer-events-none absolute top-1/2 left-1/2 size-[max(100%,3rem)] -translate-1/2 pointer-fine:hidden"
+          aria-hidden="true"
+        />
+      </>
+    ) : (
+      <>
+        <span className="inline-flex min-w-0 items-center gap-2">
+          <Blocks size={16} className="shrink-0 text-ink-faint" aria-hidden />
           <span className="truncate">
             {count > 0 ? `Skills (${count})` : 'All skills'}
           </span>
         </span>
-        <ChevronDown size={16} aria-hidden />
+        <ChevronDown className="size-4 shrink-0" aria-hidden />
+      </>
+    )
+
+  if (mobileSheet) {
+    return (
+      <>
+        <button
+          type="button"
+          aria-label={
+            count > 0
+              ? `add skills to this session, ${count} selected`
+              : 'add skills to this session'
+          }
+          aria-haspopup="dialog"
+          aria-expanded={open}
+          data-state={open ? 'open' : 'closed'}
+          disabled={disabled}
+          onClick={() => void handleOpenChange(!open)}
+          className={triggerClassName}
+        >
+          {triggerContent}
+        </button>
+        <BottomSheet open={open} onOpenChange={handleOpenChange}>
+          <BottomSheetContent heading="Skills" closeLabel="Close skills picker">
+            <SessionAddonsPickerPanel
+              value={value}
+              entries={entries}
+              disabled={disabled}
+              onClear={() => {
+                valueRef.current = undefined
+                onChange(undefined)
+              }}
+              onToggle={toggle}
+            />
+          </BottomSheetContent>
+        </BottomSheet>
+      </>
+    )
+  }
+
+  return (
+    <DropdownMenu open={open} onOpenChange={handleOpenChange}>
+      <DropdownMenuTrigger
+        aria-label={
+          count > 0
+            ? `add skills to this session, ${count} selected`
+            : 'add skills to this session'
+        }
+        disabled={disabled}
+        className={triggerClassName}
+      >
+        {triggerContent}
       </DropdownMenuTrigger>
       <DropdownMenuContent
         align="start"
@@ -106,9 +261,10 @@ export function SessionAddonsPicker({
            sentences, and an uncapped popper sizes to the widest one — a
            viewport-wide panel that clips its own checkmarks at the screen
            edge. The cap is what makes the row-level truncation engage. */
-        className="min-w-[var(--radix-dropdown-menu-trigger-width)] max-w-[min(24rem,var(--radix-dropdown-menu-content-available-width))] max-h-[min(18rem,var(--radix-dropdown-menu-content-available-height))] overflow-y-auto text-[13px]"
+        className="min-w-[var(--radix-dropdown-menu-trigger-width)] max-w-[min(24rem,var(--radix-dropdown-menu-content-available-width))] max-h-[min(18rem,var(--radix-dropdown-menu-content-available-height))] overflow-x-hidden overflow-y-auto text-[13px]"
       >
         <DropdownMenuCheckboxItem
+          className="min-w-0"
           checked={count === 0}
           onSelect={(ev) => ev.preventDefault()}
           onCheckedChange={() => {
@@ -134,6 +290,7 @@ export function SessionAddonsPicker({
           entries.map((e) => (
             <DropdownMenuCheckboxItem
               key={e.name}
+              className="min-w-0"
               checked={isChecked(e.name)}
               /* Keep the menu open across toggles: multi-select. */
               onSelect={(ev) => ev.preventDefault()}
@@ -148,7 +305,10 @@ export function SessionAddonsPicker({
                 />
               }
             >
-              <div className="min-w-0 flex-1" title={e.description}>
+              <div
+                className="min-w-0 flex-1 overflow-hidden"
+                title={e.description}
+              >
                 <div className="truncate">{e.name}</div>
                 {e.description ? (
                   <div className="truncate text-[11px] leading-[1.5] text-ink-faint">

--- a/console/web/src/components/chat/SystemPromptPicker.test.tsx
+++ b/console/web/src/components/chat/SystemPromptPicker.test.tsx
@@ -1,18 +1,10 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
-import { EmptyState } from './EmptyState'
-import { StrategyToggle } from './SystemPromptPicker'
+import { StrategyToggle, SystemPromptPickerPanel } from './SystemPromptPicker'
 import { DEFAULT_SYSTEM_PROMPT_STATE } from './system-prompt-selection'
 
-describe('new-session system prompt', () => {
-  it('explains the default and makes both named-prompt strategies explicit', () => {
-    const ready = renderToStaticMarkup(
-      <EmptyState
-        variant="ready"
-        systemPrompt={DEFAULT_SYSTEM_PROMPT_STATE}
-        onSystemPromptChange={() => {}}
-      />,
-    )
+describe('system prompt strategy', () => {
+  it('renders the selected strategy as an inline dropdown', () => {
     const strategies = renderToStaticMarkup(
       <StrategyToggle
         value={{
@@ -20,14 +12,35 @@ describe('new-session system prompt', () => {
           choice: { named: 'reviewer' },
         }}
         onChange={() => {}}
+        appearance="inline"
       />,
     )
 
-    expect(ready).toContain('System prompt')
-    expect(ready).toContain('Default uses the provider&#x27;s built-in prompt')
-    expect(ready).toContain('Locked after your first message')
-    expect(strategies).toContain('aria-pressed="true"')
-    expect(strategies).toContain('Enrich')
-    expect(strategies).toContain('Replace')
+    expect(strategies).toContain('role="combobox"')
+    expect(strategies).toContain('Extending')
+    expect(strategies).toContain('border-dashed')
+    expect(strategies).not.toContain('Enrich')
+  })
+
+  it('renders the mobile sheet options as native radios', () => {
+    const options = renderToStaticMarkup(
+      <SystemPromptPickerPanel
+        value={DEFAULT_SYSTEM_PROMPT_STATE}
+        entries={[
+          {
+            name: 'reviewer',
+            description: 'Review the proposed changes',
+            modified_at: '2026-08-26T00:00:00Z',
+          },
+        ]}
+        allowCustom
+        onSelect={() => {}}
+      />,
+    )
+
+    expect(options).toContain('type="radio"')
+    expect(options).toContain('Review the proposed changes')
+    expect(options).toContain('Custom…')
+    expect(options).toContain('aria-hidden="true"')
   })
 })

--- a/console/web/src/components/chat/SystemPromptPicker.tsx
+++ b/console/web/src/components/chat/SystemPromptPicker.tsx
@@ -1,6 +1,9 @@
 import * as SelectPrimitive from '@radix-ui/react-select'
 import { Check, ChevronDown, ScrollText } from 'lucide-react'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useId, useState } from 'react'
+import { BottomSheet, BottomSheetContent } from '@/components/ui/BottomSheet'
+import { Select } from '@/components/ui/Select'
+import { useMediaQuery } from '@/hooks/use-media-query'
 import {
   getPrompt,
   listPrompts,
@@ -10,6 +13,7 @@ import { getIiiClient } from '@/lib/iii-client'
 import { cn } from '@/lib/utils'
 import {
   choiceToValue,
+  type PromptStrategy,
   type SystemPromptState,
   valueToChoice,
 } from './system-prompt-selection'
@@ -19,11 +23,12 @@ interface SystemPromptPickerProps {
   onChange: (next: SystemPromptState) => void
   disabled?: boolean
   /**
-   * Offer the `custom…` free-text row. The new-session screen turns it off:
-   * authoring a prompt lives in the iii-directory UI's system-prompts tab,
-   * not in the chat.
+   * Offer the `custom…` free-text row. Authoring a prompt otherwise lives in
+   * the iii-directory UI's system-prompts tab.
    */
   allowCustom?: boolean
+  /** Text-only treatment used alongside the empty-state project sentence. */
+  appearance?: 'default' | 'inline'
   className?: string
 }
 
@@ -61,27 +66,120 @@ function PromptItem({
   )
 }
 
+interface SystemPromptPickerPanelProps {
+  value: SystemPromptState
+  entries: PromptEntry[] | null
+  allowCustom: boolean
+  disabled?: boolean
+  onSelect: (value: string) => void
+}
+
+/** Mobile option list for the shared sheet surface. */
+export function SystemPromptPickerPanel({
+  value,
+  entries,
+  allowCustom,
+  disabled,
+  onSelect,
+}: SystemPromptPickerPanelProps) {
+  const name = useId()
+  const selectedValue = choiceToValue(value.choice)
+  const options = [
+    {
+      value: 'default',
+      label: 'Default',
+      description: "Use the provider's built-in prompt",
+    },
+    ...(entries ?? []).map((entry) => ({
+      value: choiceToValue({ named: entry.name }),
+      label: entry.name,
+      description: entry.description,
+    })),
+    ...(allowCustom
+      ? [{ value: 'custom', label: 'Custom…', description: undefined }]
+      : []),
+  ]
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto px-3 pb-1">
+      <fieldset
+        disabled={disabled}
+        className="divide-y divide-edge overflow-hidden rounded-lg bg-surface ring-1 ring-inset ring-edge"
+      >
+        <legend className="sr-only">System prompt</legend>
+        {options.map((option) => {
+          const selected = option.value === selectedValue
+          return (
+            <label
+              key={option.value}
+              className={cn(
+                'flex min-h-14 w-full min-w-0 cursor-pointer items-center gap-3 px-3 py-2 text-left font-sans text-base text-ink hover:bg-surface-hover has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-inset has-[:focus-visible]:ring-rule-focus',
+                selected && 'bg-surface-selected',
+                disabled && 'pointer-events-none opacity-40',
+              )}
+            >
+              <input
+                type="radio"
+                name={name}
+                value={option.value}
+                checked={selected}
+                disabled={disabled}
+                onChange={() => onSelect(option.value)}
+                className="sr-only"
+              />
+              <span className="flex min-w-0 flex-1 flex-col">
+                <span className="truncate font-medium">{option.label}</span>
+                {option.description ? (
+                  <span className="truncate text-sm leading-relaxed text-ink-faint">
+                    {option.description}
+                  </span>
+                ) : null}
+              </span>
+              {selected ? (
+                <Check className="size-5 shrink-0 text-ink" aria-hidden />
+              ) : null}
+            </label>
+          )
+        })}
+        {entries === null ? (
+          <div className="px-3 py-3 font-sans text-sm text-ink-faint">
+            Loading saved prompts…
+          </div>
+        ) : null}
+      </fieldset>
+    </div>
+  )
+}
+
 export function SystemPromptPicker({
   value,
   onChange,
   disabled,
   allowCustom = true,
+  appearance = 'default',
   className,
 }: SystemPromptPickerProps) {
+  const [open, setOpen] = useState(false)
   const [entries, setEntries] = useState<PromptEntry[] | null>(null)
+  const mobileSheet = useMediaQuery('(max-width: 767px)')
 
   /* Fetch on EVERY open (keeping the last list while loading): a prompt
      added on disk or authored in the directory UI shows up on the next
      open with no cache-invalidation plumbing. A failed load degrades to
      default + custom only (directory worker absent ≠ broken chat). */
-  const handleOpenChange = useCallback(async (open: boolean) => {
-    if (!open) return
+  const handleOpenChange = useCallback(async (nextOpen: boolean) => {
+    setOpen(nextOpen)
+    if (!nextOpen) return
     try {
       setEntries(await listPrompts(await getIiiClient()))
     } catch {
       setEntries((prev) => prev ?? [])
     }
   }, [])
+
+  useEffect(() => {
+    if (disabled && open) setOpen(false)
+  }, [disabled, open])
 
   const handleValueChange = useCallback(
     async (v: string) => {
@@ -108,33 +206,119 @@ export function SystemPromptPicker({
         ? 'Custom'
         : value.choice.named
 
+  const triggerClassName = cn(
+    appearance === 'inline'
+      ? 'relative inline-flex min-h-5.5 min-w-0 items-center border-dashed border-b border-ink-faint/50 px-0.5 font-sans text-base font-medium text-ink hover:border-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus data-[state=open]:border-ink sm:text-[0.8125rem]'
+      : 'inline-flex h-9 w-full items-center justify-between gap-x-2 rounded-sm border border-transparent bg-bg px-3 font-sans text-[0.8125rem] text-ink transition-colors hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus data-[state=open]:bg-surface-active',
+    disabled && 'pointer-events-none opacity-40',
+    className,
+  )
+
+  const triggerContent = (
+    <>
+      <span
+        className={cn(
+          'inline-flex min-w-0 items-center',
+          appearance === 'default' && 'gap-2',
+        )}
+      >
+        {appearance === 'default' ? (
+          <ScrollText
+            size={16}
+            className="shrink-0 text-ink-faint"
+            aria-hidden
+          />
+        ) : null}
+        <span className="max-w-40 truncate sm:max-w-44">{label}</span>
+      </span>
+
+      {appearance === 'default' ? (
+        <ChevronDown className="size-4 shrink-0" aria-hidden />
+      ) : (
+        <span
+          className="pointer-events-none absolute top-1/2 left-1/2 size-[max(100%,3rem)] -translate-1/2 pointer-fine:hidden"
+          aria-hidden="true"
+        />
+      )}
+    </>
+  )
+
+  if (mobileSheet) {
+    return (
+      <>
+        <button
+          type="button"
+          aria-label={`system prompt, current prompt: ${label}`}
+          aria-haspopup="dialog"
+          aria-expanded={open}
+          data-state={open ? 'open' : 'closed'}
+          disabled={disabled}
+          onClick={() => void handleOpenChange(!open)}
+          className={triggerClassName}
+        >
+          {triggerContent}
+        </button>
+        <BottomSheet open={open} onOpenChange={handleOpenChange}>
+          <BottomSheetContent
+            heading="System prompt"
+            closeLabel="Close system prompt picker"
+          >
+            <SystemPromptPickerPanel
+              value={value}
+              entries={entries}
+              allowCustom={allowCustom}
+              disabled={disabled}
+              onSelect={(next) => {
+                setOpen(false)
+                void handleValueChange(next)
+              }}
+            />
+          </BottomSheetContent>
+        </BottomSheet>
+      </>
+    )
+  }
+
   return (
     <SelectPrimitive.Root
       value={choiceToValue(value.choice)}
       onValueChange={handleValueChange}
       onOpenChange={handleOpenChange}
+      open={open}
       disabled={disabled}
     >
       <SelectPrimitive.Trigger
-        aria-label="system prompt"
-        className={cn(
-          'inline-flex w-full items-center justify-between gap-x-2 rounded-sm border border-transparent bg-bg px-3 h-9 text-ink font-sans text-[13px] hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus data-[state=open]:bg-surface-active transition-colors',
-          disabled && 'opacity-40 pointer-events-none',
-          className,
-        )}
+        aria-label={`system prompt, current prompt: ${label}`}
+        className={triggerClassName}
       >
-        <span className="inline-flex items-center gap-2 min-w-0">
-          <ScrollText size={16} className="text-ink-faint" aria-hidden />
+        <span
+          className={cn(
+            'inline-flex min-w-0 items-center',
+            appearance === 'default' && 'gap-2',
+          )}
+        >
+          {appearance === 'default' ? (
+            <ScrollText
+              size={16}
+              className="shrink-0 text-ink-faint"
+              aria-hidden
+            />
+          ) : null}
           {/* Radix strips `className` off Select.Value, so the truncation
               lives on this wrapper (a flex item, hence blockified). */}
-          <span className="truncate max-w-[10rem]">
-            <SelectPrimitive.Value>{label}</SelectPrimitive.Value>
-          </span>
+          <span className="max-w-40 truncate sm:max-w-44">{label}</span>
         </span>
 
-        <SelectPrimitive.Icon asChild>
-          <ChevronDown size={16} aria-hidden />
-        </SelectPrimitive.Icon>
+        {appearance === 'default' ? (
+          <SelectPrimitive.Icon asChild>
+            <ChevronDown className="size-4 shrink-0" aria-hidden />
+          </SelectPrimitive.Icon>
+        ) : (
+          <span
+            className="pointer-events-none absolute top-1/2 left-1/2 size-[max(100%,3rem)] -translate-1/2 pointer-fine:hidden"
+            aria-hidden="true"
+          />
+        )}
       </SelectPrimitive.Trigger>
 
       <SelectPrimitive.Portal>
@@ -142,9 +326,7 @@ export function SystemPromptPicker({
           position="popper"
           sideOffset={4}
           className={cn(
-            'z-50 min-w-[var(--radix-select-trigger-width)] max-w-[var(--radix-select-content-available-width)] overflow-hidden rounded-md border border-rule-2 bg-panel-raised text-ink font-sans text-[13px] shadow-floating',
-            'data-[state=open]:animate-in data-[state=closed]:animate-out',
-            'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+            'iii-ui-motion-dropdown z-50 min-w-[var(--radix-select-trigger-width)] max-w-[var(--radix-select-content-available-width)] overflow-hidden rounded-md border border-rule-2 bg-panel-raised text-ink font-sans text-[13px] shadow-floating',
           )}
         >
           <SelectPrimitive.Viewport className="p-1">
@@ -169,62 +351,49 @@ export function SystemPromptPicker({
   )
 }
 
-/** Explicit two-state choice shown whenever the prompt isn't the default. */
+const PROMPT_STRATEGIES: Array<{
+  value: PromptStrategy
+  label: string
+  description: string
+}> = [
+  {
+    value: 'enrich',
+    label: 'Extending',
+    description: 'Add this prompt to the built-in prompt',
+  },
+  {
+    value: 'override',
+    label: 'Overriding',
+    description: 'Use this prompt instead of the built-in prompt',
+  },
+]
+
+/** Strategy choice shown whenever the prompt isn't the default. */
 export function StrategyToggle({
   value,
   onChange,
   disabled,
+  appearance = 'default',
   className,
 }: {
   value: SystemPromptState
   onChange: (next: SystemPromptState) => void
   disabled?: boolean
+  appearance?: 'default' | 'inline'
   className?: string
 }) {
   if (value.choice === 'default') return null
   return (
-    <fieldset
+    <Select<PromptStrategy>
+      value={value.strategy}
+      onChange={(strategy) => onChange({ ...value, strategy })}
+      options={PROMPT_STRATEGIES}
       disabled={disabled}
-      className={cn(
-        'inline-grid min-w-0 grid-cols-2 rounded-sm border-0 bg-bg p-[2px] gap-[2px]',
-        className,
-      )}
-    >
-      <legend className="sr-only">Apply system prompt as</legend>
-      {(['enrich', 'override'] as const).map((strategy) => {
-        const active = value.strategy === strategy
-        const label = strategy === 'enrich' ? 'Enrich' : 'Replace'
-        const detail =
-          strategy === 'enrich'
-            ? 'Add this prompt to the built-in prompt'
-            : 'Use this prompt instead of the built-in prompt'
-        return (
-          <button
-            key={strategy}
-            type="button"
-            aria-label={`${label}: ${detail}`}
-            aria-pressed={active}
-            title={detail}
-            onClick={() => onChange({ ...value, strategy })}
-            className={cn(
-              'relative inline-flex h-8 min-w-[82px] items-center justify-center rounded-xs px-2 font-sans text-[13px] font-medium transition-colors focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus disabled:pointer-events-none disabled:opacity-40',
-              active
-                ? 'bg-surface-selected text-ink'
-                : 'bg-transparent text-ink-faint hover:bg-surface-hover hover:text-ink',
-            )}
-          >
-            <Check
-              size={16}
-              aria-hidden
-              className={cn(
-                'absolute left-2 shrink-0 text-ink transition-opacity',
-                active ? 'opacity-100' : 'opacity-0',
-              )}
-            />
-            {label}
-          </button>
-        )
-      })}
-    </fieldset>
+      appearance={appearance}
+      aria-label="system prompt strategy"
+      sheetTitle="System prompt strategy"
+      sheetDescription="Choose how this prompt changes the built-in prompt."
+      className={className}
+    />
   )
 }

--- a/console/web/src/components/chat/system-prompt-selection.ts
+++ b/console/web/src/components/chat/system-prompt-selection.ts
@@ -1,13 +1,9 @@
 /**
- * Pure state for the chat system-prompt picker and the separate skill-ID
- * picker (`SessionAddonsPicker.tsx`). `SystemPromptPicker.tsx`
- * renders it on the new-session screen; the chosen value is stored on
- * `Conversation.systemPrompt` (see `use-conversations`), and `ChatView` maps
- * it onto `ChatStreamOptions.systemPrompt` via `selectionForSend` — the
- * session's FIRST send only. The harness inherits the prior turn's resolved
- * prompt on later sends that omit the prompt fields (see harness README
- * § System prompt), so the selection travels once and is frozen server-side
- * for the whole session.
+ * Pure state for the chat system-prompt and skill pickers. The selected values
+ * are stored on the conversation record, and `ChatView` maps them onto the
+ * first send. The harness inherits the prior turn's resolved prompt on later
+ * sends that omit the prompt fields (see harness README § System prompt), so
+ * the selection travels once and is frozen server-side for the whole session.
  *
  * The `custom` choice is vestigial: no surface renders that row any more —
  * authoring lives in the iii-directory UI's system-prompts tab — but

--- a/console/web/src/components/ui/BottomSheet.tsx
+++ b/console/web/src/components/ui/BottomSheet.tsx
@@ -8,38 +8,238 @@ export const BottomSheet = DialogPrimitive.Root
 export const BottomSheetTrigger = DialogPrimitive.Trigger
 export const BottomSheetClose = DialogPrimitive.Close
 
+interface BottomSheetPageNavigationValue {
+  activePageId: string | null
+  renderedPageId: string | null
+  pageHost: HTMLDivElement | null
+  openPage: (id: string, labelledBy: string, describedBy?: string) => void
+  closePage: (id: string) => void
+}
+
+const BottomSheetPageNavigationContext =
+  React.createContext<BottomSheetPageNavigationValue | null>(null)
+
+/**
+ * Lets adaptive controls replace the current sheet content with an in-sheet
+ * detail page instead of stacking a second dialog and overlay on top.
+ */
+export function useBottomSheetPageNavigation() {
+  return React.useContext(BottomSheetPageNavigationContext)
+}
+
+interface BottomSheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
+  /** Optional visible heading for simple, single-page sheets. */
+  heading?: React.ReactNode
+  description?: React.ReactNode
+  closeLabel?: string
+  headerClassName?: string
+  overlayClassName?: string
+}
+
 export const BottomSheetContent = React.forwardRef<
   React.ComponentRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
-  <DialogPrimitive.Portal>
-    <PortalScope>
-      <DialogPrimitive.Overlay className="iii-ui-motion-overlay fixed inset-0 z-40 bg-black/55 sm:hidden" />
-      <DialogPrimitive.Content
-        ref={ref}
-        className={cn(
-          'iii-ui-motion-panel fixed inset-x-3 bottom-3 z-50 flex max-h-[calc(100dvh-1.5rem)] flex-col overflow-hidden',
-          'rounded-lg border border-edge bg-panel-raised text-ink shadow-floating',
-          'pb-[max(0.75rem,env(safe-area-inset-bottom))] focus:outline-none',
-          className,
-        )}
-        {...props}
-      >
-        <div
-          className="flex h-6 shrink-0 items-center justify-center"
-          aria-hidden
-        >
-          <span className="h-1 w-10 rounded-full bg-ink-ghost/60" />
-        </div>
-        {children}
-        <DialogPrimitive.Close className="absolute right-2 top-2 flex size-12 items-center justify-center rounded-sm text-ink-faint hover:bg-surface-hover hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus">
-          <X className="size-5" aria-hidden />
-          <span className="sr-only">Close</span>
-        </DialogPrimitive.Close>
-      </DialogPrimitive.Content>
-    </PortalScope>
-  </DialogPrimitive.Portal>
-))
+  BottomSheetContentProps
+>(
+  (
+    {
+      className,
+      children,
+      heading,
+      description,
+      closeLabel = 'Close',
+      headerClassName,
+      overlayClassName,
+      onOpenAutoFocus,
+      onCloseAutoFocus,
+      'aria-labelledby': ariaLabelledBy,
+      'aria-describedby': ariaDescribedBy,
+      ...props
+    },
+    ref,
+  ) => {
+    const closeButtonRef = React.useRef<HTMLButtonElement>(null)
+    const returnFocusRef = React.useRef<HTMLElement | null>(null)
+    const pageActivationFrameRef = React.useRef<number | null>(null)
+    const [activePageId, setActivePageId] = React.useState<string | null>(null)
+    const [renderedPageId, setRenderedPageId] = React.useState<string | null>(
+      null,
+    )
+    const [pageLabelledBy, setPageLabelledBy] = React.useState<string | null>(
+      null,
+    )
+    const [pageDescribedBy, setPageDescribedBy] = React.useState<string | null>(
+      null,
+    )
+    const [pageHost, setPageHost] = React.useState<HTMLDivElement | null>(null)
+    const cancelPageActivation = React.useCallback(() => {
+      if (
+        pageActivationFrameRef.current !== null &&
+        typeof window !== 'undefined'
+      ) {
+        window.cancelAnimationFrame(pageActivationFrameRef.current)
+      }
+      pageActivationFrameRef.current = null
+    }, [])
+    const openPage = React.useCallback(
+      (id: string, labelledBy: string, describedBy?: string) => {
+        cancelPageActivation()
+        setRenderedPageId(id)
+        setPageLabelledBy(labelledBy)
+        setPageDescribedBy(describedBy ?? null)
+
+        /* Page side-by-side needs the incoming page to reach its inactive
+           offset for one paint before data-active flips. Mounting and
+           activating in the same commit skips the transition entirely. */
+        setActivePageId(null)
+        if (
+          typeof window === 'undefined' ||
+          typeof window.requestAnimationFrame !== 'function' ||
+          (typeof window.matchMedia === 'function' &&
+            window.matchMedia('(prefers-reduced-motion: reduce)').matches)
+        ) {
+          setActivePageId(id)
+          return
+        }
+        pageActivationFrameRef.current = window.requestAnimationFrame(() => {
+          pageActivationFrameRef.current = window.requestAnimationFrame(() => {
+            pageActivationFrameRef.current = null
+            setActivePageId(id)
+          })
+        })
+      },
+      [cancelPageActivation],
+    )
+    const closePage = React.useCallback(
+      (id: string) => {
+        cancelPageActivation()
+        setActivePageId((current) => (current === id ? null : current))
+      },
+      [cancelPageActivation],
+    )
+    React.useEffect(
+      () => () => {
+        cancelPageActivation()
+      },
+      [cancelPageActivation],
+    )
+    const pageNavigation = React.useMemo(
+      () => ({
+        activePageId,
+        renderedPageId,
+        pageHost,
+        openPage,
+        closePage,
+      }),
+      [activePageId, renderedPageId, pageHost, openPage, closePage],
+    )
+    const pageAria =
+      activePageId !== null
+        ? {
+            'aria-labelledby': pageLabelledBy ?? undefined,
+            'aria-describedby': pageDescribedBy ?? undefined,
+          }
+        : {
+            ...(ariaLabelledBy !== undefined
+              ? { 'aria-labelledby': ariaLabelledBy }
+              : {}),
+            ...(ariaDescribedBy !== undefined
+              ? { 'aria-describedby': ariaDescribedBy }
+              : {}),
+          }
+
+    return (
+      <DialogPrimitive.Portal>
+        <PortalScope>
+          <DialogPrimitive.Overlay
+            className={cn(
+              'iii-ui-motion-sheet-overlay fixed inset-0 z-40 bg-black/55 md:hidden',
+              overlayClassName,
+            )}
+          />
+          <DialogPrimitive.Content
+            ref={ref}
+            className={cn(
+              'iii-ui-motion-sheet fixed inset-x-3 bottom-3 z-50 flex max-h-[calc(100dvh-1.5rem)] flex-col overflow-hidden overscroll-contain md:hidden',
+              'rounded-lg border border-edge bg-panel-raised text-ink shadow-floating',
+              'pb-[max(0.75rem,env(safe-area-inset-bottom))] focus:outline-none',
+              className,
+            )}
+            onOpenAutoFocus={(event) => {
+              returnFocusRef.current =
+                document.activeElement instanceof HTMLElement
+                  ? document.activeElement
+                  : null
+              onOpenAutoFocus?.(event)
+              if (event.defaultPrevented) return
+              event.preventDefault()
+              closeButtonRef.current?.focus({ preventScroll: true })
+            }}
+            onCloseAutoFocus={(event) => {
+              onCloseAutoFocus?.(event)
+              if (event.defaultPrevented || !returnFocusRef.current) return
+              event.preventDefault()
+              returnFocusRef.current.focus({ preventScroll: true })
+            }}
+            {...pageAria}
+            {...props}
+          >
+            <div
+              className="flex h-6 shrink-0 items-center justify-center"
+              aria-hidden
+            >
+              <span className="h-1 w-10 rounded-full bg-ink-ghost/60" />
+            </div>
+
+            <BottomSheetPageNavigationContext.Provider value={pageNavigation}>
+              <div className="relative flex min-h-0 flex-1 overflow-hidden">
+                <div
+                  data-active={activePageId === null}
+                  aria-hidden={activePageId !== null}
+                  inert={activePageId !== null}
+                  className="iii-ui-motion-picker-page relative flex min-h-0 flex-1 flex-col [--picker-page-offset:calc(var(--distance-base)*-1)]"
+                >
+                  {heading ? (
+                    <div
+                      className={cn(
+                        'shrink-0 px-4 pb-4 pr-14',
+                        headerClassName,
+                      )}
+                    >
+                      <BottomSheetTitle>{heading}</BottomSheetTitle>
+                      {description ? (
+                        <BottomSheetDescription>
+                          {description}
+                        </BottomSheetDescription>
+                      ) : null}
+                    </div>
+                  ) : null}
+                  {children}
+                </div>
+
+                <div
+                  ref={setPageHost}
+                  data-active={activePageId !== null}
+                  aria-hidden={activePageId === null}
+                  inert={activePageId === null}
+                  className="iii-ui-motion-picker-page absolute inset-0 flex min-h-0 flex-col [--picker-page-offset:var(--distance-base)]"
+                />
+              </div>
+            </BottomSheetPageNavigationContext.Provider>
+
+            <DialogPrimitive.Close
+              ref={closeButtonRef}
+              className="absolute right-2 top-2 flex size-12 items-center justify-center rounded-sm text-ink-faint hover:bg-surface-hover hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus"
+            >
+              <X className="size-5" aria-hidden />
+              <span className="sr-only">{closeLabel}</span>
+            </DialogPrimitive.Close>
+          </DialogPrimitive.Content>
+        </PortalScope>
+      </DialogPrimitive.Portal>
+    )
+  },
+)
 BottomSheetContent.displayName = 'BottomSheetContent'
 
 export const BottomSheetTitle = React.forwardRef<

--- a/console/web/src/components/ui/DropdownMenu.tsx
+++ b/console/web/src/components/ui/DropdownMenu.tsx
@@ -31,7 +31,7 @@ export function DropdownMenuContent({
           sideOffset={sideOffset}
           collisionPadding={8}
           className={cn(
-            'iii-ui-motion-overlay z-50 min-w-[10rem] overflow-hidden rounded-md bg-panel-raised p-1 font-sans text-[12px] text-ink shadow-floating',
+            'iii-ui-motion-dropdown z-50 min-w-[10rem] overflow-hidden rounded-md bg-panel-raised p-1 font-sans text-[12px] text-ink shadow-floating',
             className,
           )}
           {...props}

--- a/console/web/src/components/ui/Select.stories.tsx
+++ b/console/web/src/components/ui/Select.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { useState } from 'react'
+import { BottomSheet, BottomSheetContent } from './BottomSheet'
 import { Select } from './Select'
+import { SheetPage } from './SheetNavigation'
 
 type Basic = 'one' | 'two' | 'three'
 type Region = 'us-east-1' | 'us-west-2' | 'eu-central-1' | 'ap-south-1'
@@ -211,6 +213,60 @@ export const UnmatchedValue: Story = {
           the placeholder rather than printing the raw value.
         </Hint>
       </div>
+    )
+  },
+}
+
+export const MobileSheet: Story = {
+  name: 'mobile · opens as sheet',
+  render: () => {
+    const [value, setValue] = useState<Basic>('one')
+    return (
+      <Select<Basic>
+        value={value}
+        onChange={setValue}
+        options={BASIC_OPTIONS}
+        aria-label="Example option"
+        sheetDescription="Choose one of the available options."
+        className="w-full max-w-[280px]"
+      />
+    )
+  },
+}
+
+export const InsideMobileSheet: Story = {
+  name: 'mobile · drills into existing sheet',
+  render: () => {
+    const [open, setOpen] = useState(true)
+    const [value, setValue] = useState<Basic>('one')
+    return (
+      <>
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="rounded-sm bg-surface px-3 py-2 font-sans text-sm text-ink"
+        >
+          Open settings
+        </button>
+        <BottomSheet open={open} onOpenChange={setOpen}>
+          <BottomSheetContent className="h-[min(82dvh,720px)]">
+            <SheetPage
+              title="Settings"
+              description="The select opens as a page within this sheet."
+              contentClassName="px-4 pb-4"
+            >
+              <Select<Basic>
+                value={value}
+                onChange={setValue}
+                options={BASIC_OPTIONS}
+                aria-label="Example option"
+                sheetDescription="Choose one of the available options."
+                className="w-full"
+              />
+            </SheetPage>
+          </BottomSheetContent>
+        </BottomSheet>
+      </>
     )
   },
 }

--- a/console/web/src/components/ui/Select.test.tsx
+++ b/console/web/src/components/ui/Select.test.tsx
@@ -1,0 +1,51 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Select } from './Select'
+
+const options = [
+  { value: 'one' as const, label: 'Option one' },
+  { value: 'two' as const, label: 'Option two' },
+]
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('Select', () => {
+  it('uses the Radix combobox on desktop', () => {
+    const html = renderToStaticMarkup(
+      <Select
+        value="one"
+        options={options}
+        onChange={() => {}}
+        aria-label="Example"
+      />,
+    )
+
+    expect(html).toContain('role="combobox"')
+    expect(html).toContain('Option one')
+  })
+
+  it('uses a dialog trigger on mobile', () => {
+    vi.stubGlobal('window', {
+      matchMedia: () => ({
+        matches: true,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+      }),
+    })
+
+    const html = renderToStaticMarkup(
+      <Select
+        value="one"
+        options={options}
+        onChange={() => {}}
+        aria-label="Example"
+      />,
+    )
+
+    expect(html).toContain('aria-haspopup="dialog"')
+    expect(html).toContain('aria-expanded="false"')
+    expect(html).not.toContain('role="combobox"')
+  })
+})

--- a/console/web/src/components/ui/Select.tsx
+++ b/console/web/src/components/ui/Select.tsx
@@ -1,14 +1,25 @@
 import * as SelectPrimitive from '@radix-ui/react-select'
-import { ChevronDown, ChevronUp } from 'lucide-react'
+import { Check, ChevronDown, ChevronUp } from 'lucide-react'
 import type * as React from 'react'
+import { useEffect, useId, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { useMediaQuery } from '@/hooks/use-media-query'
 import { PortalScope } from '@/lib/ui-scope'
 import { cn } from '@/lib/utils'
+import {
+  BottomSheet,
+  BottomSheetContent,
+  useBottomSheetPageNavigation,
+} from './BottomSheet'
+import { SheetPage } from './SheetNavigation'
 
 interface SelectOption<T extends string> {
   value: T
   label: string
   /** Optional hover tooltip on the option row. */
   title?: string
+  /** Supporting copy shown below the label in menus and mobile sheets. */
+  description?: string
   disabled?: boolean
 }
 
@@ -28,12 +39,20 @@ interface SelectProps<T extends string> {
   onChange: (next: T) => void
   disabled?: boolean
   className?: string
+  /** Compact text-only trigger used in inline sentences and setup controls. */
+  appearance?: 'default' | 'inline'
+  /** Overrides the trigger appearance's default chevron visibility. */
+  showChevron?: boolean
   /** Forwarded to the trigger for screen-readers. */
   'aria-label'?: string
   /** Forwarded to the trigger; used to indicate the option list is still loading. */
   'aria-busy'?: boolean
   /** Optional placeholder shown when no `value` matches an option. */
   placeholder?: string
+  /** Heading used by the mobile sheet or in-sheet drill-in page. */
+  sheetTitle?: React.ReactNode
+  /** Optional supporting copy under the mobile sheet heading. */
+  sheetDescription?: React.ReactNode
   /**
    * Render a leading option that clears the selection. Picking it calls
    * `onClear` (not `onChange`), so the consumer decides what "empty" means
@@ -65,9 +84,10 @@ export type { SelectGroup, SelectOption }
 const EMPTY_VALUE = '\u0000empty'
 
 /**
- * Radix-based dropdown. Replaces the native `<select>` so the panel can be
- * themed consistently with the rest of the console (sans interface text and
- * ink/bg/rule tokens) instead of inheriting the OS' dark-mode default look.
+ * Adaptive select: a Radix popper on desktop, a bottom sheet on mobile, or an
+ * in-sheet detail page when it already lives inside `BottomSheetContent`.
+ * Every presentation keeps the console's interface type and color tokens
+ * instead of inheriting the OS' native-select treatment.
  *
  * Keeps the same external API the native version had: pass either `options`
  * (flat list) or `groups` (sectioned). `value`, `onChange`, `disabled` and
@@ -85,13 +105,28 @@ export function Select<T extends string>({
   onChange,
   disabled,
   className,
+  appearance = 'default',
+  showChevron,
   placeholder,
+  sheetTitle,
+  sheetDescription,
   allowEmpty,
   emptyLabel,
   onClear,
   renderGroupHeader,
   ...aria
 }: SelectProps<T>) {
+  const [open, setOpen] = useState(false)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const embeddedPageRef = useRef<HTMLDivElement>(null)
+  const pageId = useId()
+  const pageTitleId = `${pageId}-title`
+  const pageDescriptionId = `${pageId}-description`
+  const mobileSheet = useMediaQuery('(max-width: 767px)')
+  const pageNavigation = useBottomSheetPageNavigation()
+  const embeddedInSheet = mobileSheet && pageNavigation !== null
+  const closeSheetPage = pageNavigation?.closePage
+
   // Pre-flatten so the trigger can resolve `value -> label` without an extra
   // children-walk inside Radix.
   const flatOptions: SelectOption<T>[] = groups
@@ -102,26 +137,182 @@ export function Select<T extends string>({
   // of rendering the raw (possibly `undefined`) token.
   const rootValue = selected ? (value as string) : ''
 
+  const heading = sheetTitle ?? aria['aria-label'] ?? 'Select option'
+  const chevronVisible = showChevron ?? appearance === 'default'
+  const triggerClassName = cn(
+    appearance === 'inline'
+      ? 'relative inline-flex min-h-5.5 min-w-0 items-center border-dashed border-b border-ink-faint/50 px-0.5 font-sans text-base font-medium text-ink hover:border-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus data-[state=open]:border-ink sm:text-[0.8125rem]'
+      : 'inline-flex h-12 max-w-full min-w-0 items-center justify-between gap-x-2 rounded-sm border border-transparent bg-surface px-3 font-sans text-base text-ink hover:bg-surface-hover focus:border-rule-focus focus:outline-none data-[state=open]:border-rule-focus data-[placeholder]:text-ink-ghost sm:h-9 sm:text-[13px]',
+    disabled && 'pointer-events-none opacity-40',
+    className,
+  )
+
+  function handleValueChange(next: string) {
+    if (allowEmpty && next === EMPTY_VALUE) {
+      onClear?.()
+      return
+    }
+    onChange(next as T)
+  }
+
+  function handleOpenChange(nextOpen: boolean) {
+    setOpen(nextOpen)
+    if (!embeddedInSheet || !pageNavigation) return
+    if (nextOpen) {
+      pageNavigation.openPage(
+        pageId,
+        pageTitleId,
+        sheetDescription ? pageDescriptionId : undefined,
+      )
+    } else pageNavigation.closePage(pageId)
+  }
+
+  function closeMobilePicker(restoreFocus: boolean) {
+    setOpen(false)
+    if (embeddedInSheet) pageNavigation?.closePage(pageId)
+    if (restoreFocus) {
+      window.requestAnimationFrame(() => triggerRef.current?.focus())
+    }
+  }
+
+  function handleMobileValueChange(next: string) {
+    handleValueChange(next)
+    closeMobilePicker(embeddedInSheet)
+  }
+
+  useEffect(() => {
+    if (!disabled || !open) return
+    setOpen(false)
+    closeSheetPage?.(pageId)
+  }, [closeSheetPage, disabled, open, pageId])
+
+  useEffect(
+    () => () => {
+      closeSheetPage?.(pageId)
+    },
+    [closeSheetPage, pageId],
+  )
+
+  useEffect(() => {
+    if (!embeddedInSheet || !open || pageNavigation?.activePageId !== pageId) {
+      return
+    }
+    const frame = window.requestAnimationFrame(() => {
+      embeddedPageRef.current?.querySelector('button')?.focus()
+    })
+    return () => window.cancelAnimationFrame(frame)
+  }, [embeddedInSheet, open, pageId, pageNavigation?.activePageId])
+
+  const mobilePanel = (
+    <SelectSheetPanel
+      value={rootValue}
+      options={options}
+      groups={groups}
+      allowEmpty={allowEmpty}
+      emptyLabel={emptyLabel}
+      disabled={disabled}
+      label={typeof heading === 'string' ? heading : aria['aria-label']}
+      onChange={handleMobileValueChange}
+    />
+  )
+
+  if (mobileSheet) {
+    const trigger = (
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-label={aria['aria-label']}
+        aria-busy={aria['aria-busy']}
+        aria-haspopup={embeddedInSheet ? undefined : 'dialog'}
+        aria-expanded={open}
+        data-state={open ? 'open' : 'closed'}
+        data-placeholder={selected ? undefined : ''}
+        disabled={disabled}
+        onClick={() => handleOpenChange(!open)}
+        className={triggerClassName}
+      >
+        <span className="min-w-0 flex-1 truncate text-left">
+          {selected?.label ?? placeholder}
+        </span>
+        {chevronVisible ? (
+          <span aria-hidden className="shrink-0 text-ink-faint">
+            <ChevronDown size={16} strokeWidth={1} />
+          </span>
+        ) : (
+          <span
+            className="pointer-events-none absolute top-1/2 left-1/2 size-[max(100%,3rem)] -translate-1/2 pointer-fine:hidden"
+            aria-hidden="true"
+          />
+        )}
+      </button>
+    )
+
+    if (embeddedInSheet) {
+      const pagePortal =
+        pageNavigation?.pageHost && pageNavigation.renderedPageId === pageId
+          ? createPortal(
+              <div
+                ref={embeddedPageRef}
+                className="flex min-h-0 flex-1 flex-col"
+              >
+                <SheetPage
+                  title={heading}
+                  description={sheetDescription}
+                  titleId={pageTitleId}
+                  descriptionId={
+                    sheetDescription ? pageDescriptionId : undefined
+                  }
+                  dialogSemantics={false}
+                  onBack={() => closeMobilePicker(true)}
+                  backLabel={`Back from ${typeof heading === 'string' ? heading : 'options'}`}
+                  contentClassName="px-3 pb-1"
+                >
+                  {mobilePanel}
+                </SheetPage>
+              </div>,
+              pageNavigation.pageHost,
+            )
+          : null
+
+      return (
+        <>
+          {trigger}
+          {pagePortal}
+        </>
+      )
+    }
+
+    return (
+      <>
+        {trigger}
+        <BottomSheet open={open} onOpenChange={handleOpenChange}>
+          <BottomSheetContent
+            heading={heading}
+            description={sheetDescription}
+            closeLabel={`Close ${typeof heading === 'string' ? heading : 'select'}`}
+          >
+            <div className="min-h-0 flex-1 overflow-y-auto px-3 pb-1">
+              {mobilePanel}
+            </div>
+          </BottomSheetContent>
+        </BottomSheet>
+      </>
+    )
+  }
+
   return (
     <SelectPrimitive.Root
       value={rootValue}
-      onValueChange={(next) => {
-        if (allowEmpty && next === EMPTY_VALUE) {
-          onClear?.()
-          return
-        }
-        onChange(next as T)
-      }}
+      onValueChange={handleValueChange}
+      open={open}
+      onOpenChange={handleOpenChange}
       disabled={disabled}
     >
       <SelectPrimitive.Trigger
+        ref={triggerRef}
         aria-label={aria['aria-label']}
         aria-busy={aria['aria-busy']}
-        className={cn(
-          'inline-flex h-12 max-w-full min-w-0 items-center justify-between gap-x-2 rounded-sm border border-transparent bg-surface px-3 font-sans text-base text-ink hover:bg-surface-hover focus:border-rule-focus focus:outline-none data-[state=open]:border-rule-focus data-[placeholder]:text-ink-ghost sm:h-9 sm:text-[13px]',
-          disabled && 'opacity-40 pointer-events-none',
-          className,
-        )}
+        className={triggerClassName}
       >
         {/*
          * Radix's `Select.Value` strips `className`/`style` from the span it
@@ -135,11 +326,18 @@ export function Select<T extends string>({
             {selected?.label}
           </SelectPrimitive.Value>
         </span>
-        <SelectPrimitive.Icon asChild>
-          <span aria-hidden className="shrink-0 text-ink-faint">
-            <ChevronDown size={16} strokeWidth={1} />
-          </span>
-        </SelectPrimitive.Icon>
+        {chevronVisible ? (
+          <SelectPrimitive.Icon asChild>
+            <span aria-hidden className="shrink-0 text-ink-faint">
+              <ChevronDown size={16} strokeWidth={1} />
+            </span>
+          </SelectPrimitive.Icon>
+        ) : (
+          <span
+            className="pointer-events-none absolute top-1/2 left-1/2 size-[max(100%,3rem)] -translate-1/2 pointer-fine:hidden"
+            aria-hidden="true"
+          />
+        )}
       </SelectPrimitive.Trigger>
 
       <SelectPrimitive.Portal>
@@ -149,7 +347,7 @@ export function Select<T extends string>({
             sideOffset={4}
             collisionPadding={8}
             className={cn(
-              'iii-ui-motion-overlay z-50 min-w-[var(--radix-select-trigger-width)] overflow-hidden rounded-md bg-panel-raised font-sans text-base text-ink shadow-floating sm:text-[13px]',
+              'iii-ui-motion-dropdown z-50 min-w-[var(--radix-select-trigger-width)] overflow-hidden rounded-md bg-panel-raised font-sans text-base text-ink shadow-floating sm:text-[13px]',
             )}
           >
             <SelectPrimitive.ScrollUpButton className="flex items-center justify-center h-5 text-ink-faint cursor-default">
@@ -175,6 +373,7 @@ export function Select<T extends string>({
                           value={opt.value}
                           label={opt.label}
                           title={opt.title}
+                          description={opt.description}
                           disabled={opt.disabled}
                         />
                       ))}
@@ -186,6 +385,7 @@ export function Select<T extends string>({
                       value={opt.value}
                       label={opt.label}
                       title={opt.title}
+                      description={opt.description}
                       disabled={opt.disabled}
                     />
                   ))}
@@ -200,14 +400,122 @@ export function Select<T extends string>({
   )
 }
 
+interface SelectSheetPanelProps<T extends string> {
+  value: string
+  options?: SelectOption<T>[]
+  groups?: SelectGroup<T>[]
+  allowEmpty?: boolean
+  emptyLabel?: string
+  disabled?: boolean
+  label?: string
+  onChange: (next: string) => void
+}
+
+function SelectSheetPanel<T extends string>({
+  value,
+  options,
+  groups,
+  allowEmpty,
+  emptyLabel,
+  disabled,
+  label = 'Options',
+  onChange,
+}: SelectSheetPanelProps<T>) {
+  const name = useId()
+  const emptyOption: SelectOption<string> = {
+    value: EMPTY_VALUE,
+    label: emptyLabel ?? 'None',
+  }
+
+  function optionRow(option: SelectOption<string>) {
+    const selected =
+      option.value === EMPTY_VALUE ? value === '' : option.value === value
+    return (
+      <label
+        key={option.value}
+        className={cn(
+          'relative flex min-h-14 w-full min-w-0 cursor-pointer items-center gap-3 px-3 py-2 text-left font-sans text-base text-ink hover:bg-surface-hover has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-inset has-[:focus-visible]:ring-rule-focus',
+          (disabled || option.disabled) &&
+            'pointer-events-none cursor-default opacity-40',
+        )}
+      >
+        <input
+          type="radio"
+          name={name}
+          value={option.value}
+          checked={selected}
+          disabled={disabled || option.disabled}
+          onChange={() => onChange(option.value)}
+          className="sr-only"
+        />
+        <span className="flex min-w-0 flex-1 flex-col">
+          <span className="font-medium">{option.label}</span>
+          {option.description || option.title ? (
+            <span className="text-sm leading-relaxed text-ink-faint">
+              {option.description ?? option.title}
+            </span>
+          ) : null}
+        </span>
+        {selected ? (
+          <Check className="size-5 shrink-0 text-ink" aria-hidden />
+        ) : null}
+      </label>
+    )
+  }
+
+  if (groups) {
+    return (
+      <div className="space-y-3">
+        {allowEmpty ? (
+          <fieldset
+            disabled={disabled}
+            className="divide-y divide-edge overflow-hidden rounded-lg bg-surface ring-1 ring-inset ring-edge"
+          >
+            <legend className="sr-only">{label}</legend>
+            {optionRow(emptyOption)}
+          </fieldset>
+        ) : null}
+        {groups.map((group) => (
+          <fieldset key={group.label} disabled={disabled}>
+            <legend className="px-1 pb-1 font-sans text-sm font-medium text-ink-faint">
+              {group.label}
+            </legend>
+            <div className="divide-y divide-edge overflow-hidden rounded-lg bg-surface ring-1 ring-inset ring-edge">
+              {group.options.map((option) => optionRow(option))}
+            </div>
+          </fieldset>
+        ))}
+      </div>
+    )
+  }
+
+  return (
+    <fieldset
+      disabled={disabled}
+      className="divide-y divide-edge overflow-hidden rounded-lg bg-surface ring-1 ring-inset ring-edge"
+    >
+      <legend className="sr-only">{label}</legend>
+      {allowEmpty ? optionRow(emptyOption) : null}
+      {(options ?? []).map((option) => optionRow(option))}
+    </fieldset>
+  )
+}
+
 interface SelectItemProps {
   value: string
   label: string
   title?: string
+  description?: string
   disabled?: boolean
 }
 
-function SelectItem({ value, label, title, disabled }: SelectItemProps) {
+function SelectItem({
+  value,
+  label,
+  title,
+  description,
+  disabled,
+}: SelectItemProps) {
   return (
     <SelectPrimitive.Item
       value={value}
@@ -223,7 +531,14 @@ function SelectItem({ value, label, title, disabled }: SelectItemProps) {
       <SelectPrimitive.ItemIndicator className="absolute left-2 top-1/2 -translate-y-1/2 text-ink">
         <span aria-hidden>✓</span>
       </SelectPrimitive.ItemIndicator>
-      <SelectPrimitive.ItemText>{label}</SelectPrimitive.ItemText>
+      <div className="min-w-0">
+        <SelectPrimitive.ItemText>{label}</SelectPrimitive.ItemText>
+        {description ? (
+          <div className="truncate text-[11px] leading-[1.5] text-ink-faint">
+            {description}
+          </div>
+        ) : null}
+      </div>
     </SelectPrimitive.Item>
   )
 }

--- a/console/web/src/components/ui/Selector.tsx
+++ b/console/web/src/components/ui/Selector.tsx
@@ -335,7 +335,7 @@ export function Selector<T extends string>({
               }}
               className={cn(
                 uiClasses.panel,
-                'iii-ui-motion-overlay z-50 flex max-h-[min(28rem,calc(100dvh-1rem))] w-(--radix-popover-trigger-width) max-w-[calc(100vw-1rem)] min-w-[min(18rem,calc(100vw-1rem))] flex-col bg-panel-raised font-sans shadow-floating',
+                'iii-ui-motion-dropdown z-50 flex max-h-[min(28rem,calc(100dvh-1rem))] w-(--radix-popover-trigger-width) max-w-[calc(100vw-1rem)] min-w-[min(18rem,calc(100vw-1rem))] flex-col bg-panel-raised font-sans shadow-floating',
                 contentClassName,
               )}
             >

--- a/console/web/src/components/ui/SheetNavigation.tsx
+++ b/console/web/src/components/ui/SheetNavigation.tsx
@@ -38,6 +38,10 @@ export function useSheetNavigation<Page extends string>(rootPage: Page) {
 interface SheetPageProps {
   title: ReactNode
   description?: ReactNode
+  titleId?: string
+  descriptionId?: string
+  /** Use plain headings when another Dialog.Title already owns the sheet. */
+  dialogSemantics?: boolean
   onBack?: () => void
   backLabel?: string
   children: ReactNode
@@ -49,6 +53,9 @@ interface SheetPageProps {
 export function SheetPage({
   title,
   description,
+  titleId,
+  descriptionId,
+  dialogSemantics = true,
   onBack,
   backLabel = 'Back',
   children,
@@ -73,9 +80,33 @@ export function SheetPage({
           </button>
         ) : null}
         <div className={cn('min-w-0 flex-1', onBack && 'pt-0.5')}>
-          <BottomSheetTitle>{title}</BottomSheetTitle>
+          {dialogSemantics ? (
+            <BottomSheetTitle {...(titleId ? { id: titleId } : {})}>
+              {title}
+            </BottomSheetTitle>
+          ) : (
+            <h2
+              id={titleId}
+              className="font-sans text-lg font-semibold text-ink"
+            >
+              {title}
+            </h2>
+          )}
           {description ? (
-            <BottomSheetDescription>{description}</BottomSheetDescription>
+            dialogSemantics ? (
+              <BottomSheetDescription
+                {...(descriptionId ? { id: descriptionId } : {})}
+              >
+                {description}
+              </BottomSheetDescription>
+            ) : (
+              <p
+                id={descriptionId}
+                className="font-sans text-base leading-relaxed text-ink-faint"
+              >
+                {description}
+              </p>
+            )
           ) : null}
         </div>
       </div>

--- a/console/web/src/components/ui/Wordmark.stories.tsx
+++ b/console/web/src/components/ui/Wordmark.stories.tsx
@@ -21,6 +21,14 @@ export const Default: Story = {
   ),
 }
 
+export const Inset: Story = {
+  render: () => (
+    <div className="flex items-center justify-center bg-bg p-8">
+      <Wordmark appearance="inset" />
+    </div>
+  ),
+}
+
 export const InverseOnInk: Story = {
   name: 'inverse (on ink panel)',
   render: () => (

--- a/console/web/src/components/ui/Wordmark.tsx
+++ b/console/web/src/components/ui/Wordmark.tsx
@@ -1,9 +1,12 @@
+import { useId } from 'react'
 import inkUrl from '@/icons/iii-ink.svg?url'
 import whiteUrl from '@/icons/iii-white.svg?url'
 import { cn } from '@/lib/utils'
 
 interface WordmarkProps {
   className?: string
+  /** A recessed, low-contrast treatment for large decorative placements. */
+  appearance?: 'default' | 'inset' | 'loading'
   /**
    * `auto` swaps ink/white with `[data-theme]` (default). `ink` and `inverse`
    * pin a variant for panels that don't follow the page theme.
@@ -12,11 +15,104 @@ interface WordmarkProps {
 }
 
 const IMG_CLASS = 'h-[32px] mx-[6px] w-auto shrink-0'
+const WORDMARK_COLUMNS = [0, 403.4, 806.81] as const
+
+function WordmarkGlyphs({
+  animated = false,
+  trademark = true,
+}: {
+  animated?: boolean
+  trademark?: boolean
+}) {
+  return (
+    <>
+      {WORDMARK_COLUMNS.map((x, index) => (
+        <g
+          key={x}
+          className={cn(
+            animated && 'model-waiting-wordmark-segment',
+            animated && index === 1 && '[animation-delay:120ms]',
+            animated && index === 2 && '[animation-delay:240ms]',
+          )}
+        >
+          <rect x={x} y="403.45" width="268.94" height="672.24" />
+          <rect x={x} y=".05" width="268.94" height="268.94" />
+        </g>
+      ))}
+      {trademark ? (
+        <path d="M1008.82,1025.81h-13.67v-6.06h34.68v6.06h-13.82v37.22h-7.19v-37.22ZM1043.08,1028.77v34.26h-6.77v-43.28h9.73l13.67,27.91,13.11-27.91h9.3v43.28h-7.05v-34.82l-13.39,27.77h-5.22l-13.39-27.21Z" />
+      ) : null}
+    </>
+  )
+}
 
 /**
  * The "iii" wordmark from brand SVGs (`iii-ink.svg` / `iii-white.svg`).
  */
-export function Wordmark({ className, tone = 'auto' }: WordmarkProps) {
+export function Wordmark({
+  className,
+  appearance = 'default',
+  tone = 'auto',
+}: WordmarkProps) {
+  const filterId = `iii-inset-${useId().replaceAll(':', '')}`
+
+  if (appearance === 'loading') {
+    return (
+      <svg
+        viewBox="0 0 1075.74 1075.74"
+        aria-hidden="true"
+        className={cn('size-6 shrink-0 fill-ink', className)}
+      >
+        <WordmarkGlyphs animated trademark={false} />
+      </svg>
+    )
+  }
+
+  if (appearance === 'inset') {
+    return (
+      <svg
+        viewBox="0 0 1075.74 1075.74"
+        role="img"
+        aria-label="iii"
+        className={cn('size-16 shrink-0 fill-ink-disabled/45', className)}
+      >
+        <defs>
+          <filter
+            id={filterId}
+            x="-10%"
+            y="-10%"
+            width="120%"
+            height="120%"
+            colorInterpolationFilters="sRGB"
+          >
+            <feGaussianBlur in="SourceAlpha" stdDeviation="20" result="blur" />
+            <feOffset in="blur" dy="18" result="offsetBlur" />
+            <feComposite
+              in="SourceAlpha"
+              in2="offsetBlur"
+              operator="out"
+              result="innerCut"
+            />
+            <feFlood
+              result="shadowColor"
+              className="[flood-color:#0a0a0a] [flood-opacity:0.32]"
+            />
+            <feComposite
+              in="shadowColor"
+              in2="innerCut"
+              operator="in"
+              result="innerShadow"
+            />
+            <feComposite in="innerShadow" in2="SourceGraphic" operator="over" />
+          </filter>
+        </defs>
+        <g filter={`url(#${filterId})`}>
+          <WordmarkGlyphs />
+        </g>
+      </svg>
+    )
+  }
+
   const sizeClass = cn(IMG_CLASS, className)
 
   if (tone === 'ink') {

--- a/console/web/src/components/workspace/MobileWorkspaceMenu.tsx
+++ b/console/web/src/components/workspace/MobileWorkspaceMenu.tsx
@@ -35,7 +35,7 @@ export function MobileWorkspaceMenu({
 }: MobileWorkspaceMenuProps) {
   return (
     <BottomSheet open={open} onOpenChange={onOpenChange}>
-      <BottomSheetContent className="sm:hidden">
+      <BottomSheetContent>
         <SheetPage
           title="Workspace"
           description="Choose a workspace, then swipe between its panels."

--- a/console/web/src/hooks/use-conversations.ts
+++ b/console/web/src/hooks/use-conversations.ts
@@ -915,10 +915,7 @@ export interface ConversationsApi {
   setThinkingLevel: (id: string, level: ThinkingLevel) => void
   /** Point this chat at a named memory bank (null = worker default). */
   setMemoryBank: (id: string, memoryBank: string | null) => void
-  /**
-   * This chat's system prompt. Written only from the new-session screen —
-   * the composer shows it read-only once the chat has messages.
-   */
+  /** This chat's system prompt, chosen on the new-session screen. */
   setSystemPrompt: (id: string, systemPrompt: SystemPromptState) => void
   setSkills: (id: string, skills: string[] | undefined) => void
   setMode: (id: string, mode: Mode) => void

--- a/console/web/src/index.css
+++ b/console/web/src/index.css
@@ -128,6 +128,19 @@
   --motion-ease-exit: cubic-bezier(0.4, 0, 1, 1);
   --ease-glide: var(--motion-ease-enter);
 
+  /* transitions.dev motion scale. These semantic tokens are shared by the
+     dropdown, sheet, and in-panel page recipes in ui-recipes.css. */
+  --duration-quick: 150ms;
+  --duration-fast: 250ms;
+  --duration-medium: 350ms;
+  --duration-slow: 400ms;
+  --ease-smooth-out: cubic-bezier(0.22, 1, 0.36, 1);
+  --distance-base: 8px;
+  --scale-medium: 0.97;
+  --scale-tiny: 0.99;
+  --blur-small: 2px;
+  --blur-medium: 3px;
+
   --spacing-gutter: 24px;
   --spacing-section-x: 36px;
   --spacing-section-y: 80px;
@@ -591,6 +604,30 @@
   }
 }
 
+@keyframes model-waiting-wordmark {
+  0%,
+  55%,
+  100% {
+    opacity: 0.14;
+  }
+  18% {
+    opacity: 1;
+  }
+  34% {
+    opacity: 0.42;
+  }
+}
+
+@utility model-waiting-wordmark-segment {
+  opacity: 0.14;
+  animation: model-waiting-wordmark 720ms ease-in-out infinite;
+
+  @media (prefers-reduced-motion: reduce) {
+    opacity: 0.28;
+    animation: none;
+  }
+}
+
 @utility thinking-shimmer {
   background-image: linear-gradient(
     90deg,
@@ -603,6 +640,12 @@
   -webkit-background-clip: text;
   color: transparent;
   animation: thinking-shimmer 2.4s linear infinite;
+
+  @media (prefers-reduced-motion: reduce) {
+    background-image: none;
+    color: var(--color-ink-faint);
+    animation: none;
+  }
 }
 
 /* A quieter shimmer for an in-flight function description. Its resting tone
@@ -832,6 +875,12 @@
 /* Content images in the transcript open in the viewer on click (see
    MessageList); controls that contain an image keep their own cursor. */
 [data-message-list]
-  img:not(a[href] *, button *, [role='button'], [role='button'] *, [data-image-zoom-exempt] *) {
+  img:not(
+    a[href] *,
+    button *,
+    [role="button"],
+    [role="button"] *,
+    [data-image-zoom-exempt] *
+  ) {
   cursor: zoom-in;
 }

--- a/console/web/src/styles/ui-recipes.css
+++ b/console/web/src/styles/ui-recipes.css
@@ -617,6 +617,75 @@ a.iii-ui-list-item,
   animation-timing-function: var(--motion-ease-exit);
 }
 
+/* Compact menus share a directional scale/fade instead of the generic
+   overlay fade. Radix keeps content mounted while the closed animation runs,
+   so both the entrance and exit remain visible without consumer timers. */
+.iii-ui-motion-dropdown {
+  transform-origin: var(
+    --radix-select-content-transform-origin,
+    var(
+      --radix-dropdown-menu-content-transform-origin,
+      var(--radix-popover-content-transform-origin, top center)
+    )
+  );
+  animation: iii-ui-dropdown-enter var(--duration-fast) var(--ease-smooth-out)
+    both;
+  will-change: transform, opacity;
+}
+
+.iii-ui-motion-dropdown[data-state="closed"] {
+  pointer-events: none;
+  animation: iii-ui-dropdown-exit var(--duration-quick) var(--ease-smooth-out)
+    both;
+}
+
+/* Radix keeps dialog content mounted while its closed keyframe runs. This is
+   the panel-reveal recipe expressed as keyframes so every BottomSheet gets
+   the same enter and exit presence behavior without consumer-owned timers. */
+.iii-ui-motion-sheet {
+  animation: iii-ui-sheet-enter var(--duration-slow) var(--ease-smooth-out) both;
+  will-change: transform, opacity, filter;
+}
+
+.iii-ui-motion-sheet[data-state="closed"] {
+  pointer-events: none;
+  animation: iii-ui-sheet-exit var(--duration-medium) var(--ease-smooth-out)
+    both;
+}
+
+.iii-ui-motion-sheet-overlay {
+  animation: iii-ui-sheet-overlay-enter var(--duration-slow)
+    var(--ease-smooth-out) both;
+  will-change: opacity;
+}
+
+.iii-ui-motion-sheet-overlay[data-state="closed"] {
+  pointer-events: none;
+  animation: iii-ui-sheet-overlay-exit var(--duration-medium)
+    var(--ease-smooth-out) both;
+}
+
+/* Picker and sheet-detail views occupy the same panel and move in opposing
+   directions: the root page leaves left, while detail pages leave right. */
+.iii-ui-motion-picker-page {
+  opacity: 0;
+  pointer-events: none;
+  filter: blur(var(--blur-medium));
+  transform: translateX(var(--picker-page-offset, var(--distance-base)));
+  transition:
+    opacity var(--duration-fast) var(--ease-smooth-out),
+    transform var(--duration-fast) var(--ease-smooth-out),
+    filter var(--duration-fast) var(--ease-smooth-out);
+  will-change: transform, opacity, filter;
+}
+
+.iii-ui-motion-picker-page[data-active="true"] {
+  opacity: 1;
+  pointer-events: auto;
+  filter: blur(0);
+  transform: translateX(0);
+}
+
 @keyframes iii-ui-panel-enter {
   from {
     opacity: 0;
@@ -653,6 +722,72 @@ a.iii-ui-list-item,
   }
 }
 
+@keyframes iii-ui-dropdown-enter {
+  from {
+    opacity: 0;
+    transform: scale(var(--scale-medium));
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes iii-ui-dropdown-exit {
+  from {
+    opacity: 1;
+    transform: scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: scale(var(--scale-tiny));
+  }
+}
+
+@keyframes iii-ui-sheet-enter {
+  from {
+    opacity: 0;
+    filter: blur(var(--blur-small));
+    transform: translateY(50%);
+  }
+  to {
+    opacity: 1;
+    filter: blur(0);
+    transform: translateY(0);
+  }
+}
+
+@keyframes iii-ui-sheet-exit {
+  from {
+    opacity: 1;
+    filter: blur(0);
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    filter: blur(var(--blur-small));
+    transform: translateY(50%);
+  }
+}
+
+@keyframes iii-ui-sheet-overlay-enter {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes iii-ui-sheet-overlay-exit {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
 @media (max-width: 640px) {
   .iii-ui-list-item {
     min-height: 3rem;
@@ -665,7 +800,14 @@ a.iii-ui-list-item,
 
 @media (prefers-reduced-motion: reduce) {
   .iii-ui-motion-panel,
-  .iii-ui-motion-overlay {
+  .iii-ui-motion-overlay,
+  .iii-ui-motion-dropdown,
+  .iii-ui-motion-sheet,
+  .iii-ui-motion-sheet-overlay {
     animation: none;
+  }
+
+  .iii-ui-motion-picker-page {
+    transition: none;
   }
 }

--- a/harness/ui/package.json
+++ b/harness/ui/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {
     "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
     "esbuild": "^0.25.0",
     "typescript": "^5.9.2"
   }

--- a/harness/ui/src/context-chip/index.tsx
+++ b/harness/ui/src/context-chip/index.tsx
@@ -10,7 +10,15 @@
  */
 
 import type { Host } from '@iii-dev/console-ui'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import type { CSSProperties, ReactNode, RefObject } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react'
+import { createPortal } from 'react-dom'
 import { formatCost, formatTokens } from '../lib/format'
 import {
   type ContextSnapshot,
@@ -21,6 +29,7 @@ import { TONE_COLOR, toneFor } from '../lib/tone'
 
 /** Per-tab handler id (host.iii.on namespaces it `::<browserId>`). */
 const STATE_FN = 'iii::harness-ui::ctx-state'
+const MOBILE_CONTEXT_QUERY = '(max-width: 767px)'
 
 export interface SessionChipProps {
   sessionId: string
@@ -36,6 +45,25 @@ interface StateEvent {
   scope?: string
   key?: string
   new_value?: unknown
+}
+
+function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(() =>
+    typeof window === 'undefined' || typeof window.matchMedia !== 'function'
+      ? false
+      : window.matchMedia(query).matches,
+  )
+
+  useEffect(() => {
+    if (typeof window.matchMedia !== 'function') return
+    const media = window.matchMedia(query)
+    const update = () => setMatches(media.matches)
+    update()
+    media.addEventListener('change', update)
+    return () => media.removeEventListener('change', update)
+  }, [query])
+
+  return matches
 }
 
 const ink = (opacity: number) =>
@@ -287,14 +315,49 @@ function SessionIdRow({ sessionId }: { sessionId: string }) {
   )
 }
 
+function ContextCloseButton({
+  onClose,
+  buttonRef,
+}: {
+  onClose: () => void
+  buttonRef: RefObject<HTMLButtonElement | null>
+}) {
+  return (
+    <button
+      ref={buttonRef}
+      type="button"
+      className="harness-ui-pop-close"
+      onClick={onClose}
+      aria-label="close context breakdown"
+    >
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        aria-hidden
+      >
+        <path d="M18 6 6 18M6 6l12 12" />
+      </svg>
+    </button>
+  )
+}
+
 function ContextPopover({
   snapshot,
   modelId,
   sessionId,
+  modal,
+  onClose,
+  closeButtonRef,
 }: {
   snapshot: ContextSnapshot
   modelId?: string
   sessionId: string
+  modal: boolean
+  onClose: () => void
+  closeButtonRef: RefObject<HTMLButtonElement | null>
 }) {
   const usable = snapshot.usable
   const pct =
@@ -309,14 +372,21 @@ function ContextPopover({
       className="harness-ui-pop"
       role="dialog"
       aria-label="context breakdown"
+      aria-modal={modal || undefined}
     >
       <div className="harness-ui-pop-head">
-        <span className="harness-ui-pop-model">
-          {snapshot.model || modelId || 'model'}
+        <span className="harness-ui-pop-head-copy">
+          <span className="harness-ui-pop-model">
+            {snapshot.model || modelId || 'model'}
+          </span>
+          <span className="harness-ui-pop-usage">
+            {pct}% of {formatTokens(usable)}
+          </span>
         </span>
-        <span className="harness-ui-pop-usage">
-          {pct}% of {formatTokens(usable)}
-        </span>
+        <ContextCloseButton
+          onClose={onClose}
+          buttonRef={closeButtonRef}
+        />
       </div>
       <div className="harness-ui-stack">
         {cats
@@ -397,10 +467,16 @@ function EmptyContextPopover({
   modelId,
   contextWindow,
   sessionId,
+  modal,
+  onClose,
+  closeButtonRef,
 }: {
   modelId?: string
   contextWindow?: number
   sessionId: string
+  modal: boolean
+  onClose: () => void
+  closeButtonRef: RefObject<HTMLButtonElement | null>
 }) {
   const hasWindow = contextWindow !== undefined && contextWindow > 0
   return (
@@ -408,10 +484,17 @@ function EmptyContextPopover({
       className="harness-ui-pop"
       role="dialog"
       aria-label="context breakdown"
+      aria-modal={modal || undefined}
     >
       <div className="harness-ui-pop-head">
-        <span className="harness-ui-pop-model">{modelId || 'model'}</span>
-        <span className="harness-ui-pop-usage">waiting for usage</span>
+        <span className="harness-ui-pop-head-copy">
+          <span className="harness-ui-pop-model">{modelId || 'model'}</span>
+          <span className="harness-ui-pop-usage">waiting for usage</span>
+        </span>
+        <ContextCloseButton
+          onClose={onClose}
+          buttonRef={closeButtonRef}
+        />
       </div>
       {hasWindow ? (
         <>
@@ -456,6 +539,219 @@ function ContextCaret() {
   )
 }
 
+interface ContextSurfaceRenderProps {
+  modal: boolean
+  onClose: () => void
+  closeButtonRef: RefObject<HTMLButtonElement | null>
+}
+
+interface ContextChipSurfaceProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  triggerLabel: string
+  trigger: ReactNode
+  renderPopover: (props: ContextSurfaceRenderProps) => ReactNode
+}
+
+/**
+ * One responsive surface for every context-chip state. The desktop trigger
+ * becomes its popover; mobile keeps the compact trigger in place and portals
+ * the same content into a modal bottom sheet.
+ */
+function ContextChipSurface({
+  open,
+  onOpenChange,
+  triggerLabel,
+  trigger,
+  renderPopover,
+}: ContextChipSurfaceProps) {
+  const mobileSheet = useMediaQuery(MOBILE_CONTEXT_QUERY)
+  const rootRef = useRef<HTMLDivElement | null>(null)
+  const triggerRef = useRef<HTMLButtonElement | null>(null)
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null)
+  const sheetRef = useRef<HTMLDivElement | null>(null)
+  const morphMenuRef = useRef<HTMLDivElement | null>(null)
+  const wasOpenRef = useRef(false)
+  const [morphOpenHeight, setMorphOpenHeight] = useState(280)
+
+  useLayoutEffect(() => {
+    if (mobileSheet) return
+    const panel = morphMenuRef.current?.querySelector<HTMLElement>(
+      '.harness-ui-pop',
+    )
+    if (!panel) return
+    const updateHeight = () =>
+      setMorphOpenHeight(Math.max(120, Math.ceil(panel.scrollHeight)))
+    updateHeight()
+    if (typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(updateHeight)
+    observer.observe(panel)
+    return () => observer.disconnect()
+  }, [mobileSheet])
+
+  useEffect(() => {
+    if (!open) return
+    const onPointerDown = (event: MouseEvent) => {
+      const target = event.target as Node
+      if (
+        !rootRef.current?.contains(target) &&
+        !sheetRef.current?.contains(target)
+      ) {
+        onOpenChange(false)
+      }
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onOpenChange(false)
+        return
+      }
+      if (event.key !== 'Tab' || !mobileSheet || !sheetRef.current) return
+      const focusable = Array.from(
+        sheetRef.current.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), [href], input:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ),
+      )
+      if (focusable.length === 0) return
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault()
+        last.focus()
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault()
+        first.focus()
+      }
+    }
+    document.addEventListener('mousedown', onPointerDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [mobileSheet, onOpenChange, open])
+
+  useEffect(() => {
+    let focusFrame: number | undefined
+    if (open) {
+      focusFrame = window.requestAnimationFrame(() => {
+        closeButtonRef.current?.focus({ preventScroll: true })
+      })
+    } else if (wasOpenRef.current) {
+      triggerRef.current?.focus({ preventScroll: true })
+    }
+    wasOpenRef.current = open
+    return () => {
+      if (focusFrame !== undefined) window.cancelAnimationFrame(focusFrame)
+    }
+  }, [mobileSheet, open])
+
+  useEffect(() => {
+    if (!mobileSheet || !open) return
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = previousOverflow
+    }
+  }, [mobileSheet, open])
+
+  const close = useCallback(() => onOpenChange(false), [onOpenChange])
+
+  if (mobileSheet) {
+    return (
+      <div className="harness-ui-chip" ref={rootRef}>
+        <button
+          ref={triggerRef}
+          type="button"
+          className="harness-ui-chip-btn"
+          onClick={() => onOpenChange(!open)}
+          aria-haspopup="dialog"
+          aria-expanded={open}
+          aria-label={triggerLabel}
+        >
+          {trigger}
+        </button>
+        {typeof document !== 'undefined'
+          ? createPortal(
+              <div
+                data-iii-ui="harness"
+                className="harness-ui-context-portal"
+                style={{ display: 'contents' }}
+              >
+                <button
+                  type="button"
+                  className="harness-ui-sheet-backdrop"
+                  data-open={open}
+                  onClick={close}
+                  tabIndex={-1}
+                  aria-hidden="true"
+                />
+                <div
+                  ref={sheetRef}
+                  className="harness-ui-context-sheet t-panel-slide"
+                  data-open={open}
+                  aria-hidden={!open}
+                  inert={!open}
+                >
+                  <div className="harness-ui-sheet-handle" aria-hidden>
+                    <span />
+                  </div>
+                  {renderPopover({
+                    modal: true,
+                    onClose: close,
+                    closeButtonRef,
+                  })}
+                </div>
+              </div>,
+              document.body,
+            )
+          : null}
+      </div>
+    )
+  }
+
+  const morphStyle = {
+    '--morph-open-height': `${morphOpenHeight}px`,
+  } as CSSProperties
+
+  return (
+    <div className="harness-ui-chip" ref={rootRef}>
+      <span className="harness-ui-chip-sizer" aria-hidden="true">
+        {trigger}
+      </span>
+      <div
+        className="harness-ui-context-morph t-morph"
+        data-open={open}
+        style={morphStyle}
+      >
+        <div
+          ref={morphMenuRef}
+          className="harness-ui-morph-menu t-morph-menu"
+          aria-hidden={!open}
+          inert={!open}
+        >
+          {renderPopover({
+            modal: false,
+            onClose: close,
+            closeButtonRef,
+          })}
+        </div>
+        <button
+          ref={triggerRef}
+          type="button"
+          className="harness-ui-chip-btn harness-ui-morph-trigger t-morph-plus"
+          onClick={() => onOpenChange(!open)}
+          aria-haspopup="dialog"
+          aria-expanded={open}
+          aria-label={triggerLabel}
+          tabIndex={open ? -1 : 0}
+        >
+          {trigger}
+        </button>
+      </div>
+    </div>
+  )
+}
+
 export function createContextChip(host: Host) {
   return function ContextChip({
     sessionId,
@@ -464,7 +760,6 @@ export function createContextChip(host: Host) {
   }: SessionChipProps) {
     const [snapshot, setSnapshot] = useState<ContextSnapshot | null>(null)
     const [open, setOpen] = useState(false)
-    const rootRef = useRef<HTMLDivElement | null>(null)
 
     // Both the hydration read and the streamed trigger write this state;
     // keep whichever snapshot is newest so a slow state::get can never
@@ -522,79 +817,63 @@ export function createContextChip(host: Host) {
       }
     }, [host, sessionId])
 
-    useEffect(() => {
-      if (!open) return
-      const onPointerDown = (event: MouseEvent) => {
-        const root = rootRef.current
-        if (root && !root.contains(event.target as Node)) setOpen(false)
-      }
-      const onKeyDown = (event: KeyboardEvent) => {
-        if (event.key === 'Escape') setOpen(false)
-      }
-      document.addEventListener('mousedown', onPointerDown)
-      document.addEventListener('keydown', onKeyDown)
-      return () => {
-        document.removeEventListener('mousedown', onPointerDown)
-        document.removeEventListener('keydown', onKeyDown)
-      }
-    }, [open])
-
     if (!snapshot || snapshot.usable <= 0) {
       if (contextWindow && contextWindow > 0) {
         return (
-          <div className="harness-ui-chip" ref={rootRef}>
-            <button
-              type="button"
-              className="harness-ui-chip-btn"
-              onClick={() => setOpen((value) => !value)}
-              aria-haspopup="dialog"
-              aria-expanded={open}
-              aria-label={`context: waiting for usage, ${contextWindow.toLocaleString()} token window — click for the breakdown`}
-            >
-              <span>ctx</span>
-              <span
-                className="harness-ui-chip-bar"
-                role="progressbar"
-                aria-label="context window usage"
-                aria-valuenow={0}
-                aria-valuemin={0}
-                aria-valuemax={100}
-              >
-                <span className="harness-ui-chip-fill" style={{ width: 0 }} />
-              </span>
-              <span className="harness-ui-chip-counts">
-                0/{formatTokens(contextWindow)}
-              </span>
-              <ContextCaret />
-            </button>
-            {open ? (
+          <ContextChipSurface
+            open={open}
+            onOpenChange={setOpen}
+            triggerLabel={`context: waiting for usage, ${contextWindow.toLocaleString()} token window — click for the breakdown`}
+            trigger={
+              <>
+                <span>ctx</span>
+                <span
+                  className="harness-ui-chip-bar"
+                  role="progressbar"
+                  aria-label="context window usage"
+                  aria-valuenow={0}
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                >
+                  <span className="harness-ui-chip-fill" style={{ width: 0 }} />
+                </span>
+                <span className="harness-ui-chip-counts">
+                  0/{formatTokens(contextWindow)}
+                </span>
+                <ContextCaret />
+              </>
+            }
+            renderPopover={(surface) => (
               <EmptyContextPopover
+                {...surface}
                 modelId={modelId}
                 contextWindow={contextWindow}
                 sessionId={sessionId}
               />
-            ) : null}
-          </div>
+            )}
+          />
         )
       }
       return (
-        <div className="harness-ui-chip" ref={rootRef}>
-          <button
-            type="button"
-            className="harness-ui-chip-btn"
-            onClick={() => setOpen((value) => !value)}
-            aria-haspopup="dialog"
-            aria-expanded={open}
-            aria-label="context: waiting for usage — click for the breakdown"
-          >
-            <span>ctx</span>
-            <span className="harness-ui-chip-empty">—</span>
-            <ContextCaret />
-          </button>
-          {open ? (
-            <EmptyContextPopover modelId={modelId} sessionId={sessionId} />
-          ) : null}
-        </div>
+        <ContextChipSurface
+          open={open}
+          onOpenChange={setOpen}
+          triggerLabel="context: waiting for usage — click for the breakdown"
+          trigger={
+            <>
+              <span>ctx</span>
+              <span className="harness-ui-chip-empty">—</span>
+              <ContextCaret />
+            </>
+          }
+          renderPopover={(surface) => (
+            <EmptyContextPopover
+              {...surface}
+              modelId={modelId}
+              sessionId={sessionId}
+            />
+          )}
+        />
       )
     }
 
@@ -603,51 +882,50 @@ export function createContextChip(host: Host) {
     const tone = toneFor(ratio)
 
     return (
-      <div className="harness-ui-chip" ref={rootRef}>
-        <button
-          type="button"
-          className="harness-ui-chip-btn"
-          onClick={() => setOpen((value) => !value)}
-          aria-haspopup="dialog"
-          aria-expanded={open}
-          aria-label={`context: ${snapshot.total.toLocaleString()} of ${snapshot.usable.toLocaleString()} tokens (${pct}%) — click for the breakdown`}
-        >
-          <span>ctx</span>
-          <span
-            className="harness-ui-chip-bar"
-            role="progressbar"
-            aria-label="context window usage"
-            aria-valuenow={pct}
-            aria-valuemin={0}
-            aria-valuemax={100}
-          >
+      <ContextChipSurface
+        open={open}
+        onOpenChange={setOpen}
+        triggerLabel={`context: ${snapshot.total.toLocaleString()} of ${snapshot.usable.toLocaleString()} tokens (${pct}%) — click for the breakdown`}
+        trigger={
+          <>
+            <span>ctx</span>
             <span
-              className="harness-ui-chip-fill"
-              style={{ width: `${pct}%`, background: TONE_COLOR[tone] }}
-            />
-          </span>
-          {/* The bar, the percentage and the counts were three encodings of
-              one quantity. The bar carries proportion; the counts carry the
-              number you actually act on. The percentage keeps its job in the
-              tooltip and the popover, and hands its tone to the counts. */}
-          <span
-            className="harness-ui-chip-counts"
-            style={tone === 'ok' ? undefined : { color: TONE_COLOR[tone] }}
-          >
-            {formatTokens(snapshot.total)}/{formatTokens(snapshot.usable)}
-          </span>
-          {/* Says "this opens something": drawn at lucide's `chevron-down`
-              geometry, since an injected bundle has no icon dependency. */}
-          <ContextCaret />
-        </button>
-        {open ? (
+              className="harness-ui-chip-bar"
+              role="progressbar"
+              aria-label="context window usage"
+              aria-valuenow={pct}
+              aria-valuemin={0}
+              aria-valuemax={100}
+            >
+              <span
+                className="harness-ui-chip-fill"
+                style={{ width: `${pct}%`, background: TONE_COLOR[tone] }}
+              />
+            </span>
+            {/* The bar, the percentage and the counts were three encodings of
+                one quantity. The bar carries proportion; the counts carry the
+                number you actually act on. The percentage keeps its job in the
+                tooltip and the popover, and hands its tone to the counts. */}
+            <span
+              className="harness-ui-chip-counts"
+              style={tone === 'ok' ? undefined : { color: TONE_COLOR[tone] }}
+            >
+              {formatTokens(snapshot.total)}/{formatTokens(snapshot.usable)}
+            </span>
+            {/* Says "this opens something": drawn at lucide's `chevron-down`
+                geometry, since an injected bundle has no icon dependency. */}
+            <ContextCaret />
+          </>
+        }
+        renderPopover={(surface) => (
           <ContextPopover
+            {...surface}
             snapshot={snapshot}
             modelId={modelId}
             sessionId={sessionId}
           />
-        ) : null}
-      </div>
+        )}
+      />
     )
   }
 }

--- a/harness/ui/styles.css
+++ b/harness/ui/styles.css
@@ -8,6 +8,25 @@
  * so light/dark theming is free.
  */
 
+[data-iii-ui="harness"] {
+  --morph-open-dur: 350ms;
+  --morph-close-dur: 250ms;
+  --morph-ease: cubic-bezier(0.34, 1.25, 0.64, 1);
+  --morph-close-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --morph-r-closed: 40px;
+  --morph-r-open: 6px;
+  --morph-fade-dur: 200ms;
+  --morph-slide: 40px;
+  --morph-rotate: 45deg;
+  --morph-scale: 0.97;
+  --morph-blur: 2px;
+  --panel-open-dur: 400ms;
+  --panel-close-dur: 350ms;
+  --panel-translate-y: 50%;
+  --panel-blur: 2px;
+  --panel-ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
 /* --- session chip (context) ------------------------------------------ */
 [data-iii-ui="harness"] .harness-ui-chip {
   position: relative;
@@ -20,6 +39,7 @@
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: var(--color-ink-faint);
+  min-height: 24px;
 }
 [data-iii-ui="harness"] .harness-ui-chip-empty {
   color: var(--color-ink-ghost);
@@ -84,24 +104,111 @@
   color: var(--color-ink-ghost);
 }
 
-/* --- context popover -------------------------------------------------- */
-[data-iii-ui="harness"] .harness-ui-pop {
+/* --- context surface: desktop chip-to-popover morph ----------------- */
+[data-iii-ui="harness"] .harness-ui-chip-sizer {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+[data-iii-ui="harness"] .t-morph {
   position: absolute;
-  top: calc(100% + 6px);
+  top: 0;
   right: 0;
   z-index: 1000;
+  width: 100%;
+  height: 100%;
+  min-height: 24px;
+  border-radius: var(--morph-r-closed);
+  overflow: hidden;
+  box-sizing: border-box;
+  background-color: transparent;
+  box-shadow: 0 0 0 rgb(0 0 0 / 0%);
+  transition:
+    width var(--morph-close-dur) var(--morph-close-ease),
+    height var(--morph-close-dur) var(--morph-close-ease),
+    border-radius var(--morph-close-dur) var(--morph-close-ease),
+    background-color var(--morph-close-dur) var(--morph-close-ease),
+    box-shadow var(--morph-close-dur) var(--morph-close-ease);
+}
+
+[data-iii-ui="harness"] .t-morph[data-open="true"] {
+  width: 300px;
+  height: var(--morph-open-height, 280px);
+  border-radius: var(--morph-r-open);
+  background-color: var(--color-panel-raised);
+  box-shadow: var(--shadow-floating);
+  color: var(--color-ink);
+  transition:
+    width var(--morph-open-dur) var(--morph-ease),
+    height var(--morph-open-dur) var(--morph-ease),
+    border-radius var(--morph-open-dur) var(--morph-ease),
+    background-color var(--morph-fade-dur) var(--morph-close-ease),
+    box-shadow var(--morph-fade-dur) var(--morph-close-ease);
+}
+
+[data-iii-ui="harness"] .t-morph-plus {
+  position: absolute;
+  inset: 0 0 auto auto;
+  width: 100%;
+  height: 100%;
+  transition:
+    opacity var(--morph-fade-dur) var(--morph-close-ease),
+    transform var(--morph-open-dur) var(--morph-close-ease),
+    filter var(--morph-fade-dur) var(--morph-close-ease);
+}
+
+[data-iii-ui="harness"] .t-morph-plus svg {
+  transition: transform var(--morph-open-dur) var(--morph-close-ease);
+}
+
+[data-iii-ui="harness"] .t-morph[data-open="true"] .t-morph-plus {
+  opacity: 0;
+  transform: translateX(calc(-1 * var(--morph-slide)));
+  filter: blur(var(--morph-blur));
+  pointer-events: none;
+}
+
+[data-iii-ui="harness"] .t-morph[data-open="true"] .t-morph-plus svg {
+  transform: scale(var(--morph-scale)) rotate(var(--morph-rotate));
+}
+
+[data-iii-ui="harness"] .t-morph-menu {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  transform: translateX(var(--morph-slide)) scale(var(--morph-scale));
+  filter: blur(var(--morph-blur));
+  pointer-events: none;
+  transition:
+    opacity var(--morph-fade-dur) var(--morph-close-ease),
+    transform var(--morph-open-dur) var(--morph-close-ease),
+    filter var(--morph-fade-dur) var(--morph-close-ease);
+}
+
+[data-iii-ui="harness"] .t-morph[data-open="true"] .t-morph-menu {
+  opacity: 1;
+  transform: translateX(0) scale(1);
+  filter: blur(0);
+  pointer-events: auto;
+}
+
+[data-iii-ui="harness"] .harness-ui-morph-trigger {
+  justify-content: flex-end;
+  white-space: nowrap;
+}
+
+/* --- context popover -------------------------------------------------- */
+[data-iii-ui="harness"] .harness-ui-pop {
   width: 300px;
   padding: 12px;
   display: flex;
   flex-direction: column;
   gap: 10px;
-  /* Floating surfaces in this system lift with a shadow, not a stroke — the
-     console's own DropdownMenu is `bg-panel-raised … shadow-floating`, and
-     the `1px solid var(--color-rule)` this had was transparent, so the
-     popover was reading flat against the panel behind it. */
-  background: var(--color-panel-raised);
-  border-radius: 6px;
-  box-shadow: var(--shadow-floating);
+  box-sizing: border-box;
+  font-family: var(--font-mono, ui-monospace, monospace);
   color: var(--color-ink);
   font-size: 12px;
   text-transform: none;
@@ -111,9 +218,42 @@
 }
 [data-iii-ui="harness"] .harness-ui-pop-head {
   display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+[data-iii-ui="harness"] .harness-ui-pop-head-copy {
+  display: flex;
   align-items: baseline;
   justify-content: space-between;
   gap: 8px;
+  min-width: 0;
+  flex: 1;
+}
+[data-iii-ui="harness"] .harness-ui-pop-close {
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  flex: none;
+  margin: -6px -6px -6px 0;
+  padding: 0;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--color-ink-faint);
+  cursor: pointer;
+}
+[data-iii-ui="harness"] .harness-ui-pop-close:hover {
+  background: var(--color-surface-hover);
+  color: var(--color-ink);
+}
+[data-iii-ui="harness"] .harness-ui-pop-close:focus-visible {
+  outline: 2px solid var(--color-rule-focus);
+  outline-offset: 1px;
+}
+[data-iii-ui="harness"] .harness-ui-pop-close svg {
+  width: 14px;
+  height: 14px;
 }
 [data-iii-ui="harness"] .harness-ui-pop-model {
   overflow: hidden;
@@ -246,6 +386,111 @@
 
 [data-iii-ui="harness"] .harness-ui-cache-hit[data-tone="warn"] {
   color: var(--color-warn);
+}
+
+/* --- context surface: mobile bottom sheet ---------------------------- */
+[data-iii-ui="harness"] .harness-ui-sheet-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1090;
+  padding: 0;
+  border: 0;
+  background: rgb(0 0 0 / 55%);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--panel-close-dur) var(--panel-ease);
+  will-change: opacity;
+}
+
+[data-iii-ui="harness"] .harness-ui-sheet-backdrop[data-open="true"] {
+  opacity: 1;
+  pointer-events: auto;
+  transition-duration: var(--panel-open-dur);
+}
+
+[data-iii-ui="harness"] .t-panel-slide {
+  transform: translateY(var(--panel-translate-y));
+  opacity: 0;
+  filter: blur(var(--panel-blur));
+  pointer-events: none;
+  transition:
+    transform var(--panel-close-dur) var(--panel-ease),
+    opacity var(--panel-close-dur) var(--panel-ease),
+    filter var(--panel-close-dur) var(--panel-ease);
+  will-change: transform, opacity, filter;
+}
+
+[data-iii-ui="harness"] .t-panel-slide[data-open="true"] {
+  transform: translateY(0);
+  opacity: 1;
+  filter: blur(0);
+  pointer-events: auto;
+  transition:
+    transform var(--panel-open-dur) var(--panel-ease),
+    opacity var(--panel-open-dur) var(--panel-ease),
+    filter var(--panel-open-dur) var(--panel-ease);
+}
+
+[data-iii-ui="harness"] .harness-ui-context-sheet {
+  position: fixed;
+  right: 12px;
+  bottom: 12px;
+  left: 12px;
+  z-index: 1100;
+  display: flex;
+  max-height: calc(100dvh - 24px);
+  flex-direction: column;
+  overflow: hidden;
+  overscroll-behavior: contain;
+  padding-bottom: max(12px, env(safe-area-inset-bottom));
+  border: 1px solid var(--color-edge, var(--color-rule));
+  border-radius: 8px;
+  background: var(--color-panel-raised);
+  box-shadow: var(--shadow-floating);
+  color: var(--color-ink);
+}
+
+[data-iii-ui="harness"] .harness-ui-sheet-handle {
+  display: flex;
+  height: 24px;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+}
+
+[data-iii-ui="harness"] .harness-ui-sheet-handle span {
+  width: 40px;
+  height: 4px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--color-ink-ghost) 60%, transparent);
+}
+
+[data-iii-ui="harness"] .harness-ui-context-sheet .harness-ui-pop {
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 4px 16px 16px;
+}
+
+[data-iii-ui="harness"] .harness-ui-context-sheet .harness-ui-pop-close {
+  width: 48px;
+  height: 48px;
+  margin: -12px -8px -12px 0;
+}
+
+[data-iii-ui="harness"] .harness-ui-context-sheet .harness-ui-pop-close svg {
+  width: 20px;
+  height: 20px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-iii-ui="harness"] .t-morph,
+  [data-iii-ui="harness"] .t-morph-plus,
+  [data-iii-ui="harness"] .t-morph-menu,
+  [data-iii-ui="harness"] .t-panel-slide,
+  [data-iii-ui="harness"] .harness-ui-sheet-backdrop {
+    transition: none !important;
+  }
 }
 
 /* --- function-trigger message (chat / traces card) ------------------- */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -438,6 +438,9 @@ importers:
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
       esbuild:
         specifier: ^0.25.0
         version: 0.25.12


### PR DESCRIPTION
## Summary

- simplify the empty chat into a centered inset wordmark and a single project-aware prompt
- keep system-prompt selection directly below the question, with explicit enrich/replace strategies for named prompts
- let users curate session skills through an inline selector and removable selected-skill chips
- make folder selection denser, remove secondary metadata, and keep the selected checkmark as the final row action
- add a branded three-glyph waiting animation with status text and elapsed time
- animate selects and dropdowns with an anchored scale/fade entrance and a shorter exit
- reveal working-directory selection as a slide/fade/blur panel on mobile and a compact anchored dropdown on desktop
- transition the model catalog, reasoning effort, and provider configuration side-by-side while keeping hidden views inert
- turn the harness context chip into an animated popover morph on desktop and a modal bottom sheet on mobile
- respect reduced-motion preferences across the new waiting and picker motion

## Validation

- `pnpm --dir console/web typecheck`
- focused Biome checks for the updated chat, select, and motion files
- focused chat component tests
- `pnpm --dir console/web build`
- `pnpm --dir harness/ui build`
- Storybook interaction checks for dropdown open/close, directory selection at desktop/mobile breakpoints, and model-page navigation in both directions

The full Vitest run completed with 1772 passing tests and still reports the same three unrelated baseline failures in `TriggerActivityCard.test.tsx`, `redact-raw.test.tsx`, and `icon-size-conformance.test.ts` for unchanged `security-scan` files.

Fixes MOT-4577


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Configure working directories, worktrees, system prompts, and skills from the chat setup screen.
  - Review and remove selected skills before starting a session.
  - View an animated model-waiting indicator with elapsed wait time.
  - Use mobile-friendly bottom sheets for model, prompt, skill, and directory pickers.
  - Explore context details through responsive desktop popovers and mobile sheets.

- **Improvements**
  - Refined picker layouts, accessibility, focus handling, transitions, and reduced-motion support.
  - Added animated wordmark appearances.
  - Improved model and provider configuration transitions.
  - Chat settings and workspace menus now display consistently across screen sizes.

- **Tests**
  - Expanded coverage for setup controls, waiting states, accessibility, and formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
