### PR TITLE
(MOT-4149) fix(bridge): honor injected local engine URL

### DIFF
--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -642,7 +642,7 @@ dependencies = [
 
 [[package]]
 name = "iii-bridge"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "iii-bridge"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "Bridge worker for iii — connects to a remote iii instance to expose and forward functions"
 license = "Apache-2.0"
@@ -27,7 +27,7 @@ serde_yaml = "0.9"
 anyhow = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 schemars = "0.8"
 
 [dev-dependencies]

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -35,9 +35,16 @@ Configuration is owned by the `configuration` worker — edit it from the
 console (**Configuration → Workers → bridge**) or seed it once via
 `--config <file>.yaml` on first boot:
 
+The worker uses two independent WebSocket connections:
+
+| Connection | URL selection | Purpose |
+|---|---|---|
+| Local/control engine | `--url` → `III_URL` → `ws://127.0.0.1:49134` | Register the `bridge` worker and receive local invocations. |
+| Remote target | `config.url` | Forward invocations to the other iii engine. |
+
 | Field | Default | Description |
 |---|---|---|
-| `url` | `ws://0.0.0.0:49134` | Remote engine WebSocket URL. Fallback chain: `config.url` → `III_URL` env var → the default above. |
+| `url` | `ws://0.0.0.0:49134` | Remote target WebSocket URL. Set it explicitly when `III_URL` selects a non-default local/control engine. |
 | `expose[]` | `[]` | `{ local_function, remote_function? }` — local functions the remote engine may call; `remote_function` is the name registered on the remote (defaults to `local_function`). |
 | `forward[]` | `[]` | `{ local_function, remote_function, timeout_ms? }` — local aliases that proxy outbound to a remote function; `timeout_ms` overrides the per-call default (`30000`). |
 
@@ -48,6 +55,12 @@ entries registers just the additions live. **Removing** a `forward`/`expose`
 entry does not un-register its handler — the SDK has no unregister — so the
 function id stays live but its handler returns `bridge_error` until the worker
 is restarted.
+
+For backward compatibility, a missing remote `config.url` still falls back to
+`III_URL`, then `ws://0.0.0.0:49134`. This fallback predates `III_URL` support
+for the local/control connection. In Compose or other supervised deployments,
+always set `config.url`; otherwise both connections can point to the local
+engine and create a self-bridge.
 
 ## Requires removing the legacy built-in bridge worker
 
@@ -78,7 +91,8 @@ depended on the legacy built-in worker.
 | `invoke_async` result | `NoResult` (absent) | `null` (SDK functions must return a value) |
 | Forward functions | one local function per entry, description `Forward to remote function {id}` | same |
 | Expose functions | registered on the remote engine, name defaults to local, real error body forwarded | same |
-| Remote URL | `config.url` → `III_URL` env → `ws://0.0.0.0:49134` | same |
+| Local/control URL | engine-managed | `--url` → `III_URL` → `ws://127.0.0.1:49134` |
+| Remote target URL | `config.url` → `III_URL` env → `ws://0.0.0.0:49134` | same legacy-compatible chain; set `config.url` explicitly under Compose |
 | Trigger types | none | none |
 | Config source | engine `config.yaml` (restart to change) | `configuration` worker entry `bridge`, hot-reload |
 | Removing forward/expose entries | restart re-registers cleanly | entry disabled (handler errors); full removal needs worker restart |

--- a/bridge/skills/SKILL.md
+++ b/bridge/skills/SKILL.md
@@ -10,10 +10,11 @@ description: >-
 # bridge
 
 The `bridge` worker connects this iii engine to another iii instance over
-`iii-sdk` so functions on either side can call across the boundary. It opens a
-single outbound WebSocket to the configured `url`, and stays open for the
-worker's lifetime — bridging is request/response over that long-lived
-connection. There are no trigger types.
+`iii-sdk` so functions on either side can call across the boundary. It keeps a
+local/control WebSocket to this engine, selected by `--url`, `III_URL`, or the
+local default. A separate WebSocket connects to the remote target selected by
+`config.url` and reconnects when that value changes. Both connections stay
+open for the worker's lifetime. There are no trigger types.
 
 The worker is configuration-driven. The primary surface is two list-shaped
 config fields (`forward` and `expose`) that wire stable function ids on both

--- a/bridge/skills/SKILL.md
+++ b/bridge/skills/SKILL.md
@@ -75,9 +75,12 @@ malformed input, `bridge_error` otherwise).
 Configuration lives in the `configuration` worker's `bridge` entry (hot-reload
 — no restart needed for most changes):
 
-- `url` — WebSocket URL of the remote iii instance. Fallback chain:
-  `config.url` → `III_URL` env var → `ws://0.0.0.0:49134`. Changing it
-  reconnects to the new remote.
+- The local/control engine connection uses `--url`, then `III_URL`, then
+  `ws://127.0.0.1:49134`. This is where the worker registers and receives
+  local invocations.
+- `url` — WebSocket URL of the remote target. Set it explicitly when
+  `III_URL` selects a non-default local/control engine. Changing it reconnects
+  to the new remote.
 - `expose: [{ local_function, remote_function? }]` — functions on this engine
   the remote may call; `remote_function` is the name registered on the remote
   (defaults to `local_function`). Newly added entries register live on the
@@ -91,3 +94,8 @@ Configuration lives in the `configuration` worker's `bridge` entry (hot-reload
 Removing a `forward`/`expose` entry does not un-register its handler (the SDK
 has no unregister): the function id stays callable but returns a
 `bridge_error` until the worker restarts.
+
+For backward compatibility, a missing remote `config.url` still falls back to
+`III_URL`, then `ws://0.0.0.0:49134`. In Compose or another supervised setup,
+always set `config.url` so this legacy fallback cannot point the remote target
+back at the local/control engine.

--- a/bridge/src/config.rs
+++ b/bridge/src/config.rs
@@ -1,6 +1,8 @@
-//! Worker configuration — field parity with the builtin's BridgeClientConfig
-//! (engine/src/workers/bridge_client/mod.rs:22-48), plus the same URL
-//! fallback chain (config.url -> III_URL env -> ws://0.0.0.0:49134).
+//! Worker configuration for the remote target connection. It keeps field
+//! parity with the builtin's BridgeClientConfig
+//! (engine/src/workers/bridge_client/mod.rs:22-48). The `III_URL` fallback is
+//! legacy public behavior; supervised deployments must set `config.url`
+//! because `III_URL` selects the worker's local/control engine.
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -11,7 +13,8 @@ pub const DEFAULT_REMOTE_URL: &str = "ws://0.0.0.0:49134";
 #[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct BridgeConfig {
-    /// Remote engine WebSocket URL. Fallback: `III_URL` env var, then ws://0.0.0.0:49134.
+    /// Remote target WebSocket URL. A missing value uses the legacy `III_URL`
+    /// fallback, then ws://0.0.0.0:49134.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
     /// Local functions registered ON the remote engine (remote -> local calls).
@@ -54,7 +57,8 @@ impl BridgeConfig {
         self.effective_url_with(std::env::var("III_URL").ok())
     }
 
-    /// Pure variant for tests — `env_url` stands in for `III_URL`.
+    /// Pure variant for tests — `env_url` stands in for the legacy remote
+    /// `III_URL` fallback, not the local/control CLI argument.
     pub fn effective_url_with(&self, env_url: Option<String>) -> String {
         self.url
             .clone()

--- a/bridge/src/main.rs
+++ b/bridge/src/main.rs
@@ -6,8 +6,9 @@
 //! until Ctrl+C. The optional `--config` YAML file is a **seed only**: it is
 //! used to populate the configuration entry the first time, after which the
 //! configuration worker is the source of truth. The REMOTE engine URL comes
-//! from the configuration value (`url` field / `III_URL` env / built-in
-//! default), never from `--url`.
+//! from the configuration value. A legacy `III_URL` fallback remains when
+//! that value is absent; supervised deployments must set `config.url` so the
+//! remote target stays separate from the local/control `III_URL`.
 
 use std::sync::Arc;
 
@@ -27,7 +28,8 @@ struct Cli {
     /// authoritative source and `--config` is ignored for the stored value.
     #[arg(long)]
     config: Option<String>,
-    #[arg(long, default_value = "ws://127.0.0.1:49134")]
+    /// Local/control engine URL used to register this worker.
+    #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
     url: String,
     #[arg(long)]
     manifest: bool,
@@ -118,4 +120,81 @@ async fn main() -> Result<()> {
     boot.shutdown().await;
     iii.shutdown_async().await;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::Command;
+
+    use super::*;
+
+    const CHILD_MODE_ENV: &str = "BRIDGE_CLI_URL_TEST_CHILD";
+    const EXPLICIT_URL_ENV: &str = "BRIDGE_CLI_URL_TEST_EXPLICIT";
+    const OUTPUT_PREFIX: &str = "bridge-cli-url=";
+
+    fn parse_url_in_subprocess(explicit_url: Option<&str>, env_url: Option<&str>) -> String {
+        let mut command = Command::new(std::env::current_exe().expect("resolve test executable"));
+        command
+            .args(["--exact", "tests::print_cli_url_for_parent", "--nocapture"])
+            .env(CHILD_MODE_ENV, "1")
+            .env_remove(EXPLICIT_URL_ENV)
+            .env_remove("III_URL");
+
+        if let Some(url) = explicit_url {
+            command.env(EXPLICIT_URL_ENV, url);
+        }
+        if let Some(url) = env_url {
+            command.env("III_URL", url);
+        }
+
+        let output = command.output().expect("run CLI parser subprocess");
+        assert!(
+            output.status.success(),
+            "CLI parser subprocess failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout)
+            .expect("CLI parser output is UTF-8")
+            .lines()
+            .find_map(|line| line.strip_prefix(OUTPUT_PREFIX))
+            .map(str::to_owned)
+            .expect("CLI parser subprocess printed the selected URL")
+    }
+
+    #[test]
+    fn explicit_url_overrides_iii_url() {
+        let url =
+            parse_url_in_subprocess(Some("ws://127.0.0.1:49311"), Some("ws://127.0.0.1:49312"));
+
+        assert_eq!(url, "ws://127.0.0.1:49311");
+    }
+
+    #[test]
+    fn iii_url_is_used_without_explicit_url() {
+        let url = parse_url_in_subprocess(None, Some("ws://127.0.0.1:49312"));
+
+        assert_eq!(url, "ws://127.0.0.1:49312");
+    }
+
+    #[test]
+    fn default_url_is_used_without_overrides() {
+        let url = parse_url_in_subprocess(None, None);
+
+        assert_eq!(url, "ws://127.0.0.1:49134");
+    }
+
+    #[test]
+    fn print_cli_url_for_parent() {
+        if std::env::var(CHILD_MODE_ENV).ok().as_deref() != Some("1") {
+            return;
+        }
+
+        let mut args = vec!["bridge".to_string()];
+        if let Ok(url) = std::env::var(EXPLICIT_URL_ENV) {
+            args.extend(["--url".to_string(), url]);
+        }
+        let cli = Cli::parse_from(args);
+
+        println!("{OUTPUT_PREFIX}{}", cli.url);
+    }
 }

--- a/bridge/tests/local_control_url.rs
+++ b/bridge/tests/local_control_url.rs
@@ -1,0 +1,191 @@
+//! Runtime regression test for the local/control URL selected from `III_URL`.
+//! The test starts an isolated engine on a non-default port, starts the bridge
+//! without `--url`, and verifies that the engine sees worker name `bridge`.
+
+use std::io::Write as _;
+use std::net::TcpListener;
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::{register_worker, IIIClient, InitOptions};
+use serde_json::{json, Value};
+
+struct Engine {
+    child: Child,
+    url: String,
+    directory: PathBuf,
+}
+
+impl Drop for Engine {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        let _ = std::fs::remove_dir_all(&self.directory);
+    }
+}
+
+struct Worker(Child);
+
+impl Drop for Worker {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+fn engine_binary() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("III_ENGINE_BIN") {
+        return Some(path.into());
+    }
+
+    Command::new("iii")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .ok()
+        .filter(|status| status.success())
+        .map(|_| PathBuf::from("iii"))
+}
+
+fn free_non_default_port() -> u16 {
+    loop {
+        let port = TcpListener::bind("127.0.0.1:0")
+            .expect("bind an ephemeral port")
+            .local_addr()
+            .expect("read the ephemeral port")
+            .port();
+        if port != 49134 {
+            return port;
+        }
+    }
+}
+
+async fn trigger_workers_list(client: &IIIClient) -> Option<Value> {
+    client
+        .trigger(TriggerRequest {
+            function_id: "engine::workers::list".to_string(),
+            payload: json!({}),
+            action: None,
+            timeout_ms: Some(1_000),
+        })
+        .await
+        .ok()
+}
+
+async fn spawn_engine() -> Option<Engine> {
+    let binary = engine_binary()?;
+    let port = free_non_default_port();
+    let directory =
+        std::env::temp_dir().join(format!("bridge-local-url-{}-{port}", std::process::id()));
+    std::fs::create_dir_all(directory.join("configuration"))
+        .expect("create integration test directory");
+
+    let config = format!(
+        r#"workers:
+  - name: iii-worker-manager
+    config:
+      host: 127.0.0.1
+      port: {port}
+  - name: configuration
+    config:
+      adapter:
+        name: fs
+        config:
+          directory: {directory}/configuration
+      ttl_seconds: 0
+"#,
+        directory = directory.display()
+    );
+    let config_path = directory.join("config.yaml");
+    std::fs::File::create(&config_path)
+        .and_then(|mut file| file.write_all(config.as_bytes()))
+        .expect("write engine config");
+
+    let child = Command::new(binary)
+        .args(["--no-update-check", "--config"])
+        .arg(&config_path)
+        .current_dir(&directory)
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("spawn iii engine");
+    let engine = Engine {
+        child,
+        url: format!("ws://127.0.0.1:{port}"),
+        directory,
+    };
+
+    let probe = register_worker(&engine.url, InitOptions::default());
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while Instant::now() < deadline {
+        if trigger_workers_list(&probe).await.is_some() {
+            probe.shutdown_async().await;
+            return Some(engine);
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+    probe.shutdown_async().await;
+
+    panic!("engine did not become ready at {}", engine.url);
+}
+
+fn bridge_is_registered(workers: &Value) -> bool {
+    workers
+        .get("workers")
+        .and_then(Value::as_array)
+        .is_some_and(|entries| {
+            entries
+                .iter()
+                .any(|entry| entry.get("name").and_then(Value::as_str) == Some("bridge"))
+        })
+}
+
+#[tokio::test]
+async fn bridge_registers_on_non_default_local_engine_from_iii_url() {
+    let Some(engine) = spawn_engine().await else {
+        eprintln!("skipping: no iii engine (set III_ENGINE_BIN or put `iii` on PATH)");
+        return;
+    };
+
+    let remote_port = free_non_default_port();
+    let seed_path = engine.directory.join("bridge-seed.yaml");
+    std::fs::write(&seed_path, format!("url: ws://127.0.0.1:{remote_port}\n"))
+        .expect("write bridge seed config");
+    let mut worker = Worker(
+        Command::new(env!("CARGO_BIN_EXE_bridge"))
+            .args(["--config"])
+            .arg(&seed_path)
+            .env("III_URL", &engine.url)
+            .env("III_CONFIG_NAME", format!("bridge-local-url-{remote_port}"))
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn bridge worker"),
+    );
+
+    let probe = register_worker(&engine.url, InitOptions::default());
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut last_workers = Value::Null;
+    while Instant::now() < deadline {
+        if let Some(status) = worker.0.try_wait().expect("query bridge process") {
+            panic!("bridge exited before registration with status {status}");
+        }
+        if let Some(workers) = trigger_workers_list(&probe).await {
+            if bridge_is_registered(&workers) {
+                probe.shutdown_async().await;
+                return;
+            }
+            last_workers = workers;
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+    probe.shutdown_async().await;
+
+    panic!(
+        "bridge did not register on the III_URL engine {}; last worker list: {last_workers}",
+        engine.url
+    );
+}


### PR DESCRIPTION
## Summary

- Make the bridge local/control connection use --url, then III_URL, then the default port.
- Keep the configured remote target separate and document the legacy remote fallback.
- Add subprocess coverage for URL precedence and a real-engine regression test on a non-default port.
- Bump bridge to 0.1.6.

## Validation

- cargo fmt --manifest-path bridge/Cargo.toml -- --check
- cargo test --manifest-path bridge/Cargo.toml --locked
- cargo clippy --manifest-path bridge/Cargo.toml --all-targets --all-features --locked -- -D warnings

Refs MOT-4149

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The bridge now supports configuring its local engine connection through `--url` or the `III_URL` environment variable.
  - Remote target connections can be specified separately through the configured remote URL.
  - Existing configurations remain supported through documented fallback behavior.

- **Documentation**
  - Clarified local and remote connection settings, defaults, precedence, and deployment considerations.
  - Added guidance to help prevent accidental connections to the local engine.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->