### PR TITLE
(MOT-4574) fix(shell): follow current turn without hiding uncommitted changes

### DIFF
--- a/shell/src/turns.rs
+++ b/shell/src/turns.rs
@@ -42,6 +42,7 @@ const PRE_HOOK_FN_ID: &str = "shell::turns::on-pre-trigger";
 const POST_HOOK_FN_ID: &str = "shell::turns::on-post-trigger";
 const STARTED_FN_ID: &str = "shell::turns::on-turn-started";
 const COMPLETED_FN_ID: &str = "shell::turns::on-turn-completed";
+const ADOPT_ROOT_FN_ID: &str = "shell::turns::adopt-root";
 // Every shell call is hooked, not only the file verbs: calls that name no
 // paths (`shell::exec`, pty writes) still tell the observer which
 // session, turn and root are live so the workspace watch can start.
@@ -311,6 +312,124 @@ fn now_ms() -> u64 {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
         .unwrap_or(0)
+}
+
+fn system_time_ms(value: SystemTime) -> Option<u64> {
+    value
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|duration| duration.as_millis() as u64)
+}
+
+fn recent_enough(value: Option<u64>, started_at: u64) -> bool {
+    value.is_some_and(|value| value.saturating_add(2_000) >= started_at)
+}
+
+fn adoptable_project_path(root: &Path, path: &Path) -> bool {
+    let Ok(relative) = path.strip_prefix(root) else {
+        return false;
+    };
+    let ignored = [
+        ".git",
+        "node_modules",
+        "target",
+        "dist",
+        "build",
+        "out",
+        "vendor",
+        "__pycache__",
+    ];
+    if relative
+        .components()
+        .any(|part| ignored.iter().any(|name| part.as_os_str() == *name))
+    {
+        return false;
+    }
+    !matches!(
+        path.extension().and_then(|extension| extension.to_str()),
+        Some(
+            "o" | "a"
+                | "d"
+                | "rlib"
+                | "rmeta"
+                | "so"
+                | "dylib"
+                | "dll"
+                | "class"
+                | "pyc"
+                | "wasm"
+                | "map"
+                | "log"
+                | "tmp"
+                | "swp"
+                | "part"
+                | "pid"
+                | "sock"
+        )
+    )
+}
+
+fn scan_adopted_project(root: &Path, started_at: u64) -> Vec<(String, String)> {
+    struct Candidate {
+        path: PathBuf,
+        created_at: Option<u64>,
+        modified_at: Option<u64>,
+    }
+
+    let root_created_at = std::fs::metadata(root)
+        .ok()
+        .and_then(|metadata| metadata.created().ok())
+        .and_then(system_time_ms);
+    let mut stack = vec![root.to_path_buf()];
+    let mut candidates = Vec::new();
+    while let Some(directory) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(directory) else {
+            continue;
+        };
+        let mut entries = entries.flatten().collect::<Vec<_>>();
+        entries.sort_by_key(std::fs::DirEntry::path);
+        for entry in entries {
+            let path = entry.path();
+            if !adoptable_project_path(root, &path) {
+                continue;
+            }
+            let Ok(metadata) = entry.metadata() else {
+                continue;
+            };
+            if metadata.file_type().is_symlink() {
+                continue;
+            }
+            if metadata.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if !metadata.is_file() || candidates.len() >= MAX_FILES_PER_TURN {
+                continue;
+            }
+            candidates.push(Candidate {
+                path,
+                created_at: metadata.created().ok().and_then(system_time_ms),
+                modified_at: metadata.modified().ok().and_then(system_time_ms),
+            });
+        }
+    }
+    let whole_project_is_new = recent_enough(root_created_at, started_at)
+        || (!candidates.is_empty()
+            && candidates
+                .iter()
+                .all(|candidate| recent_enough(candidate.modified_at, started_at)));
+    candidates
+        .into_iter()
+        .filter(|candidate| whole_project_is_new || recent_enough(candidate.created_at, started_at))
+        .filter_map(|candidate| {
+            std::fs::read(&candidate.path).ok().map(|bytes| {
+                (
+                    candidate.path.to_string_lossy().into_owned(),
+                    content_revision(&bytes),
+                )
+            })
+        })
+        .collect()
 }
 
 struct ReadImage {
@@ -718,6 +837,63 @@ impl TurnLog {
         .await
     }
 
+    pub async fn adopt_root(
+        &self,
+        session_id: &str,
+        turn_id: &str,
+        root: &str,
+    ) -> Result<usize, Error> {
+        let root = tokio::fs::canonicalize(root)
+            .await
+            .map_err(|error| Error::Handler(format!("project root is not accessible: {error}")))?;
+        if !root.is_dir() {
+            return Err(Error::Handler("project root is not a directory".into()));
+        }
+        let record = self.load(session_id).await?;
+        let started_at = record
+            .turns
+            .iter()
+            .find(|turn| turn.turn_id == turn_id)
+            .map(|turn| turn.started_at)
+            .ok_or_else(|| Error::Handler("turn is not present in session history".into()))?;
+        let scan_root = root.clone();
+        let files =
+            tokio::task::spawn_blocking(move || scan_adopted_project(&scan_root, started_at))
+                .await
+                .map_err(|error| Error::Handler(format!("project scan failed: {error}")))?;
+        let count = files.len();
+        let root = root.to_string_lossy().into_owned();
+        let at = now_ms();
+        self.update(session_id, |record| {
+            let turn = turn_mut(record, turn_id, at);
+            for (path, after_revision) in files {
+                record_file(
+                    turn,
+                    FileRecord {
+                        path,
+                        root: Some(root.clone()),
+                        kind: "created".into(),
+                        cause: "console::working-directory::propose".into(),
+                        first_seen: at,
+                        last_seen: at,
+                        from: None,
+                        before: Some(PreImage {
+                            revision: None,
+                            content: None,
+                            truncated: false,
+                            stored: false,
+                            missing: true,
+                            binary: false,
+                        }),
+                        after_revision: Some(after_revision),
+                    },
+                );
+            }
+        })
+        .await?;
+        Ok(count)
+    }
+
     pub async fn on_pre_trigger(&self, input: HookInput) {
         let (Some(session_id), Some(turn_id), Some(call)) =
             (input.session_id, input.turn_id, input.call)
@@ -862,6 +1038,18 @@ pub struct GetOutput {
     pub turn: Option<TurnRecord>,
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct AdoptRootInput {
+    pub session_id: String,
+    pub turn_id: String,
+    pub root: String,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct AdoptRootOutput {
+    pub recorded: usize,
+}
+
 pub fn register(iii: &IIIClient, config: &TurnsConfig) -> Arc<TurnLog> {
     let data_dir = config.resolved_data_dir();
     let log = Arc::new(TurnLog::new(TurnStore::new(
@@ -910,6 +1098,25 @@ pub fn register(iii: &IIIClient, config: &TurnsConfig) -> Arc<TurnLog> {
             .description(
                 "Internal: records a file change made through a shell or coder call into \
                  the session's durable change history. Observes only; always continues.",
+            )
+            .metadata(json!({ "internal": true, "trace_hidden": true })),
+        );
+    }
+    {
+        let log = log.clone();
+        iii.register_function(
+            ADOPT_ROOT_FN_ID,
+            RegisterFunction::new_async(move |input: AdoptRootInput| {
+                let log = log.clone();
+                async move {
+                    let recorded = log
+                        .adopt_root(&input.session_id, &input.turn_id, &input.root)
+                        .await?;
+                    Ok::<AdoptRootOutput, Error>(AdoptRootOutput { recorded })
+                }
+            })
+            .description(
+                "Internal: add a newly created project root to the active Harness turn after a confirmed workspace proposal.",
             )
             .metadata(json!({ "internal": true, "trace_hidden": true })),
         );
@@ -1056,7 +1263,7 @@ pub fn register(iii: &IIIClient, config: &TurnsConfig) -> Arc<TurnLog> {
             ),
         );
     }
-    tracing::info!("registered shell::turns::list, shell::turns::get and the turn-history hooks");
+    tracing::info!("registered shell::turns::list, shell::turns::get, shell::turns::adopt-root and the turn-history hooks");
     log
 }
 
@@ -1395,5 +1602,38 @@ mod tests {
         })
         .await;
         assert!(!dir.path().join("turns").exists());
+    }
+
+    #[tokio::test]
+    async fn adopted_new_project_files_join_the_existing_turn() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("project");
+        let log = log_in(dir.path());
+        log.on_turn_started("session", "turn").await.unwrap();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::create_dir_all(root.join("test")).unwrap();
+        std::fs::write(root.join("package.json"), "{}\n").unwrap();
+        std::fs::write(root.join("src/index.js"), "export const value = 1\n").unwrap();
+        std::fs::write(root.join("test/index.test.js"), "// test\n").unwrap();
+        std::fs::create_dir_all(root.join("node_modules/pkg")).unwrap();
+        std::fs::write(root.join("node_modules/pkg/index.js"), "noise\n").unwrap();
+
+        let recorded = log
+            .adopt_root("session", "turn", root.to_str().unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(recorded, 3);
+        let record = log.load("session").await.unwrap();
+        let files = &record.turns[0].files;
+        assert_eq!(files.len(), 3);
+        assert!(files.iter().all(|file| file.kind == "created"));
+        assert!(files
+            .iter()
+            .all(|file| file.before.as_ref().is_some_and(|before| before.missing)));
+        assert!(files
+            .iter()
+            .all(|file| file.cause == "console::working-directory::propose"));
+        assert!(!files.iter().any(|file| file.path.contains("node_modules")));
     }
 }

--- a/shell/ui/src/page/ReviewScopePicker.tsx
+++ b/shell/ui/src/page/ReviewScopePicker.tsx
@@ -15,6 +15,7 @@ import { useEffect, useRef, useState } from 'react'
 
 export type ReviewScopeSelection =
   | { kind: 'last-turn' }
+  | { kind: 'session' }
   | { kind: 'uncommitted' }
   | { kind: 'unstaged' }
   | { kind: 'staged' }
@@ -40,12 +41,16 @@ export interface ReviewBranchChoice {
   current: boolean
 }
 
-export type ReviewScopeCounts = Partial<Record<'last-turn' | 'uncommitted' | 'unstaged' | 'staged', number>>
+export type ReviewScopeCounts = Partial<
+  Record<'last-turn' | 'session' | 'uncommitted' | 'unstaged' | 'staged', number>
+>
 
 export function reviewScopeLabel(scope: ReviewScopeSelection, currentTurn = false): string {
   switch (scope.kind) {
     case 'last-turn':
       return currentTurn ? 'Current Turn' : 'Last Turn'
+    case 'session':
+      return 'Session Changes'
     case 'uncommitted':
       return 'Uncommitted'
     case 'unstaged':
@@ -65,6 +70,8 @@ function scopeIcon(scope: ReviewScopeSelection) {
   switch (scope.kind) {
     case 'last-turn':
       return <History aria-hidden className="menu-icon" />
+    case 'session':
+      return <MessagesSquare aria-hidden className="menu-icon" />
     case 'uncommitted':
       return <FilePen aria-hidden className="menu-icon" />
     case 'unstaged':
@@ -172,7 +179,7 @@ export function ReviewScopePicker({
           {subMenu === null ? (
             <>
               <div className="shui-review-menu-label">Activity</div>
-              {([{ kind: 'last-turn' }] as const).map((scope) => (
+              {([{ kind: 'last-turn' }, { kind: 'session' }] as const).map((scope) => (
                 <div key={scope.kind}>
                   <button
                     type="button"

--- a/shell/ui/src/page/ReviewScopePicker.tsx
+++ b/shell/ui/src/page/ReviewScopePicker.tsx
@@ -40,10 +40,12 @@ export interface ReviewBranchChoice {
   current: boolean
 }
 
-export function reviewScopeLabel(scope: ReviewScopeSelection): string {
+export type ReviewScopeCounts = Partial<Record<'last-turn' | 'uncommitted' | 'unstaged' | 'staged', number>>
+
+export function reviewScopeLabel(scope: ReviewScopeSelection, currentTurn = false): string {
   switch (scope.kind) {
     case 'last-turn':
-      return 'Last Turn'
+      return currentTurn ? 'Current Turn' : 'Last Turn'
     case 'uncommitted':
       return 'Uncommitted'
     case 'unstaged':
@@ -91,6 +93,8 @@ export function ReviewScopePicker({
   commits,
   branches,
   turns = [],
+  counts = {},
+  currentTurn = false,
   metadataLoading,
   metadataError,
   onOpen,
@@ -101,13 +105,15 @@ export function ReviewScopePicker({
   branches: readonly ReviewBranchChoice[]
   /** Stored turns of the chat this page follows, newest first. */
   turns?: readonly ReviewTurnChoice[]
+  counts?: ReviewScopeCounts
+  currentTurn?: boolean
   metadataLoading: boolean
   metadataError: string | null
   onOpen: () => void
   onChange: (scope: ReviewScopeSelection) => void
 }) {
   const [open, setOpen] = useState(false)
-  const [subMenu, setSubMenu] = useState<'committed' | 'branch' | 'turns' | null>(null)
+  const [subMenu, setSubMenu] = useState<'commits' | 'branches' | 'turns' | null>(null)
   const wrapRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -137,12 +143,11 @@ export function ReviewScopePicker({
     setSubMenu(null)
   }
 
-  const primary: readonly ReviewScopeSelection[] = [
-    { kind: 'last-turn' },
+  const workingTreeScopes = [
     { kind: 'uncommitted' },
     { kind: 'unstaged' },
     { kind: 'staged' },
-  ]
+  ] as const satisfies readonly ReviewScopeSelection[]
 
   return (
     <div ref={wrapRef} className="shui-review-scope-wrap">
@@ -159,16 +164,16 @@ export function ReviewScopePicker({
         }}
       >
         {scopeIcon(value)}
-        <span>{reviewScopeLabel(value)}</span>
+        <span>{reviewScopeLabel(value, currentTurn)}</span>
         <ChevronDown aria-hidden />
       </button>
       {open ? (
         <div className="shui-review-scope-menu" role="menu">
           {subMenu === null ? (
             <>
-              {primary.map((scope, index) => (
+              <div className="shui-review-menu-label">Activity</div>
+              {([{ kind: 'last-turn' }] as const).map((scope) => (
                 <div key={scope.kind}>
-                  {index === 1 ? <div className="shui-review-menu-separator" /> : null}
                   <button
                     type="button"
                     role="menuitemradio"
@@ -176,12 +181,19 @@ export function ReviewScopePicker({
                     onClick={() => choose(scope)}
                   >
                     {scopeIcon(scope)}
-                    <span>{reviewScopeLabel(scope)}</span>
-                    {scopeMatches(value, scope) ? <Check aria-hidden /> : <span className="menu-icon-gap" />}
+                    <span className="scope-menu-main">
+                      <span>{reviewScopeLabel(scope, currentTurn)}</span>
+                      {counts[scope.kind] !== undefined ? (
+                        <>
+                          <small aria-hidden>{counts[scope.kind]}</small>
+                          <span className="shui-sr-only">{counts[scope.kind]} files</span>
+                        </>
+                      ) : null}
+                    </span>
+                    <span className="scope-selected">{scopeMatches(value, scope) ? <Check aria-hidden /> : null}</span>
                   </button>
                 </div>
               ))}
-              <div className="shui-review-menu-separator" />
               {turns.length > 0 ? (
                 <button type="button" role="menuitem" onClick={() => setSubMenu('turns')}>
                   <MessagesSquare aria-hidden className="menu-icon" />
@@ -189,14 +201,38 @@ export function ReviewScopePicker({
                   <ChevronRight aria-hidden />
                 </button>
               ) : null}
-              <button type="button" role="menuitem" onClick={() => setSubMenu('committed')}>
+              <div className="shui-review-menu-label">Working tree</div>
+              {workingTreeScopes.map((scope) => (
+                <div key={scope.kind}>
+                  <button
+                    type="button"
+                    role="menuitemradio"
+                    aria-checked={scopeMatches(value, scope)}
+                    onClick={() => choose(scope)}
+                  >
+                    {scopeIcon(scope)}
+                    <span className="scope-menu-main">
+                      <span>{reviewScopeLabel(scope)}</span>
+                      {counts[scope.kind] !== undefined ? (
+                        <>
+                          <small aria-hidden>{counts[scope.kind]}</small>
+                          <span className="shui-sr-only">{counts[scope.kind]} files</span>
+                        </>
+                      ) : null}
+                    </span>
+                    <span className="scope-selected">{scopeMatches(value, scope) ? <Check aria-hidden /> : null}</span>
+                  </button>
+                </div>
+              ))}
+              <div className="shui-review-menu-label">History</div>
+              <button type="button" role="menuitem" onClick={() => setSubMenu('commits')}>
                 <GitCommitHorizontal aria-hidden className="menu-icon" />
-                <span>Committed</span>
+                <span>Commits</span>
                 <ChevronRight aria-hidden />
               </button>
-              <button type="button" role="menuitem" onClick={() => setSubMenu('branch')}>
+              <button type="button" role="menuitem" onClick={() => setSubMenu('branches')}>
                 <GitBranch aria-hidden className="menu-icon" />
-                <span>Branch</span>
+                <span>Branches</span>
                 <ChevronRight aria-hidden />
               </button>
             </>
@@ -204,9 +240,7 @@ export function ReviewScopePicker({
             <>
               <button type="button" className="submenu-back" onClick={() => setSubMenu(null)}>
                 <ChevronLeft aria-hidden />
-                <span>
-                  {subMenu === 'committed' ? 'Committed' : subMenu === 'branch' ? 'Branch' : 'Turns'}
-                </span>
+                <span>{subMenu === 'commits' ? 'Commits' : subMenu === 'branches' ? 'Branches' : 'Turns'}</span>
               </button>
               <div className="shui-review-menu-separator" />
               {subMenu === 'turns'
@@ -218,12 +252,21 @@ export function ReviewScopePicker({
                       role="menuitemradio"
                       aria-checked={value.kind === 'turn' && value.turnId === turn.turnId}
                       title={turn.turnId}
-                      onClick={() => choose({ kind: 'turn', turnId: turn.turnId, label: turn.label })}
+                      onClick={() =>
+                        choose({
+                          kind: 'turn',
+                          turnId: turn.turnId,
+                          label: turn.label,
+                        })
+                      }
                     >
                       <MessagesSquare aria-hidden />
                       <span className="scope-detail-main">
                         <span>{turn.label}</span>
-                        <small>{turn.active ? 'running' : turn.turnId.slice(0, 10)}</small>
+                        <small>
+                          {turn.active ? 'running' : turn.turnId.slice(0, 10)} · {turn.fileCount}{' '}
+                          {turn.fileCount === 1 ? 'file' : 'files'}
+                        </small>
                       </span>
                       {value.kind === 'turn' && value.turnId === turn.turnId ? <Check aria-hidden /> : null}
                     </button>
@@ -233,13 +276,13 @@ export function ReviewScopePicker({
               {subMenu !== 'turns' && !metadataLoading && metadataError ? (
                 <div className="shui-review-scope-note warn">{metadataError}</div>
               ) : null}
-              {!metadataLoading && metadataError === null && subMenu === 'committed' && commits.length === 0 ? (
+              {!metadataLoading && metadataError === null && subMenu === 'commits' && commits.length === 0 ? (
                 <div className="shui-review-scope-note">no commits</div>
               ) : null}
-              {!metadataLoading && metadataError === null && subMenu === 'branch' && branches.length === 0 ? (
+              {!metadataLoading && metadataError === null && subMenu === 'branches' && branches.length === 0 ? (
                 <div className="shui-review-scope-note">no branches</div>
               ) : null}
-              {subMenu === 'committed'
+              {subMenu === 'commits'
                 ? commits.map((commit) => (
                     <button
                       key={commit.sha}
@@ -258,7 +301,9 @@ export function ReviewScopePicker({
                       {value.kind === 'commit' && value.sha === commit.sha ? <Check aria-hidden /> : null}
                     </button>
                   ))
-                : branches.map((branch) => (
+                : null}
+              {subMenu === 'branches'
+                ? branches.map((branch) => (
                     <button
                       key={branch.ref}
                       type="button"
@@ -266,7 +311,13 @@ export function ReviewScopePicker({
                       role="menuitemradio"
                       aria-checked={value.kind === 'branch' && value.ref === branch.ref}
                       title={branch.ref}
-                      onClick={() => choose({ kind: 'branch', ref: branch.ref, name: branch.name })}
+                      onClick={() =>
+                        choose({
+                          kind: 'branch',
+                          ref: branch.ref,
+                          name: branch.name,
+                        })
+                      }
                     >
                       <GitBranch aria-hidden />
                       <span className="scope-detail-main">
@@ -275,7 +326,8 @@ export function ReviewScopePicker({
                       </span>
                       {value.kind === 'branch' && value.ref === branch.ref ? <Check aria-hidden /> : null}
                     </button>
-                  ))}
+                  ))
+                : null}
             </>
           )}
         </div>

--- a/shell/ui/src/page/__tests__/review-scope.test.ts
+++ b/shell/ui/src/page/__tests__/review-scope.test.ts
@@ -5,6 +5,7 @@ import {
   isLiveGitReviewScope,
   isShellUiStatePath,
   shouldFallbackToTurnScope,
+  shouldEnterTurnScope,
   shouldFollowHarnessTurn,
 } from '../review-scope'
 
@@ -39,6 +40,14 @@ describe('review scope defaults', () => {
         subject: 'previous work',
       }),
     ).toBe(false)
+  })
+
+  it('waits for a relevant workspace change before entering Current Turn', () => {
+    expect(shouldEnterTurnScope(true, DEFAULT_REVIEW_SCOPE, 0)).toBe(false)
+    expect(shouldEnterTurnScope(true, DEFAULT_REVIEW_SCOPE, 1)).toBe(true)
+    expect(shouldEnterTurnScope(false, DEFAULT_REVIEW_SCOPE, 1)).toBe(false)
+    expect(shouldEnterTurnScope(false, { kind: 'last-turn' }, 0)).toBe(false)
+    expect(shouldEnterTurnScope(false, { kind: 'last-turn' }, 1)).toBe(true)
   })
 
   it('ignores Shell UI persistence events that would refresh the active diff again', () => {

--- a/shell/ui/src/page/__tests__/review-scope.test.ts
+++ b/shell/ui/src/page/__tests__/review-scope.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_REVIEW_SCOPE,
+  EMPTY_TURN_FALLBACK_MS,
+  isLiveGitReviewScope,
+  isShellUiStatePath,
+  shouldFallbackToTurnScope,
+  shouldFollowHarnessTurn,
+} from '../review-scope'
+
+describe('review scope defaults', () => {
+  it('opens cumulative uncommitted changes by default', () => {
+    expect(DEFAULT_REVIEW_SCOPE).toEqual({ kind: 'uncommitted' })
+  })
+
+  it('refreshes live Git scopes without replacing historical selections', () => {
+    expect(isLiveGitReviewScope({ kind: 'uncommitted' })).toBe(true)
+    expect(isLiveGitReviewScope({ kind: 'unstaged' })).toBe(true)
+    expect(isLiveGitReviewScope({ kind: 'staged' })).toBe(true)
+    expect(isLiveGitReviewScope({ kind: 'last-turn' })).toBe(false)
+    expect(isLiveGitReviewScope({ kind: 'turn', turnId: 't1', label: 'Turn 1' })).toBe(false)
+    expect(
+      isLiveGitReviewScope({
+        kind: 'commit',
+        sha: 'abc123',
+        subject: 'previous work',
+      }),
+    ).toBe(false)
+  })
+
+  it('follows a new Harness turn until the user selects another scope', () => {
+    expect(shouldFollowHarnessTurn(true, DEFAULT_REVIEW_SCOPE)).toBe(true)
+    expect(shouldFollowHarnessTurn(false, DEFAULT_REVIEW_SCOPE)).toBe(false)
+    expect(shouldFollowHarnessTurn(false, { kind: 'last-turn' })).toBe(true)
+    expect(
+      shouldFollowHarnessTurn(false, {
+        kind: 'commit',
+        sha: 'abc123',
+        subject: 'previous work',
+      }),
+    ).toBe(false)
+  })
+
+  it('ignores Shell UI persistence events that would refresh the active diff again', () => {
+    expect(isShellUiStatePath('config/shell-ui.yaml')).toBe(true)
+    expect(isShellUiStatePath('config/shell-ui.yaml.tmp')).toBe(true)
+    expect(isShellUiStatePath('project/config/shell-ui.yaml')).toBe(true)
+    expect(isShellUiStatePath('project\\config\\shell-ui.yaml.tmp')).toBe(true)
+    expect(isShellUiStatePath('docs/shell-ui.yaml')).toBe(false)
+    expect(isShellUiStatePath('src/app.ts')).toBe(false)
+  })
+
+  it('uses turn entries when a live Git scope is opened outside a repository', () => {
+    expect(shouldFallbackToTurnScope(DEFAULT_REVIEW_SCOPE, 'not-a-repo')).toBe(true)
+    expect(shouldFallbackToTurnScope({ kind: 'staged' }, 'ready')).toBe(false)
+    expect(shouldFallbackToTurnScope({ kind: 'last-turn' }, 'not-a-repo')).toBe(false)
+  })
+
+  it('leaves enough time for the final workspace event batch before empty fallback', () => {
+    expect(EMPTY_TURN_FALLBACK_MS).toBeGreaterThan(650)
+  })
+})

--- a/shell/ui/src/page/__tests__/review.test.ts
+++ b/shell/ui/src/page/__tests__/review.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import type { GitChange } from '../git'
 import {
+  canUseGitMetadataForLiveEntry,
   diffForReviewEntry,
   mergeGitReviewEntries,
   mergeReviewEntry,
+  reviewContentsRepresentChange,
   type ReviewEntry,
   statusForLiveKind,
 } from '../review'
@@ -17,6 +19,61 @@ describe('statusForLiveKind', () => {
 })
 
 describe('review entries', () => {
+  it('does not invent an empty baseline from Git during turn catch-up', () => {
+    expect(canUseGitMetadataForLiveEntry(false, false, undefined)).toBe(false)
+    expect(canUseGitMetadataForLiveEntry(true, true, undefined)).toBe(false)
+    expect(canUseGitMetadataForLiveEntry(true, false, undefined)).toBe(true)
+    expect(canUseGitMetadataForLiveEntry(false, false, '')).toBe(true)
+  })
+
+  it('does not promote an observed path without a usable baseline', () => {
+    const entry: ReviewEntry = {
+      path: 'config/console.yaml',
+      change: {
+        path: 'config/console.yaml',
+        status: 'modified',
+        staged: false,
+      },
+      baseline: null,
+    }
+
+    expect(
+      reviewContentsRepresentChange(entry, {
+        oldContents: '',
+        newContents: '',
+        noBaseline: true,
+      }),
+    ).toBe(false)
+    expect(
+      reviewContentsRepresentChange(entry, {
+        oldContents: 'same\n',
+        newContents: 'same\n',
+      }),
+    ).toBe(false)
+    expect(
+      reviewContentsRepresentChange(entry, {
+        oldContents: 'before\n',
+        newContents: 'after\n',
+      }),
+    ).toBe(true)
+  })
+
+  it('keeps structural changes even when both text sides are empty', () => {
+    for (const status of ['untracked', 'deleted', 'renamed'] as const) {
+      const entry: ReviewEntry = {
+        path: 'empty.txt',
+        change: { path: 'empty.txt', status, staged: false },
+        baseline: '',
+      }
+      expect(
+        reviewContentsRepresentChange(entry, {
+          oldContents: '',
+          newContents: '',
+        }),
+      ).toBe(true)
+    }
+  })
+
   it('preserves the first baseline across repeated writes', () => {
     const first = mergeReviewEntry(new Map(), 'src/app.ts', 'modified', 'before')
     const second = mergeReviewEntry(first, 'src/app.ts', 'modified', 'after first write')

--- a/shell/ui/src/page/__tests__/turns.test.ts
+++ b/shell/ui/src/page/__tests__/turns.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import {
   baselineFor,
+  reviewEntriesFromSession,
   relativeToRoot,
   reviewEntriesFromTurn,
+  summarizeSessionActivity,
   type SessionTurn,
+  type SessionTurnSummary,
   turnLabel,
 } from '../turns'
 
@@ -143,5 +146,147 @@ describe('turnLabel', () => {
     expect(turnLabel({ started_at: Date.UTC(2026, 7, 20, 12, 0), file_count: 1 })).toMatch(/1 file$/)
     expect(turnLabel({ started_at: Date.UTC(2026, 7, 20, 12, 0), file_count: 3 })).toMatch(/3 files$/)
     expect(turnLabel({ started_at: Number.NaN, file_count: 0 })).toBe('turn · 0 files')
+  })
+})
+
+describe('reviewEntriesFromSession', () => {
+  it('keeps the earliest baseline and latest state for each path', () => {
+    const turns: SessionTurn[] = [
+      {
+        turn_id: 'newer',
+        started_at: 20,
+        ended_at: 21,
+        files: [
+          {
+            path: '/r/src/a.ts',
+            kind: 'modified',
+            cause: 'shell::fs::write',
+            first_seen: 20,
+            last_seen: 20,
+            before: { content: 'middle\n' },
+          },
+          {
+            path: '/r/src/new.ts',
+            kind: 'modified',
+            cause: 'shell::fs::write',
+            first_seen: 20,
+            last_seen: 20,
+            before: { content: 'created\n' },
+          },
+        ],
+      },
+      {
+        turn_id: 'older',
+        started_at: 10,
+        ended_at: 11,
+        files: [
+          {
+            path: '/r/src/a.ts',
+            kind: 'modified',
+            cause: 'shell::fs::write',
+            first_seen: 10,
+            last_seen: 10,
+            before: { content: 'original\n' },
+          },
+          {
+            path: '/r/src/new.ts',
+            kind: 'created',
+            cause: 'coder::create-file',
+            first_seen: 10,
+            last_seen: 10,
+            before: { missing: true },
+          },
+        ],
+      },
+    ]
+
+    const { entries } = reviewEntriesFromSession(turns, '/r')
+    expect(entries.get('src/a.ts')).toMatchObject({
+      change: { status: 'modified' },
+      baseline: 'original\n',
+    })
+    expect(entries.get('src/new.ts')).toMatchObject({
+      change: { status: 'added' },
+      baseline: '',
+    })
+  })
+
+  it('drops a file created and deleted during the session', () => {
+    const turns: SessionTurn[] = [
+      {
+        turn_id: 'delete',
+        started_at: 20,
+        files: [
+          {
+            path: '/r/transient.txt',
+            kind: 'deleted',
+            cause: 'shell::fs::rm',
+            first_seen: 20,
+            last_seen: 20,
+          },
+        ],
+      },
+      {
+        turn_id: 'create',
+        started_at: 10,
+        files: [
+          {
+            path: '/r/transient.txt',
+            kind: 'created',
+            cause: 'shell::fs::write',
+            first_seen: 10,
+            last_seen: 10,
+            before: { missing: true },
+          },
+        ],
+      },
+    ]
+    expect(reviewEntriesFromSession(turns, '/r').entries.size).toBe(0)
+  })
+})
+
+describe('summarizeSessionActivity', () => {
+  const summaries: SessionTurnSummary[] = [
+    {
+      turn_id: 't2',
+      started_at: 20,
+      file_count: 2,
+      files: [
+        { path: '/tmp/workers-vscode/vscode/package.json', kind: 'modified' },
+        { path: '/tmp/workers-vscode/vscode/src/index.ts', kind: 'created' },
+      ],
+    },
+    {
+      turn_id: 't1',
+      started_at: 10,
+      file_count: 2,
+      files: [
+        { path: '/tmp/workers-vscode/vscode/package.json', kind: 'created' },
+        { path: '/chat/config/console.yaml', kind: 'modified' },
+      ],
+    },
+  ]
+
+  it('deduplicates session paths and suggests their shared outside folder', () => {
+    expect(summarizeSessionActivity(summaries, '/chat')).toEqual({
+      inside: 1,
+      outside: 2,
+      outsideRoot: '/tmp/workers-vscode/vscode',
+    })
+  })
+
+  it('does not suggest a filesystem-wide ancestor for unrelated activity', () => {
+    const unrelated: SessionTurnSummary[] = [
+      {
+        turn_id: 't',
+        started_at: 1,
+        file_count: 2,
+        files: [
+          { path: '/tmp/a.txt', kind: 'created' },
+          { path: '/Users/me/b.txt', kind: 'created' },
+        ],
+      },
+    ]
+    expect(summarizeSessionActivity(unrelated, '/chat').outsideRoot).toBeNull()
   })
 })

--- a/shell/ui/src/page/__tests__/turns.test.ts
+++ b/shell/ui/src/page/__tests__/turns.test.ts
@@ -139,6 +139,45 @@ describe('reviewEntriesFromTurn', () => {
       baseline: null,
     })
   })
+
+  it('drops durable rows whose before and after revisions are identical', () => {
+    const unchanged: SessionTurn = {
+      turn_id: 'unchanged',
+      started_at: 1,
+      files: [
+        {
+          path: '/r/config/console.yaml',
+          kind: 'modified',
+          cause: 'shell::fs::write',
+          first_seen: 1,
+          last_seen: 2,
+          before: { revision: 'sha256:same', content: 'same\n' },
+          after_revision: 'sha256:same',
+        },
+      ],
+    }
+
+    expect(reviewEntriesFromTurn(unchanged, '/r').entries.size).toBe(0)
+  })
+
+  it('drops a file created and deleted within one turn', () => {
+    const transient: SessionTurn = {
+      turn_id: 'transient',
+      started_at: 1,
+      files: [
+        {
+          path: '/r/transient.txt',
+          kind: 'deleted',
+          cause: 'shell::fs::rm',
+          first_seen: 1,
+          last_seen: 2,
+          before: { missing: true },
+        },
+      ],
+    }
+
+    expect(reviewEntriesFromTurn(transient, '/r').entries.size).toBe(0)
+  })
 })
 
 describe('turnLabel', () => {

--- a/shell/ui/src/page/index.tsx
+++ b/shell/ui/src/page/index.tsx
@@ -11,6 +11,7 @@
  */
 
 import {
+  Button,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -21,6 +22,7 @@ import {
   PageBody,
   PageHeader,
   PageMain,
+  Panel,
   type PageRenderProps,
   PageShell,
   PageSidebar,
@@ -29,6 +31,7 @@ import {
 import type { GitStatusEntry } from '@pierre/trees'
 import {
   Check,
+  CircleAlert,
   ChevronsDownUp,
   ChevronsUpDown,
   ClipboardCopy,
@@ -36,9 +39,12 @@ import {
   EyeOff,
   FileSearch,
   FileStack,
+  FolderOpen,
+  FolderSymlink,
   FolderTree,
   Image,
   MoreHorizontal,
+  MessageSquare,
   PanelLeft,
   PanelRight,
   RefreshCw,
@@ -3244,69 +3250,114 @@ export function ShellExplorerPage({
 
           <PageMain>
             {workingDirError ? (
-              <div className="shui-review-message warn" role="alert">
-                <span>{workingDirError}</span>
-                <button
-                  type="button"
-                  className="shui-review-inline-action"
-                  onClick={() => {
-                    const next = workingDirRef.current
-                    if (next === null) return
-                    if (workingDirRetryTimerRef.current !== null) {
-                      window.clearTimeout(workingDirRetryTimerRef.current)
-                      workingDirRetryTimerRef.current = null
-                    }
-                    workingDirRetryRef.current = { path: next, failures: 0 }
-                    setWorkingDirError(null)
-                    setWorkingDirRetryEpoch((epoch) => epoch + 1)
-                  }}
-                >
-                  retry
-                </button>
-              </div>
+              <Panel className="shui-review-notice warn" role="alert">
+                <span className="shui-review-notice-icon" aria-hidden="true">
+                  <CircleAlert />
+                </span>
+                <span className="shui-review-notice-copy">
+                  <span className="shui-review-notice-title">
+                    Working directory unavailable
+                  </span>
+                  <span className="shui-review-notice-detail">
+                    {workingDirError}
+                  </span>
+                </span>
+                <span className="shui-review-notice-actions">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => {
+                      const next = workingDirRef.current
+                      if (next === null) return
+                      if (workingDirRetryTimerRef.current !== null) {
+                        window.clearTimeout(workingDirRetryTimerRef.current)
+                        workingDirRetryTimerRef.current = null
+                      }
+                      workingDirRetryRef.current = { path: next, failures: 0 }
+                      setWorkingDirError(null)
+                      setWorkingDirRetryEpoch((epoch) => epoch + 1)
+                    }}
+                  >
+                    <RefreshCw aria-hidden="true" />
+                    Retry
+                  </Button>
+                </span>
+              </Panel>
             ) : null}
             {pendingOpenError ? (
-              <div className="shui-review-message warn" role="alert">
-                <span>{pendingOpenError}</span>
-                <button
-                  type="button"
-                  className="shui-review-inline-action"
-                  onClick={() => {
-                    pendingOpenRetryRef.current = 0
-                    pendingOpenWaitingForRetryRef.current = false
-                    setPendingOpenError(null)
-                    setOpenBump((bump) => bump + 1)
-                  }}
-                >
-                  retry
-                </button>
-              </div>
+              <Panel className="shui-review-notice warn" role="alert">
+                <span className="shui-review-notice-icon" aria-hidden="true">
+                  <CircleAlert />
+                </span>
+                <span className="shui-review-notice-copy">
+                  <span className="shui-review-notice-title">
+                    File could not be opened
+                  </span>
+                  <span className="shui-review-notice-detail">
+                    {pendingOpenError}
+                  </span>
+                </span>
+                <span className="shui-review-notice-actions">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => {
+                      pendingOpenRetryRef.current = 0
+                      pendingOpenWaitingForRetryRef.current = false
+                      setPendingOpenError(null)
+                      setOpenBump((bump) => bump + 1)
+                    }}
+                  >
+                    <RefreshCw aria-hidden="true" />
+                    Retry
+                  </Button>
+                </span>
+              </Panel>
             ) : null}
             {sessionActivity.outside > 0 ? (
-              <div className="shui-review-message" role="status">
-                <span>
-                  {sessionActivity.outside}{' '}
-                  {sessionActivity.outside === 1 ? 'file changed' : 'files changed'}
-                  {' '}outside this folder
-                  {sessionActivity.outsideRoot
-                    ? ` in ${sessionActivity.outsideRoot}`
-                    : ''}
+              <Panel
+                className="shui-review-notice"
+                role="status"
+                aria-label={`${sessionActivity.outside} ${sessionActivity.outside === 1 ? 'change' : 'changes'} outside this folder`}
+              >
+                <span className="shui-review-notice-icon" aria-hidden="true">
+                  <FolderSymlink />
+                </span>
+                <span className="shui-review-notice-copy">
+                  <span className="shui-review-notice-title">
+                    {sessionActivity.outside}{' '}
+                    {sessionActivity.outside === 1 ? 'change' : 'changes'} outside
+                    this folder
+                  </span>
+                  {sessionActivity.outsideRoot ? (
+                    <span
+                      className="shui-review-notice-detail"
+                      title={sessionActivity.outsideRoot}
+                    >
+                      {sessionActivity.outsideRoot}
+                    </span>
+                  ) : null}
                 </span>
                 {sessionActivity.outsideRoot ? (
-                  <>
-                    <button
+                  <span className="shui-review-notice-actions">
+                    <Button
                       type="button"
-                      className="shui-review-inline-action"
+                      variant="ghost"
+                      size="sm"
                       onClick={() =>
                         changeManualRoot(sessionActivity.outsideRoot!)
                       }
                     >
-                      open in Shell
-                    </button>
+                      <FolderOpen aria-hidden="true" />
+                      Open in Shell
+                    </Button>
                     {canUseSessionOutsideForChat ? (
-                      <button
+                      <Button
                         type="button"
-                        className="shui-review-inline-action"
+                        variant="primary"
+                        size="sm"
                         onClick={() =>
                           (host as WorkingDirectoryHost).chat?.requestWorkingDirectoryChange?.(
                             {
@@ -3316,12 +3367,13 @@ export function ShellExplorerPage({
                           )
                         }
                       >
-                        use for chat
-                      </button>
+                        <MessageSquare aria-hidden="true" />
+                        Use for chat
+                      </Button>
                     ) : null}
-                  </>
+                  </span>
                 ) : null}
-              </div>
+              </Panel>
             ) : null}
             {!(terminalOpen && terminalDock === 'editor' && terminalActive) ? (
               <div className="shui-review-toolbar">

--- a/shell/ui/src/page/index.tsx
+++ b/shell/ui/src/page/index.tsx
@@ -142,8 +142,9 @@ import {
   isLiveGitReviewScope,
   isShellUiStatePath,
   LAST_TURN_SCOPE,
+  SESSION_SCOPE,
   shouldFallbackToTurnScope,
-  shouldFollowHarnessTurn,
+  shouldEnterTurnScope,
 } from './review-scope'
 import { useShellReviewSummaryBridge } from './review-summary-store'
 import { changedParentDirs, withReviewChanges } from './review-tree'
@@ -178,8 +179,13 @@ import {
 import {
   fetchSessionTurn,
   fetchSessionTurns,
+  relativeToRoot,
+  reviewEntriesFromSession,
   reviewEntriesFromTurn,
+  summarizeSessionActivity,
+  type SessionTurn,
   type SessionTurnSummary,
+  type TurnEntries,
   turnLabel,
 } from './turns'
 import { WorkspaceBrowser } from './WorkspaceBrowser'
@@ -218,6 +224,15 @@ interface ReviewEditBackup {
 }
 
 type RootChangeOutcome = RootTargetValidation['outcome'] | 'declined'
+
+type WorkingDirectoryHost = Host & {
+  chat?: {
+    requestWorkingDirectoryChange?(request: {
+      sessionId: string
+      path: string
+    }): boolean
+  }
+}
 
 function ReviewOption({
   label,
@@ -512,6 +527,7 @@ export function ShellExplorerPage({
   const copyApplyCommand = async () => {
     if (
       reviewScope.kind === 'last-turn' ||
+      reviewScope.kind === 'session' ||
       reviewScope.kind === 'turn' ||
       copyingPatch ||
       root === null
@@ -554,6 +570,8 @@ export function ShellExplorerPage({
     readonly SessionTurnSummary[]
   >([])
   const [turnOutside, setTurnOutside] = useState(0)
+  const [turnOutsideRoot, setTurnOutsideRoot] = useState<string | null>(null)
+  const sessionTurnsSeqRef = useRef(0)
   const [scopeMetadataLoading, setScopeMetadataLoading] = useState(false)
   const [scopeMetadataError, setScopeMetadataError] = useState<string | null>(
     null,
@@ -763,18 +781,14 @@ export function ShellExplorerPage({
       setReviewSummary([])
       setScopeMetadataLoading(false)
       setScopeMetadataError(null)
-      if (
-        shouldFollowHarnessTurn(
-          followHarnessTurnsRef.current,
-          reviewScopeRef.current,
-        )
-      ) {
+      setTurnOutside(0)
+      setTurnOutsideRoot(null)
+      if (reviewScopeRef.current.kind === 'last-turn') {
         setDiff(null)
-        forceReviewScope(LAST_TURN_SCOPE)
       }
       return true
     },
-    [forceReviewScope, reviewSaveBarrier],
+    [reviewSaveBarrier],
   )
 
   // This runs inside Harness's awaited pre-turn hook: the snapshot is fully
@@ -1092,6 +1106,17 @@ export function ShellExplorerPage({
     reviewScope.kind === 'last-turn' &&
     observedReview.active &&
     reviewEntries.size === 0
+  const sessionActivity = useMemo(
+    () =>
+      root === null
+        ? { inside: 0, outside: 0, outsideRoot: null }
+        : summarizeSessionActivity(sessionTurns, root),
+    [root, sessionTurns],
+  )
+  const canUseSessionOutsideForChat =
+    !!conversationId &&
+    typeof (host as WorkingDirectoryHost).chat?.requestWorkingDirectoryChange ===
+      'function'
 
   // The panel, not the viewport, decides what fits: a shell page shares the
   // console with other panels. Below the same width the stylesheet treats as
@@ -1140,6 +1165,7 @@ export function ShellExplorerPage({
     const next: ReviewScopeCounts = {
       ...scopeCounts,
       'last-turn': reviewEntries.size,
+      session: sessionActivity.inside,
     }
     if (isLiveGitReviewScope(reviewScope)) {
       if (scopeLoading || scopeError !== null) delete next[reviewScope.kind]
@@ -1150,6 +1176,7 @@ export function ShellExplorerPage({
     orderedReviewEntries.length,
     reviewEntries.size,
     reviewScope,
+    sessionActivity.inside,
     scopeCounts,
     scopeError,
     scopeLoading,
@@ -1302,18 +1329,111 @@ export function ShellExplorerPage({
     [reviewSaveBarrier],
   )
 
+  useEffect(() => {
+    if (
+      !conversationId ||
+      root === null ||
+      observedReview.turnId === null ||
+      observedReview.active ||
+      observedReview.completedAtMs === null
+    ) {
+      return
+    }
+    let cancelled = false
+    const completedTurnId = observedReview.turnId
+    const completedRoot = root
+    void fetchSessionTurn(host, conversationId, completedTurnId)
+      .then((turn) => {
+        if (
+          cancelled ||
+          turn === null ||
+          rootRef.current !== completedRoot ||
+          reviewWindowRef.current.turnId !== completedTurnId
+        ) {
+          return
+        }
+        const mapped = reviewEntriesFromTurn(turn, completedRoot)
+        setTurnOutside(mapped.outside)
+        setTurnOutsideRoot(mapped.outsideRoot)
+
+        const merged = new Map(reviewEntriesRef.current)
+        for (const [path, stored] of mapped.entries) {
+          const live = merged.get(path)
+          merged.set(path, {
+            ...stored,
+            ...(live ?? {}),
+            baseline:
+              live?.baseline === undefined || live.baseline === null
+                ? stored.baseline
+                : live.baseline,
+          })
+        }
+        reviewEntriesRef.current = merged
+        setReviewEntries(merged)
+
+        const scope = reviewScopeRef.current
+        if (
+          !shouldEnterTurnScope(
+            followHarnessTurnsRef.current,
+            scope,
+            merged.size,
+          )
+        ) {
+          return
+        }
+        forceReviewScope(LAST_TURN_SCOPE)
+        const activePath = diffRef.current?.change.path
+        const entry =
+          (activePath ? merged.get(activePath) : undefined) ??
+          merged.values().next().value
+        if (entry) openReviewEntry(entry)
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [
+    conversationId,
+    forceReviewScope,
+    host,
+    observedReview.active,
+    observedReview.completedAtMs,
+    observedReview.turnId,
+    openReviewEntry,
+    root,
+  ])
+
+  const refreshSessionTurns = useCallback(() => {
+    if (!conversationId) {
+      setSessionTurns([])
+      return
+    }
+    const seq = ++sessionTurnsSeqRef.current
+    void fetchSessionTurns(host, conversationId)
+      .then((turns) => {
+        if (sessionTurnsSeqRef.current === seq) setSessionTurns(turns)
+      })
+      .catch(() => {})
+  }, [conversationId, host])
+
+  useEffect(() => {
+    refreshSessionTurns()
+    if (!observedReview.active) return
+    const timer = window.setInterval(refreshSessionTurns, 1_500)
+    return () => window.clearInterval(timer)
+  }, [
+    observedReview.active,
+    observedReview.completedAtMs,
+    observedReview.turnId,
+    refreshSessionTurns,
+  ])
+
   const loadScopeMetadata = useCallback(() => {
     if (root === null) return
     const seq = ++scopeMetadataSeqRef.current
     setScopeMetadataLoading(true)
     setScopeMetadataError(null)
-    if (conversationId) {
-      void fetchSessionTurns(host, conversationId)
-        .then((turns) => {
-          if (scopeMetadataSeqRef.current === seq) setSessionTurns(turns)
-        })
-        .catch(() => {})
-    }
+    refreshSessionTurns()
     void Promise.all([
       gitRecentCommits(host, root),
       gitRefs(host, root),
@@ -1351,7 +1471,7 @@ export function ShellExplorerPage({
       .finally(() => {
         if (scopeMetadataSeqRef.current === seq) setScopeMetadataLoading(false)
       })
-  }, [host, root, conversationId])
+  }, [host, refreshSessionTurns, root])
 
   const loadReviewScope = useCallback(
     (
@@ -1363,6 +1483,77 @@ export function ShellExplorerPage({
       setScopeLoading(true)
       setScopeError(null)
       setTurnOutside(0)
+      setTurnOutsideRoot(null)
+      const applyMapped = (mapped: TurnEntries) => {
+        if (scopeLoadSeqRef.current !== seq || rootRef.current !== root)
+          return
+        scopeEntriesRef.current = mapped.entries
+        setScopeEntries(mapped.entries)
+        setTurnOutside(mapped.outside)
+        setTurnOutsideRoot(mapped.outsideRoot)
+        const activePath = diffRef.current?.change.path
+        const entry =
+          (preferredPath
+            ? mapped.entries.get(preferredPath)
+            : undefined) ??
+          (activePath ? mapped.entries.get(activePath) : undefined) ??
+          (preferredPath === undefined
+            ? mapped.entries.values().next().value
+            : undefined)
+        if (entry) openReviewEntry(entry)
+        else {
+          diffRequestRef.current += 1
+          setDiff(null)
+        }
+      }
+      if (scope.kind === 'session') {
+        if (!conversationId) {
+          setScopeLoading(false)
+          setScopeError('no chat session')
+          return
+        }
+        void fetchSessionTurns(host, conversationId)
+          .then(async (summaries) => {
+            if (scopeLoadSeqRef.current !== seq || rootRef.current !== root)
+              return null
+            setSessionTurns(summaries)
+            const relevant = summaries.filter((turn) =>
+              turn.files.some(
+                (file) => relativeToRoot(file.path, root) !== null,
+              ),
+            )
+            const turns = (
+              await Promise.all(
+                relevant.map((turn) =>
+                  fetchSessionTurn(host, conversationId, turn.turn_id),
+                ),
+              )
+            ).filter((turn): turn is SessionTurn => turn !== null)
+            const mapped = reviewEntriesFromSession(turns, root)
+            const activity = summarizeSessionActivity(summaries, root)
+            return {
+              entries: mapped.entries,
+              outside: activity.outside,
+              outsideRoot: activity.outsideRoot,
+            } satisfies TurnEntries
+          })
+          .then((mapped) => {
+            if (mapped) applyMapped(mapped)
+          })
+          .catch((error: unknown) => {
+            if (scopeLoadSeqRef.current !== seq || rootRef.current !== root)
+              return
+            scopeEntriesRef.current = new Map()
+            setScopeEntries(new Map())
+            setScopeError(errorMessage(error))
+            diffRequestRef.current += 1
+            setDiff(null)
+          })
+          .finally(() => {
+            if (scopeLoadSeqRef.current === seq) setScopeLoading(false)
+          })
+        return
+      }
       if (scope.kind === 'turn') {
         if (!conversationId) {
           setScopeLoading(false)
@@ -1373,26 +1564,11 @@ export function ShellExplorerPage({
           .then((turn) => {
             if (scopeLoadSeqRef.current !== seq || rootRef.current !== root)
               return
-            const mapped = turn
-              ? reviewEntriesFromTurn(turn, root)
-              : { entries: new Map(), outside: 0 }
-            scopeEntriesRef.current = mapped.entries
-            setScopeEntries(mapped.entries)
-            setTurnOutside(mapped.outside)
-            const activePath = diffRef.current?.change.path
-            const entry =
-              (preferredPath
-                ? mapped.entries.get(preferredPath)
-                : undefined) ??
-              (activePath ? mapped.entries.get(activePath) : undefined) ??
-              (preferredPath === undefined
-                ? mapped.entries.values().next().value
-                : undefined)
-            if (entry) openReviewEntry(entry)
-            else {
-              diffRequestRef.current += 1
-              setDiff(null)
-            }
+            applyMapped(
+              turn
+                ? reviewEntriesFromTurn(turn, root)
+                : { entries: new Map(), outside: 0, outsideRoot: null },
+            )
           })
           .catch((error: unknown) => {
             if (scopeLoadSeqRef.current !== seq || rootRef.current !== root)
@@ -1423,6 +1599,10 @@ export function ShellExplorerPage({
           if (state.kind !== 'ready') {
             if (shouldFallbackToTurnScope(scope, state.kind)) {
               followHarnessTurnsRef.current = true
+              if (conversationId) {
+                forceReviewScope(SESSION_SCOPE)
+                return
+              }
               forceReviewScope(LAST_TURN_SCOPE)
               const activePath = diffRef.current?.change.path
               const entry =
@@ -1852,6 +2032,21 @@ export function ShellExplorerPage({
           setReviewEntries(enriched)
 
           const activeScope = reviewScopeRef.current
+          if (
+            activeScope.kind !== 'last-turn' &&
+            shouldEnterTurnScope(
+              followHarnessTurnsRef.current,
+              activeScope,
+              enriched.size,
+            )
+          ) {
+            forceReviewScope(LAST_TURN_SCOPE)
+            const entry =
+              (follow ? enriched.get(follow.rel) : undefined) ??
+              enriched.values().next().value
+            if (entry) openReviewEntry(entry)
+            return
+          }
           if (isLiveGitReviewScope(activeScope)) {
             loadReviewScope(activeScope, follow?.rel ?? null)
             return
@@ -2117,6 +2312,8 @@ export function ShellExplorerPage({
         setScopeCommits([])
         setScopeRefs([])
         setScopeCounts({})
+        setTurnOutside(0)
+        setTurnOutsideRoot(null)
         setScopeMetadataLoading(false)
         setScopeMetadataError(null)
         followHarnessTurnsRef.current = true
@@ -3014,6 +3211,47 @@ export function ShellExplorerPage({
                 </button>
               </div>
             ) : null}
+            {sessionActivity.outside > 0 ? (
+              <div className="shui-review-message" role="status">
+                <span>
+                  {sessionActivity.outside}{' '}
+                  {sessionActivity.outside === 1 ? 'file changed' : 'files changed'}
+                  {' '}outside this folder
+                  {sessionActivity.outsideRoot
+                    ? ` in ${sessionActivity.outsideRoot}`
+                    : ''}
+                </span>
+                {sessionActivity.outsideRoot ? (
+                  <>
+                    <button
+                      type="button"
+                      className="shui-review-inline-action"
+                      onClick={() =>
+                        changeManualRoot(sessionActivity.outsideRoot!)
+                      }
+                    >
+                      open in Shell
+                    </button>
+                    {canUseSessionOutsideForChat ? (
+                      <button
+                        type="button"
+                        className="shui-review-inline-action"
+                        onClick={() =>
+                          (host as WorkingDirectoryHost).chat?.requestWorkingDirectoryChange?.(
+                            {
+                              sessionId: conversationId!,
+                              path: sessionActivity.outsideRoot!,
+                            },
+                          )
+                        }
+                      >
+                        use for chat
+                      </button>
+                    ) : null}
+                  </>
+                ) : null}
+              </div>
+            ) : null}
             {!(terminalOpen && terminalDock === 'editor' && terminalActive) ? (
               <div className="shui-review-toolbar">
                 {reviewSavePending ? (
@@ -3060,10 +3298,13 @@ export function ShellExplorerPage({
                     unavailable
                   </span>
                 ) : null}
-                {reviewScope.kind === 'turn' && turnOutside > 0 ? (
+                {(reviewScope.kind === 'last-turn' ||
+                  reviewScope.kind === 'session' ||
+                  reviewScope.kind === 'turn') &&
+                turnOutside > 0 ? (
                   <span
                     className="shui-review-count"
-                    title="files this turn changed outside the folder you are browsing"
+                    title={`files changed outside the folder you are browsing${turnOutsideRoot ? ` in ${turnOutsideRoot}` : ''}`}
                   >
                     +{turnOutside} outside
                   </span>
@@ -3174,6 +3415,7 @@ export function ShellExplorerPage({
                     <ReviewMenuAction
                       label={
                         reviewScope.kind === 'last-turn' ||
+                        reviewScope.kind === 'session' ||
                         reviewScope.kind === 'turn'
                           ? 'Copy git apply command (git scopes only)'
                           : 'Copy git apply command'
@@ -3181,6 +3423,7 @@ export function ShellExplorerPage({
                       icon={<ClipboardCopy />}
                       disabled={
                         reviewScope.kind === 'last-turn' ||
+                        reviewScope.kind === 'session' ||
                         reviewScope.kind === 'turn' ||
                         copyingPatch
                       }

--- a/shell/ui/src/page/index.tsx
+++ b/shell/ui/src/page/index.tsx
@@ -121,6 +121,7 @@ import {
   type ReviewEditDraft,
   type ReviewFileSummary,
   type ReviewOptions,
+  loadReviewContents,
   ReviewPane,
   runReviewTransition,
 } from './ReviewPane'
@@ -131,9 +132,11 @@ import {
   reviewScopeLabel,
 } from './ReviewScopePicker'
 import {
+  canUseGitMetadataForLiveEntry,
   diffForReviewEntry,
   mergeGitReviewEntries,
   mergeReviewEntry,
+  reviewContentsRepresentChange,
   type ReviewEntry,
 } from './review'
 import {
@@ -348,6 +351,29 @@ function reviewEntriesFromGit(
       ] as const
     }),
   )
+}
+
+async function withoutUnreviewableBaselines(
+  host: Host,
+  root: string,
+  entries: ReadonlyMap<string, ReviewEntry>,
+  paths?: ReadonlySet<string>,
+): Promise<ReadonlyMap<string, ReviewEntry>> {
+  const next = new Map(entries)
+  const candidates = [...entries].filter(
+    ([path, entry]) => entry.baseline === null && (!paths || paths.has(path)),
+  )
+  await Promise.all(
+    candidates.map(async ([path, entry]) => {
+      try {
+        const contents = await loadReviewContents(host, root, entry)
+        if (!reviewContentsRepresentChange(entry, contents)) next.delete(path)
+      } catch {
+        return
+      }
+    }),
+  )
+  return next
 }
 
 const SIDEBAR_DEFAULT_WIDTH = 244
@@ -1343,7 +1369,7 @@ export function ShellExplorerPage({
     const completedTurnId = observedReview.turnId
     const completedRoot = root
     void fetchSessionTurn(host, conversationId, completedTurnId)
-      .then((turn) => {
+      .then(async (turn) => {
         if (
           cancelled ||
           turn === null ||
@@ -1353,11 +1379,23 @@ export function ShellExplorerPage({
           return
         }
         const mapped = reviewEntriesFromTurn(turn, completedRoot)
+        const storedEntries = await withoutUnreviewableBaselines(
+          host,
+          completedRoot,
+          mapped.entries,
+        )
+        if (
+          cancelled ||
+          rootRef.current !== completedRoot ||
+          reviewWindowRef.current.turnId !== completedTurnId
+        ) {
+          return
+        }
         setTurnOutside(mapped.outside)
         setTurnOutsideRoot(mapped.outsideRoot)
 
         const merged = new Map(reviewEntriesRef.current)
-        for (const [path, stored] of mapped.entries) {
+        for (const [path, stored] of storedEntries) {
           const live = merged.get(path)
           merged.set(path, {
             ...stored,
@@ -1530,9 +1568,16 @@ export function ShellExplorerPage({
               )
             ).filter((turn): turn is SessionTurn => turn !== null)
             const mapped = reviewEntriesFromSession(turns, root)
+            const entries = await withoutUnreviewableBaselines(
+              host,
+              root,
+              mapped.entries,
+            )
+            if (scopeLoadSeqRef.current !== seq || rootRef.current !== root)
+              return null
             const activity = summarizeSessionActivity(summaries, root)
             return {
-              entries: mapped.entries,
+              entries,
               outside: activity.outside,
               outsideRoot: activity.outsideRoot,
             } satisfies TurnEntries
@@ -1561,14 +1606,20 @@ export function ShellExplorerPage({
           return
         }
         void fetchSessionTurn(host, conversationId, scope.turnId)
-          .then((turn) => {
+          .then(async (turn) => {
             if (scopeLoadSeqRef.current !== seq || rootRef.current !== root)
               return
-            applyMapped(
-              turn
-                ? reviewEntriesFromTurn(turn, root)
-                : { entries: new Map(), outside: 0, outsideRoot: null },
+            const mapped = turn
+              ? reviewEntriesFromTurn(turn, root)
+              : { entries: new Map(), outside: 0, outsideRoot: null }
+            const entries = await withoutUnreviewableBaselines(
+              host,
+              root,
+              mapped.entries,
             )
+            if (scopeLoadSeqRef.current !== seq || rootRef.current !== root)
+              return
+            applyMapped({ ...mapped, entries })
           })
           .catch((error: unknown) => {
             if (scopeLoadSeqRef.current !== seq || rootRef.current !== root)
@@ -1954,7 +2005,7 @@ export function ShellExplorerPage({
             fileEvents.map(({ abs }) => abs),
           ).catch(() => null),
           refreshGit(),
-        ]).then(([results, state]) => {
+        ]).then(async ([results, state]) => {
           if (
             rootGenerationRef.current !== generation ||
             reviewEpochRef.current !== reviewEpoch ||
@@ -2020,7 +2071,13 @@ export function ShellExplorerPage({
               // An added/untracked Git status normally supplies an empty
               // baseline. Do not use that fallback when an incomplete tree
               // may simply have omitted an existing pre-turn file.
-              baselineUnavailable ? undefined : currentGitByPath.get(rel),
+              canUseGitMetadataForLiveEntry(
+                baselineCapturedRef.current,
+                baselineUnavailable,
+                decision.baseline,
+              )
+                ? currentGitByPath.get(rel)
+                : undefined,
             )
           }
           const enriched = mergeGitReviewEntries(
@@ -2028,8 +2085,21 @@ export function ShellExplorerPage({
             currentGitChanges,
             false,
           )
-          reviewEntriesRef.current = enriched
-          setReviewEntries(enriched)
+          const validated = await withoutUnreviewableBaselines(
+            host,
+            currentRoot,
+            enriched,
+            new Set(fileEvents.map(({ rel }) => rel)),
+          )
+          if (
+            rootGenerationRef.current !== generation ||
+            reviewEpochRef.current !== reviewEpoch ||
+            rootRef.current !== currentRoot
+          ) {
+            return
+          }
+          reviewEntriesRef.current = validated
+          setReviewEntries(validated)
 
           const activeScope = reviewScopeRef.current
           if (
@@ -2037,13 +2107,13 @@ export function ShellExplorerPage({
             shouldEnterTurnScope(
               followHarnessTurnsRef.current,
               activeScope,
-              enriched.size,
+              validated.size,
             )
           ) {
             forceReviewScope(LAST_TURN_SCOPE)
             const entry =
-              (follow ? enriched.get(follow.rel) : undefined) ??
-              enriched.values().next().value
+              (follow ? validated.get(follow.rel) : undefined) ??
+              validated.values().next().value
             if (entry) openReviewEntry(entry)
             return
           }
@@ -2057,10 +2127,10 @@ export function ShellExplorerPage({
             diffRequestRef.current === followTicket
           ) {
             const entry =
-              enriched.get(follow.rel) ??
+              validated.get(follow.rel) ??
               [...fileEvents]
                 .reverse()
-                .map(({ rel }) => enriched.get(rel))
+                .map(({ rel }) => validated.get(rel))
                 .find((candidate) => candidate !== undefined)
             if (entry) {
               openReviewEntry(entry)
@@ -2073,8 +2143,9 @@ export function ShellExplorerPage({
             open !== null &&
             changed.has(joinPath(currentRoot, open.change.path))
           ) {
-            const entry = enriched.get(open.change.path)
+            const entry = validated.get(open.change.path)
             if (entry) setDiff(diffForReviewEntry(entry))
+            else setDiff(null)
           }
         })
       })

--- a/shell/ui/src/page/index.tsx
+++ b/shell/ui/src/page/index.tsx
@@ -125,6 +125,7 @@ import {
   runReviewTransition,
 } from './ReviewPane'
 import {
+  type ReviewScopeCounts,
   ReviewScopePicker,
   type ReviewScopeSelection,
   reviewScopeLabel,
@@ -135,6 +136,15 @@ import {
   mergeReviewEntry,
   type ReviewEntry,
 } from './review'
+import {
+  DEFAULT_REVIEW_SCOPE,
+  EMPTY_TURN_FALLBACK_MS,
+  isLiveGitReviewScope,
+  isShellUiStatePath,
+  LAST_TURN_SCOPE,
+  shouldFallbackToTurnScope,
+  shouldFollowHarnessTurn,
+} from './review-scope'
 import { useShellReviewSummaryBridge } from './review-summary-store'
 import { changedParentDirs, withReviewChanges } from './review-tree'
 import { SearchTab } from './SearchTab'
@@ -188,8 +198,6 @@ import {
 } from './working-dir-sync'
 
 type SideTab = 'files' | 'search'
-
-const LAST_TURN_SCOPE: ReviewScopeSelection = { kind: 'last-turn' }
 
 interface DiffSelection {
   /** The change shown — from git status, or synthesized for live
@@ -276,11 +284,13 @@ function UnifiedDiffIcon() {
 function ReviewMenuAction({
   label,
   icon,
+  description,
   disabled,
   onSelect,
 }: {
   label: string
   icon: ReactNode
+  description?: string
   disabled?: boolean
   onSelect: () => void
 }) {
@@ -293,7 +303,10 @@ function ReviewMenuAction({
       <span className="menu-icon" aria-hidden>
         {icon}
       </span>
-      <span>{label}</span>
+      <span className="shui-review-option-copy">
+        <span>{label}</span>
+        {description ? <small>{description}</small> : null}
+      </span>
     </DropdownMenuItem>
   )
 }
@@ -328,9 +341,7 @@ const SIDEBAR_MAX_WIDTH = 560
 const TERMINAL_BOTTOM_DEFAULT_SIZE = 280
 const TERMINAL_RIGHT_DEFAULT_SIZE = 420
 function reviewablePath(rel: string): boolean {
-  // This page's own persisted UI state changes on every tab/expand and
-  // must never become part of the user's review set.
-  if (rel.endsWith('shell-ui.yaml')) return false
+  if (isShellUiStatePath(rel)) return false
   const noise = [
     'Library',
     'node_modules',
@@ -519,9 +530,11 @@ export function ShellExplorerPage({
     }
   }
   const [reviewScope, setReviewScope] =
-    useState<ReviewScopeSelection>(LAST_TURN_SCOPE)
+    useState<ReviewScopeSelection>(DEFAULT_REVIEW_SCOPE)
   const reviewScopeRef = useRef(reviewScope)
   reviewScopeRef.current = reviewScope
+  const followHarnessTurnsRef = useRef(true)
+  const emptyTurnFallbackTimerRef = useRef<number | null>(null)
   const [scopeEntries, setScopeEntries] = useState<
     ReadonlyMap<string, ReviewEntry>
   >(new Map())
@@ -536,6 +549,7 @@ export function ShellExplorerPage({
     [],
   )
   const [scopeRefs, setScopeRefs] = useState<readonly GitRefSummary[]>([])
+  const [scopeCounts, setScopeCounts] = useState<ReviewScopeCounts>({})
   const [sessionTurns, setSessionTurns] = useState<
     readonly SessionTurnSummary[]
   >([])
@@ -691,17 +705,19 @@ export function ShellExplorerPage({
     return () => window.removeEventListener('beforeunload', warn)
   }, [dirtyPaths, reviewDirtyPaths, reviewSavePending])
 
-  const forceLastTurnScope = useCallback(() => {
-    if (!reviewSaveBarrier.canTransition()) return false
-    // Every forced Last Turn transition must retire an in-flight Git scope
-    // request before changing the visible scope. Otherwise its late result can
-    // replace the file selected from the chat summary or live watcher.
-    scopeLoadSeqRef.current += 1
-    setReviewScope(LAST_TURN_SCOPE)
-    setScopeLoading(false)
-    setScopeError(null)
-    return true
-  }, [reviewSaveBarrier])
+  const forceReviewScope = useCallback(
+    (scope: ReviewScopeSelection) => {
+      if (!reviewSaveBarrier.canTransition()) return false
+      // Forced transitions retire in-flight scope requests so a late Git result
+      // cannot replace a file selected from the chat summary or live watcher.
+      scopeLoadSeqRef.current += 1
+      setReviewScope(scope)
+      setScopeLoading(scope.kind !== 'last-turn')
+      setScopeError(null)
+      return true
+    },
+    [reviewSaveBarrier],
+  )
 
   const beginReviewTurn = useCallback(
     (turnId: string) => {
@@ -744,17 +760,21 @@ export function ShellExplorerPage({
       setBaselineCoverage(null)
       reviewEntriesRef.current = new Map()
       setReviewEntries(new Map())
-      scopeEntriesRef.current = new Map()
-      setScopeEntries(new Map())
-      setScopeSummary([])
+      setReviewSummary([])
       setScopeMetadataLoading(false)
       setScopeMetadataError(null)
-      forceLastTurnScope()
-      setReviewSummary([])
-      setDiff(null)
+      if (
+        shouldFollowHarnessTurn(
+          followHarnessTurnsRef.current,
+          reviewScopeRef.current,
+        )
+      ) {
+        setDiff(null)
+        forceReviewScope(LAST_TURN_SCOPE)
+      }
       return true
     },
-    [forceLastTurnScope, reviewSaveBarrier],
+    [forceReviewScope, reviewSaveBarrier],
   )
 
   // This runs inside Harness's awaited pre-turn hook: the snapshot is fully
@@ -824,6 +844,46 @@ export function ShellExplorerPage({
     beginReviewTurn,
     reviewSavingPaths,
     reviewSaveBarrier,
+  ])
+
+  useEffect(() => {
+    if (emptyTurnFallbackTimerRef.current !== null) {
+      window.clearTimeout(emptyTurnFallbackTimerRef.current)
+      emptyTurnFallbackTimerRef.current = null
+    }
+    if (
+      observedReview.turnId === null ||
+      observedReview.active ||
+      observedReview.completedAtMs === null ||
+      reviewScopeRef.current.kind !== 'last-turn' ||
+      !followHarnessTurnsRef.current
+    ) {
+      return
+    }
+    const completedTurnId = observedReview.turnId
+    emptyTurnFallbackTimerRef.current = window.setTimeout(() => {
+      emptyTurnFallbackTimerRef.current = null
+      if (
+        reviewWindowRef.current.turnId !== completedTurnId ||
+        reviewWindowRef.current.active ||
+        reviewScopeRef.current.kind !== 'last-turn' ||
+        reviewEntriesRef.current.size > 0
+      ) {
+        return
+      }
+      forceReviewScope(DEFAULT_REVIEW_SCOPE)
+    }, EMPTY_TURN_FALLBACK_MS)
+    return () => {
+      if (emptyTurnFallbackTimerRef.current !== null) {
+        window.clearTimeout(emptyTurnFallbackTimerRef.current)
+        emptyTurnFallbackTimerRef.current = null
+      }
+    }
+  }, [
+    forceReviewScope,
+    observedReview.active,
+    observedReview.completedAtMs,
+    observedReview.turnId,
   ])
 
   // ── boot: worker info + this workspace tab's persisted state ──
@@ -1028,6 +1088,10 @@ export function ShellExplorerPage({
     !scopeLoading &&
     scopeError === null &&
     scopeEntries.size === 0
+  const currentTurnEmpty =
+    reviewScope.kind === 'last-turn' &&
+    observedReview.active &&
+    reviewEntries.size === 0
 
   // The panel, not the viewport, decides what fits: a shell page shares the
   // console with other panels. Below the same width the stylesheet treats as
@@ -1072,6 +1136,24 @@ export function ShellExplorerPage({
       ),
     [visibleReviewSummary],
   )
+  const reviewScopeCounts = useMemo<ReviewScopeCounts>(() => {
+    const next: ReviewScopeCounts = {
+      ...scopeCounts,
+      'last-turn': reviewEntries.size,
+    }
+    if (isLiveGitReviewScope(reviewScope)) {
+      if (scopeLoading || scopeError !== null) delete next[reviewScope.kind]
+      else next[reviewScope.kind] = orderedReviewEntries.length
+    }
+    return next
+  }, [
+    orderedReviewEntries.length,
+    reviewEntries.size,
+    reviewScope,
+    scopeCounts,
+    scopeError,
+    scopeLoading,
+  ])
   // The Files tree is also the review navigator. Review-only rows keep
   // deleted files visible even after they disappear from coder::tree.
   const reviewTree = useMemo(
@@ -1232,12 +1314,25 @@ export function ShellExplorerPage({
         })
         .catch(() => {})
     }
-    void Promise.all([gitRecentCommits(host, root), gitRefs(host, root)])
-      .then(([commits, refs]) => {
+    void Promise.all([
+      gitRecentCommits(host, root),
+      gitRefs(host, root),
+      gitComparison(host, root, 'uncommitted'),
+      gitComparison(host, root, 'unstaged'),
+      gitComparison(host, root, 'staged'),
+    ])
+      .then(([commits, refs, uncommitted, unstaged, staged]) => {
         if (scopeMetadataSeqRef.current !== seq || rootRef.current !== root)
           return
         setScopeCommits(commits.kind === 'ready' ? commits.commits : [])
         setScopeRefs(refs.kind === 'ready' ? refs.refs : [])
+        const counts: ReviewScopeCounts = {}
+        if (uncommitted.kind === 'ready')
+          counts.uncommitted = uncommitted.changes.length
+        if (unstaged.kind === 'ready')
+          counts.unstaged = unstaged.changes.length
+        if (staged.kind === 'ready') counts.staged = staged.changes.length
+        setScopeCounts(counts)
         const failure =
           commits.kind === 'error'
             ? commits.message
@@ -1248,13 +1343,21 @@ export function ShellExplorerPage({
                 : null
         setScopeMetadataError(failure)
       })
+      .catch((error: unknown) => {
+        if (scopeMetadataSeqRef.current !== seq || rootRef.current !== root)
+          return
+        setScopeMetadataError(errorMessage(error))
+      })
       .finally(() => {
         if (scopeMetadataSeqRef.current === seq) setScopeMetadataLoading(false)
       })
   }, [host, root, conversationId])
 
   const loadReviewScope = useCallback(
-    (scope: Exclude<ReviewScopeSelection, { kind: 'last-turn' }>) => {
+    (
+      scope: Exclude<ReviewScopeSelection, { kind: 'last-turn' }>,
+      preferredPath?: string | null,
+    ) => {
       if (root === null) return
       const seq = ++scopeLoadSeqRef.current
       setScopeLoading(true)
@@ -1278,8 +1381,13 @@ export function ShellExplorerPage({
             setTurnOutside(mapped.outside)
             const activePath = diffRef.current?.change.path
             const entry =
+              (preferredPath
+                ? mapped.entries.get(preferredPath)
+                : undefined) ??
               (activePath ? mapped.entries.get(activePath) : undefined) ??
-              mapped.entries.values().next().value
+              (preferredPath === undefined
+                ? mapped.entries.values().next().value
+                : undefined)
             if (entry) openReviewEntry(entry)
             else {
               diffRequestRef.current += 1
@@ -1313,6 +1421,25 @@ export function ShellExplorerPage({
           if (scopeLoadSeqRef.current !== seq || rootRef.current !== root)
             return
           if (state.kind !== 'ready') {
+            if (shouldFallbackToTurnScope(scope, state.kind)) {
+              followHarnessTurnsRef.current = true
+              forceReviewScope(LAST_TURN_SCOPE)
+              const activePath = diffRef.current?.change.path
+              const entry =
+                (preferredPath
+                  ? reviewEntriesRef.current.get(preferredPath)
+                  : undefined) ??
+                (activePath
+                  ? reviewEntriesRef.current.get(activePath)
+                  : undefined) ??
+                reviewEntriesRef.current.values().next().value
+              if (entry) openReviewEntry(entry)
+              else {
+                diffRequestRef.current += 1
+                setDiff(null)
+              }
+              return
+            }
             const message =
               state.kind === 'error' ? state.message : 'not a git repository'
             scopeEntriesRef.current = new Map()
@@ -1325,10 +1452,19 @@ export function ShellExplorerPage({
           const next = reviewEntriesFromGit(state.changes)
           scopeEntriesRef.current = next
           setScopeEntries(next)
+          if (isLiveGitReviewScope(scope)) {
+            setScopeCounts((previous) => ({
+              ...previous,
+              [scope.kind]: next.size,
+            }))
+          }
           const activePath = diffRef.current?.change.path
           const entry =
+            (preferredPath ? next.get(preferredPath) : undefined) ??
             (activePath ? next.get(activePath) : undefined) ??
-            next.values().next().value
+            (preferredPath === undefined
+              ? next.values().next().value
+              : undefined)
           if (entry) openReviewEntry(entry)
           else {
             diffRequestRef.current += 1
@@ -1348,47 +1484,8 @@ export function ShellExplorerPage({
           if (scopeLoadSeqRef.current === seq) setScopeLoading(false)
         })
     },
-    [host, root, conversationId, openReviewEntry],
+    [host, root, conversationId, forceReviewScope, openReviewEntry],
   )
-
-  // A chat reopened after its work is done has no live turn to follow; its
-  // latest stored turn stands in, loaded from the shell's durable history.
-  const autoTurnSessionRef = useRef<string | null>(null)
-  useEffect(() => {
-    if (!conversationId || root === null) {
-      autoTurnSessionRef.current = null
-      return
-    }
-    if (observedReview.turnId !== null) return
-    if (autoTurnSessionRef.current === conversationId) return
-    autoTurnSessionRef.current = conversationId
-    let cancelled = false
-    void fetchSessionTurns(host, conversationId)
-      .then((turns) => {
-        if (cancelled || rootRef.current !== root) return
-        setSessionTurns(turns)
-        // Only a turn that touched files is worth restoring: landing a
-        // chat-switcher on "0 files at 02:55 PM" reads as a broken pane,
-        // where the plain Last Turn default reads as an empty one.
-        const latest = turns.find((turn) => turn.file_count > 0)
-        if (!latest || observedReviewKeyRef.current !== null) return
-        if (reviewEntriesRef.current.size > 0) return
-        const scope = {
-          kind: 'turn' as const,
-          turnId: latest.turn_id,
-          label: turnLabel(latest),
-        }
-        scopeLoadSeqRef.current += 1
-        setReviewScope(scope)
-        scopeEntriesRef.current = new Map()
-        setScopeEntries(new Map())
-        loadReviewScope(scope)
-      })
-      .catch(() => {})
-    return () => {
-      cancelled = true
-    }
-  }, [host, conversationId, root, observedReview.turnId, loadReviewScope])
 
   const onReviewEditDirtyChange = useCallback(
     (path: string, dirty: boolean) => {
@@ -1529,11 +1626,12 @@ export function ShellExplorerPage({
   const selectReviewScope = useCallback(
     (next: ReviewScopeSelection) => {
       if (!confirmDiscardReviewEdits()) return
+      followHarnessTurnsRef.current = next.kind === 'last-turn'
       setScopeSummary([])
       setScopeError(null)
       setReviewMenuOpen(false)
       if (next.kind === 'last-turn') {
-        forceLastTurnScope()
+        forceReviewScope(LAST_TURN_SCOPE)
         const activePath = diffRef.current?.change.path
         const entry =
           (activePath ? reviewEntriesRef.current.get(activePath) : undefined) ??
@@ -1553,7 +1651,7 @@ export function ShellExplorerPage({
       diffRequestRef.current += 1
       setDiff(null)
     },
-    [confirmDiscardReviewEdits, forceLastTurnScope, openReviewEntry],
+    [confirmDiscardReviewEdits, forceReviewScope, openReviewEntry],
   )
 
   useShellReviewSummaryBridge({
@@ -1565,7 +1663,8 @@ export function ShellExplorerPage({
       if (!confirmDiscardReviewEdits()) return
       const entry = reviewEntriesRef.current.get(path)
       if (entry) {
-        forceLastTurnScope()
+        followHarnessTurnsRef.current = true
+        forceReviewScope(LAST_TURN_SCOPE)
         openReviewEntry(entry)
       }
     },
@@ -1574,6 +1673,7 @@ export function ShellExplorerPage({
   useWorkspaceChanges(host, root, (event) => {
     if (rootTransitionRef.current) return
     if (event.root !== rootRef.current) return
+    if (isShellUiStatePath(event.path)) return
     const eventAbs = joinPath(event.root, event.path)
     changedAbsRef.current.set(eventAbs, event.kind)
     // Directories refresh the tree but must never open as files —
@@ -1751,7 +1851,16 @@ export function ShellExplorerPage({
           reviewEntriesRef.current = enriched
           setReviewEntries(enriched)
 
-          if (follow !== null && diffRequestRef.current === followTicket) {
+          const activeScope = reviewScopeRef.current
+          if (isLiveGitReviewScope(activeScope)) {
+            loadReviewScope(activeScope, follow?.rel ?? null)
+            return
+          }
+          if (
+            activeScope.kind === 'last-turn' &&
+            follow !== null &&
+            diffRequestRef.current === followTicket
+          ) {
             const entry =
               enriched.get(follow.rel) ??
               [...fileEvents]
@@ -1759,7 +1868,6 @@ export function ShellExplorerPage({
                 .map(({ rel }) => enriched.get(rel))
                 .find((candidate) => candidate !== undefined)
             if (entry) {
-              forceLastTurnScope()
               openReviewEntry(entry)
             }
             return
@@ -2008,9 +2116,11 @@ export function ShellExplorerPage({
         setScopeSummary([])
         setScopeCommits([])
         setScopeRefs([])
+        setScopeCounts({})
         setScopeMetadataLoading(false)
         setScopeMetadataError(null)
-        forceLastTurnScope()
+        followHarnessTurnsRef.current = true
+        forceReviewScope(DEFAULT_REVIEW_SCOPE)
         setTree(null)
         setGit(null)
         setSubtrees(new Map())
@@ -2031,7 +2141,7 @@ export function ShellExplorerPage({
     },
     [
       confirmDiscardAllEdits,
-      forceLastTurnScope,
+      forceReviewScope,
       host,
       refreshGit,
       refreshTree,
@@ -2603,6 +2713,34 @@ export function ShellExplorerPage({
           },
         },
         {
+          id: 'review-uncommitted',
+          title: 'View uncommitted changes',
+          detail: 'All working tree changes since the last commit',
+          keywords: ['review', 'diff', 'git', 'working tree'],
+          run: () => selectReviewScope(DEFAULT_REVIEW_SCOPE),
+        },
+        {
+          id: 'review-unstaged',
+          title: 'View unstaged changes',
+          detail: 'Working tree changes not added to the index',
+          keywords: ['review', 'diff', 'git', 'working tree'],
+          run: () => selectReviewScope({ kind: 'unstaged' }),
+        },
+        {
+          id: 'review-staged',
+          title: 'View staged changes',
+          detail: 'Changes added to the Git index',
+          keywords: ['review', 'diff', 'git', 'index'],
+          run: () => selectReviewScope({ kind: 'staged' }),
+        },
+        {
+          id: 'review-last-turn',
+          title: 'Follow Harness turn changes',
+          detail: 'Current turn while running, then the completed turn',
+          keywords: ['review', 'diff', 'activity', 'agent', 'turn'],
+          run: () => selectReviewScope(LAST_TURN_SCOPE),
+        },
+        {
           id: 'next-change',
           title: 'Next changed file',
           detail: 'Open the next file in the review',
@@ -2621,7 +2759,15 @@ export function ShellExplorerPage({
           run: () => stepReviewEntry(-1),
         },
       ]),
-    [commands, host, toggleTerminal, onCloseTab, stepReviewEntry, frameEl],
+    [
+      commands,
+      host,
+      toggleTerminal,
+      onCloseTab,
+      selectReviewScope,
+      stepReviewEntry,
+      frameEl,
+    ],
   )
 
   const header = (
@@ -2886,6 +3032,8 @@ export function ShellExplorerPage({
                 <ReviewScopePicker
                   value={reviewScope}
                   commits={scopeCommits}
+                  counts={reviewScopeCounts}
+                  currentTurn={observedReview.active}
                   turns={sessionTurns.map((turn) => ({
                     turnId: turn.turn_id,
                     label: turnLabel(turn),
@@ -3250,7 +3398,14 @@ export function ShellExplorerPage({
             ) : scopeEmpty ? (
               <div className="shui-main-empty">
                 <span className="t-ghost">
-                  No changes in {reviewScopeLabel(reviewScope)}
+                  No changes in{' '}
+                  {reviewScopeLabel(reviewScope, observedReview.active)}
+                </span>
+              </div>
+            ) : currentTurnEmpty ? (
+              <div className="shui-main-empty">
+                <span className="t-ghost">
+                  Changes from this turn will appear here…
                 </span>
               </div>
             ) : tabs.active !== null ? (
@@ -3286,16 +3441,9 @@ export function ShellExplorerPage({
               <ShellLauncher
                 host={host}
                 browserAvailable={browserAvailable}
-                // Changes is the navbar's review scope: the last turn when it
-                // touched anything, otherwise everything the working tree has
-                // that HEAD does not.
-                onOpenChanges={() =>
-                  selectReviewScope(
-                    reviewEntriesRef.current.size > 0
-                      ? LAST_TURN_SCOPE
-                      : { kind: 'uncommitted' },
-                  )
-                }
+                // Changes is cumulative working-tree work since HEAD. Last
+                // Turn remains available as an explicit review scope.
+                onOpenChanges={() => selectReviewScope(DEFAULT_REVIEW_SCOPE)}
                 onOpenTerminal={() => {
                   setTerminalOpen(true)
                   setTerminalActive(true)

--- a/shell/ui/src/page/review-scope.ts
+++ b/shell/ui/src/page/review-scope.ts
@@ -1,0 +1,33 @@
+import type { ReviewScopeSelection } from './ReviewScopePicker'
+
+export type LiveGitReviewScope = Extract<ReviewScopeSelection, { kind: 'uncommitted' | 'unstaged' | 'staged' }>
+
+export const LAST_TURN_SCOPE = {
+  kind: 'last-turn',
+} as const satisfies ReviewScopeSelection
+
+export const DEFAULT_REVIEW_SCOPE = {
+  kind: 'uncommitted',
+} as const satisfies LiveGitReviewScope
+
+export const EMPTY_TURN_FALLBACK_MS = 750
+
+export function isLiveGitReviewScope(scope: ReviewScopeSelection): scope is LiveGitReviewScope {
+  return scope.kind === 'uncommitted' || scope.kind === 'unstaged' || scope.kind === 'staged'
+}
+
+export function isShellUiStatePath(path: string): boolean {
+  const normalized = path.replaceAll('\\', '/')
+  return /(^|\/)config\/shell-ui\.yaml(?:\.tmp)?$/.test(normalized)
+}
+
+export function shouldFollowHarnessTurn(autoFollow: boolean, scope: ReviewScopeSelection): boolean {
+  return autoFollow || scope.kind === 'last-turn'
+}
+
+export function shouldFallbackToTurnScope(
+  scope: ReviewScopeSelection,
+  gitState: 'ready' | 'not-a-repo' | 'error',
+): boolean {
+  return gitState === 'not-a-repo' && isLiveGitReviewScope(scope)
+}

--- a/shell/ui/src/page/review-scope.ts
+++ b/shell/ui/src/page/review-scope.ts
@@ -6,6 +6,10 @@ export const LAST_TURN_SCOPE = {
   kind: 'last-turn',
 } as const satisfies ReviewScopeSelection
 
+export const SESSION_SCOPE = {
+  kind: 'session',
+} as const satisfies ReviewScopeSelection
+
 export const DEFAULT_REVIEW_SCOPE = {
   kind: 'uncommitted',
 } as const satisfies LiveGitReviewScope
@@ -23,6 +27,14 @@ export function isShellUiStatePath(path: string): boolean {
 
 export function shouldFollowHarnessTurn(autoFollow: boolean, scope: ReviewScopeSelection): boolean {
   return autoFollow || scope.kind === 'last-turn'
+}
+
+export function shouldEnterTurnScope(
+  autoFollow: boolean,
+  scope: ReviewScopeSelection,
+  inRootChanges: number,
+): boolean {
+  return inRootChanges > 0 && shouldFollowHarnessTurn(autoFollow, scope)
 }
 
 export function shouldFallbackToTurnScope(

--- a/shell/ui/src/page/review.ts
+++ b/shell/ui/src/page/review.ts
@@ -18,6 +18,42 @@ export interface ReviewDiff {
   gitDir?: string
 }
 
+export interface ReviewContentsSnapshot {
+  oldContents: string
+  newContents: string
+  noBaseline?: true
+  image?: string | null
+  imageUnavailable?: true
+}
+
+export function reviewContentsRepresentChange(
+  entry: ReviewEntry,
+  contents: ReviewContentsSnapshot,
+): boolean {
+  if (contents.noBaseline) return false
+  if (contents.image !== undefined || contents.imageUnavailable) return true
+  if (
+    entry.change.status === 'added' ||
+    entry.change.status === 'untracked' ||
+    entry.change.status === 'deleted' ||
+    entry.change.status === 'renamed'
+  ) {
+    return true
+  }
+  return contents.oldContents !== contents.newContents
+}
+
+export function canUseGitMetadataForLiveEntry(
+  baselineCaptured: boolean,
+  baselineUnavailable: boolean,
+  baseline: string | null | undefined,
+): boolean {
+  return (
+    !baselineUnavailable &&
+    (baselineCaptured || baseline !== undefined)
+  )
+}
+
 /** Each activation gets a fresh change identity so ReviewPane re-reads the
     working copy even when the same selected row is clicked again. */
 export function diffForReviewEntry(entry: ReviewEntry): ReviewDiff {

--- a/shell/ui/src/page/turns.ts
+++ b/shell/ui/src/page/turns.ts
@@ -117,10 +117,19 @@ export interface SessionActivitySummary {
   outsideRoot: string | null
 }
 
+function hasNoDurableChange(file: TurnFileRecord): boolean {
+  if (file.before?.missing && file.kind === 'deleted') return true
+  return (
+    typeof file.before?.revision === 'string' &&
+    file.before.revision === file.after_revision
+  )
+}
+
 export function reviewEntriesFromTurn(turn: SessionTurn, root: string): TurnEntries {
   const entries = new Map<string, ReviewEntry>()
   const outsidePaths: string[] = []
   for (const file of turn.files) {
+    if (hasNoDurableChange(file)) continue
     const rel = relativeToRoot(file.path, root)
     if (rel === null) {
       outsidePaths.push(file.path)
@@ -198,6 +207,7 @@ export function reviewEntriesFromSession(
 
   for (const turn of chronological) {
     for (const file of turn.files) {
+      if (hasNoDurableChange(file)) continue
       if (relativeToRoot(file.path, root) === null) {
         outside.add(file.path)
         continue

--- a/shell/ui/src/page/turns.ts
+++ b/shell/ui/src/page/turns.ts
@@ -108,15 +108,22 @@ export interface TurnEntries {
   entries: ReadonlyMap<string, ReviewEntry>
   /** Files the turn changed outside the browsed root. */
   outside: number
+  outsideRoot: string | null
+}
+
+export interface SessionActivitySummary {
+  inside: number
+  outside: number
+  outsideRoot: string | null
 }
 
 export function reviewEntriesFromTurn(turn: SessionTurn, root: string): TurnEntries {
   const entries = new Map<string, ReviewEntry>()
-  let outside = 0
+  const outsidePaths: string[] = []
   for (const file of turn.files) {
     const rel = relativeToRoot(file.path, root)
     if (rel === null) {
-      outside += 1
+      outsidePaths.push(file.path)
       continue
     }
     const from = file.from ? relativeToRoot(file.from, root) : null
@@ -138,5 +145,102 @@ export function reviewEntriesFromTurn(turn: SessionTurn, root: string): TurnEntr
     }
     entries.set(rel, entry)
   }
-  return { entries, outside }
+  return {
+    entries,
+    outside: new Set(outsidePaths).size,
+    outsideRoot: sharedFolder([...new Set(outsidePaths)]),
+  }
+}
+
+function parentPath(path: string): string | null {
+  const normalized = path.replace(/\/+$/, '')
+  const separator = normalized.lastIndexOf('/')
+  if (separator <= 0) return null
+  return normalized.slice(0, separator)
+}
+
+function sharedFolder(paths: readonly string[]): string | null {
+  const parents = paths.map(parentPath).filter((path): path is string => path !== null)
+  if (parents.length !== paths.length || parents.length === 0) return null
+  const parts = parents.map((path) => path.split('/').filter(Boolean))
+  const common: string[] = []
+  for (let index = 0; index < parts[0].length; index += 1) {
+    const segment = parts[0][index]
+    if (parts.some((path) => path[index] !== segment)) break
+    common.push(segment)
+  }
+  return common.length >= 2 ? `/${common.join('/')}` : null
+}
+
+export function summarizeSessionActivity(
+  turns: readonly SessionTurnSummary[],
+  root: string,
+): SessionActivitySummary {
+  const paths = new Set(turns.flatMap((turn) => turn.files.map((file) => file.path)))
+  const outsidePaths = [...paths].filter((path) => relativeToRoot(path, root) === null)
+  return {
+    inside: paths.size - outsidePaths.length,
+    outside: outsidePaths.length,
+    outsideRoot: sharedFolder(outsidePaths),
+  }
+}
+
+export function reviewEntriesFromSession(
+  turns: readonly SessionTurn[],
+  root: string,
+): TurnEntries {
+  const chronological = [...turns].sort((left, right) => left.started_at - right.started_at)
+  const history = new Map<
+    string,
+    { first: TurnFileRecord; latest: TurnFileRecord }
+  >()
+  const outside = new Set<string>()
+
+  for (const turn of chronological) {
+    for (const file of turn.files) {
+      if (relativeToRoot(file.path, root) === null) {
+        outside.add(file.path)
+        continue
+      }
+      const previous = history.get(file.path)
+      history.set(file.path, {
+        first: previous?.first ?? file,
+        latest: file,
+      })
+    }
+  }
+
+  const entries = new Map<string, ReviewEntry>()
+  for (const [path, { first, latest }] of history) {
+    const rel = relativeToRoot(path, root)
+    if (rel === null) continue
+    const firstBaseline =
+      first.before == null && first.kind === 'created'
+        ? ''
+        : baselineFor(first.before)
+    if (firstBaseline === '' && latest.kind === 'deleted') continue
+
+    const status: GitFileStatus =
+      latest.kind === 'deleted'
+        ? 'deleted'
+        : firstBaseline === ''
+          ? 'added'
+          : statusFor(latest.kind)
+    const from = latest.from ? relativeToRoot(latest.from, root) : null
+    entries.set(rel, {
+      path: rel,
+      change: {
+        path: rel,
+        status,
+        staged: false,
+        ...(from ? { from } : {}),
+      },
+      baseline: firstBaseline,
+    })
+  }
+  return {
+    entries,
+    outside: outside.size,
+    outsideRoot: sharedFolder([...outside]),
+  }
 }

--- a/shell/ui/styles.css
+++ b/shell/ui/styles.css
@@ -540,21 +540,34 @@
   gap: 2px;
   overflow: visible;
 }
-[data-iii-ui="shell"] .shui-header-root-select {
+[data-iii-ui="shell"] .shui-header-root-wrap {
   display: block;
   max-width: min(220px, 24vw);
-  padding: 0 16px 0 0;
+}
+[data-iii-ui="shell"] .shui-header-root-select {
+  display: block;
+  max-width: 100%;
+}
+[data-iii-ui="shell"] .shui-header-root-select > button {
+  width: auto;
+  max-width: 100%;
+  height: 24px;
+  min-height: 24px;
+  padding: 0 4px;
   border: 0;
   outline: 0;
   color: var(--color-ink-ghost);
   background: transparent;
   font: inherit;
-  text-overflow: ellipsis;
 }
-[data-iii-ui="shell"] .shui-header-root-select:focus-visible {
+[data-iii-ui="shell"] .shui-header-root-select > button:hover {
+  color: var(--color-ink);
+  background: var(--color-surface-hover);
+}
+[data-iii-ui="shell"] .shui-header-root-select > button:focus-visible {
   color: var(--color-ink);
   outline: 1px solid var(--color-rule-focus);
-  outline-offset: 3px;
+  outline-offset: 1px;
 }
 
 [data-iii-ui="shell"] .shui-collapse-btn {
@@ -1191,7 +1204,10 @@
 [data-iii-ui="shell"] .shui-review-scope-menu button:hover {
   background: var(--color-surface-hover);
 }
-[data-iii-ui="shell"] .shui-review-scope-menu button > span:not(.menu-icon-gap) {
+[data-iii-ui="shell"]
+  .shui-review-scope-menu
+  button
+  > span:not(.menu-icon-gap, .scope-selected) {
   min-width: 0;
   flex: 1;
 }
@@ -1206,6 +1222,37 @@
 }
 [data-iii-ui="shell"] .shui-review-scope-menu .submenu-back {
   font-weight: 500;
+}
+[data-iii-ui="shell"] .shui-review-menu-label {
+  padding: 8px 9px 3px;
+  color: var(--color-ink-ghost);
+  font: 500 10px / 14px var(--font-mono, ui-monospace, monospace);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+[data-iii-ui="shell"] .shui-review-scope-menu .scope-menu-main {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+[data-iii-ui="shell"] .shui-review-scope-menu .scope-menu-main small {
+  flex: none;
+  color: var(--color-ink-ghost);
+  font: 400 11px / 14px var(--font-mono, ui-monospace, monospace);
+  font-variant-numeric: tabular-nums;
+}
+[data-iii-ui="shell"] .shui-review-scope-menu .scope-selected {
+  display: inline-flex;
+  width: 16px;
+  height: 16px;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+}
+[data-iii-ui="shell"] .shui-review-scope-menu .scope-selected svg {
+  width: 16px;
+  height: 16px;
 }
 [data-iii-ui="shell"] .shui-review-menu-separator {
   height: 1px;
@@ -1346,6 +1393,17 @@
 [data-iii-ui="shell"] .shui-review-option .check svg {
   width: 16px;
   height: 16px;
+}
+[data-iii-ui="shell"] .shui-review-option-copy {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+}
+[data-iii-ui="shell"] .shui-review-option-copy small {
+  color: var(--color-ink-ghost);
+  font-size: 11px;
+  line-height: 15px;
 }
 [data-iii-ui="shell"] .shui-review-body {
   flex: 1;

--- a/shell/ui/styles.css
+++ b/shell/ui/styles.css
@@ -1684,25 +1684,61 @@
   font-size: 12px;
   font-variant-numeric: tabular-nums;
 }
-[data-iii-ui="shell"] .shui-review-message {
-  display: flex;
+[data-iii-ui="shell"] .shui-review-notice {
+  display: grid;
+  grid-template-columns: 32px minmax(0, 1fr) auto;
   align-items: center;
-  gap: 8px;
-  padding: 14px 16px;
-  color: var(--color-ink-ghost);
-  font: 400 12px / 18px var(--font-mono, ui-monospace, monospace);
+  gap: 12px;
+  margin: 8px 10px 0;
+  padding: 10px 12px;
+  box-shadow: none;
+  font-family: var(--font-sans);
 }
-[data-iii-ui="shell"] .shui-review-message.warn {
+[data-iii-ui="shell"] .shui-review-notice-icon {
+  display: inline-flex;
+  width: 32px;
+  height: 32px;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  color: var(--color-ink-faint);
+}
+[data-iii-ui="shell"] .shui-review-notice-icon > svg {
+  width: 18px;
+  height: 18px;
+}
+[data-iii-ui="shell"] .shui-review-notice.warn .shui-review-notice-icon {
   color: var(--color-warn);
 }
-[data-iii-ui="shell"] .shui-review-inline-action {
-  padding: 0;
-  border: 0;
-  border-bottom: 1px solid currentColor;
-  background: transparent;
-  color: inherit;
-  font: inherit;
-  cursor: pointer;
+[data-iii-ui="shell"] .shui-review-notice-copy {
+  display: grid;
+  min-width: 0;
+  gap: 1px;
+}
+[data-iii-ui="shell"] .shui-review-notice-title {
+  overflow: hidden;
+  color: var(--color-ink);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 18px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+[data-iii-ui="shell"] .shui-review-notice-detail {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--color-ink-faint);
+  font: 400 11px / 16px var(--font-mono);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+[data-iii-ui="shell"] .shui-review-notice-actions {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
 }
 [data-iii-ui="shell"] .shui-review-diff {
   display: block;
@@ -2824,6 +2860,16 @@
 /* Narrow panels — phones, and desktop panels split small ------------------- */
 
 @container shui-page (max-width: 720px) {
+  [data-iii-ui='shell'] .shui-review-notice {
+    grid-template-columns: 32px minmax(0, 1fr);
+  }
+
+  [data-iii-ui='shell'] .shui-review-notice-actions {
+    grid-column: 2;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+
   [data-iii-ui='shell'] .shui-sidebar {
     position: absolute;
     top: 0;


### PR DESCRIPTION
## Problem

Shell treated **Last Turn** as the primary Changes view. That view is useful for auditing agent activity, but it is not the repository's current state. A fast Harness turn could briefly show a diff, then replace it with an empty or incomplete turn snapshot while uncommitted files still existed.

Three independent data sources made the failure more visible:

- Git reports the current working tree.
- Harness emits turn lifecycle events.
- Shell observes filesystem writes and stores pre-turn revisions.

Those sources do not arrive atomically. Starting a turn before its first write, receiving a filesystem event without a captured baseline, or completing a turn while the final event batch is still settling could produce `0 files`, repeated refreshes, or rows that said there was no earlier version to compare.

Project handoffs exposed another gap. A turn can create or clone a project outside the current Shell root through `shell::exec`. The old root watcher cannot observe those files, so accepting the new working directory could move Chat and Shell correctly while losing the project from turn history.

## Behavior

| Situation | Review behavior |
| --- | --- |
| Shell opens without active review activity | Defaults to **Uncommitted** |
| A Harness turn starts but has not changed a reviewable file | Remains on the current scope |
| The followed turn produces its first renderable in-root diff | Switches to **Current Turn** |
| A turn with reviewable changes completes | Settles on **Last Turn** |
| A turn completes without reviewable changes | Falls back to **Uncommitted** |
| The user manually chooses a scope | Keeps that choice until the user changes it |
| Several turns modify the same session | **Session Changes** shows the cumulative result |
| Files change outside the browsed root | Shows the outside-file count, root, and handoff actions |
| The root is not a Git repository | Uses captured activity instead of presenting an empty Git view |

**Last Turn** stays available as a quick filter. **Uncommitted**, **Unstaged**, **Staged**, commit, and branch views keep their Git meaning. Scope actions are also available through the existing command palette, with no new chord layer.

## Implementation

### Stable scope state

- Defines **Uncommitted** as the explicit initial scope.
- Separates automatic turn following from user-selected scope state.
- Enters Current Turn only after a real review entry exists, rather than on the lifecycle start event alone.
- Invalidates stale asynchronous scope requests so an older Git or turn response cannot replace a newer selection.
- Reconciles completed activity without restarting the live Git polling loop or replacing the rendered diff.

### Reviewable-change filtering

- Compares stored before and after revisions and removes identical entries.
- Removes files that were created and deleted during the same turn.
- Probes entries whose pre-turn baseline is missing before promoting them into Current Turn, Last Turn, or Session Changes.
- Rejects catch-up entries that cannot render an actual before/after diff instead of inventing an empty Git baseline for an existing untracked file.
- Keeps structural additions, deletions, renames, and binary/image changes when they are genuinely reviewable.
- Clears an open diff if later reconciliation proves that entry has no durable change.

This removes the `nothing to diff` and `earlier version was not captured` rows from the primary activity views. It also prevents runtime state writes from making the review pane blink between populated and empty states.

### Durable session activity

- Stores turn summaries and bounded pre-image revisions in Shell-owned history.
- Rebuilds Last Turn and Session Changes from durable records when the UI opens late or reconnects.
- Keeps completed turn content stable while working-tree views continue to refresh independently.
- Excludes Shell UI persistence files from review activity.

### New-project handoff recovery

- Adds the internal `shell::turns::adopt-root` function used after Console validates a proposed project directory.
- Scans a newly created project deterministically and attaches its source files to the originating session and turn.
- Records those files as created with a missing pre-image, which produces a real addition diff after the user accepts the workspace handoff.
- Excludes dependency, build, cache, temporary, socket, log, and binary-output paths such as `.git`, `node_modules`, `target`, `dist`, and `__pycache__`.
- Caps adopted activity with the same per-turn file bound as normal Shell history.

### Console-native activity notices

- Replaces the raw monospace outside-change strip with the shared Console `Panel` and `Button` components.
- Separates the human-readable change count from the machine path, with ellipsis and a full-path tooltip instead of allowing the path to consume the panel.
- Uses the standard Lucide icon set for outside activity, opening a folder, adopting a chat directory, retries, and warning states.
- Keeps icon sizing at the Console 16px-plus baseline and uses only shared typography, spacing, radius, and color tokens.
- Moves actions onto a dedicated responsive row when the Shell panel is narrow, while preserving non-wrapping button labels and full touch targets.
- Applies the same hierarchy to unavailable-directory and failed-open warnings so all review notices share one interaction pattern.

## Real Harness acceptance test

Tested against the local Console on `http://127.0.0.1:3113/` with current-main Harness and the PR builds of Console and Shell.

1. A real Harness turn created a dependency-free Node calculator project in a new directory with `package.json`, source, tests, and README, ran the full project tests, and proposed the new working directory.
2. Before confirmation, Shell remained on Uncommitted and reported four files outside the current folder.
3. After **Use for chat**, Chat and Shell moved together and Last Turn rendered all four project additions with `+62/-0`.
4. A second real turn added subtraction and division, expanded tests including divide-by-zero behavior, updated README, added `CHANGELOG.md`, and ran the full project tests.
5. Last Turn rendered four files with `+49/-6` and remained unchanged across a 12-second stability check.
6. Session Changes rendered the cumulative five-file project with `+105/-0`.

No zero-diff placeholder rows appeared, and the view did not flash back to an empty scope.

A separate real Harness turn exercised the outside-folder notice itself:

1. Chat worked in `attachments/harness` while the side-by-side Shell independently browsed a temporary project.
2. Harness implemented and verified a dependency-free Node color-palette CLI across `package.json`, `src/palette.js`, and `README.md`.
3. Session Changes reported three changes outside the browsed folder as soon as the files were created.
4. The notice rendered the outside root, FolderSymlink icon, **Open in Shell**, and **Use for chat** using shared Console components.
5. **Open in Shell** changed only the Shell root to the exact generated project; Chat remained on Harness.
6. After the turn completed, 30 one-second samples observed zero missing notices, one constant height, one stable text value, and no scope change.

## Verification

- Shell UI: 32 test files, 328 tests passed
- Shell UI production build passed
- `cargo build --bin shell` passed with the rebuilt UI bundle embedded
- New adopted-project Rust test passed
- Full Shell Rust suite: 687 tests passed; one unchanged filesystem mode test, `mkdir_setgid_mode_allowed_when_opted_in`, fails in this local environment
- Real-turn browser verification at `http://127.0.0.1:3113/`, including narrow split-panel layout and both outside-root actions
- 30-second post-turn stability observation with no missing frame, height change, or scope snap-back
- `cargo fmt -- --check`
- `git diff --check`

The complete working-directory handoff and cross-root history path is exercised together with #942.

Fixes MOT-4574
