### PR TITLE
(MOT-4484/4485/4486) feat: reusable agent profiles — directory family, native harness resolution, console picker

### DIFF
--- a/console/web/src/components/chat/ActiveSubagentChips.css
+++ b/console/web/src/components/chat/ActiveSubagentChips.css
@@ -16,47 +16,47 @@
   );
 }
 
-.active-subagent-chip[data-color="blue"] {
+:is(.active-subagent-chip, .subagent-tree-icon)[data-color="blue"] {
   --subagent-chip-tone: #235f9c;
 }
 
-.active-subagent-chip[data-color="purple"] {
+:is(.active-subagent-chip, .subagent-tree-icon)[data-color="purple"] {
   --subagent-chip-tone: #7250a0;
 }
 
-.active-subagent-chip[data-color="teal"] {
+:is(.active-subagent-chip, .subagent-tree-icon)[data-color="teal"] {
   --subagent-chip-tone: #0d746c;
 }
 
-.active-subagent-chip[data-color="green"] {
+:is(.active-subagent-chip, .subagent-tree-icon)[data-color="green"] {
   --subagent-chip-tone: var(--color-ok);
 }
 
-.active-subagent-chip[data-color="amber"] {
+:is(.active-subagent-chip, .subagent-tree-icon)[data-color="amber"] {
   --subagent-chip-tone: #765200;
 }
 
-.active-subagent-chip[data-color="rose"] {
+:is(.active-subagent-chip, .subagent-tree-icon)[data-color="rose"] {
   --subagent-chip-tone: #b5375c;
 }
 
-[data-theme="dark"] .active-subagent-chip[data-color="blue"] {
+[data-theme="dark"] :is(.active-subagent-chip, .subagent-tree-icon)[data-color="blue"] {
   --subagent-chip-tone: #79b7f2;
 }
 
-[data-theme="dark"] .active-subagent-chip[data-color="purple"] {
+[data-theme="dark"] :is(.active-subagent-chip, .subagent-tree-icon)[data-color="purple"] {
   --subagent-chip-tone: #c09ae8;
 }
 
-[data-theme="dark"] .active-subagent-chip[data-color="teal"] {
+[data-theme="dark"] :is(.active-subagent-chip, .subagent-tree-icon)[data-color="teal"] {
   --subagent-chip-tone: #5acac0;
 }
 
-[data-theme="dark"] .active-subagent-chip[data-color="rose"] {
+[data-theme="dark"] :is(.active-subagent-chip, .subagent-tree-icon)[data-color="rose"] {
   --subagent-chip-tone: #f28ca8;
 }
 
-[data-theme="dark"] .active-subagent-chip[data-color="amber"] {
+[data-theme="dark"] :is(.active-subagent-chip, .subagent-tree-icon)[data-color="amber"] {
   --subagent-chip-tone: #e8b949;
 }
 
@@ -75,4 +75,11 @@
 .active-subagent-chip[data-status="disconnected"]
   .active-subagent-chip__status {
   background-color: var(--color-ink-ghost);
+}
+
+/* The sidebar tree reuses the chip tone palette for its per-session
+   subagent icon: tint only, no background. Rows without a declared
+   color keep the ghost ink they had. */
+.subagent-tree-icon[data-color] {
+  color: var(--subagent-chip-tone, var(--color-ink-ghost));
 }

--- a/console/web/src/components/chat/AgentPicker.tsx
+++ b/console/web/src/components/chat/AgentPicker.tsx
@@ -1,33 +1,27 @@
 import * as SelectPrimitive from '@radix-ui/react-select'
 import { Bot, Check, ChevronDown } from 'lucide-react'
 import { useCallback, useState } from 'react'
-import {
-  type AgentEntry,
-  getAgent,
-  listAgents,
-} from '@/lib/backend/directory-prompts'
+import { type AgentEntry, listAgents } from '@/lib/backend/directory-prompts'
 import { getIiiClient } from '@/lib/iii-client'
 import { cn } from '@/lib/utils'
 import { SUBAGENT_ICON_COMPONENTS } from './ActiveSubagentChips'
-import type { SkillSelection, SystemPromptState } from './system-prompt-selection'
+import {
+  AGENT_CHOICE_PREFIX,
+  type SystemPromptState,
+} from './system-prompt-selection'
 import type { SubagentIcon } from '@/types/chat'
 
 /**
  * The new-session agent picker: "Default" (the provider's built-in prompt)
  * or one of the reusable agent profiles the iii-directory worker serves.
  *
- * Picking an agent maps onto the machinery the system-prompt picker
- * already established (`Conversation.systemPrompt`, frozen on the first
- * send): the profile's body becomes the named prompt under the `enrich`
- * strategy with a `You are <name>.` line, and the profile's skill filter
- * becomes the session's skill selection. Until the harness resolves
- * `options.agent` natively (MOT-4485), this is the resolution.
+ * The picker stores only the id (`choice: { named: 'agent:<id>' }`); the
+ * first send carries it as `harness::send` `options.agent` and the harness
+ * resolves the profile server-side (MOT-4485) — prompt, skill filter, and
+ * default model all come from the frozen profile.
  */
 
-/** `agent:` inside the named choice keeps agent selections distinct from
- * fs system prompts (prompt names are `[a-z0-9_-]`, so the prefix is
- * unambiguous). */
-export const AGENT_CHOICE_PREFIX = 'agent:'
+export { AGENT_CHOICE_PREFIX }
 
 function agentIcon(icon: string | null): React.ComponentType<{
   size?: number
@@ -80,13 +74,11 @@ function AgentItem({
 export function AgentPicker({
   value,
   onChange,
-  onSkillsChange,
   disabled,
   className,
 }: {
   value: SystemPromptState
   onChange: (next: SystemPromptState) => void
-  onSkillsChange?: (next: SkillSelection) => void
   disabled?: boolean
   className?: string
 }) {
@@ -116,30 +108,22 @@ export function AgentPicker({
       : null
 
   const handleValueChange = useCallback(
-    async (v: string) => {
+    (v: string) => {
       if (v === 'default') {
         onChange({ ...value, choice: 'default', namedBody: '' })
-        onSkillsChange?.(undefined)
         return
       }
+      /* Store only the id; the harness resolves the profile on the first
+         send (`options.agent`) and freezes it server-side. */
       const id = v.slice(`named:${AGENT_CHOICE_PREFIX}`.length)
-      try {
-        /* Resolve the profile at selection time; the first send freezes it
-           server-side, same contract as the named system prompts. */
-        const agent = await getAgent(await getIiiClient(), id)
-        onChange({
-          ...value,
-          choice: { named: `${AGENT_CHOICE_PREFIX}${id}` },
-          namedBody: `You are ${agent.name || id}.\n\n${agent.system_prompt}`,
-          strategy: 'enrich',
-        })
-        onSkillsChange?.(agent.skills.length ? agent.skills : undefined)
-      } catch {
-        onChange({ ...value, choice: 'default', namedBody: '' })
-        onSkillsChange?.(undefined)
-      }
+      onChange({
+        ...value,
+        choice: { named: `${AGENT_CHOICE_PREFIX}${id}` },
+        namedBody: '',
+        strategy: 'enrich',
+      })
     },
-    [onChange, onSkillsChange, value],
+    [onChange, value],
   )
 
   const selectedEntry = entries?.find((e) => e.id === selectedId)

--- a/console/web/src/components/chat/AgentPicker.tsx
+++ b/console/web/src/components/chat/AgentPicker.tsx
@@ -1,0 +1,209 @@
+import * as SelectPrimitive from '@radix-ui/react-select'
+import { Bot, Check, ChevronDown } from 'lucide-react'
+import { useCallback, useState } from 'react'
+import {
+  type AgentEntry,
+  getAgent,
+  listAgents,
+} from '@/lib/backend/directory-prompts'
+import { getIiiClient } from '@/lib/iii-client'
+import { cn } from '@/lib/utils'
+import { SUBAGENT_ICON_COMPONENTS } from './ActiveSubagentChips'
+import type { SkillSelection, SystemPromptState } from './system-prompt-selection'
+import type { SubagentIcon } from '@/types/chat'
+
+/**
+ * The new-session agent picker: "Default" (the provider's built-in prompt)
+ * or one of the reusable agent profiles the iii-directory worker serves.
+ *
+ * Picking an agent maps onto the machinery the system-prompt picker
+ * already established (`Conversation.systemPrompt`, frozen on the first
+ * send): the profile's body becomes the named prompt under the `enrich`
+ * strategy with a `You are <name>.` line, and the profile's skill filter
+ * becomes the session's skill selection. Until the harness resolves
+ * `options.agent` natively (MOT-4485), this is the resolution.
+ */
+
+/** `agent:` inside the named choice keeps agent selections distinct from
+ * fs system prompts (prompt names are `[a-z0-9_-]`, so the prefix is
+ * unambiguous). */
+export const AGENT_CHOICE_PREFIX = 'agent:'
+
+function agentIcon(icon: string | null): React.ComponentType<{
+  size?: number
+  className?: string
+  'aria-hidden'?: boolean
+}> {
+  return (
+    (icon && SUBAGENT_ICON_COMPONENTS[icon as SubagentIcon]) ||
+    Bot
+  )
+}
+
+function AgentItem({
+  value,
+  label,
+  description,
+  icon,
+}: {
+  value: string
+  label: string
+  description?: string
+  icon?: string | null
+}) {
+  const Icon = agentIcon(icon ?? null)
+  return (
+    <SelectPrimitive.Item
+      value={value}
+      className={cn(
+        'relative flex items-start gap-2 rounded-xs pl-7 pr-3 py-2 cursor-pointer outline-none select-none',
+        'data-[highlighted]:bg-surface-hover data-[highlighted]:text-ink',
+        'data-[state=checked]:text-ink',
+      )}
+    >
+      <SelectPrimitive.ItemIndicator className="absolute left-2 top-1/2 -translate-y-1/2 text-ink">
+        <Check size={16} aria-hidden />
+      </SelectPrimitive.ItemIndicator>
+      <Icon size={16} className="mt-0.5 shrink-0 text-ink-faint" aria-hidden />
+      <div className="min-w-0">
+        <SelectPrimitive.ItemText>{label}</SelectPrimitive.ItemText>
+        {description ? (
+          <div className="truncate text-[11px] leading-[1.5] text-ink-faint">
+            {description}
+          </div>
+        ) : null}
+      </div>
+    </SelectPrimitive.Item>
+  )
+}
+
+export function AgentPicker({
+  value,
+  onChange,
+  onSkillsChange,
+  disabled,
+  className,
+}: {
+  value: SystemPromptState
+  onChange: (next: SystemPromptState) => void
+  onSkillsChange?: (next: SkillSelection) => void
+  disabled?: boolean
+  className?: string
+}) {
+  const [entries, setEntries] = useState<AgentEntry[] | null>(null)
+
+  /* Fetch on EVERY open (keeping the last list while loading): an agent
+     authored in the directory UI shows up on the next open with no
+     cache-invalidation plumbing. A failed load degrades to Default only
+     (directory worker absent ≠ broken chat). */
+  const handleOpenChange = useCallback(async (open: boolean) => {
+    if (!open) return
+    try {
+      /* Leaf agents are spawn targets for orchestrators, not session
+         identities — the picker offers only agents that may delegate. */
+      setEntries(
+        (await listAgents(await getIiiClient())).filter((e) => !e.leaf),
+      )
+    } catch {
+      setEntries((prev) => prev ?? [])
+    }
+  }, [])
+
+  const selectedId =
+    typeof value.choice === 'object' &&
+    value.choice.named.startsWith(AGENT_CHOICE_PREFIX)
+      ? value.choice.named.slice(AGENT_CHOICE_PREFIX.length)
+      : null
+
+  const handleValueChange = useCallback(
+    async (v: string) => {
+      if (v === 'default') {
+        onChange({ ...value, choice: 'default', namedBody: '' })
+        onSkillsChange?.(undefined)
+        return
+      }
+      const id = v.slice(`named:${AGENT_CHOICE_PREFIX}`.length)
+      try {
+        /* Resolve the profile at selection time; the first send freezes it
+           server-side, same contract as the named system prompts. */
+        const agent = await getAgent(await getIiiClient(), id)
+        onChange({
+          ...value,
+          choice: { named: `${AGENT_CHOICE_PREFIX}${id}` },
+          namedBody: `You are ${agent.name || id}.\n\n${agent.system_prompt}`,
+          strategy: 'enrich',
+        })
+        onSkillsChange?.(agent.skills.length ? agent.skills : undefined)
+      } catch {
+        onChange({ ...value, choice: 'default', namedBody: '' })
+        onSkillsChange?.(undefined)
+      }
+    },
+    [onChange, onSkillsChange, value],
+  )
+
+  const selectedEntry = entries?.find((e) => e.id === selectedId)
+  const label = selectedId === null ? 'Default' : (selectedEntry?.name ?? selectedId)
+  const TriggerIconComp = agentIcon(selectedEntry?.icon ?? null)
+
+  return (
+    <SelectPrimitive.Root
+      value={
+        selectedId === null
+          ? 'default'
+          : `named:${AGENT_CHOICE_PREFIX}${selectedId}`
+      }
+      onValueChange={handleValueChange}
+      onOpenChange={handleOpenChange}
+      disabled={disabled}
+    >
+      <SelectPrimitive.Trigger
+        aria-label="agent"
+        className={cn(
+          'inline-flex w-full items-center justify-between gap-x-2 rounded-sm border border-transparent bg-bg px-3 h-9 text-ink font-sans text-[13px] hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus data-[state=open]:bg-surface-active transition-colors',
+          disabled && 'opacity-40 pointer-events-none',
+          className,
+        )}
+      >
+        <span className="inline-flex items-center gap-2 min-w-0">
+          <TriggerIconComp size={16} className="text-ink-faint" aria-hidden />
+          <span className="truncate max-w-[14rem]">
+            <SelectPrimitive.Value>{label}</SelectPrimitive.Value>
+          </span>
+        </span>
+        <SelectPrimitive.Icon asChild>
+          <ChevronDown size={16} aria-hidden />
+        </SelectPrimitive.Icon>
+      </SelectPrimitive.Trigger>
+
+      <SelectPrimitive.Portal>
+        <SelectPrimitive.Content
+          position="popper"
+          sideOffset={4}
+          className={cn(
+            'z-50 min-w-[var(--radix-select-trigger-width)] max-w-[var(--radix-select-content-available-width)] overflow-hidden rounded-md border border-rule-2 bg-panel-raised text-ink font-sans text-[13px] shadow-floating',
+            'data-[state=open]:animate-in data-[state=closed]:animate-out',
+            'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+          )}
+        >
+          <SelectPrimitive.Viewport className="p-1">
+            <AgentItem
+              value="default"
+              label="Default"
+              description="No agent — the provider's built-in prompt"
+            />
+            {(entries ?? []).map((e) => (
+              <AgentItem
+                key={e.id}
+                value={`named:${AGENT_CHOICE_PREFIX}${e.id}`}
+                label={e.name || e.id}
+                description={e.description}
+                icon={e.icon}
+              />
+            ))}
+          </SelectPrimitive.Viewport>
+        </SelectPrimitive.Content>
+      </SelectPrimitive.Portal>
+    </SelectPrimitive.Root>
+  )
+}

--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -92,6 +92,7 @@ import { isSessionSubmitBlockedByHydration } from './chat-submit-blocking'
 import { MessageList } from './MessageList'
 import { SessionTriggers } from './SessionTriggers'
 import {
+  agentIdForSend,
   DEFAULT_SYSTEM_PROMPT_STATE,
   selectionForSend,
   skillSelectionForSend,
@@ -1140,14 +1141,23 @@ export function ChatView({
       const turnEstablished = messagesRef.current.some(
         (m) => m.role === 'assistant',
       )
-      const systemPrompt = selectionForSend(
-        effectiveSystemPrompt,
-        turnEstablished,
-      )
-      const skills = skillSelectionForSend(conversation.skills, {
+      // An agent selection resolves server-side (options.agent) and supplies
+      // prompt + skills itself; suppressing the client-side selection also
+      // covers pre-upgrade drafts whose persisted namedBody would otherwise
+      // collide with the agent field.
+      const agentId = agentIdForSend(effectiveSystemPrompt, {
         turnEstablished,
         willQueue,
       })
+      const systemPrompt = agentId
+        ? null
+        : selectionForSend(effectiveSystemPrompt, turnEstablished)
+      const skills = agentId
+        ? undefined
+        : skillSelectionForSend(conversation.skills, {
+            turnEstablished,
+            willQueue,
+          })
 
       if (!willQueue) onAppendMessage(conversationId, userMsg)
 
@@ -1353,6 +1363,7 @@ export function ChatView({
               thinkingLevel,
               systemPrompt,
               skills,
+              ...(agentId ? { agent: agentId } : {}),
               workingDir: conversation.workingDir,
               approvalGateAvailable: approvalEnabled,
               ...(attachedBlocks && attachedBlocks.length > 0
@@ -1403,6 +1414,7 @@ export function ChatView({
             thinkingLevel,
             systemPrompt,
             skills,
+            ...(agentId ? { agent: agentId } : {}),
             workingDir: conversation.workingDir,
             approvalGateAvailable: approvalEnabled,
             approvalSessionMatcher,

--- a/console/web/src/components/chat/EmptyState.stories.tsx
+++ b/console/web/src/components/chat/EmptyState.stories.tsx
@@ -53,21 +53,18 @@ export const Ready: Story = {
     variant: 'ready',
     systemPrompt: DEFAULT_SYSTEM_PROMPT_STATE,
     onSystemPromptChange: fn(),
-    onSkillsChange: fn(),
   },
 }
 
 export const ReadyWithNamedPrompt: Story = {
-  name: 'ready (named system prompt)',
+  name: 'ready (agent selected)',
   args: {
     variant: 'ready',
     systemPrompt: {
       ...DEFAULT_SYSTEM_PROMPT_STATE,
-      choice: { named: 'ptbr' },
+      choice: { named: 'agent:tech-leader' },
     },
     onSystemPromptChange: fn(),
-    skills: ['review', 'release'],
-    onSkillsChange: fn(),
   },
 }
 

--- a/console/web/src/components/chat/EmptyState.tsx
+++ b/console/web/src/components/chat/EmptyState.tsx
@@ -6,10 +6,7 @@ import type { InstallStage } from '@/hooks/use-harness-status'
 import { normalizeErrorMessage } from '@/lib/providers'
 import { cn } from '@/lib/utils'
 import { AgentPicker } from './AgentPicker'
-import type {
-  SkillSelection,
-  SystemPromptState,
-} from './system-prompt-selection'
+import type { SystemPromptState } from './system-prompt-selection'
 
 /**
  * The chat empty state, as a small set of presentational variants:
@@ -53,8 +50,6 @@ export interface EmptyStateProps {
    */
   systemPrompt?: SystemPromptState
   onSystemPromptChange?: (next: SystemPromptState) => void
-  skills?: SkillSelection
-  onSkillsChange?: (next: SkillSelection) => void
 }
 
 const HARNESS_INSTALL_COMMAND = 'iii worker add harness'
@@ -73,7 +68,6 @@ export function EmptyState({
   onConfigureProvider,
   systemPrompt,
   onSystemPromptChange,
-  onSkillsChange,
 }: EmptyStateProps) {
   const emptyPad = density === 'dock' ? 'px-3 sm:px-4' : 'px-3 sm:px-6 lg:px-9'
   const eyebrow =
@@ -95,7 +89,6 @@ export function EmptyState({
           <ReadyBody
             systemPrompt={systemPrompt}
             onSystemPromptChange={onSystemPromptChange}
-            onSkillsChange={onSkillsChange}
           />
         ) : null}
         {variant === 'no-provider' ? (
@@ -128,11 +121,9 @@ const EXPLORE_FUNCTIONS = [
 function ReadyBody({
   systemPrompt,
   onSystemPromptChange,
-  onSkillsChange,
 }: {
   systemPrompt?: SystemPromptState
   onSystemPromptChange?: (next: SystemPromptState) => void
-  onSkillsChange?: (next: SkillSelection) => void
 }) {
   return (
     <>
@@ -184,7 +175,6 @@ function ReadyBody({
           <AgentPicker
             value={systemPrompt}
             onChange={onSystemPromptChange}
-            onSkillsChange={onSkillsChange}
             className="min-w-0"
           />
           <p className="font-sans text-base/6 text-ink-faint sm:text-sm/5">

--- a/console/web/src/components/chat/EmptyState.tsx
+++ b/console/web/src/components/chat/EmptyState.tsx
@@ -5,8 +5,7 @@ import { Button } from '@/components/ui/Button'
 import type { InstallStage } from '@/hooks/use-harness-status'
 import { normalizeErrorMessage } from '@/lib/providers'
 import { cn } from '@/lib/utils'
-import { SessionAddonsPicker } from './SessionAddonsPicker'
-import { StrategyToggle, SystemPromptPicker } from './SystemPromptPicker'
+import { AgentPicker } from './AgentPicker'
 import type {
   SkillSelection,
   SystemPromptState,
@@ -74,7 +73,6 @@ export function EmptyState({
   onConfigureProvider,
   systemPrompt,
   onSystemPromptChange,
-  skills,
   onSkillsChange,
 }: EmptyStateProps) {
   const emptyPad = density === 'dock' ? 'px-3 sm:px-4' : 'px-3 sm:px-6 lg:px-9'
@@ -97,7 +95,6 @@ export function EmptyState({
           <ReadyBody
             systemPrompt={systemPrompt}
             onSystemPromptChange={onSystemPromptChange}
-            skills={skills}
             onSkillsChange={onSkillsChange}
           />
         ) : null}
@@ -131,12 +128,10 @@ const EXPLORE_FUNCTIONS = [
 function ReadyBody({
   systemPrompt,
   onSystemPromptChange,
-  skills,
   onSkillsChange,
 }: {
   systemPrompt?: SystemPromptState
   onSystemPromptChange?: (next: SystemPromptState) => void
-  skills?: SkillSelection
   onSkillsChange?: (next: SkillSelection) => void
 }) {
   return (
@@ -172,50 +167,30 @@ function ReadyBody({
           composer that starts and locks the session. */}
       {systemPrompt && onSystemPromptChange ? (
         <section
-          aria-labelledby="session-system-prompt"
+          aria-labelledby="session-agent"
           className="rounded-sm bg-surface p-4 flex flex-col gap-3"
         >
           <div className="flex flex-col gap-1">
             <h2
-              id="session-system-prompt"
+              id="session-agent"
               className="font-sans text-base font-semibold text-ink sm:text-sm"
             >
-              System prompt
+              Agent
             </h2>
             <p className="font-sans text-base/6 text-ink-faint sm:text-sm/6">
-              Choose the instructions the agent follows in this session.
+              Choose who the agent is in this session.
             </p>
           </div>
-          <div className="flex items-start gap-2">
-            <SystemPromptPicker
-              value={systemPrompt}
-              onChange={onSystemPromptChange}
-              allowCustom={false}
-              className="min-w-0 flex-1"
-            />
-            <StrategyToggle
-              value={systemPrompt}
-              onChange={onSystemPromptChange}
-            />
-          </div>
-          {onSkillsChange ? (
-            <div className="flex flex-col gap-1.5">
-              <p className="font-sans text-base/6 text-ink-faint sm:text-sm/5">
-                Choose which skills the agent can discover:
-              </p>
-              <SessionAddonsPicker
-                value={skills}
-                onChange={onSkillsChange}
-                className="min-w-0"
-              />
-            </div>
-          ) : null}
+          <AgentPicker
+            value={systemPrompt}
+            onChange={onSystemPromptChange}
+            onSkillsChange={onSkillsChange}
+            className="min-w-0"
+          />
           <p className="font-sans text-base/6 text-ink-faint sm:text-sm/5">
             {systemPrompt.choice === 'default'
               ? "Default uses the provider's built-in prompt"
-              : systemPrompt.strategy === 'enrich'
-                ? 'Enrich adds this prompt to the built-in prompt'
-                : 'Replace uses this prompt instead of the built-in prompt'}
+              : "The agent's instructions and skill selection apply to this session"}
             {' · Locked after your first message'}
           </p>
         </section>

--- a/console/web/src/components/chat/MessageList.tsx
+++ b/console/web/src/components/chat/MessageList.tsx
@@ -50,7 +50,6 @@ import { functionTriggerGroups } from './function-trigger-groups'
 import { Message, type SpawnTaskContext } from './Message'
 import {
   DEFAULT_SYSTEM_PROMPT_STATE,
-  type SkillSelection,
   type SystemPromptState,
 } from './system-prompt-selection'
 import {
@@ -874,10 +873,6 @@ function resolveEmptyState(
     systemPrompt: active?.systemPrompt ?? DEFAULT_SYSTEM_PROMPT_STATE,
     onSystemPromptChange: active
       ? (next: SystemPromptState) => ctx.setSystemPrompt(active.id, next)
-      : undefined,
-    skills: active?.skills,
-    onSkillsChange: active
-      ? (next: SkillSelection) => ctx.setSkills(active.id, next)
       : undefined,
   }
 

--- a/console/web/src/components/chat/system-prompt-selection.test.ts
+++ b/console/web/src/components/chat/system-prompt-selection.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
+  AGENT_CHOICE_PREFIX,
+  agentIdForSend,
   choiceToValue,
   DEFAULT_SYSTEM_PROMPT_STATE,
   type SystemPromptState,
@@ -178,5 +180,46 @@ describe('skill selection', () => {
         willQueue: true,
       }),
     ).toBeUndefined()
+  })
+})
+
+describe('agentIdForSend', () => {
+  const agentState: SystemPromptState = {
+    ...DEFAULT_SYSTEM_PROMPT_STATE,
+    choice: { named: `${AGENT_CHOICE_PREFIX}tech-leader` },
+  }
+
+  it('returns the id only on a first, non-queued send', () => {
+    expect(
+      agentIdForSend(agentState, { turnEstablished: false, willQueue: false }),
+    ).toBe('tech-leader')
+    // Once a turn exists the harness refuses options.agent.
+    expect(
+      agentIdForSend(agentState, { turnEstablished: true, willQueue: false }),
+    ).toBeUndefined()
+    // A queued mid-stream send targets a session with a prior turn — the
+    // willQueue gate is load-bearing, not symmetry with selectionForSend.
+    expect(
+      agentIdForSend(agentState, { turnEstablished: false, willQueue: true }),
+    ).toBeUndefined()
+  })
+
+  it('ignores non-agent choices', () => {
+    expect(
+      agentIdForSend(DEFAULT_SYSTEM_PROMPT_STATE, {
+        turnEstablished: false,
+        willQueue: false,
+      }),
+    ).toBeUndefined()
+    expect(
+      agentIdForSend(
+        { ...DEFAULT_SYSTEM_PROMPT_STATE, choice: { named: 'pirate' } },
+        { turnEstablished: false, willQueue: false },
+      ),
+    ).toBeUndefined()
+  })
+
+  it('an agent choice with an empty namedBody yields no prompt selection', () => {
+    expect(toSelection(agentState)).toBeNull()
   })
 })

--- a/console/web/src/components/chat/system-prompt-selection.ts
+++ b/console/web/src/components/chat/system-prompt-selection.ts
@@ -19,6 +19,11 @@ import type { SystemPromptSelection } from '@/lib/backend/harness-send'
 
 export type PromptStrategy = 'enrich' | 'override'
 
+/** `agent:` inside the named choice keeps agent selections distinct from fs
+ * system prompts (prompt names are `[a-z0-9_-]`, so the prefix is
+ * unambiguous). The id resolves server-side via `options.agent` (MOT-4485). */
+export const AGENT_CHOICE_PREFIX = 'agent:'
+
 /** Undefined/empty means every model-invocable skill; otherwise exact IDs. */
 export type SkillSelection = string[] | undefined
 
@@ -89,6 +94,30 @@ export function selectionForSend(
   turnEstablished: boolean,
 ): SystemPromptSelection | null {
   return turnEstablished ? null : toSelection(s)
+}
+
+/**
+ * The agent id for a given send, or undefined. Gated harder than
+ * `selectionForSend`: the harness REFUSES `options.agent` on a session with a
+ * prior turn, and a queued mid-stream send targets exactly such a session —
+ * so queue sends must never carry it (a re-sent prompt field is merely
+ * re-resolved; a re-sent agent is an error).
+ */
+export function agentIdForSend(
+  s: SystemPromptState,
+  state: { turnEstablished: boolean; willQueue: boolean },
+): string | undefined {
+  if (state.turnEstablished || state.willQueue) return undefined
+  if (
+    typeof s.choice === 'object' &&
+    s.choice !== null &&
+    'named' in s.choice &&
+    s.choice.named.startsWith(AGENT_CHOICE_PREFIX)
+  ) {
+    const id = s.choice.named.slice(AGENT_CHOICE_PREFIX.length)
+    return id || undefined
+  }
+  return undefined
 }
 
 export function toggleSkillSelection(

--- a/console/web/src/components/sidebar/ConversationRow.tsx
+++ b/console/web/src/components/sidebar/ConversationRow.tsx
@@ -1,5 +1,7 @@
 import { Bot, ChevronDown, ChevronRight, Trash2 } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
+import { SUBAGENT_ICON_COMPONENTS } from '@/components/chat/ActiveSubagentChips'
+import '@/components/chat/ActiveSubagentChips.css'
 import { StatusDot } from '@/components/ui/StatusDot'
 import { TriggerIcon } from '@/components/ui/TriggerIcon'
 import { cn } from '@/lib/utils'
@@ -138,15 +140,22 @@ export function ConversationRow({
           />
         )
       ) : null}
-      {/* Sub-agent origin: ⚡ a trigger reaction spawned it, 🤖 an agent's
-          direct harness::spawn did. Absent on roots and pre-stamp sessions. */}
+      {/* Sub-agent origin: ⚡ a trigger reaction spawned it, otherwise the
+          spawn's declared display identity (subagent_display icon + color)
+          when present, falling back to the generic 🤖. Absent on roots and
+          pre-stamp sessions. */}
       {depth > 0 && conversation.spawnedBy ? (
         <span
-          className="flex items-center shrink-0 text-ink-ghost"
+          className="subagent-tree-icon flex items-center shrink-0 text-ink-ghost"
+          data-color={
+            conversation.spawnedBy === 'agent'
+              ? conversation.subagentAppearance?.color
+              : undefined
+          }
           title={
             conversation.spawnedBy === 'trigger'
               ? 'spawned by a trigger'
-              : 'spawned by an agent'
+              : (conversation.subagentAppearance?.name ?? 'spawned by an agent')
           }
         >
           {conversation.spawnedBy === 'trigger' ? (
@@ -155,7 +164,19 @@ export function ConversationRow({
               className="size-4 shrink-0 fill-ink-ghost"
             />
           ) : (
-            <Bot aria-label="spawned by an agent" className="size-4 shrink-0" />
+            (() => {
+              const icon = conversation.subagentAppearance?.icon
+              const Icon = (icon && SUBAGENT_ICON_COMPONENTS[icon]) || Bot
+              return (
+                <Icon
+                  aria-label={
+                    conversation.subagentAppearance?.name ??
+                    'spawned by an agent'
+                  }
+                  className="size-4 shrink-0"
+                />
+              )
+            })()
           )}
         </span>
       ) : null}

--- a/console/web/src/lib/backend/directory-prompts.ts
+++ b/console/web/src/lib/backend/directory-prompts.ts
@@ -148,12 +148,6 @@ export interface AgentEntry {
   modified_at: string
 }
 
-export interface AgentProfile extends AgentEntry {
-  system_prompt: string
-  skills: string[]
-  unknown_skills: string[]
-}
-
 export async function listAgents(client: IiiClient): Promise<AgentEntry[]> {
   const res = await client.trigger<{ agents: AgentEntry[] }>(
     'directory::agents::list',
@@ -161,15 +155,4 @@ export async function listAgents(client: IiiClient): Promise<AgentEntry[]> {
     { timeoutMs: FETCH_TIMEOUT_MS },
   )
   return res.agents
-}
-
-export async function getAgent(
-  client: IiiClient,
-  id: string,
-): Promise<AgentProfile> {
-  return client.trigger<AgentProfile>(
-    'directory::agents::get',
-    { id },
-    { timeoutMs: FETCH_TIMEOUT_MS },
-  )
 }

--- a/console/web/src/lib/backend/directory-prompts.ts
+++ b/console/web/src/lib/backend/directory-prompts.ts
@@ -131,3 +131,45 @@ export async function getSkill(
     { timeoutMs: FETCH_TIMEOUT_MS },
   )
 }
+
+/* ── agent profiles (`directory::agents::*`) — the new-session picker ── */
+
+export interface AgentEntry {
+  id: string
+  name: string
+  description: string
+  logo: string | null
+  icon: string | null
+  model: string | null
+  skill_count: number | null
+  /** true = a specialist meant to be spawned, not to front a session.
+   * Absent on directory workers that predate the field. */
+  leaf?: boolean
+  modified_at: string
+}
+
+export interface AgentProfile extends AgentEntry {
+  system_prompt: string
+  skills: string[]
+  unknown_skills: string[]
+}
+
+export async function listAgents(client: IiiClient): Promise<AgentEntry[]> {
+  const res = await client.trigger<{ agents: AgentEntry[] }>(
+    'directory::agents::list',
+    {},
+    { timeoutMs: FETCH_TIMEOUT_MS },
+  )
+  return res.agents
+}
+
+export async function getAgent(
+  client: IiiClient,
+  id: string,
+): Promise<AgentProfile> {
+  return client.trigger<AgentProfile>(
+    'directory::agents::get',
+    { id },
+    { timeoutMs: FETCH_TIMEOUT_MS },
+  )
+}

--- a/console/web/src/lib/backend/harness-send.ts
+++ b/console/web/src/lib/backend/harness-send.ts
@@ -44,6 +44,10 @@ export type HarnessSendMode = 'ask' | 'agent'
 
 /** Per-send options frozen onto the turn record. */
 export interface HarnessSendOptions {
+  /** Directory agent profile id the session runs as, resolved server-side
+   * (MOT-4485). Session-creating sends only — the harness REFUSES it on a
+   * session with a prior turn, and combined with either prompt field. */
+  agent?: string
   /** Sticky per session: a send that omits BOTH prompt fields inherits the
    * prior turn's resolved prompt; naming either field resolves fresh (a bare
    * strategy is the harness's reset-to-default escape hatch). */

--- a/console/web/src/lib/backend/real.ts
+++ b/console/web/src/lib/backend/real.ts
@@ -210,6 +210,7 @@ async function buildSendRequest(
     options: {
       mode,
       functions: functionPolicy,
+      ...(opts?.agent ? { agent: opts.agent } : {}),
       ...toSystemPromptOptions(opts?.systemPrompt),
       ...toSkillOptions(opts?.skills),
       ...(thinkingLevel ? { thinking_level: thinkingLevel } : {}),

--- a/console/web/src/lib/backend/types.ts
+++ b/console/web/src/lib/backend/types.ts
@@ -135,6 +135,13 @@ export interface ChatStreamOptions {
    * (provider default identity prompt). Mock backends ignore this.
    */
   systemPrompt?: import('./harness-send').SystemPromptSelection | null
+  /**
+   * Directory agent profile id, forwarded as `harness::send` `options.agent`
+   * (resolved server-side, MOT-4485). First send of a session only — the
+   * harness refuses it once a turn exists. Mutually exclusive with
+   * `systemPrompt`/`skills`: the profile supplies both.
+   */
+  agent?: string
   /** First-send skill curation. Undefined/empty means all skills. */
   skills?: string[]
   /**

--- a/harness/README.md
+++ b/harness/README.md
@@ -192,6 +192,36 @@ hatch. Because the inherited string is frozen at its original resolution,
 changing `mode` on a later send without prompt fields keeps the old
 operating-mode paragraph — resend the prompt fields to re-resolve.
 
+### Agent profiles
+
+`options.agent` on a session-creating `harness::send` names a directory agent
+profile (`directory::agents::*`, one markdown file per agent). The harness
+resolves it ONCE via `directory::agents::get` and freezes the result onto the
+turn: `"You are <name>."` plus the file body becomes the enrich system prompt
+over the top-level identity, the profile's skill filter becomes the session's
+skill selection (an explicit `options.skills` wins), its `model` is the
+fallback when the send names none, and — when the send also omits
+`options.functions` — the dispatch policy defaults to the configured
+`default_functions` baseline instead of deny-all (an identity picked to DO
+something must be able to dispatch; the ask-mode cap still applies). The
+frozen identity travels with the prompt-stickiness rule: bare later sends
+inherit it, an explicit prompt field sheds it. Refused on an existing
+session, combined with either prompt field, or naming a `leaf: true` profile
+(leaves are spawn targets). Directory edits after resolution never reach a
+live session — start a new one to pick them up.
+
+`harness::spawn` takes the same id as a top-level `agent` field, typically a
+`leaf` specialist: the profile body enriches the sub-agent identity, its
+skills/model slot in the same way (model precedence `model` → profile →
+parent, without dragging the parent's provider onto a foreign model), its
+name and icon become the display defaults, and an unset
+`options.orchestrator` defaults to `true` for a non-leaf profile. When the
+SPAWNING turn itself runs as an agent whose `delegates_to` frontmatter names
+specific ids, spawns naming an `agent` outside that list are rejected with
+`harness/delegation_denied`; profile-less spawns are never gated. Spawning
+with `agent` into an already RUNNING session of the caller's own tree merges
+the task like any reuse and does not re-apply the profile.
+
 New sessions also freeze a names-and-descriptions-only skill index into the
 system-prompt prefix. `options.skills` on `harness::send` or `harness::spawn`
 accepts exact skill ids. For a fresh session, omitted or empty means all

--- a/harness/iii.worker.yaml
+++ b/harness/iii.worker.yaml
@@ -15,7 +15,7 @@ dependencies:
   configuration: "0.x"
   iii-observability: "0.x"
   iii-stream: "0.x"
-  iii-directory: "^1.2.3"
+  iii-directory: "^1.2.4"
   llm-router: "^1.4.12"
   session-manager: "^1.0.13"
   context-manager: "^1.1.3"

--- a/harness/iii.worker.yaml
+++ b/harness/iii.worker.yaml
@@ -15,7 +15,7 @@ dependencies:
   configuration: "0.x"
   iii-observability: "0.x"
   iii-stream: "0.x"
-  iii-directory: "^1.2.4"
+  iii-directory: "^1.2.3"
   llm-router: "^1.4.12"
   session-manager: "^1.0.13"
   context-manager: "^1.1.3"

--- a/harness/src/agents.rs
+++ b/harness/src/agents.rs
@@ -1,0 +1,183 @@
+//! Agent-profile resolution (`directory::agents::*`): `options.agent` on
+//! `harness::send` and `agent` on `harness::spawn` name a filesystem-backed
+//! profile served by the iii-directory worker. The profile is fetched ONCE
+//! here and frozen onto the turn (identity, prompt, skills, model, display) —
+//! later directory edits never reach a live session, matching the skills
+//! baseline freeze.
+
+use serde::Deserialize;
+use serde_json::json;
+
+use iii_sdk::protocol::TriggerRequest;
+
+use crate::config::WorkerConfig;
+use crate::deps::Deps;
+use crate::error::HarnessError;
+use crate::functions::spawn::SubagentIcon;
+use crate::types::turn::AgentIdentity;
+
+const AGENTS_GET_ID: &str = "directory::agents::get";
+
+/// The wire subset of `directory::agents::get` the harness consumes; unknown
+/// fields are ignored so directory additions never break resolution.
+#[derive(Debug, Deserialize)]
+struct AgentGetWire {
+    name: String,
+    system_prompt: String,
+    #[serde(default)]
+    skills: Vec<String>,
+    #[serde(default)]
+    delegates_to: Option<Vec<String>>,
+    #[serde(default)]
+    leaf: bool,
+    #[serde(default)]
+    model: Option<String>,
+    #[serde(default)]
+    icon: Option<String>,
+}
+
+/// A profile resolved and normalized for turn seeding.
+#[derive(Debug, Clone)]
+pub struct ResolvedAgent {
+    /// Frozen onto `TurnOptions.agent`.
+    pub identity: AgentIdentity,
+    /// `"You are <name>.\n\n<body>"` — the enrich payload.
+    pub prompt: String,
+    /// `None` when the profile filters nothing (every skill).
+    pub skills: Option<Vec<String>>,
+    /// Default model for sessions running as this agent.
+    pub model: Option<String>,
+    /// Display name for spawn identity defaults.
+    pub name: String,
+    /// Harness display icon; `None` when the profile has none (the token set
+    /// is shared, so a directory-validated icon always parses).
+    pub icon: Option<SubagentIcon>,
+    /// `true` = spawn target only, refused as a session identity.
+    pub leaf: bool,
+}
+
+/// Fetch and normalize one agent profile. An unknown id maps to
+/// `InvalidRequest` (the directory's D410 message already carries the
+/// did-you-mean and next-action hints); any other failure is `Dependency`.
+pub async fn resolve(
+    deps: &Deps,
+    cfg: &WorkerConfig,
+    id: &str,
+) -> Result<ResolvedAgent, HarnessError> {
+    let value = deps
+        .iii
+        .trigger(TriggerRequest {
+            function_id: AGENTS_GET_ID.into(),
+            payload: json!({ "id": id }),
+            action: None,
+            timeout_ms: Some(cfg.dispatch_timeout_ms),
+        })
+        .await
+        .map_err(|e| classify_fetch_error(&e.to_string()))?;
+    let wire: AgentGetWire = serde_json::from_value(value).map_err(|e| {
+        HarnessError::Dependency(format!("{AGENTS_GET_ID}: malformed response: {e}"))
+    })?;
+    Ok(normalize(id, wire))
+}
+
+/// D410 is the directory's not-found code for agents — the caller named a
+/// bad id, not a broken dependency.
+fn classify_fetch_error(message: &str) -> HarnessError {
+    if message.contains("D410") {
+        HarnessError::InvalidRequest(format!("agent resolution failed: {message}"))
+    } else {
+        HarnessError::Dependency(format!("{AGENTS_GET_ID}: {message}"))
+    }
+}
+
+fn normalize(id: &str, wire: AgentGetWire) -> ResolvedAgent {
+    let name = if wire.name.trim().is_empty() {
+        id.to_string()
+    } else {
+        wire.name.trim().to_string()
+    };
+    ResolvedAgent {
+        identity: AgentIdentity {
+            id: id.to_string(),
+            delegates_to: wire.delegates_to,
+        },
+        prompt: format!("You are {name}.\n\n{}", wire.system_prompt),
+        skills: (!wire.skills.is_empty()).then_some(wire.skills),
+        model: wire.model,
+        name,
+        icon: wire.icon.and_then(|t| {
+            serde_json::from_value::<SubagentIcon>(serde_json::Value::String(t)).ok()
+        }),
+        leaf: wire.leaf,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn wire(json: serde_json::Value) -> AgentGetWire {
+        serde_json::from_value(json).unwrap()
+    }
+
+    #[test]
+    fn not_found_maps_to_invalid_request_and_keeps_the_directory_hint() {
+        let err = classify_fetch_error(
+            "handler error: D410 not_found: agent \"nope\" does not exist. Did you mean: coder. \
+             Next: call directory::agents::list to browse agent ids.",
+        );
+        assert_eq!(err.code(), "harness/invalid_request");
+        assert!(err.to_string().contains("directory::agents::list"));
+
+        let err = classify_fetch_error("dispatch timed out");
+        assert_eq!(err.code(), "harness/dependency");
+        assert!(err.to_string().contains(AGENTS_GET_ID));
+    }
+
+    #[test]
+    fn normalize_builds_the_you_are_prompt_and_optionalizes_fields() {
+        let agent = normalize(
+            "tech-leader",
+            wire(serde_json::json!({
+                "name": "Tech Leader",
+                "system_prompt": "Delegate everything.",
+                "skills": [],
+                "delegates_to": ["coder"],
+                "leaf": false,
+                "model": "codex/gpt-5.4",
+                "icon": "agent",
+            })),
+        );
+        assert_eq!(agent.prompt, "You are Tech Leader.\n\nDelegate everything.");
+        assert_eq!(agent.skills, None, "empty filter means every skill");
+        assert_eq!(agent.identity.id, "tech-leader");
+        assert_eq!(
+            agent.identity.delegates_to.as_deref(),
+            Some(&["coder".to_string()][..])
+        );
+        assert_eq!(agent.icon, Some(SubagentIcon::Agent));
+        assert_eq!(agent.model.as_deref(), Some("codex/gpt-5.4"));
+    }
+
+    #[test]
+    fn normalize_survives_blank_name_and_unknown_icon() {
+        let agent = normalize(
+            "coder",
+            wire(serde_json::json!({
+                "name": "  ",
+                "system_prompt": "Write code.",
+                "skills": ["review"],
+                "leaf": true,
+                "icon": "magnifier",
+            })),
+        );
+        assert_eq!(
+            agent.name, "coder",
+            "blank display name falls back to the id"
+        );
+        assert_eq!(agent.prompt, "You are coder.\n\nWrite code.");
+        assert_eq!(agent.skills.as_deref(), Some(&["review".to_string()][..]));
+        assert_eq!(agent.icon, None, "unknown token degrades, never errors");
+        assert!(agent.leaf);
+    }
+}

--- a/harness/src/functions/send.rs
+++ b/harness/src/functions/send.rs
@@ -40,6 +40,15 @@ impl From<String> for MessageInput {
 /// Per-send options frozen onto the turn record (harness.md § `harness::send`).
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct SendOptions {
+    /// Run the session as a directory agent profile (`directory::agents::*`
+    /// id). Session-creating sends only — the profile's body becomes the
+    /// enrich system prompt, its skill filter the session's skill selection,
+    /// its `model` the fallback when this send names none, and its identity
+    /// sticks like the system prompt (later sends inherit; naming an explicit
+    /// prompt field sheds it). Refused on an existing session, combined with
+    /// either prompt field, or naming a `leaf` profile (a spawn target).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub system_prompt: Option<String>,
     /// How `system_prompt` combines with the built-in prompt: `override`
@@ -229,7 +238,17 @@ async fn start_with_delivery_lock(
     )? {
         return Ok(outcome);
     }
-    let (model, provider) = match (req.model.clone(), &prev) {
+    // Resolve the agent profile (if named) BEFORE the model gate and session
+    // creation: the profile's model is a fallback for a session-creating send,
+    // and a failed resolve must leave no session or budget ledger behind.
+    let agent = resolve_send_agent(deps, &cfg, &req, prev.as_ref()).await?;
+
+    let (model, provider) = match (
+        req.model
+            .clone()
+            .or_else(|| agent.as_ref().and_then(|a| a.model.clone())),
+        &prev,
+    ) {
         (Some(m), _) => (m, req.provider.clone()),
         (None, Some(prev)) => (
             prev.options.model.clone(),
@@ -255,11 +274,18 @@ async fn start_with_delivery_lock(
 
     // Freeze the per-send options before moving the message out of `req`.
     let inherits_prompt = prev.is_some() && prompt_fields_omitted(req.options.as_ref());
-    let mut options = build_options(&cfg, &req, model, provider);
+    let mut options = build_options(&cfg, &req, model, provider, agent.as_ref());
     inherit_prior_functions(
         &cfg,
         &mut options,
-        prev.as_ref().and_then(|p| p.options.functions.as_ref()),
+        prev.as_ref()
+            .and_then(|p| p.options.functions.as_ref())
+            // An agent send with no explicit policy gets the configured
+            // default instead of deny-all: an identity picked to DO something
+            // must be able to dispatch. `prev` and `agent` are mutually
+            // exclusive (resolve_send_agent), and the ask-mode clamp inside
+            // still caps the result.
+            .or_else(|| agent.as_ref().and(cfg.default_functions.as_ref())),
     );
     if let (true, Some(prev)) = (inherits_prompt, prev.as_ref()) {
         inherit_prior_system_prompt(&mut options, &prev.options);
@@ -270,7 +296,8 @@ async fn start_with_delivery_lock(
         prev.as_ref().map(|record| &record.options),
         req.options
             .as_ref()
-            .and_then(|options| options.skills.as_deref()),
+            .and_then(|options| options.skills.as_deref())
+            .or_else(|| agent.as_ref().and_then(|a| a.skills.as_deref())),
     )
     .await?;
 
@@ -722,18 +749,30 @@ fn build_options(
     req: &SendRequest,
     model: String,
     provider: Option<String>,
+    agent: Option<&crate::agents::ResolvedAgent>,
 ) -> TurnOptions {
     let opts = req.options.clone().unwrap_or_default();
     let functions = clamp_for_mode(cfg, opts.mode, opts.functions);
     TurnOptions {
         model,
         provider,
-        system_prompt: prompt::resolve_system_prompt(
-            opts.system_prompt,
-            opts.system_prompt_strategy.unwrap_or_default(),
-            opts.mode,
-            prompt::DEFAULT,
-        ),
+        // An agent profile supplies the prompt (validated exclusive with the
+        // explicit prompt fields in resolve_send_agent), always as Enrich
+        // over the top-level identity.
+        system_prompt: match agent {
+            Some(a) => prompt::resolve_system_prompt(
+                Some(a.prompt.clone()),
+                SystemPromptStrategy::Enrich,
+                opts.mode,
+                prompt::DEFAULT,
+            ),
+            None => prompt::resolve_system_prompt(
+                opts.system_prompt,
+                opts.system_prompt_strategy.unwrap_or_default(),
+                opts.mode,
+                prompt::DEFAULT,
+            ),
+        },
         skills_prompt: None,
         skill_context: None,
         mode: opts.mode,
@@ -747,6 +786,7 @@ fn build_options(
         output: opts.output.unwrap_or_default(),
         functions,
         metadata: opts.metadata,
+        agent: agent.map(|a| a.identity.clone()),
         max_validation_retries: opts
             .max_validation_retries
             .unwrap_or(cfg.max_validation_retries),
@@ -891,10 +931,68 @@ fn prompt_fields_omitted(opts: Option<&SendOptions>) -> bool {
 /// system prompt, the same way model/provider/functions are inherited. A
 /// prior `disabled` turn's `None` inherits too — disabled stays disabled.
 /// Any explicit prompt field resolves fresh; a bare `system_prompt_strategy`
-/// is the reset-to-default escape hatch.
+/// is the reset-to-default escape hatch. The frozen agent identity travels
+/// with the prompt: inherited together, shed together (an explicit prompt
+/// field also drops the identity and its `delegates_to` spawn gate).
 fn inherit_prior_system_prompt(options: &mut TurnOptions, prev: &TurnOptions) {
     options.system_prompt = prev.system_prompt.clone();
     options.skills_prompt = prev.skills_prompt.clone();
+    options.agent = prev.agent.clone();
+}
+
+/// Resolve `options.agent` for this send, or `None` when absent. Validation
+/// happens before any session/budget side effects; the fetched profile is
+/// checked by [`validate_resolved_agent`].
+async fn resolve_send_agent(
+    deps: &Deps,
+    cfg: &WorkerConfig,
+    req: &SendRequest,
+    prev: Option<&TurnRecord>,
+) -> Result<Option<crate::agents::ResolvedAgent>, HarnessError> {
+    let Some(id) = agent_send_id(req.options.as_ref(), prev.is_some())? else {
+        return Ok(None);
+    };
+    let agent = crate::agents::resolve(deps, cfg, id).await?;
+    validate_resolved_agent(&agent)?;
+    Ok(Some(agent))
+}
+
+/// The pre-fetch half of agent-send validation: which id (if any) this send
+/// resolves, or why it may not name one.
+fn agent_send_id(
+    options: Option<&SendOptions>,
+    has_prev: bool,
+) -> Result<Option<&str>, HarnessError> {
+    let Some(id) = options.and_then(|o| o.agent.as_deref()) else {
+        return Ok(None);
+    };
+    if has_prev {
+        return Err(HarnessError::InvalidRequest(
+            "`options.agent` applies only when starting a session; later sends inherit the \
+             frozen identity — start a new session to run as a different agent"
+                .into(),
+        ));
+    }
+    if !prompt_fields_omitted(options) {
+        return Err(HarnessError::InvalidRequest(
+            "`options.agent` supplies the system prompt; drop `system_prompt` / \
+             `system_prompt_strategy` or drop `agent`"
+                .into(),
+        ));
+    }
+    Ok(Some(id))
+}
+
+/// The IO-free half of send-side agent validation.
+fn validate_resolved_agent(agent: &crate::agents::ResolvedAgent) -> Result<(), HarnessError> {
+    if agent.leaf {
+        return Err(HarnessError::InvalidRequest(format!(
+            "agent `{}` is `leaf: true` — a spawn target, not a session identity; pass it to \
+             `harness::spawn` as `agent` instead",
+            agent.identity.id
+        )));
+    }
+    Ok(())
 }
 
 /// A send whose metadata does not name the `fs_scope` key inherits the prior
@@ -1396,7 +1494,13 @@ mod tests {
                 ..Default::default()
             }),
         };
-        let opts = build_options(&cfg, &req, "claude-sonnet-4".into(), req.provider.clone());
+        let opts = build_options(
+            &cfg,
+            &req,
+            "claude-sonnet-4".into(),
+            req.provider.clone(),
+            None,
+        );
         let prompt = opts.system_prompt.expect("built-in prompt");
         assert!(prompt.contains("operating in agent mode"));
         assert!(prompt.contains("# System rules"));
@@ -1419,7 +1523,13 @@ mod tests {
                 ..Default::default()
             }),
         };
-        let opts = build_options(&cfg, &req, "claude-sonnet-4".into(), req.provider.clone());
+        let opts = build_options(
+            &cfg,
+            &req,
+            "claude-sonnet-4".into(),
+            req.provider.clone(),
+            None,
+        );
         assert_eq!(opts.system_prompt.as_deref(), Some("custom"));
     }
 
@@ -1441,6 +1551,7 @@ mod tests {
             output: OutputContract::Text,
             functions,
             metadata: None,
+            agent: None,
             max_validation_retries: 2,
             max_transient_resumes: 1,
         }
@@ -1825,7 +1936,7 @@ mod tests {
                 ..Default::default()
             }),
         };
-        let opts = build_options(&cfg, &req, "m".into(), req.provider.clone());
+        let opts = build_options(&cfg, &req, "m".into(), req.provider.clone(), None);
         let compiled = policy::CompiledPolicy::from(opts.functions.as_ref());
         // The wildcard default preserves the requested policy…
         assert!(compiled.allows("state::get"));
@@ -1857,7 +1968,7 @@ mod tests {
                     ..Default::default()
                 }),
             };
-            let opts = build_options(&cfg, &req, "m".into(), None);
+            let opts = build_options(&cfg, &req, "m".into(), None, None);
             let compiled = policy::CompiledPolicy::from(opts.functions.as_ref());
             assert!(
                 compiled.allows("state::set"),
@@ -1882,7 +1993,13 @@ mod tests {
                 ..Default::default()
             }),
         };
-        let opts = build_options(&cfg, &req, "claude-sonnet-4".into(), req.provider.clone());
+        let opts = build_options(
+            &cfg,
+            &req,
+            "claude-sonnet-4".into(),
+            req.provider.clone(),
+            None,
+        );
         let prompt = opts.system_prompt.expect("enriched prompt");
         assert!(prompt.starts_with(crate::prompt::DEFAULT));
         assert!(prompt.ends_with("Speak only in haiku."));
@@ -1901,6 +2018,7 @@ mod tests {
                 options: None,
             },
             "m".into(),
+            None,
             None,
         )
     }
@@ -2016,5 +2134,197 @@ mod tests {
             cfg.resolved_default_filesystem_root(),
             Some("/srv/projects".to_string())
         );
+    }
+
+    fn resolved_agent(leaf: bool, model: Option<&str>) -> crate::agents::ResolvedAgent {
+        crate::agents::ResolvedAgent {
+            identity: crate::types::turn::AgentIdentity {
+                id: "tech-leader".into(),
+                delegates_to: Some(vec!["coder".into()]),
+            },
+            prompt: "You are Tech Leader.\n\nDelegate everything.".into(),
+            skills: Some(vec!["review".into()]),
+            model: model.map(str::to_string),
+            name: "Tech Leader".into(),
+            icon: None,
+            leaf,
+        }
+    }
+
+    fn agent_send_request(options: SendOptions) -> SendRequest {
+        SendRequest {
+            session_id: None,
+            message: MessageInput::Text("hi".into()),
+            model: None,
+            provider: None,
+            idempotency_key: None,
+            session: None,
+            options: Some(options),
+        }
+    }
+
+    #[test]
+    fn agent_send_id_refusal_matrix() {
+        let named = |options: &SendOptions| {
+            agent_send_id(Some(options), false).map(|id| id.map(String::from))
+        };
+        // Plain agent send resolves.
+        assert_eq!(
+            named(&SendOptions {
+                agent: Some("tech-leader".into()),
+                ..Default::default()
+            })
+            .unwrap(),
+            Some("tech-leader".to_string())
+        );
+        // No agent named → no resolution, whatever else is set.
+        assert_eq!(agent_send_id(None, true).unwrap(), None);
+        // Existing session → refused.
+        let err = agent_send_id(
+            Some(&SendOptions {
+                agent: Some("tech-leader".into()),
+                ..Default::default()
+            }),
+            true,
+        )
+        .unwrap_err();
+        assert_eq!(err.code(), "harness/invalid_request");
+        assert!(err.to_string().contains("starting a session"));
+        // Combined with either explicit prompt field → refused.
+        for options in [
+            SendOptions {
+                agent: Some("tech-leader".into()),
+                system_prompt: Some("be terse".into()),
+                ..Default::default()
+            },
+            SendOptions {
+                agent: Some("tech-leader".into()),
+                system_prompt_strategy: Some(SystemPromptStrategy::Enrich),
+                ..Default::default()
+            },
+        ] {
+            let err = named(&options).unwrap_err();
+            assert!(err.to_string().contains("drop `system_prompt`"), "{err}");
+        }
+    }
+
+    #[test]
+    fn leaf_agents_are_refused_as_session_identities() {
+        let err = validate_resolved_agent(&resolved_agent(true, None)).unwrap_err();
+        assert!(err.to_string().contains("harness::spawn"), "{err}");
+        assert!(validate_resolved_agent(&resolved_agent(false, None)).is_ok());
+    }
+
+    #[test]
+    fn build_options_applies_agent_prompt_and_identity() {
+        let cfg = WorkerConfig::default();
+        let req = agent_send_request(SendOptions {
+            agent: Some("tech-leader".into()),
+            ..Default::default()
+        });
+        let agent = resolved_agent(false, None);
+        let opts = build_options(&cfg, &req, "m".into(), None, Some(&agent));
+        let prompt = opts.system_prompt.expect("agent prompt");
+        assert!(
+            prompt.starts_with(crate::prompt::DEFAULT),
+            "enrich, not override"
+        );
+        assert!(prompt.ends_with("You are Tech Leader.\n\nDelegate everything."));
+        assert_eq!(opts.agent, Some(agent.identity));
+    }
+
+    #[test]
+    fn agent_send_defaults_functions_to_the_configured_baseline() {
+        let cfg = WorkerConfig::default();
+        let agent = resolved_agent(false, None);
+        let req = agent_send_request(SendOptions {
+            agent: Some("tech-leader".into()),
+            ..Default::default()
+        });
+        // Absent policy + agent → the configured default applies.
+        let mut opts = build_options(&cfg, &req, "m".into(), None, Some(&agent));
+        inherit_prior_functions(
+            &cfg,
+            &mut opts,
+            None.or_else(|| Some(&agent).and(cfg.default_functions.as_ref())),
+        );
+        let compiled = policy::CompiledPolicy::from(opts.functions.as_ref());
+        assert!(compiled.allows("harness::spawn"));
+        assert!(compiled.allows("state::set"));
+        // Explicit policy wins over the agent default.
+        let req = agent_send_request(SendOptions {
+            agent: Some("tech-leader".into()),
+            functions: Some(FunctionPolicy {
+                allow: vec!["state::get".into()],
+                deny: vec![],
+                expose: Default::default(),
+            }),
+            ..Default::default()
+        });
+        let mut opts = build_options(&cfg, &req, "m".into(), None, Some(&agent));
+        inherit_prior_functions(
+            &cfg,
+            &mut opts,
+            None.or_else(|| Some(&agent).and(cfg.default_functions.as_ref())),
+        );
+        let compiled = policy::CompiledPolicy::from(opts.functions.as_ref());
+        assert!(compiled.allows("state::get"));
+        assert!(!compiled.allows("harness::spawn"));
+        // Ask mode still clamps: the shipped wildcard baseline is identity, so
+        // the agent default survives — same as an explicit `allow:["*"]` ask
+        // send. A narrowed operator baseline stays authoritative.
+        let narrow_cfg = WorkerConfig {
+            default_functions: Some(FunctionPolicy {
+                allow: vec!["state::get".into()],
+                deny: vec![],
+                expose: Default::default(),
+            }),
+            ..Default::default()
+        };
+        let req = agent_send_request(SendOptions {
+            agent: Some("tech-leader".into()),
+            mode: Some(Mode::Ask),
+            ..Default::default()
+        });
+        let mut opts = build_options(&narrow_cfg, &req, "m".into(), None, Some(&agent));
+        inherit_prior_functions(
+            &narrow_cfg,
+            &mut opts,
+            None.or_else(|| Some(&agent).and(narrow_cfg.default_functions.as_ref())),
+        );
+        let compiled = policy::CompiledPolicy::from(opts.functions.as_ref());
+        assert!(compiled.allows("state::get"));
+        assert!(!compiled.allows("harness::spawn"), "ask cap holds");
+    }
+
+    #[test]
+    fn agent_identity_inherits_with_the_prompt_and_sheds_with_it() {
+        let cfg = WorkerConfig::default();
+        let agent = resolved_agent(false, None);
+        let req = agent_send_request(SendOptions {
+            agent: Some("tech-leader".into()),
+            ..Default::default()
+        });
+        let prev = build_options(&cfg, &req, "m".into(), None, Some(&agent));
+
+        // A bare steer inherits prompt AND identity.
+        let mut next = bare_options();
+        inherit_prior_system_prompt(&mut next, &prev);
+        assert_eq!(next.system_prompt, prev.system_prompt);
+        assert_eq!(next.agent, prev.agent);
+
+        // An explicit prompt field resolves fresh — no inherit call — and the
+        // freshly built options carry no identity.
+        let explicit = build_options(
+            &cfg,
+            &agent_send_request(SendOptions {
+                system_prompt: Some("be terse".into()),
+                ..Default::default()
+            }),
+            "m".into(),
+            None,
+            None,
+        );
+        assert_eq!(explicit.agent, None);
     }
 }

--- a/harness/src/functions/spawn.rs
+++ b/harness/src/functions/spawn.rs
@@ -98,9 +98,10 @@ pub struct SpawnOptions {
     /// and `engine::registered-triggers::*`, so it performs its assignment and
     /// updates shared state without spawning, messaging sessions, or touching
     /// trigger registrations. `true` skips those denies; the child still never
-    /// exceeds its parent's policy.
-    #[serde(default)]
-    pub orchestrator: bool,
+    /// exceeds its parent's policy. When the spawn names an `agent` profile
+    /// and this field is omitted, a non-leaf profile defaults it to `true`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub orchestrator: Option<bool>,
     /// Fan-out guard for the child's own spawns.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_children: Option<u32>,
@@ -119,6 +120,16 @@ pub struct SpawnRequest {
     /// every resolved required selector literally (for example `Use database
     /// db: "primary"`); the child cannot infer resources from the parent.
     pub task: MessageInput,
+    /// Run the child as a directory agent profile (`directory::agents::*`
+    /// id) — typically a `leaf` specialist. The profile's body becomes the
+    /// child's enrich system prompt (over the sub-agent identity), its skill
+    /// filter applies when `options.skills` is omitted, its `model` slots
+    /// between an explicit `model` and the parent's, and its name/icon become
+    /// the display defaults. When the SPAWNING turn runs as an agent whose
+    /// `delegates_to` names specific ids, this id must be one of them.
+    /// Refused combined with `options.system_prompt`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent: Option<String>,
     /// Optional display-only identity for the child session. This never affects
     /// session ids, policy, routing, or execution. On named-session reuse the
     /// existing session title and metadata are retained.
@@ -183,6 +194,22 @@ mod tests {
         })
         .unwrap();
         assert_eq!(value["skills"], json!(["review"]));
+    }
+
+    #[test]
+    fn orchestrator_round_trips_unset_and_both_values() {
+        let unset: SpawnOptions = serde_json::from_value(json!({})).unwrap();
+        assert_eq!(unset.orchestrator, None);
+        assert!(!serde_json::to_value(&unset)
+            .unwrap()
+            .as_object()
+            .unwrap()
+            .contains_key("orchestrator"));
+        for value in [true, false] {
+            let opts: SpawnOptions =
+                serde_json::from_value(json!({ "orchestrator": value })).unwrap();
+            assert_eq!(opts.orchestrator, Some(value));
+        }
     }
 
     #[test]

--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -7,6 +7,7 @@
 //! function calls, and repeat until the turn stops — as durable enqueued steps
 //! so a crash resumes mid-turn.
 
+pub mod agents;
 pub mod bindings;
 pub mod budget;
 pub mod clients;

--- a/harness/src/subagent.rs
+++ b/harness/src/subagent.rs
@@ -48,6 +48,7 @@ pub async fn spawn_from_turn(
             format!("invalid spawn arguments: {e}"),
         )
     })?;
+    validate_delegation(parent, &req)?;
     // Depth budget.
     if parent.depth + 1 > cfg.max_depth {
         return Err(is_error(
@@ -88,6 +89,32 @@ pub async fn spawn_from_turn(
     )
     .await
     .map_err(|e| is_error(e.code(), e.to_string()))
+}
+
+/// The delegation gate: a turn running as an agent whose frozen
+/// `delegates_to` names specific ids may spawn with `agent:` only those ids.
+/// Profile-less spawns, identity-less parents, and `delegates_to: null`
+/// (= every agent) all pass — the gate narrows profile delegation, it never
+/// forbids plain spawning.
+fn validate_delegation(parent: &TurnRecord, req: &SpawnRequest) -> Result<(), ResultData> {
+    let (Some(child), Some(identity)) = (req.agent.as_deref(), parent.options.agent.as_ref())
+    else {
+        return Ok(());
+    };
+    let Some(allowed) = identity.delegates_to.as_deref() else {
+        return Ok(());
+    };
+    if allowed.iter().any(|id| id == child) {
+        return Ok(());
+    }
+    Err(is_error(
+        "harness/delegation_denied",
+        format!(
+            "agent `{}` may delegate only to {allowed:?}; this spawn named agent `{child}` — \
+             pick a listed agent or spawn without `agent`",
+            identity.id
+        ),
+    ))
 }
 
 /// At-capacity preflight for an explicitly named session. A successful result
@@ -236,11 +263,35 @@ async fn seed_child(
     reuse_only: bool,
 ) -> Result<ChildIds, HarnessError> {
     let session = deps.session().await;
-    let display = normalize_display(req.display.as_ref())?;
+
+    // Resolve the agent profile (if named) before anything else fallible —
+    // an unknown id must not leave a session behind. Leaf profiles are the
+    // POINT here (specialists meant to be spawned), so unlike send there is
+    // no leaf refusal.
+    let agent = match req.agent.as_deref() {
+        Some(id) => {
+            if req
+                .options
+                .as_ref()
+                .is_some_and(|o| o.system_prompt.is_some())
+            {
+                return Err(HarnessError::InvalidRequest(
+                    "spawn `agent` supplies the child's system prompt; drop \
+                     `options.system_prompt` or drop `agent` (with `agent` set, \
+                     `system_prompt_strategy` is ignored and enrich applies)"
+                        .into(),
+                ));
+            }
+            Some(crate::agents::resolve(deps, cfg, id).await?)
+        }
+        None => None,
+    };
+    let display = normalize_display(merged_display(req.display.as_ref(), agent.as_ref()).as_ref())?;
 
     let model = req
         .model
         .clone()
+        .or_else(|| agent.as_ref().and_then(|a| a.model.clone()))
         .or_else(|| parent_record.map(|p| p.options.model.clone()))
         .ok_or_else(|| {
             HarnessError::InvalidRequest(
@@ -250,20 +301,28 @@ async fn seed_child(
                     .into(),
             )
         })?;
-    let provider = child_provider(req, parent_record);
+    let inherits_parent_model =
+        req.model.is_none() && agent.as_ref().is_none_or(|a| a.model.is_none());
+    let provider = child_provider(req, parent_record, inherits_parent_model);
     // Children get the embedded minimal sub-agent identity, never the
     // top-level orchestrator prompt: a child
     // knows its one task, its state destination, and nothing else — by
     // design. Spawn `options.system_prompt` (+ override strategy) is the
-    // escape hatch for a child that genuinely needs a different identity.
+    // escape hatch for a child that genuinely needs a different identity;
+    // an `agent` profile enriches this same identity with its body.
     let identity = prompt::SUBAGENT;
+
+    let orchestrator = child_orchestrator(
+        req.options.as_ref().and_then(|o| o.orchestrator),
+        agent.as_ref(),
+    );
 
     let functions = child_functions(
         cfg,
         parent_record,
         req.options.as_ref().and_then(|o| o.functions.as_ref()),
         req.options.as_ref().and_then(|o| o.mode),
-        req.options.as_ref().is_some_and(|o| o.orchestrator),
+        orchestrator,
     );
 
     let depth = parent_record.map(|p| p.depth + 1).unwrap_or(0);
@@ -288,15 +347,23 @@ async fn seed_child(
     let mut options = TurnOptions {
         model,
         provider,
-        system_prompt: prompt::resolve_system_prompt(
-            req.options.as_ref().and_then(|o| o.system_prompt.clone()),
-            req.options
-                .as_ref()
-                .map(|o| o.system_prompt_strategy)
-                .unwrap_or_default(),
-            req.options.as_ref().and_then(|o| o.mode),
-            identity,
-        ),
+        system_prompt: match agent.as_ref() {
+            Some(a) => prompt::resolve_system_prompt(
+                Some(a.prompt.clone()),
+                crate::prompt::SystemPromptStrategy::Enrich,
+                req.options.as_ref().and_then(|o| o.mode),
+                identity,
+            ),
+            None => prompt::resolve_system_prompt(
+                req.options.as_ref().and_then(|o| o.system_prompt.clone()),
+                req.options
+                    .as_ref()
+                    .map(|o| o.system_prompt_strategy)
+                    .unwrap_or_default(),
+                req.options.as_ref().and_then(|o| o.mode),
+                identity,
+            ),
+        },
         skills_prompt: None,
         skill_context: None,
         mode: req.options.as_ref().and_then(|o| o.mode),
@@ -326,6 +393,9 @@ async fn seed_child(
                 .and_then(|o| o.filesystem_root.as_deref()),
             parent_record,
         )?,
+        // The child's OWN identity (its `delegates_to` gates the child's
+        // spawns), never the parent's.
+        agent: agent.as_ref().map(|a| a.identity.clone()),
         max_validation_retries: req
             .options
             .as_ref()
@@ -404,21 +474,26 @@ async fn seed_child(
     } else {
         None
     };
+    // A profile's skill filter counts as an explicit request: it must survive
+    // terminal-session reuse (the rebase pass otherwise restores the prior
+    // turn's filter), which also means an agent-spawn into an ACTIVE reused
+    // session fails the no-mid-turn-skill-change guard — acceptable.
+    let requested_skills = req
+        .options
+        .as_ref()
+        .and_then(|options| options.skills.as_deref())
+        .or_else(|| agent.as_ref().and_then(|a| a.skills.as_deref()));
     crate::functions::send::validate_active_skill_request(
         previous_child
             .as_ref()
             .is_some_and(|record| !record.status.is_terminal()),
-        req.options
-            .as_ref()
-            .is_some_and(|options| options.skills.is_some()),
+        requested_skills.is_some(),
     )?;
     crate::functions::send::prepare_skill_context(
         deps,
         &mut options,
         child_skill_previous(reused, previous_child.as_ref()),
-        req.options
-            .as_ref()
-            .and_then(|options| options.skills.as_deref()),
+        requested_skills,
     )
     .await?;
 
@@ -458,10 +533,7 @@ async fn seed_child(
                 parent_record,
                 &child_session_id,
             ),
-            skills_explicit: req
-                .options
-                .as_ref()
-                .is_some_and(|options| options.skills.is_some()),
+            skills_explicit: requested_skills.is_some(),
         },
     )
     .await?;
@@ -484,6 +556,40 @@ fn caller_holds_child_session_lock(
     child_session_id: &str,
 ) -> bool {
     parent_record.is_some_and(|parent| parent.session_id == child_session_id)
+}
+
+/// An unset `orchestrator` follows the profile: a non-leaf agent exists to
+/// delegate, so it gets the orchestration surface; a leaf (or no profile)
+/// stays a leaf. An explicit value always wins.
+fn child_orchestrator(
+    explicit: Option<bool>,
+    agent: Option<&crate::agents::ResolvedAgent>,
+) -> bool {
+    explicit.unwrap_or_else(|| agent.is_some_and(|a| !a.leaf))
+}
+
+/// Display defaults from the agent profile: no explicit display → the
+/// profile's name (truncated to the 48-char cap) and icon; an explicit
+/// display keeps its fields and only borrows the profile icon when it names
+/// none. Without a profile the request passes through untouched.
+fn merged_display(
+    display: Option<&SubagentDisplay>,
+    agent: Option<&crate::agents::ResolvedAgent>,
+) -> Option<SubagentDisplay> {
+    let Some(agent) = agent else {
+        return display.cloned();
+    };
+    match display {
+        Some(d) => Some(SubagentDisplay {
+            icon: d.icon.or(agent.icon),
+            ..d.clone()
+        }),
+        None => Some(SubagentDisplay {
+            name: agent.name.chars().take(48).collect(),
+            icon: agent.icon,
+            color: None,
+        }),
+    }
 }
 
 fn normalize_display(
@@ -551,17 +657,21 @@ fn child_session_metadata(
 
 /// The child's provider. An explicit request wins; otherwise the parent's
 /// provider is inherited ONLY when the model is inherited too — model and
-/// provider must stay a coherent pair. A spawn that names its own model must
-/// not carry the parent's provider onto a foreign model (a zai::glm parent
-/// spawning `model=claude-*` would pin the claude model to Z.AI, which
-/// rejects it upstream as an unknown model); leaving it unset lets the
-/// router route the model by catalog.
-fn child_provider(req: &SpawnRequest, parent_record: Option<&TurnRecord>) -> Option<String> {
+/// provider must stay a coherent pair. A spawn that names its own model (or
+/// takes one from an agent profile) must not carry the parent's provider onto
+/// a foreign model (a zai::glm parent spawning `model=claude-*` would pin the
+/// claude model to Z.AI, which rejects it upstream as an unknown model);
+/// leaving it unset lets the router route the model by catalog.
+fn child_provider(
+    req: &SpawnRequest,
+    parent_record: Option<&TurnRecord>,
+    inherits_parent_model: bool,
+) -> Option<String> {
     req.provider.clone().or_else(|| {
-        if req.model.is_some() {
-            None
-        } else {
+        if inherits_parent_model {
             parent_record.and_then(|p| p.options.provider.clone())
+        } else {
+            None
         }
     })
 }
@@ -666,6 +776,7 @@ mod tests {
                 output: OutputContract::Text,
                 functions: None,
                 metadata,
+                agent: None,
                 max_validation_retries: 2,
                 max_transient_resumes: 1,
             },
@@ -701,6 +812,7 @@ mod tests {
     fn spawn_request(model: Option<&str>, provider: Option<&str>) -> SpawnRequest {
         SpawnRequest {
             task: crate::functions::send::MessageInput::Text("t".into()),
+            agent: None,
             display: None,
             model: model.map(str::to_string),
             provider: provider.map(str::to_string),
@@ -783,29 +895,37 @@ mod tests {
         assert_eq!(
             child_provider(
                 &spawn_request(Some("claude-sonnet-4-6"), None),
-                Some(&parent)
+                Some(&parent),
+                false
             ),
             None
         );
         // Neither given: the parent's coherent model+provider pair applies.
         assert_eq!(
-            child_provider(&spawn_request(None, None), Some(&parent)),
+            child_provider(&spawn_request(None, None), Some(&parent), true),
             Some("zai".into())
+        );
+        // A model taken from an agent PROFILE is foreign too: the parent
+        // pair must not split even though the request itself named no model.
+        assert_eq!(
+            child_provider(&spawn_request(None, None), Some(&parent), false),
+            None
         );
         // An explicit provider always wins, with or without an explicit model.
         assert_eq!(
             child_provider(
                 &spawn_request(Some("glm-5.2"), Some("openai")),
-                Some(&parent)
+                Some(&parent),
+                false
             ),
             Some("openai".into())
         );
         assert_eq!(
-            child_provider(&spawn_request(None, Some("openai")), Some(&parent)),
+            child_provider(&spawn_request(None, Some("openai")), Some(&parent), true),
             Some("openai".into())
         );
         // Parentless spawns have nothing to inherit either way.
-        assert_eq!(child_provider(&spawn_request(None, None), None), None);
+        assert_eq!(child_provider(&spawn_request(None, None), None, true), None);
     }
 
     #[test]
@@ -1198,5 +1318,108 @@ mod tests {
         assert!(error.details["message"]
             .as_str()
             .is_some_and(|message| message.contains("8 child sessions created this turn")));
+    }
+
+    fn resolved_agent(
+        name: &str,
+        leaf: bool,
+        icon: Option<SubagentIcon>,
+    ) -> crate::agents::ResolvedAgent {
+        crate::agents::ResolvedAgent {
+            identity: crate::types::turn::AgentIdentity {
+                id: name.to_lowercase(),
+                delegates_to: None,
+            },
+            prompt: format!("You are {name}.\n\nWork."),
+            skills: None,
+            model: None,
+            name: name.to_string(),
+            icon,
+            leaf,
+        }
+    }
+
+    fn spawn_naming_agent(agent: Option<&str>) -> SpawnRequest {
+        SpawnRequest {
+            agent: agent.map(str::to_string),
+            ..spawn_request(None, None)
+        }
+    }
+
+    fn parent_running_as(delegates_to: Option<Vec<String>>) -> TurnRecord {
+        let mut parent = parent_record(None);
+        parent.options.agent = Some(crate::types::turn::AgentIdentity {
+            id: "tech-leader".into(),
+            delegates_to,
+        });
+        parent
+    }
+
+    #[test]
+    fn delegation_gate_matrix() {
+        let listed = parent_running_as(Some(vec!["coder".into(), "tester".into()]));
+        assert!(validate_delegation(&listed, &spawn_naming_agent(Some("coder"))).is_ok());
+        // Unlisted profile → denied with the allowed list in the message.
+        let err = validate_delegation(&listed, &spawn_naming_agent(Some("plumber"))).unwrap_err();
+        assert_eq!(err.details["error"], "harness/delegation_denied");
+        assert!(err.details["message"]
+            .as_str()
+            .is_some_and(|m| m.contains("coder") && m.contains("plumber")));
+        // Profile-less spawns are never gated.
+        assert!(validate_delegation(&listed, &spawn_naming_agent(None)).is_ok());
+        // `delegates_to: null` = every agent.
+        let open = parent_running_as(None);
+        assert!(validate_delegation(&open, &spawn_naming_agent(Some("plumber"))).is_ok());
+        // A parent with no identity is never gated.
+        let plain = parent_record(None);
+        assert!(validate_delegation(&plain, &spawn_naming_agent(Some("plumber"))).is_ok());
+    }
+
+    #[test]
+    fn orchestrator_defaults_follow_the_profile() {
+        let lead = resolved_agent("Lead", false, None);
+        let coder = resolved_agent("Coder", true, None);
+        assert!(child_orchestrator(None, Some(&lead)));
+        assert!(!child_orchestrator(None, Some(&coder)));
+        assert!(!child_orchestrator(None, None));
+        // Explicit always wins, both directions.
+        assert!(!child_orchestrator(Some(false), Some(&lead)));
+        assert!(child_orchestrator(Some(true), Some(&coder)));
+    }
+
+    #[test]
+    fn display_merges_profile_defaults_under_explicit_fields() {
+        let coder = resolved_agent("Coder", true, Some(SubagentIcon::Code));
+        // No explicit display → full profile identity.
+        let display = merged_display(None, Some(&coder)).unwrap();
+        assert_eq!(display.name, "Coder");
+        assert_eq!(display.icon, Some(SubagentIcon::Code));
+        assert_eq!(display.color, None);
+        // Explicit display keeps its fields, borrowing only a missing icon.
+        let explicit = SubagentDisplay {
+            name: "Fixer".into(),
+            icon: None,
+            color: Some(SubagentColor::Blue),
+        };
+        let display = merged_display(Some(&explicit), Some(&coder)).unwrap();
+        assert_eq!(display.name, "Fixer");
+        assert_eq!(display.icon, Some(SubagentIcon::Code));
+        assert_eq!(display.color, Some(SubagentColor::Blue));
+        let iconed = SubagentDisplay {
+            icon: Some(SubagentIcon::Search),
+            ..explicit.clone()
+        };
+        assert_eq!(
+            merged_display(Some(&iconed), Some(&coder)).unwrap().icon,
+            Some(SubagentIcon::Search)
+        );
+        // No profile → request passes through untouched (including None).
+        assert_eq!(merged_display(None, None), None);
+        assert_eq!(merged_display(Some(&explicit), None), Some(explicit));
+        // Long profile names are truncated to the display cap, not rejected.
+        let long = resolved_agent(&"x".repeat(60), false, None);
+        let display = merged_display(None, Some(&long)).unwrap();
+        assert_eq!(display.name.chars().count(), 48);
+        assert!(normalize_display(Some(&display)).is_ok());
     }
 }

--- a/harness/src/types/turn.rs
+++ b/harness/src/types/turn.rs
@@ -85,6 +85,20 @@ pub struct SkillAck {
     pub fingerprint: Option<String>,
 }
 
+/// The agent profile a turn runs as, frozen at resolution time
+/// (`options.agent` on `harness::send`, `agent` on `harness::spawn`). Only
+/// what later turn machinery needs survives here: the id for display and
+/// inheritance, and `delegates_to` to gate which profiles this turn's spawns
+/// may name. Directory edits after resolution never reach a live session.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct AgentIdentity {
+    pub id: String,
+    /// Agent ids this turn may spawn with `agent:`; `None` = every agent
+    /// (directory semantics, verbatim). Profile-less spawns are ungated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delegates_to: Option<Vec<String>>,
+}
+
 /// Per-send options frozen onto the turn record when it is created; they
 /// apply unchanged until the turn ends (a merged send never changes them).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
@@ -130,6 +144,11 @@ pub struct TurnOptions {
     pub functions: Option<FunctionPolicy>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Value>,
+    /// The agent profile this turn runs as, resolved once and frozen. Sticky
+    /// like the system prompt: a send naming neither prompt field inherits it;
+    /// naming an explicit prompt field sheds it (the escape hatch).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent: Option<AgentIdentity>,
     /// Cap on output-contract validation retries before finalising with a
     /// best-effort result (harness.md § Output contract).
     #[serde(default = "default_max_validation_retries")]
@@ -408,6 +427,7 @@ mod tests {
                 output: OutputContract::Text,
                 functions: None,
                 metadata: None,
+                agent: None,
                 max_validation_retries: 2,
                 max_transient_resumes: 1,
             },
@@ -580,6 +600,23 @@ mod tests {
         assert_eq!(r.options.skill_context, None);
         assert_eq!(r.skill_ack, None);
         assert!(!r.skills_started);
+        assert_eq!(r.options.agent, None);
+    }
+
+    #[test]
+    fn agent_identity_round_trips_and_stays_off_the_wire_when_absent() {
+        let mut r = record();
+        assert!(!serde_json::to_value(&r.options)
+            .unwrap()
+            .as_object()
+            .unwrap()
+            .contains_key("agent"));
+        r.options.agent = Some(AgentIdentity {
+            id: "tech-leader".into(),
+            delegates_to: Some(vec!["coder".into()]),
+        });
+        let back: TurnRecord = serde_json::from_value(serde_json::to_value(&r).unwrap()).unwrap();
+        assert_eq!(back, r);
     }
 
     #[test]

--- a/harness/tests/golden/schemas/harness.send.json
+++ b/harness/tests/golden/schemas/harness.send.json
@@ -429,6 +429,13 @@
       "SendOptions": {
         "description": "Per-send options frozen onto the turn record (harness.md § `harness::send`).",
         "properties": {
+          "agent": {
+            "description": "Run the session as a directory agent profile (`directory::agents::*` id). Session-creating sends only — the profile's body becomes the enrich system prompt, its skill filter the session's skill selection, its `model` the fallback when this send names none, and its identity sticks like the system prompt (later sends inherit; naming an explicit prompt field sheds it). Refused on an existing session, combined with either prompt field, or naming a `leaf` profile (a spawn target).",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "functions": {
             "anyOf": [
               {

--- a/harness/tests/golden/schemas/harness.spawn.json
+++ b/harness/tests/golden/schemas/harness.spawn.json
@@ -493,9 +493,11 @@
             ]
           },
           "orchestrator": {
-            "default": false,
-            "description": "Grant this child the orchestration surface. Default false: a spawned child is a LEAF — its policy gains deny globs for `harness::spawn`, `harness::send`, `engine::register_trigger`, `engine::unregister_trigger` and `engine::registered-triggers::*`, so it performs its assignment and updates shared state without spawning, messaging sessions, or touching trigger registrations. `true` skips those denies; the child still never exceeds its parent's policy.",
-            "type": "boolean"
+            "description": "Grant this child the orchestration surface. Default false: a spawned child is a LEAF — its policy gains deny globs for `harness::spawn`, `harness::send`, `engine::register_trigger`, `engine::unregister_trigger` and `engine::registered-triggers::*`, so it performs its assignment and updates shared state without spawning, messaging sessions, or touching trigger registrations. `true` skips those denies; the child still never exceeds its parent's policy. When the spawn names an `agent` profile and this field is omitted, a non-leaf profile defaults it to `true`.",
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "output": {
             "anyOf": [
@@ -736,6 +738,13 @@
       }
     },
     "properties": {
+      "agent": {
+        "description": "Run the child as a directory agent profile (`directory::agents::*` id) — typically a `leaf` specialist. The profile's body becomes the child's enrich system prompt (over the sub-agent identity), its skill filter applies when `options.skills` is omitted, its `model` slots between an explicit `model` and the parent's, and its name/icon become the display defaults. When the SPAWNING turn runs as an agent whose `delegates_to` names specific ids, this id must be one of them. Refused combined with `options.system_prompt`.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
       "display": {
         "anyOf": [
           {

--- a/harness/tests/integration/src/expand.rs
+++ b/harness/tests/integration/src/expand.rs
@@ -41,7 +41,13 @@ pub(crate) fn expand_compiled_fixture(
     base.expand_value(&mut scenario)?;
     let scenario: CompiledScenarioV1 = serde_json::from_value(scenario)?;
 
-    let mut allowed_functions = scenario.send.options.functions.allow.clone();
+    let mut allowed_functions = scenario
+        .send
+        .options
+        .functions
+        .as_ref()
+        .map(|policy| policy.allow.clone())
+        .unwrap_or_default();
     allowed_functions.sort_unstable();
     allowed_functions.dedup();
     let system_prompt = base

--- a/harness/tests/integration/src/fixtures/loading.rs
+++ b/harness/tests/integration/src/fixtures/loading.rs
@@ -47,6 +47,10 @@ pub struct ScenarioFixture {
     /// outside the compiled subject scenario: it is test synchronization, not
     /// a public harness request.
     pub intervention: Option<ScenarioIntervention>,
+    /// Files written under the run's skills dir before the stack boots —
+    /// `(relative path, content)` — e.g. `agents/lead.md` profiles the
+    /// iii-directory worker scans at startup.
+    pub skills_files: Vec<(String, String)>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -209,6 +213,18 @@ impl ScenarioFixture {
                     );
                 }
             }
+        }
+        for (path, content) in &self.skills_files {
+            anyhow::ensure!(
+                !path.is_empty()
+                    && !path.starts_with('/')
+                    && !path.split('/').any(|part| part.is_empty() || part == ".."),
+                "skills file path {path:?} must be a clean relative path"
+            );
+            anyhow::ensure!(
+                !content.trim().is_empty(),
+                "skills file {path:?} must not be empty"
+            );
         }
         // A direct scenario is one external send, but the harness may seed
         // further turns from it (a reseed after a parked message); those extra

--- a/harness/tests/integration/src/fixtures/tests.rs
+++ b/harness/tests/integration/src/fixtures/tests.rs
@@ -31,6 +31,7 @@ fn all_selection_returns_the_checked_in_fixtures() {
             "INT-023",
             "INT-024",
             "INT-025",
+            "INT-026",
             "UI-001",
             "UI-002",
             "UI-003",
@@ -44,7 +45,7 @@ fn all_selection_returns_the_checked_in_fixtures() {
             .iter()
             .filter(|fixture| fixture.driver == crate::scenarios::ScenarioDriver::Direct)
             .count(),
-        21
+        22
     );
 }
 

--- a/harness/tests/integration/src/scenario/runner.rs
+++ b/harness/tests/integration/src/scenario/runner.rs
@@ -218,6 +218,12 @@ impl<'a> ScenarioRunner<'a> {
             return Err(self.finish_without_stack(error));
         }
 
+        // Fixture skill files (agent profiles etc.) must be on disk before
+        // the iii-directory worker's startup scan.
+        if let Err(error) = write_skills_files(&paths, &self.fixture.skills_files) {
+            let error = RunError::runner(RunPhase::Allocate, "write fixture skills files", error);
+            return Err(self.finish_without_stack(error));
+        }
         let mut stack = match Stack::boot(self.bins, paths).await {
             Ok(stack) => stack,
             Err(failure) => {
@@ -376,4 +382,17 @@ pub(super) fn combine_teardown(
         return classification.combine(Classification::RunnerError);
     }
     classification
+}
+
+/// Write fixture-declared files under the run's skills dir (validated as
+/// clean relative paths by `ScenarioFixture::validate`).
+fn write_skills_files(paths: &RunLayout, files: &[(String, String)]) -> anyhow::Result<()> {
+    for (relative, content) in files {
+        let path = paths.skills_dir().join(relative);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&path, content)?;
+    }
+    Ok(())
 }

--- a/harness/tests/integration/src/scenarios/agent_identity_delegation.rs
+++ b/harness/tests/integration/src/scenarios/agent_identity_delegation.rs
@@ -1,0 +1,202 @@
+//! INT-026 — agent-profile identity, end to end (MOT-4485): a send naming
+//! `options.agent` (and OMITTING `options.functions`) runs as the directory
+//! profile, and the frozen identity gates delegation:
+//!   * the parent's prompt is the top-level identity ENRICHED with
+//!     `You are Lead.` + the profile body, resolved server-side from the
+//!     run's `skills/agents/lead.md` — no prompt fields on the send;
+//!   * the omitted policy defaults to the configured baseline (`allow: *`),
+//!     which is what lets the spawn dispatch at all;
+//!   * a spawn naming an agent OUTSIDE the lead's `delegates_to` comes back
+//!     as a `harness/delegation_denied` error result — the turn survives;
+//!   * the corrected spawn (`agent: coder`) seeds a child whose prompt is
+//!     the sub-agent identity enriched with `You are Coder.` — the leaf
+//!     profile applied spawn-side, no `options.system_prompt` anywhere.
+//!
+//! The child runs in its own session (untracked by the floor); its generation
+//! being consumed with the profile-enriched prompt is the evidence the
+//! spawn-side resolution ran.
+
+use serde_json::json;
+
+use super::dsl::{Generation, Message, Model, Request, Response, Scenario, Send};
+use super::ScenarioDriver;
+use crate::fixtures::ScenarioFixture;
+
+const SPAWN: &str = "harness::spawn";
+
+const LEAD_PROFILE: &str = "---
+name: Lead
+description: Orchestrator test profile.
+delegates_to:
+  - coder
+---
+You are the integration lead. Delegate the task to your coder and report.
+";
+
+const CODER_PROFILE: &str = "---
+name: Coder
+description: Implementation leaf test profile.
+icon: code
+leaf: true
+---
+Do the one task you are given, then stop.
+";
+
+pub(super) fn scenario() -> ScenarioFixture {
+    const ID: &str = "INT-026";
+    const MESSAGE: &str = "Have the coder say hello.";
+
+    let model = Model::scripted("fixture-model");
+
+    // Unlisted profile: `tester` is not in the lead's delegates_to.
+    let denied_args = json!({
+        "task": "Say hello.",
+        "agent": "tester",
+        "session_id": "{{run_id}}-denied"
+    });
+    let coder_args = json!({
+        "task": "Say hello, then stop.",
+        "agent": "coder",
+        "session_id": "{{run_id}}-coder"
+    });
+
+    Scenario::new(
+        ID,
+        "agent-identity-delegation",
+        "A send running as a directory agent profile (no functions policy on the wire) \
+         delegates through harness::spawn: an unlisted agent id is denied, the listed leaf \
+         profile seeds the child with its own enriched identity.",
+        ScenarioDriver::Direct,
+        model.clone(),
+    )
+    .send(
+        Send::message(MESSAGE)
+            .idempotency_key("{{run_id}}:integration-026")
+            .agent("lead")
+            .omit_functions(),
+    )
+    .skills_file("agents/lead.md", LEAD_PROFILE)
+    .skills_file("agents/coder.md", CODER_PROFILE)
+    // The child's opening step races the parent's post-spawn step — every
+    // generation here is uniquely matchable (step + prompt), so dispatch by
+    // match instead of arrival order.
+    .match_any_dispatch()
+    .generation(
+        Generation::new(1)
+            .expect(
+                Request::new()
+                    .turn_request_step(0)
+                    // DEFAULT identity enriched with the resolved profile.
+                    .system_prompt_regex("(?s)# System rules.*You are Lead\\.")
+                    .messages_exact([Message::user(MESSAGE)])
+                    .tools_subset([]),
+            )
+            .respond(Response::function_call_raw(
+                "call-denied",
+                SPAWN,
+                denied_args,
+                8,
+                4,
+            )),
+    )
+    .generation(
+        Generation::new(2)
+            .expect(
+                Request::new()
+                    .turn_request_step(1)
+                    .system_prompt_regex("You are Lead\\.")
+                    .messages_subset([
+                        json!({ "role": "user" }),
+                        json!({ "role": "assistant", "content": [
+                            { "type": "function_call", "id": "call-denied", "function_id": SPAWN }
+                        ] }),
+                        json!({ "role": "function_result", "function_call_id": "call-denied",
+                                "is_error": true }),
+                    ])
+                    .tools_subset([]),
+            )
+            .respond(Response::function_call_raw(
+                "call-coder",
+                SPAWN,
+                coder_args,
+                8,
+                4,
+            )),
+    )
+    .generation(
+        Generation::new(3)
+            .expect(
+                Request::new()
+                    .turn_request_step(0)
+                    // Sub-agent identity enriched with the LEAF profile.
+                    .system_prompt_regex("(?s)You are an iii sub-agent.*You are Coder\\.")
+                    .messages_subset([json!({ "role": "user" })])
+                    .tools_subset([]),
+            )
+            .respond(Response::text("hello from the coder", 10, 2)),
+    )
+    .generation(
+        Generation::new(4)
+            .expect(
+                Request::new()
+                    .turn_request_step(2)
+                    .system_prompt_regex("You are Lead\\.")
+                    .messages_subset([
+                        json!({ "role": "user" }),
+                        json!({ "role": "assistant", "content": [
+                            { "type": "function_call", "id": "call-denied", "function_id": SPAWN }
+                        ] }),
+                        json!({ "role": "function_result", "function_call_id": "call-denied",
+                                "is_error": true }),
+                        json!({ "role": "assistant", "content": [
+                            { "type": "function_call", "id": "call-coder", "function_id": SPAWN }
+                        ] }),
+                        json!({ "role": "function_result", "function_call_id": "call-coder",
+                                "is_error": false }),
+                    ])
+                    .tools_subset([]),
+            )
+            .respond(Response::text("delegated to the coder", 10, 2)),
+    )
+    .verify(|run| {
+        run.expect_assistant_texts(["delegated to the coder"])?;
+
+        // The denial named the gate and the allowed list, as an error RESULT
+        // (the turn survived it — generation 4 ran).
+        let denial: String = run
+            .transcript
+            .iter()
+            .map(|item| serde_json::to_string(item).unwrap_or_default())
+            .filter(|text| text.contains("harness/delegation_denied"))
+            .collect();
+        anyhow::ensure!(
+            denial.contains("tester") && denial.contains("coder"),
+            "the delegation denial must name the refused id and the allowed list: {denial}"
+        );
+        run.expect_no_duplicate_messages()
+    })
+    .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fixture_declares_the_profile_files_and_the_child_generation() {
+        let fixture = scenario();
+        fixture.validate().unwrap();
+        // One primary terminal turn; the coder's turn runs in its own session
+        // and chains into the send's trace (spawned from inside the turn).
+        assert_eq!(fixture.expected_turn_statuses, ["completed"]);
+        assert_eq!(fixture.expected_traces(), 1);
+        // Four generations: three parent (denied spawn, corrected spawn,
+        // final), one child.
+        assert_eq!(fixture.script.generations.len(), 4);
+        assert_eq!(fixture.skills_files.len(), 2);
+        // The send carries the agent id and NO functions policy — the
+        // harness-side default is part of what this scenario pins.
+        assert_eq!(fixture.scenario.send.options.agent.as_deref(), Some("lead"));
+        assert!(fixture.scenario.send.options.functions.is_none());
+    }
+}

--- a/harness/tests/integration/src/scenarios/dsl.rs
+++ b/harness/tests/integration/src/scenarios/dsl.rs
@@ -65,6 +65,8 @@ pub(super) struct Scenario {
     await_target_calls: Option<usize>,
     traces_override: Option<usize>,
     intervention: Option<ScenarioIntervention>,
+    skills_files: Vec<(String, String)>,
+    match_any: bool,
 }
 
 impl Scenario {
@@ -94,6 +96,8 @@ impl Scenario {
             await_target_calls: None,
             traces_override: None,
             intervention: None,
+            skills_files: Vec::new(),
+            match_any: false,
         }
     }
 
@@ -279,6 +283,23 @@ impl Scenario {
         self
     }
 
+    /// Dispatch generations by expectation match instead of strict ordinal.
+    /// For scenarios whose concurrent turns race (a spawned child's opening
+    /// step vs the parent's next step) — every generation must then be
+    /// uniquely matchable (distinct step/prompt/messages).
+    pub(super) fn match_any_dispatch(mut self) -> Self {
+        self.match_any = true;
+        self
+    }
+
+    /// Write a file under the run's skills dir before the stack boots (e.g.
+    /// an `agents/<id>.md` profile the iii-directory worker serves).
+    pub(super) fn skills_file(mut self, path: &str, content: &str) -> Self {
+        self.skills_files
+            .push((path.to_string(), content.to_string()));
+        self
+    }
+
     pub(super) fn build(self) -> ScenarioFixture {
         let send = self.send.expect("scenario send is required");
         let allowed_functions = send.allowed_functions.clone();
@@ -311,7 +332,7 @@ impl Scenario {
                 schema_version: SchemaVersion1::V1,
                 scenario_id: self.id,
                 model: self.model,
-                dispatch: if self.intervention.is_some() {
+                dispatch: if self.intervention.is_some() || self.match_any {
                     RouterDispatchV1::MatchAny
                 } else {
                     RouterDispatchV1::Ordinal
@@ -325,6 +346,7 @@ impl Scenario {
             await_target_calls: self.await_target_calls,
             traces_override: self.traces_override,
             intervention: self.intervention,
+            skills_files: self.skills_files,
         }
     }
 }
@@ -333,6 +355,8 @@ pub(super) struct Send {
     message: String,
     idempotency_key: Option<String>,
     allowed_functions: Vec<String>,
+    omit_functions: bool,
+    agent: Option<String>,
     expose: CompiledFunctionExposureV1,
 }
 
@@ -342,6 +366,8 @@ impl Send {
             message: message.to_string(),
             idempotency_key: None,
             allowed_functions: Vec::new(),
+            omit_functions: false,
+            agent: None,
             expose: CompiledFunctionExposureV1::Native,
         }
     }
@@ -351,7 +377,28 @@ impl Send {
         self
     }
 
+    /// Documentation-only: the send still carries an explicit empty policy
+    /// (deny-all), which also keeps the sha-matched system prompt identical
+    /// to every other policy-less scenario. To leave the field off the wire
+    /// entirely, use [`Send::omit_functions`].
     pub(super) fn without_functions(self) -> Self {
+        self
+    }
+
+    /// Omit `options.functions` from the wire request entirely, exercising
+    /// the harness's own defaulting (deny-all; the configured baseline on an
+    /// agent send) instead of an explicit empty policy. The rendered system
+    /// prompt differs from the empty-policy template — match prompts by
+    /// regex in scenarios using this.
+    pub(super) fn omit_functions(mut self) -> Self {
+        self.omit_functions = true;
+        self
+    }
+
+    /// Run the session as a directory agent profile (`options.agent`),
+    /// resolved server-side from the run's `skills/agents/*.md` fixtures.
+    pub(super) fn agent(mut self, id: &str) -> Self {
+        self.agent = Some(id.to_string());
         self
     }
 
@@ -394,11 +441,12 @@ impl Send {
                 .idempotency_key
                 .unwrap_or_else(|| format!("{{{{run_id}}}}:{}", scenario_id.to_ascii_lowercase())),
             options: CompiledSendOptionsV1 {
-                functions: CompiledFunctionPolicyV1 {
+                functions: (!self.omit_functions).then_some(CompiledFunctionPolicyV1 {
                     allow: self.allowed_functions,
                     deny: Vec::new(),
                     expose: self.expose,
-                },
+                }),
+                agent: self.agent,
             },
         }
     }

--- a/harness/tests/integration/src/scenarios/mod.rs
+++ b/harness/tests/integration/src/scenarios/mod.rs
@@ -1,6 +1,7 @@
 //! The checked-in integration fixtures.
 
 mod adversarial_content_rendering;
+mod agent_identity_delegation;
 mod child_discovery_granted;
 mod condition_failure_notice;
 mod console_streamed_text;
@@ -43,6 +44,7 @@ pub enum ScenarioDriver {
 pub fn all() -> Vec<ScenarioFixture> {
     let mut fixtures = vec![
         adversarial_content_rendering::scenario(),
+        agent_identity_delegation::scenario(),
         child_discovery_granted::scenario(),
         condition_failure_notice::scenario(),
         console_streamed_text::scenario(),
@@ -78,7 +80,7 @@ mod tests {
     #[test]
     fn every_fixture_is_unique_and_valid() {
         let fixtures = all();
-        assert_eq!(fixtures.len(), 27);
+        assert_eq!(fixtures.len(), 28);
         let mut slugs = std::collections::BTreeSet::new();
         let mut ids = std::collections::BTreeSet::new();
         for fixture in fixtures {

--- a/harness/tests/integration/src/types/scenario/compiled.rs
+++ b/harness/tests/integration/src/types/scenario/compiled.rs
@@ -50,7 +50,14 @@ pub struct CompiledSendV1 {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct CompiledSendOptionsV1 {
-    pub functions: CompiledFunctionPolicyV1,
+    /// `None` omits the field from the wire request — the harness's own
+    /// defaulting applies (deny-all, or the configured baseline on an
+    /// agent send) instead of an explicit empty policy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub functions: Option<CompiledFunctionPolicyV1>,
+    /// Directory agent profile id, resolved server-side (`options.agent`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]

--- a/iii-directory/README.md
+++ b/iii-directory/README.md
@@ -3,13 +3,14 @@
 Workers registry HTTP proxy and filesystem-backed skill + prompt
 reader for the [iii engine](https://github.com/iii-hq/iii). Every
 public function sits under a single `directory::*` namespace, split
-into five surfaces (all MCP-agnostic):
+into six surfaces (all MCP-agnostic):
 
 | Surface | What clients see | When to use it |
 |---|---|---|
 | **Skills** (`directory::skills::*`) | Enriched listing via `directory::skills::list` (`{ id, title, type, function_id, disable_model_invocation, description, bytes, modified_at }` per row), a single-skill reader `directory::skills::get { id }` returning `{ id, title, type, function_id, disable_model_invocation, path, body, modified_at }` (the full body instead of the list teaser), and `directory::skills::index` which renders a short per-worker overview document (one `## <title>` + first paragraph + `read more` link per `type: index` skill). Authored by `create`, edited by `update`, removed by `delete`. `title` prefers the YAML frontmatter `title:` (then `name:`) over the body H1; `type` is lifted from frontmatter `type:` (e.g. `index`, `how-to`, `reference`) and serialised as `null` when absent. System-installed agent skills under the read-only `agents_skills_folder` are served too (see [On-disk layout](#on-disk-layout)). | Orientation: "when and why to use my worker's tools" |
 | **Prompts** (`directory::prompts::*`) | Command templates listed by `directory::prompts::list`, read by `get`, authored by `create`, edited by `update`. Stored under any `prompts/` path segment; `create` writes `<skills_folder>/prompts/<name>.md`. | Parametric command templates the *user* invokes |
 | **System prompts** (`directory::system-prompts::*`) | Identity prompts with the same four verbs and the same response shapes as Prompts — including the `prompts` field name on `list`. Stored under any `system-prompts/` path segment; `create` writes `<skills_folder>/system-prompts/<name>.md`. | What the chat's system-prompt picker offers as an identity prompt (enrich or replace) |
+| **Agents** (`directory::agents::*`) | Reusable agent profiles — a session identity whose file body is the system prompt, with display `name`, emoji `logo`, a `skills` filter and `delegates_to`/`leaf` delegation fields in required frontmatter. Same five verbs as the prompt families; `list` rows carry `{ id, name, description, logo, skill_count, modified_at }` and `get` adds `system_prompt`, `unknown_skills`, and `unknown_delegates`. Stored under any `agents/` path segment; `create` writes `<skills_folder>/agents/<id>.md`. See `harness/architecture/agents.md`. | A named identity a session runs as (`harness::send { options: { agent } }`) |
 | **Search** (`directory::search_functions`) | One to six external capabilities → compact function-id candidates (installed, plus registry workers under `installable`), with a conditional pre-generate hint pointing agents at it. | "Which functions do I call for this task?" |
 | **Registry** (`directory::registry::*`) | HTTP proxy over `api.workers.iii.dev` with `workers::{list,info}`. Rows share the core `name` / `description` / `version` fields with the engine's `engine::workers::list` and add publication metadata (`type`, `config`, `supported_targets`, `total_downloads`, `dependencies`, optional `image`). `workers::list` is cursor-paginated with a server-authored page size. | "What's published in the public registry?" |
 
@@ -26,8 +27,9 @@ Skills and prompts are sourced from a single configured folder on disk
 functions, which pull markdown into `skills_folder` from either the
 [workers registry](https://workers.iii.dev) or a GitHub repo, plus the
 per-kind single-file editors — `directory::skills::{create,update,delete}`,
-`directory::prompts::{create,update,delete}` and
-`directory::system-prompts::{create,update,delete}`. Once downloaded, files
+`directory::prompts::{create,update,delete}`,
+`directory::system-prompts::{create,update,delete}` and
+`directory::agents::{create,update,delete}`. Once downloaded, files
 belong to the developer — edit them however you want, in the editor of
 your choice: a change made directly on disk fires the matching
 `on-change` with `op: "external"` (see [Custom trigger
@@ -203,10 +205,14 @@ skills_folder/
       triage.md
     system-prompts/            # ← magic marker for system prompts
       reviewer.md              # ← identity prompt (needs YAML frontmatter)
+    agents/                    # ← magic marker for agent profiles
+      release-captain.md       # ← agent profile (needs YAML frontmatter)
   prompts/                     # top level works too — the marker is the
     quick-note.md              #   segment, not its depth
   system-prompts/              # ← where system-prompts::create writes
     pirate.md
+  agents/                      # ← where agents::create writes
+    frontend-design.md
 ```
 
 A second, READ-ONLY root — `agents_skills_folder` (default `.agents/skills`
@@ -255,8 +261,21 @@ A few rules:
   accepts arbitrary typed text, and the operator owns `skills_folder`.
   Worth knowing before you point `skills_folder` at a directory other
   people can write to.
-- Files anywhere else (i.e. *not* in a `prompts/` or `system-prompts/`
-  segment) are skills.
+- **Agent profiles** live under any `*/agents/*.md` path (unrelated to the
+  read-only `agents_skills_folder` above, which holds external tools'
+  *skills*). Frontmatter is required and must declare a non-empty `name`
+  (the display name — the id is always the file stem); `description` may
+  be empty, `logo` is emoji-only (≤16 bytes, no path characters),
+  `skills:` filters the skill index (absent/empty = every skill),
+  `delegates_to:` and `leaf:` describe delegation, and `model:` names a
+  default model id for sessions running as this agent (absent = the
+  send decides; stored verbatim, resolved against the live model
+  catalog where it is used). The body is the
+  system prompt, verbatim. Unknown `skills`/`delegates_to` ids are
+  warnings surfaced by `get`, never load failures. Prompt-ish segments
+  win over `agents/` when a path carries several markers.
+- Files anywhere else (i.e. *not* in a `prompts/`, `system-prompts/`, or
+  `agents/` segment) are skills.
 
 The download function namespaces by source:
 
@@ -327,6 +346,16 @@ other adapter.
 | `directory::system-prompts::update` | Overwrite one EXISTING system prompt file with new full-file content: `{ name, content }`. The frontmatter must keep a non-empty `description` (and a valid `name` when declared) — the same rules the scanner enforces. Atomic write; fans out `directory::system-prompts::on-change` with `op: "update"`. Returns the system prompt's effective name after the write. |
 | `directory::system-prompts::create` | Create a NEW system prompt file at `<skills_folder>/system-prompts/<name>.md` from full-file content: `{ name, content }`, where `content` is the FULL file including frontmatter. The frontmatter must carry a non-empty `description` (and a `name` matching the request, when declared) — the same rules `update` enforces. Refuses a `name` that already exists anywhere in the merged system-prompt scan, and a target path that already exists on disk even if the scanner would skip it. Atomic write; fans out `directory::system-prompts::on-change` with `op: "create"`. Returns `{ name, description, bytes, modified_at }`. |
 | `directory::system-prompts::delete` | Permanently remove one EXISTING system prompt file by `{ name }`. Resolves against the same merged scan as `list`/`get`, fans out `directory::system-prompts::on-change` with `op: "delete"`, and returns `{ name }`. |
+
+### `directory::agents::*` (filesystem reader + editor)
+
+| Function ID | Description |
+|---|---|
+| `directory::agents::list` | Metadata-only listing of every fs-backed agent profile: `{ id, name, description, logo, skill_count, model, modified_at }` per row (`skill_count: null` = every skill; `model: null` = the send decides). |
+| `directory::agents::get` | Fetch one agent by `{ id }`: `system_prompt` (the file body), `skills` + `unknown_skills` (filter entries matching no visible skill — warnings), `delegates_to`/`leaf` + `unknown_delegates`, `model` (default model id, `null` = the send decides), and `modified_at`. Pass `raw: true` to additionally get the FULL on-disk file as `raw`. |
+| `directory::agents::update` | Overwrite one EXISTING agent file with new full-file content: `{ id, content }`. Same rules the scanner enforces (required frontmatter with non-empty `name`, emoji-only `logo`, non-empty body); the id stays the file stem. Atomic write; fans out `directory::agents::on-change` with `op: "update"`. |
+| `directory::agents::create` | Create a NEW agent at `<skills_folder>/agents/<id>.md` from full-file content: `{ id, content }`. Refuses an `id` that already exists in the merged agents scan, and a target path that already exists on disk even if the scanner would skip it. Atomic write; fans out `directory::agents::on-change` with `op: "create"`. Returns `{ id, name, description, logo, bytes, modified_at }`. |
+| `directory::agents::delete` | Permanently remove one EXISTING agent file by `{ id }`. Resolves against the same merged scan as `list`/`get`, fans out `directory::agents::on-change` with `op: "delete"`, and returns `{ id }`. Sessions already running as the agent are unaffected. |
 
 ### Engine introspection (native, plus one wrapper)
 
@@ -437,6 +466,7 @@ Knobs (`inject_hint`, `hint_min_workers`, `registry_search`) live in the
 | `directory::skills::on-change` | After a `directory::skills::download` that wrote at least one skill markdown file, a `directory::skills::update`, `create`, or `delete`, or external (file pasted/edited/deleted directly on disk — including under `agents_skills_folder`) | download: `{ "op": "download", "namespace": "<ns>", "source": "repo" \| "registry" }`; update/create/delete: `{ "op": "<operation>", "namespace": "<ns>", "id": "<id>" }`; external (file pasted/edited/deleted directly on disk): `{ "op": "external" }` |
 | `directory::prompts::on-change` | After a `directory::skills::download` that wrote at least one prompt markdown file, a `directory::prompts::update`, `create`, `delete`, or external (file pasted/edited/deleted directly on disk) | download: `{ "op": "download", "namespace": "<ns>", "source": "repo" \| "registry" }`; update/create/delete: `{ "op": "<operation>", "name": "<name>" }`; external (file pasted/edited/deleted directly on disk): `{ "op": "external" }` |
 | `directory::system-prompts::on-change` | After a `directory::skills::download` that wrote at least one system prompt markdown file, a `directory::system-prompts::update`, `create`, `delete`, or external file change | download: `{ "op": "download", "namespace": "<ns>", "source": "repo" \| "registry" }`; update/create/delete: `{ "op": "<operation>", "name": "<name>" }`; external: `{ "op": "external" }` |
+| `directory::agents::on-change` | After a `directory::skills::download` that wrote at least one agent profile, a `directory::agents::update`, `create`, `delete`, or external file change | download: `{ "op": "download", "namespace": "<ns>", "source": "repo" \| "registry" }`; update/create/delete: `{ "op": "<operation>", "name": "<id>" }`; external: `{ "op": "external" }` |
 
 Dispatches are fire-and-forget (Void), so the write path doesn't
 block on downstream latency.

--- a/iii-directory/iii.worker.yaml
+++ b/iii-directory/iii.worker.yaml
@@ -5,8 +5,8 @@ deploy: binary
 manifest: Cargo.toml
 license: Apache-2.0
 bin: iii-directory
-tags: [introspect, registry, skills, directory, search, functions]
-description: Engine introspection (functions / triggers / workers), workers registry proxy, filesystem-backed skill, prompt + system-prompt reader/editor, and one-shot lexical function search with a conditional pre-generate search hint.
+tags: [introspect, registry, skills, directory, search, functions, agents]
+description: Engine introspection (functions / triggers / workers), workers registry proxy, filesystem-backed skill, prompt, system-prompt + agent-profile reader/editor, and one-shot lexical function search with a conditional pre-generate search hint.
 
 dependencies:
   configuration: "0.x"

--- a/iii-directory/skills/SKILL.md
+++ b/iii-directory/skills/SKILL.md
@@ -10,10 +10,12 @@ description: >-
 # iii-directory
 
 The directory worker is how an agent finds its way around the engine. It does
-four things: serves the markdown docs installed workers ship (`directory::skills::*`),
+five things: serves the markdown docs installed workers ship (`directory::skills::*`),
 serves the slash-command prompt templates a human runs (`directory::prompts::*`),
 serves the system prompts the chat picker offers as an identity override
-(`directory::system-prompts::*`), and proxies the public worker catalogue at
+(`directory::system-prompts::*`), serves reusable agent profiles — session
+identities whose file body is the system prompt (`directory::agents::*`), and
+proxies the public worker catalogue at
 `api.workers.iii.dev` (`directory::registry::*`). A download pulls a bundle
 onto disk, and each filesystem-backed family also takes direct `create` /
 `update` / `delete` calls — those are this worker's only writes. Everything
@@ -47,6 +49,7 @@ never appear in `index` and `update`/`delete` refuse them.
 - You need to find a skill across the repo with filters — `directory::skills::list`.
 - You need the slash-command prompt templates a worker ships — `directory::prompts::list` / `get`.
 - You need the system prompts the chat picker offers as an identity override — `directory::system-prompts::list` / `get`.
+- You need a reusable agent profile (display name, emoji logo, skill selection, and its system prompt) — `directory::agents::list` / `get`.
 - You are about to build against a worker you have **not** installed — `directory::registry::workers::info` returns the same schema shape you would get after install.
 - You need to install a published worker's skills — `directory::skills::download_from_registry`.
 - You can only reach the `directory::` namespace but need one engine function's exact schema — `directory::engine::functions::info`.
@@ -59,7 +62,8 @@ never appear in `index` and `update`/`delete` refuse them.
 - Not the live-connection view. `directory::*` reflects what is on disk or in the registry, not what is connected right now. For that, call the engine directly (`engine::functions::list`, `engine::workers::list`, …); daemon-managed providers (`http`, `cron`, `state`) open no WebSocket, so merge `worker::list` by `name`.
 - Do not put a skill id (`/`) in `agent_trigger`'s `function:` field, and do not pass a function id (`::`) to `directory::skills::get`.
 - Prompt files without a `description:` in frontmatter are silently skipped by `directory::prompts::list` and `directory::system-prompts::list` alike.
-- The two prompt families are split by path segment, not by frontmatter: a `system-prompts/` path component makes a file a system prompt, a `prompts/` component makes it a command template, and `system-prompts/` wins if a path carries both. Names are per-family, so the same name can exist as both kinds.
+- The filesystem families are split by path segment, not by frontmatter: a `system-prompts/` path component makes a file a system prompt, a `prompts/` component makes it a command template, an `agents/` component makes it an agent profile (prompt-ish segments win over `agents/` if a path carries several). Names are per-family, so the same name can exist as more than one kind.
+- An agent's `skills:` list is curation, not enforcement: it narrows what a skill index shows, grants no access, and unknown ids are reported by `get` as `unknown_skills` warnings rather than errors. `agents/` profiles are unrelated to the read-only `agents_skills_folder` (`~/.agents/skills`), which holds external tools' skills.
 - Registry answers (`registry::workers::list` / `info`) are cached ~60 s per unique input by default (`registry_cache_ttl_ms`) — change a parameter to refresh.
 
 ## Functions
@@ -83,17 +87,22 @@ never appear in `index` and `update`/`delete` refuse them.
 - `directory::system-prompts::create` — create a NEW system prompt at `<skills_folder>/system-prompts/<name>.md`; same rules and refusals as `prompts::create`, scoped to the system scan.
 - `directory::system-prompts::update` — overwrite one EXISTING system prompt; same rules as `prompts::update`.
 - `directory::system-prompts::delete` — permanently remove one EXISTING system prompt by name.
+- `directory::agents::list` — list agent profiles (id, display name, description, emoji logo, `skill_count` where null means every skill).
+- `directory::agents::get` — read one agent by id: its system prompt (the file body), skill filter + `unknown_skills`, `delegates_to`/`leaf` + `unknown_delegates`, and `model` (the agent's default model id — use it when spawning/sending as this agent; `null` = caller decides); `raw: true` as above.
+- `directory::agents::create` — create a NEW agent at `<skills_folder>/agents/<id>.md` from full-file content; frontmatter needs a non-empty `name`, `logo` is emoji-only.
+- `directory::agents::update` — overwrite one EXISTING agent (same scanner rules; the id stays the file stem, frontmatter `name` is display-only).
+- `directory::agents::delete` — permanently remove one EXISTING agent by id; running sessions are unaffected.
 - `directory::registry::workers::list` — page through published workers in the public registry (`pagination.next_cursor` feeds the next page's `cursor`).
 - `directory::registry::workers::info` — full registry detail for one worker, including ones not installed: `api_reference` (functions + triggers with schemas) and `skills_tree`.
 - `directory::engine::functions::info` — thin proxy to the engine's `engine::functions::info`; returns request/response schema, metadata, and registered triggers for one function id.
 
-A failed call returns one plain sentence carrying a `Did you mean:` suggestion and a `Next:` function to call (codes `D110`/`D112`/`D210`/`D310`/`D311`, `D320` when the registry is unreachable, and on the write paths `D213` for content the next scan would skip, `D214`/`D114` for a create whose name/id or target path is already taken, `D115` for a skill id the visibility filter or an agents namespace reserves, and `D116` for a write to a read-only system-installed skill) — follow it instead of retrying the same input. Both prompt families share those codes; the message names which kind it means ("prompt" vs "system prompt") and its `Next:` stays inside that family. Downloads overwrite file-by-file, so hand-edited extra files survive a re-pull.
+A failed call returns one plain sentence carrying a `Did you mean:` suggestion and a `Next:` function to call (codes `D110`/`D112`/`D210`/`D310`/`D311`, `D410` for a missing agent, `D320` when the registry is unreachable, and on the write paths `D213` for content the next scan would skip, `D214`/`D114`/`D414` for a create whose name/id or target path is already taken, `D115` for a skill id the visibility filter or an agents namespace reserves, and `D116` for a write to a read-only system-installed skill) — follow it instead of retrying the same input. Both prompt families share those codes; the message names which kind it means ("prompt" vs "system prompt") and its `Next:` stays inside that family. Downloads overwrite file-by-file, so hand-edited extra files survive a re-pull.
 
 ## Reactive triggers
 
-The worker publishes three custom trigger types, one per kind —
-`directory::skills::on-change`, `directory::prompts::on-change`, and
-`directory::system-prompts::on-change`. Each fires for its own kind only, on any
+The worker publishes four custom trigger types, one per kind —
+`directory::skills::on-change`, `directory::prompts::on-change`,
+`directory::system-prompts::on-change`, and `directory::agents::on-change`. Each fires for its own kind only, on any
 of: a download that wrote at least one file of that kind (`op: "download"`), that
 family's `update`, `create`, or `delete` (`op: "update"` / `"create"` /
 `"delete"`), or a change made to
@@ -109,7 +118,7 @@ Reach for it when:
 
 Do not bind when:
 
-- You ran the download yourself — its return payload already lists `skills_written` / `prompts_written` / `system_prompts_written`.
+- You ran the download yourself — its return payload already lists `skills_written` / `prompts_written` / `system_prompts_written` / `agents_written`.
 - Your own reaction writes `.md` files under `skills_folder` through some path OTHER than this worker's `update` / `create` (a shell or coder worker, say). Writes made through this worker are suppressed, but outside writes are not: your handler would re-trigger itself.
 
 ### How to bind

--- a/iii-directory/src/fs_source.rs
+++ b/iii-directory/src/fs_source.rs
@@ -69,6 +69,7 @@ pub enum SourceKind {
     Skill,
     Prompt,
     SystemPrompt,
+    Agent,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -190,17 +191,27 @@ impl PromptKind {
     }
 }
 
+/// Path component that marks the agents family in the walk (also the
+/// top-level folder `directory::agents::create` writes into). Unrelated
+/// to the `agents_skills_folder` config root (`~/.agents/skills`), which
+/// is an external-tool *skills* convention.
+pub const AGENTS_SEGMENT: &str = "agents";
+
 /// Classify one path (relative to a scan root) by its segments — the
 /// single discriminator the scanner, the download classifier, and the
-/// fs watcher all share. `system-prompts` wins over `prompts` regardless
-/// of component order, so a path carrying both classifies as exactly one
-/// kind.
+/// fs watcher all share. NOT an exhaustive match: a kind missing an arm
+/// here silently falls through to `Skill`, so every new family must add
+/// one. Precedence when a path carries several marker segments:
+/// `system-prompts` > `prompts` > `agents`, so any path classifies as
+/// exactly one kind regardless of component order.
 pub fn classify_rel_path(rel: &Path) -> SourceKind {
     let has = |seg: &str| rel.components().any(|c| c.as_os_str() == seg);
     if has(PromptKind::System.segment()) {
         SourceKind::SystemPrompt
     } else if has(PromptKind::Command.segment()) {
         SourceKind::Prompt
+    } else if has(AGENTS_SEGMENT) {
+        SourceKind::Agent
     } else {
         SourceKind::Skill
     }
@@ -451,6 +462,266 @@ pub fn scan_prompts(skills_folder: &Path, kind: PromptKind) -> (Vec<FsPrompt>, V
 
     prompts.sort_by(|a, b| a.name.cmp(&b.name));
     (prompts, skipped)
+}
+
+// ───────────────────────── agents family ─────────────────────────────
+
+/// One filesystem-backed agent profile entry. Everything a `list` row
+/// or a delegation catalog needs is parsed at scan time; only the body
+/// (the system prompt) is re-read on `get`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FsAgent {
+    /// Flat id: the file stem, validated like a prompt name.
+    pub name: String,
+    /// Frontmatter `name` — the display name ("Release Captain").
+    pub display_name: String,
+    pub description: String,
+    /// Emoji logo, verbatim from frontmatter. v1 is emoji-only.
+    pub logo: Option<String>,
+    /// Skill-id filter. Empty = every skill.
+    pub skills: Vec<String>,
+    /// Delegation catalog filter. `None` = every agent.
+    pub delegates_to: Option<Vec<String>>,
+    /// `true` = this agent may not delegate at all.
+    pub leaf: bool,
+    /// Default model id for sessions running as this agent (a router
+    /// model id, e.g. `codex/gpt-5.4-mini`). `None` = the send decides.
+    /// Stored verbatim — whether the id resolves is checked where it is
+    /// used (the harness / the UI's model catalog), not at scan time,
+    /// so an agent never fails to load over a retired model.
+    pub model: Option<String>,
+    /// Harness subagent icon token (one of [`AGENT_ICON_TOKENS`]) for
+    /// spawn display identities. `None` = caller picks.
+    pub icon: Option<String>,
+    pub abs_path: PathBuf,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct AgentFrontmatter {
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub logo: Option<String>,
+    #[serde(default)]
+    pub skills: Vec<String>,
+    #[serde(default)]
+    pub delegates_to: Option<Vec<String>>,
+    #[serde(default)]
+    pub leaf: bool,
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub icon: Option<String>,
+}
+
+/// The harness `SubagentIcon` closed token set — `harness::spawn`
+/// rejects anything else, so writes validate against this list rather
+/// than letting a typo fail every future spawn.
+pub const AGENT_ICON_TOKENS: &[&str] = &[
+    "agent", "code", "search", "terminal", "database", "test", "review", "docs", "design",
+];
+
+/// Max byte length for an emoji logo (a couple of emoji with modifiers).
+pub const AGENT_LOGO_MAX_BYTES: usize = 16;
+
+/// Parse and validate the REQUIRED agent frontmatter block. Shared by
+/// [`scan_agents`] (scan-time) and `directory::agents::create` /
+/// `::update` (write-time) so the two can't drift: a write this rejects
+/// is exactly a file the next scan would skip.
+///
+/// Hard rules: frontmatter present and valid YAML, non-empty `name`,
+/// valid emoji `logo` when present. `description` missing is an empty
+/// string; `skills` / `delegates_to` entries are NOT shape-checked here —
+/// an id that matches nothing surfaces as `unknown_*` on `get`, a
+/// warning rather than a load failure.
+pub fn parse_agent_frontmatter(content: &str) -> Result<AgentFrontmatter, String> {
+    let (fm_text, _) = split_frontmatter(content);
+    let Some(fm_text) = fm_text else {
+        return Err("missing YAML frontmatter (expected --- ... --- block at file start)".into());
+    };
+    let fm: AgentFrontmatter =
+        serde_yaml::from_str(fm_text).map_err(|e| format!("invalid frontmatter YAML: {e}"))?;
+    if fm.name.as_deref().map(str::trim).unwrap_or("").is_empty() {
+        return Err("frontmatter missing non-empty `name`".into());
+    }
+    if let Some(logo) = fm.logo.as_deref() {
+        validate_agent_logo(logo)?;
+    }
+    if let Some(icon) = fm.icon.as_deref().map(str::trim).filter(|i| !i.is_empty()) {
+        if !AGENT_ICON_TOKENS.contains(&icon) {
+            return Err(format!(
+                "`icon` must be one of {} (got {icon:?})",
+                AGENT_ICON_TOKENS.join(", ")
+            ));
+        }
+    }
+    Ok(fm)
+}
+
+/// v1 logos are emoji only: short, no path characters, no whitespace.
+pub fn validate_agent_logo(logo: &str) -> Result<(), String> {
+    let logo = logo.trim();
+    if logo.is_empty() {
+        return Err("`logo` must be non-empty when present (emoji only)".into());
+    }
+    if logo.len() > AGENT_LOGO_MAX_BYTES {
+        return Err(format!(
+            "`logo` too long ({} bytes; max {AGENT_LOGO_MAX_BYTES}) — emoji only",
+            logo.len()
+        ));
+    }
+    if logo
+        .chars()
+        .any(|c| c == '/' || c == '\\' || c.is_whitespace())
+    {
+        return Err("`logo` may not contain path separators or whitespace — emoji only".into());
+    }
+    Ok(())
+}
+
+/// Scan agent profiles (`agents/` path segment) under `root`. Mirrors
+/// [`scan_prompts`]: required frontmatter, stem-derived flat id
+/// validated by [`validate_name`], first-wins dedupe with a
+/// [`SkipReason`] for the loser.
+pub fn scan_agents(root: &Path) -> (Vec<FsAgent>, Vec<SkipReason>) {
+    let mut agents: Vec<FsAgent> = Vec::new();
+    let mut skipped: Vec<SkipReason> = Vec::new();
+
+    let entries = match walk_markdown(root) {
+        Ok(v) => v,
+        Err(e) => {
+            skipped.push(SkipReason {
+                kind: SourceKind::Agent,
+                path: root.to_path_buf(),
+                reason: e,
+            });
+            return (agents, skipped);
+        }
+    };
+
+    for (abs, rel) in entries {
+        if classify_rel_path(&rel) != SourceKind::Agent {
+            continue;
+        }
+        let mut skip = |reason: String| {
+            skipped.push(SkipReason {
+                kind: SourceKind::Agent,
+                path: abs.clone(),
+                reason,
+            });
+        };
+        let content = match std::fs::read_to_string(&abs) {
+            Ok(c) => c,
+            Err(e) => {
+                skip(format!("read: {e}"));
+                continue;
+            }
+        };
+        let fm = match parse_agent_frontmatter(&content) {
+            Ok(f) => f,
+            Err(reason) => {
+                skip(reason);
+                continue;
+            }
+        };
+        let name = abs
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .to_string();
+        if let Err(e) = validate_name(&name) {
+            skip(format!("invalid agent id {name:?}: {e}"));
+            continue;
+        }
+        if let Some(existing) = agents.iter().find(|a| a.name == name) {
+            if existing.abs_path != abs {
+                let reason = format!(
+                    "duplicate id {name:?} also produced by {}",
+                    existing.abs_path.display()
+                );
+                skip(reason);
+            }
+            continue;
+        }
+        agents.push(FsAgent {
+            name,
+            display_name: fm.name.as_deref().unwrap_or("").trim().to_string(),
+            description: fm
+                .description
+                .as_deref()
+                .map(str::trim)
+                .unwrap_or("")
+                .to_string(),
+            logo: fm.logo.map(|l| l.trim().to_string()),
+            skills: fm.skills,
+            delegates_to: fm.delegates_to,
+            leaf: fm.leaf,
+            model: fm
+                .model
+                .as_deref()
+                .map(str::trim)
+                .filter(|m| !m.is_empty())
+                .map(str::to_string),
+            icon: fm
+                .icon
+                .as_deref()
+                .map(str::trim)
+                .filter(|i| !i.is_empty())
+                .map(str::to_string),
+            abs_path: abs,
+        });
+    }
+
+    agents.sort_by(|a, b| a.name.cmp(&b.name));
+    (agents, skipped)
+}
+
+/// Merged scan of agents from a global root and a local root — same
+/// whole-namespace override semantics as [`scan_prompts_merged`].
+pub fn scan_agents_merged(
+    global_root: &Path,
+    local_root: &Path,
+) -> (Vec<FsAgent>, Vec<SkipReason>) {
+    let local_ns = top_level_namespaces(local_root);
+
+    let (global_agents, mut global_skipped) = scan_agents(global_root);
+    let global_filtered: Vec<FsAgent> = global_agents
+        .into_iter()
+        .filter(|a| {
+            let top_seg = a
+                .abs_path
+                .strip_prefix(global_root)
+                .ok()
+                .and_then(|r| r.components().next())
+                .and_then(|c| c.as_os_str().to_str())
+                .unwrap_or("");
+            !local_ns.contains(&top_seg.to_string())
+        })
+        .collect();
+
+    global_skipped.retain(|s| {
+        let rel = s
+            .path
+            .strip_prefix(global_root)
+            .ok()
+            .and_then(|p| p.components().next())
+            .and_then(|c| c.as_os_str().to_str())
+            .unwrap_or("");
+        !local_ns.contains(&rel.to_string())
+    });
+
+    let (local_agents, local_skipped) = scan_agents(local_root);
+
+    let mut merged = local_agents;
+    merged.extend(global_filtered);
+    merged.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let mut all_skipped = global_skipped;
+    all_skipped.extend(local_skipped);
+
+    (merged, all_skipped)
 }
 
 /// Read a fs entry's body fresh from disk, strip any leading
@@ -1477,6 +1748,157 @@ mod tests {
         assert_eq!(sys.len(), 1);
         assert_eq!(cmd[0].description, "c");
         assert_eq!(sys[0].description, "s");
+    }
+
+    // ── fourth kind: agents ──────────────────────────────────────────
+
+    #[test]
+    fn classify_rel_path_agents_kind_and_precedence() {
+        assert_eq!(
+            classify_rel_path(Path::new("agents/captain.md")),
+            SourceKind::Agent
+        );
+        assert_eq!(
+            classify_rel_path(Path::new("ns/agents/captain.md")),
+            SourceKind::Agent
+        );
+        // Prompt-ish segments win over agents regardless of order.
+        assert_eq!(
+            classify_rel_path(Path::new("ns/agents/prompts/a.md")),
+            SourceKind::Prompt
+        );
+        assert_eq!(
+            classify_rel_path(Path::new("system-prompts/agents/a.md")),
+            SourceKind::SystemPrompt
+        );
+        // Component-boundary near-misses stay skills.
+        assert_eq!(
+            classify_rel_path(Path::new("agentsx/a.md")),
+            SourceKind::Skill
+        );
+        assert_eq!(
+            classify_rel_path(Path::new("ns/agents-extra/a.md")),
+            SourceKind::Skill
+        );
+    }
+
+    #[test]
+    fn scan_agents_parses_full_frontmatter() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_fixture(
+            tmp.path(),
+            "agents/captain.md",
+            "---\nname: Release Captain\ndescription: Cuts releases.\nlogo: \"🚢\"\nskills:\n  - iii-sandbox\ndelegates_to: [frontend]\nleaf: true\nmodel: codex/gpt-5.4-mini\n---\nYou are the captain.\n",
+        );
+        let (agents, skipped) = scan_agents(tmp.path());
+        assert!(skipped.is_empty(), "unexpected skips: {skipped:?}");
+        assert_eq!(agents.len(), 1);
+        let a = &agents[0];
+        assert_eq!(a.name, "captain");
+        assert_eq!(a.display_name, "Release Captain");
+        assert_eq!(a.description, "Cuts releases.");
+        assert_eq!(a.logo.as_deref(), Some("🚢"));
+        assert_eq!(a.skills, vec!["iii-sandbox".to_string()]);
+        assert_eq!(
+            a.delegates_to.as_deref(),
+            Some(&["frontend".to_string()][..])
+        );
+        assert!(a.leaf);
+        assert_eq!(a.model.as_deref(), Some("codex/gpt-5.4-mini"));
+    }
+
+    #[test]
+    fn scan_agents_empty_description_and_absent_optionals_ok() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_fixture(tmp.path(), "agents/min.md", "---\nname: Min\n---\nBody.\n");
+        let (agents, skipped) = scan_agents(tmp.path());
+        assert!(skipped.is_empty(), "unexpected skips: {skipped:?}");
+        let a = &agents[0];
+        assert_eq!(a.description, "");
+        assert!(a.logo.is_none());
+        assert!(a.skills.is_empty());
+        assert!(a.delegates_to.is_none());
+        assert!(!a.leaf);
+        assert!(a.model.is_none());
+    }
+
+    #[test]
+    fn scan_agents_skips_invalid_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_fixture(tmp.path(), "agents/no-fm.md", "no frontmatter\n");
+        write_fixture(
+            tmp.path(),
+            "agents/no-name.md",
+            "---\ndescription: x\n---\nB\n",
+        );
+        write_fixture(
+            tmp.path(),
+            "agents/bad-logo.md",
+            "---\nname: X\nlogo: ./logo.png\n---\nB\n",
+        );
+        write_fixture(tmp.path(), "agents/Bad-Stem.md", "---\nname: X\n---\nB\n");
+        write_fixture(tmp.path(), "agents/good.md", "---\nname: Good\n---\nB\n");
+        let (agents, skipped) = scan_agents(tmp.path());
+        let ids: Vec<&str> = agents.iter().map(|a| a.name.as_str()).collect();
+        assert_eq!(ids, vec!["good"]);
+        assert_eq!(skipped.len(), 4, "{skipped:?}");
+        for s in &skipped {
+            assert_eq!(s.kind, SourceKind::Agent);
+        }
+        let reasons = skipped
+            .iter()
+            .map(|s| s.reason.as_str())
+            .collect::<Vec<_>>();
+        assert!(reasons
+            .iter()
+            .any(|r| r.contains("missing YAML frontmatter")));
+        assert!(reasons.iter().any(|r| r.contains("non-empty `name`")));
+        assert!(reasons.iter().any(|r| r.contains("emoji only")));
+        assert!(reasons.iter().any(|r| r.contains("invalid agent id")));
+    }
+
+    #[test]
+    fn scan_agents_duplicate_stem_first_wins() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_fixture(tmp.path(), "agents/shared.md", "---\nname: Top\n---\nA\n");
+        write_fixture(tmp.path(), "ns/agents/shared.md", "---\nname: Ns\n---\nB\n");
+        let (agents, skipped) = scan_agents(tmp.path());
+        assert_eq!(agents.len(), 1);
+        assert_eq!(skipped.len(), 1);
+        assert!(skipped[0].reason.contains("duplicate id \"shared\""));
+    }
+
+    #[test]
+    fn scan_skills_excludes_agents_segment() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_fixture(tmp.path(), "ns/skill.md", "# Skill\n");
+        write_fixture(tmp.path(), "ns/agents/a.md", "---\nname: A\n---\nB\n");
+        let (skills, skipped) = scan_skills(tmp.path());
+        assert!(skipped.is_empty(), "{skipped:?}");
+        let ids: Vec<_> = skills.iter().map(|s| s.id.as_str()).collect();
+        assert_eq!(ids, vec!["ns/skill"]);
+    }
+
+    #[test]
+    fn scan_agents_merged_local_namespace_shadows_global() {
+        let global = tempfile::tempdir().unwrap();
+        let local = tempfile::tempdir().unwrap();
+        write_fixture(global.path(), "agents/a.md", "---\nname: GA\n---\nG\n");
+        write_fixture(local.path(), "agents/b.md", "---\nname: LB\n---\nL\n");
+        // Local top-level `agents/` dir shadows the global one wholesale.
+        let (merged, _) = scan_agents_merged(global.path(), local.path());
+        let ids: Vec<&str> = merged.iter().map(|a| a.name.as_str()).collect();
+        assert_eq!(ids, vec!["b"]);
+    }
+
+    #[test]
+    fn validate_agent_logo_rules() {
+        assert!(validate_agent_logo("🚢").is_ok());
+        assert!(validate_agent_logo("⚡🔥").is_ok());
+        assert!(validate_agent_logo("").is_err());
+        assert!(validate_agent_logo("./x.png").is_err());
+        assert!(validate_agent_logo("a b").is_err());
+        assert!(validate_agent_logo("🚢🚢🚢🚢🚢").is_err(), "over byte cap");
     }
 
     #[test]

--- a/iii-directory/src/functions/agents.rs
+++ b/iii-directory/src/functions/agents.rs
@@ -1,0 +1,765 @@
+//! Filesystem-backed agent profiles (`directory::agents::*`).
+//!
+//! An agent is a reusable identity a session runs as: a system prompt
+//! (the file body), a display name, a description, an emoji logo, and a
+//! skill filter — one markdown file with required YAML frontmatter under
+//! an `agents/` path segment (see `harness/architecture/agents.md`).
+//! Five verbs mirroring the prompt families:
+//!
+//!   * `directory::agents::list`   — metadata-only listing.
+//!   * `directory::agents::get`    — one agent's system prompt + metadata,
+//!     plus `unknown_skills` / `unknown_delegates` (ids that resolve to
+//!     nothing — warnings, never load failures).
+//!   * `directory::agents::create` / `update` / `delete` — full-file
+//!     writes, atomic, fanning out `directory::agents::on-change`.
+//!
+//! Not to be confused with the read-only `agents_skills_folder` config
+//! root (`~/.agents/skills`) — that is an external tool's *skills*
+//! convention; agent profiles live under the ordinary skills roots.
+
+use std::sync::Arc;
+
+use iii_sdk::errors::Error;
+use iii_sdk::{IIIClient, RegisterFunction};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::config::{SharedConfig, SkillsConfig};
+use crate::fs_source::{self, FsAgent, FsSkill};
+use crate::functions::error::{invalid_input_message, not_found_message, NextAction};
+use crate::functions::prompts::validate_name;
+use crate::functions::skills::{
+    find_fs_skill_in, resolve_visible_skills, RegisteredWorkersCache, SKILL_BODY_MAX_BYTES,
+};
+use crate::sources::{mark_self_write, write_file_atomic};
+use crate::trigger_types;
+
+/// Recovery pointer attached to a `directory::agents::get` / write miss.
+const AGENT_NOT_FOUND_NEXT: &[NextAction] = &[NextAction::new(
+    "directory::agents::list",
+    "browse agent ids",
+)];
+
+const AGENT_CREATE_CONFLICT_NEXT: &[NextAction] = &[
+    NextAction::new("directory::agents::update", "edit the existing agent"),
+    NextAction::new("directory::agents::list", "browse agent ids"),
+];
+
+// ---------- wire shapes ----------
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+struct ListAgentsInput {}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct AgentEntry {
+    /// Flat agent id (the file stem) — what `harness::send { options:
+    /// { agent } }` will take.
+    pub id: String,
+    /// Display name from frontmatter (`name:`).
+    pub name: String,
+    pub description: String,
+    /// Emoji logo, `null` when the agent has none.
+    pub logo: Option<String>,
+    /// Length of the agent's skill filter; `null` = no filter (every
+    /// skill).
+    pub skill_count: Option<usize>,
+    /// Default model id for sessions running as this agent; `null` =
+    /// the send decides.
+    pub model: Option<String>,
+    /// Harness subagent icon token for spawn display identities;
+    /// `null` = caller picks.
+    pub icon: Option<String>,
+    /// `true` = this agent may not delegate — a specialist meant to be
+    /// spawned by an orchestrator, not to front a session.
+    pub leaf: bool,
+    /// File mtime as RFC 3339.
+    pub modified_at: String,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ListAgentsOutput {
+    pub agents: Vec<AgentEntry>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct AgentGetInput {
+    pub id: String,
+    /// When `true`, the response includes the FULL on-disk file content
+    /// (frontmatter block included) as `raw` — the exact string to hand
+    /// back to `directory::agents::update`.
+    #[serde(default)]
+    pub raw: Option<bool>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct AgentGetOutput {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub logo: Option<String>,
+    /// The file body, frontmatter stripped — the identity, verbatim.
+    pub system_prompt: String,
+    /// The frontmatter skill filter. Empty = every skill.
+    pub skills: Vec<String>,
+    /// Filter entries that resolve to no currently visible skill.
+    /// Warnings — the agent still loads and runs.
+    pub unknown_skills: Vec<String>,
+    /// Agent ids this agent may delegate to; `null` = every agent.
+    pub delegates_to: Option<Vec<String>>,
+    /// `true` = this agent may not delegate at all.
+    pub leaf: bool,
+    /// `delegates_to` entries that name no existing agent. Warnings.
+    pub unknown_delegates: Vec<String>,
+    /// Default model id for sessions running as this agent; `null` =
+    /// the send decides. Served verbatim — resolution against the live
+    /// model catalog happens where it is used.
+    pub model: Option<String>,
+    /// Harness subagent icon token (closed set, validated at write
+    /// time); `null` = caller picks.
+    pub icon: Option<String>,
+    /// FULL on-disk file content. Present only when the request set
+    /// `raw: true`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub raw: Option<String>,
+    /// File mtime as RFC 3339.
+    pub modified_at: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct AgentCreateInput {
+    /// New agent id — becomes the file stem
+    /// (`<skills_folder>/agents/<id>.md`). Lowercase ASCII, digits,
+    /// `-` and `_` only. Must not collide with an existing agent or an
+    /// on-disk file at the target path.
+    pub id: String,
+    /// FULL file content, frontmatter block included. Frontmatter must
+    /// carry a non-empty `name`; the body is the system prompt and must
+    /// be non-empty.
+    pub content: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct AgentUpdateInput {
+    /// Existing agent id, as returned by `directory::agents::list`.
+    pub id: String,
+    /// FULL new file content, frontmatter block included — the string
+    /// `directory::agents::get { raw: true }` returns, edited.
+    pub content: String,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct AgentWriteOutput {
+    pub id: String,
+    /// Display name parsed from the (new) frontmatter.
+    pub name: String,
+    pub description: String,
+    pub logo: Option<String>,
+    /// Bytes written.
+    pub bytes: usize,
+    /// File mtime after the write, RFC 3339.
+    pub modified_at: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct AgentDeleteInput {
+    /// Existing agent id, as returned by `directory::agents::list`.
+    pub id: String,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct AgentDeleteOutput {
+    pub id: String,
+}
+
+// ---------- registration ----------
+
+pub fn register(
+    iii: &Arc<IIIClient>,
+    cfg: &SharedConfig,
+    subs: &super::Subscribers,
+    cache: &Arc<RegisteredWorkersCache>,
+) {
+    register_list(iii, cfg);
+    register_get(iii, cfg, cache);
+    register_create(iii, cfg, &subs.agents);
+    register_update(iii, cfg, &subs.agents);
+    register_delete(iii, cfg, &subs.agents);
+}
+
+fn register_list(iii: &Arc<IIIClient>, cfg: &SharedConfig) {
+    let cfg_inner = cfg.clone();
+    iii.register_function(
+        "directory::agents::list",
+        RegisterFunction::new_async(move |_input: ListAgentsInput| {
+            let cfg = cfg_inner.load_full();
+            async move { Ok::<_, Error>(list_agents(&cfg)) }
+        })
+        .description(
+            "List filesystem-backed agent profiles (id, display name, description, emoji \
+             logo, skill_count, modified_at) from the merged skills roots (`agents/` path \
+             segment). An agent is a reusable session identity: its file body is the \
+             system prompt. skill_count null = the agent uses every skill.",
+        ),
+    );
+}
+
+fn register_get(iii: &Arc<IIIClient>, cfg: &SharedConfig, cache: &Arc<RegisteredWorkersCache>) {
+    let cfg_inner = cfg.clone();
+    let iii_inner = iii.clone();
+    let cache_inner = cache.clone();
+    iii.register_function(
+        "directory::agents::get",
+        RegisterFunction::new_async(move |req: AgentGetInput| {
+            let cfg = cfg_inner.load_full();
+            let iii = iii_inner.clone();
+            let cache = cache_inner.clone();
+            async move {
+                let visible = resolve_visible_skills(&cfg, &cache, &iii, false).await;
+                get_agent(&cfg, req, &visible).map_err(Error::Handler)
+            }
+        })
+        .description(
+            "Fetch one agent profile by id. Returns the system prompt (the file body, \
+             frontmatter stripped), display name, description, emoji logo, the skill \
+             filter plus unknown_skills (filter entries matching no visible skill — \
+             warnings, the agent still runs), delegates_to/leaf plus unknown_delegates, \
+             and modified_at. Pass raw: true to also get the exact on-disk file for \
+             editing with directory::agents::update.",
+        ),
+    );
+}
+
+fn register_create(iii: &Arc<IIIClient>, cfg: &SharedConfig, subs: &trigger_types::SubscriberSet) {
+    let cfg_inner = cfg.clone();
+    let iii_inner = iii.clone();
+    let subs_inner = subs.clone();
+    iii.register_function(
+        "directory::agents::create",
+        RegisterFunction::new_async(move |req: AgentCreateInput| {
+            let cfg = cfg_inner.load_full();
+            let iii = iii_inner.clone();
+            let subs = subs_inner.clone();
+            async move {
+                let out = create_agent(&cfg, &req).map_err(Error::Handler)?;
+                trigger_types::dispatch(&iii, &subs, json!({ "op": "create", "name": out.id }))
+                    .await;
+                Ok::<_, Error>(out)
+            }
+        })
+        .description(
+            "Create a NEW agent profile at <skills_folder>/agents/<id>.md from full-file \
+             markdown content (frontmatter block included; a non-empty `name` is \
+             required, `logo` is emoji-only, and the body — the system prompt — must be \
+             non-empty). Rejects ids that already exist anywhere in the merged agents \
+             scan, or a target path that already exists on disk. The write is atomic and \
+             fans out directory::agents::on-change with { op: \"create\" }.",
+        )
+        .metadata(json!({"tool": {"label": "Create agent"}})),
+    );
+}
+
+fn register_update(iii: &Arc<IIIClient>, cfg: &SharedConfig, subs: &trigger_types::SubscriberSet) {
+    let cfg_inner = cfg.clone();
+    let iii_inner = iii.clone();
+    let subs_inner = subs.clone();
+    iii.register_function(
+        "directory::agents::update",
+        RegisterFunction::new_async(move |req: AgentUpdateInput| {
+            let cfg = cfg_inner.load_full();
+            let iii = iii_inner.clone();
+            let subs = subs_inner.clone();
+            async move {
+                let out = update_agent(&cfg, &req).map_err(Error::Handler)?;
+                trigger_types::dispatch(&iii, &subs, json!({ "op": "update", "name": out.id }))
+                    .await;
+                Ok::<_, Error>(out)
+            }
+        })
+        .description(
+            "Overwrite one EXISTING agent profile with new full-file markdown content — \
+             the same rules the scanner enforces (required frontmatter with a non-empty \
+             `name`, emoji-only `logo`, non-empty body), so an update can never produce \
+             a file the next directory::agents::list would skip. The agent id stays the \
+             file stem; frontmatter `name` is only the display name. The write is atomic \
+             and fans out directory::agents::on-change with { op: \"update\" }.",
+        )
+        .metadata(json!({"tool": {"label": "Update agent"}})),
+    );
+}
+
+fn register_delete(iii: &Arc<IIIClient>, cfg: &SharedConfig, subs: &trigger_types::SubscriberSet) {
+    let cfg_inner = cfg.clone();
+    let iii_inner = iii.clone();
+    let subs_inner = subs.clone();
+    iii.register_function(
+        "directory::agents::delete",
+        RegisterFunction::new_async(move |req: AgentDeleteInput| {
+            let cfg = cfg_inner.load_full();
+            let iii = iii_inner.clone();
+            let subs = subs_inner.clone();
+            async move {
+                let out = delete_agent(&cfg, &req).map_err(Error::Handler)?;
+                trigger_types::dispatch(&iii, &subs, json!({ "op": "delete", "name": out.id }))
+                    .await;
+                Ok::<_, Error>(out)
+            }
+        })
+        .description(
+            "Permanently delete one EXISTING agent profile by id. Resolves against the \
+             same merged scan as directory::agents::list, removes only that agent's \
+             markdown file, and fans out directory::agents::on-change with \
+             { op: \"delete\" }. Sessions already running as this agent are not \
+             affected; the id just stops resolving for new sends.",
+        )
+        .metadata(json!({"tool": {"label": "Delete agent"}})),
+    );
+}
+
+// ---------- core helpers (engine-free, reusable in tests) ----------
+
+fn scan_merged(cfg: &SkillsConfig) -> Vec<FsAgent> {
+    fs_source::scan_agents_merged(&cfg.resolved_skills_folder(), &cfg.local_skills_folder()).0
+}
+
+pub fn list_agents(cfg: &SkillsConfig) -> ListAgentsOutput {
+    let agents = scan_merged(cfg)
+        .into_iter()
+        .map(|a| AgentEntry {
+            modified_at: fs_modified_at(&a.abs_path),
+            skill_count: (!a.skills.is_empty()).then_some(a.skills.len()),
+            model: a.model,
+            icon: a.icon,
+            leaf: a.leaf,
+            id: a.name,
+            name: a.display_name,
+            description: a.description,
+            logo: a.logo,
+        })
+        .collect();
+    ListAgentsOutput { agents }
+}
+
+/// `visible_skills` is the same set `directory::skills::list` serves
+/// (`resolve_visible_skills`); the registered handler supplies it, tests
+/// hand-build one.
+pub fn get_agent(
+    cfg: &SkillsConfig,
+    req: AgentGetInput,
+    visible_skills: &[FsSkill],
+) -> Result<AgentGetOutput, String> {
+    validate_name(&req.id)?;
+    let agents = scan_merged(cfg);
+    let Some(agent) = agents.iter().find(|a| a.name == req.id).cloned() else {
+        return Err(agent_not_found(&agents, &req.id));
+    };
+    let body = fs_source::read_body(&agent.abs_path)?;
+    let raw = if req.raw.unwrap_or(false) {
+        Some(fs_source::read_raw(&agent.abs_path)?)
+    } else {
+        None
+    };
+    // `find_fs_skill_in` resolves the `<ns>` ↔ `<ns>/index` overview
+    // alias, so both id forms an author might write count as known.
+    let unknown_skills = agent
+        .skills
+        .iter()
+        .filter(|id| find_fs_skill_in(visible_skills, id).is_none())
+        .cloned()
+        .collect();
+    let unknown_delegates = agent
+        .delegates_to
+        .as_deref()
+        .unwrap_or(&[])
+        .iter()
+        .filter(|id| !agents.iter().any(|a| &a.name == *id))
+        .cloned()
+        .collect();
+    Ok(AgentGetOutput {
+        modified_at: fs_modified_at(&agent.abs_path),
+        id: agent.name,
+        name: agent.display_name,
+        description: agent.description,
+        logo: agent.logo,
+        system_prompt: body,
+        skills: agent.skills,
+        unknown_skills,
+        delegates_to: agent.delegates_to,
+        leaf: agent.leaf,
+        unknown_delegates,
+        model: agent.model,
+        icon: agent.icon,
+        raw,
+    })
+}
+
+pub fn create_agent(
+    cfg: &SkillsConfig,
+    req: &AgentCreateInput,
+) -> Result<AgentWriteOutput, String> {
+    validate_name(&req.id)?;
+    let agents = scan_merged(cfg);
+    if agents.iter().any(|a| a.name == req.id) {
+        return Err(invalid_input_message(
+            "D414",
+            &format!("agent {:?} already exists.", req.id),
+            AGENT_CREATE_CONFLICT_NEXT,
+        ));
+    }
+    let dest = cfg
+        .resolved_skills_folder()
+        .join(fs_source::AGENTS_SEGMENT)
+        .join(format!("{}.md", req.id));
+    if dest.exists() {
+        return Err(invalid_input_message(
+            "D414",
+            &format!(
+                "a file already exists at {} (currently skipped by the scanner); edit or \
+                 remove it on disk.",
+                dest.display()
+            ),
+            AGENT_CREATE_CONFLICT_NEXT,
+        ));
+    }
+    let fm = validate_agent_content(&req.content)?;
+    write_file_atomic(&dest, req.content.as_bytes())?;
+    Ok(write_output(req.id.clone(), fm, req.content.len(), &dest))
+}
+
+pub fn update_agent(
+    cfg: &SkillsConfig,
+    req: &AgentUpdateInput,
+) -> Result<AgentWriteOutput, String> {
+    validate_name(&req.id)?;
+    let agents = scan_merged(cfg);
+    let Some(agent) = agents.iter().find(|a| a.name == req.id) else {
+        return Err(agent_not_found(&agents, &req.id));
+    };
+    let fm = validate_agent_content(&req.content)?;
+    write_file_atomic(&agent.abs_path, req.content.as_bytes())?;
+    Ok(write_output(
+        req.id.clone(),
+        fm,
+        req.content.len(),
+        &agent.abs_path,
+    ))
+}
+
+pub fn delete_agent(
+    cfg: &SkillsConfig,
+    req: &AgentDeleteInput,
+) -> Result<AgentDeleteOutput, String> {
+    validate_name(&req.id)?;
+    let agents = scan_merged(cfg);
+    let Some(agent) = agents.iter().find(|a| a.name == req.id) else {
+        return Err(agent_not_found(&agents, &req.id));
+    };
+    // Suppress the watcher's `{ op: "external" }` for our own delete —
+    // the precise `{ op: "delete" }` fan-out already covers it.
+    mark_self_write(&agent.abs_path);
+    std::fs::remove_file(&agent.abs_path)
+        .map_err(|e| format!("delete {}: {e}", agent.abs_path.display()))?;
+    Ok(AgentDeleteOutput { id: req.id.clone() })
+}
+
+// ---------- validation ----------
+
+/// Write-time content check, byte-identical to what the scanner
+/// enforces: size cap on the raw file, required valid frontmatter
+/// ([`fs_source::parse_agent_frontmatter`]), non-empty body.
+fn validate_agent_content(content: &str) -> Result<fs_source::AgentFrontmatter, String> {
+    if content.len() > SKILL_BODY_MAX_BYTES {
+        return Err(format!(
+            "content too large ({} bytes; max {SKILL_BODY_MAX_BYTES})",
+            content.len()
+        ));
+    }
+    let fm = fs_source::parse_agent_frontmatter(content)?;
+    let (_, body) = fs_source::split_frontmatter(content);
+    if body.trim().is_empty() {
+        return Err("body (the system prompt) must be non-empty".into());
+    }
+    Ok(fm)
+}
+
+fn agent_not_found(agents: &[FsAgent], missed: &str) -> String {
+    let names: Vec<String> = agents.iter().map(|a| a.name.clone()).collect();
+    let missed_lc = missed.to_lowercase();
+    let mut scored: Vec<(usize, &String)> = names
+        .iter()
+        .map(|n| {
+            (
+                crate::functions::skills::levenshtein(&missed_lc, &n.to_lowercase()),
+                n,
+            )
+        })
+        .collect();
+    scored.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(b.1)));
+    let candidates: Vec<String> = scored.into_iter().take(3).map(|(_, n)| n.clone()).collect();
+    not_found_message("D410", "agent", missed, &candidates, AGENT_NOT_FOUND_NEXT)
+}
+
+fn write_output(
+    id: String,
+    fm: fs_source::AgentFrontmatter,
+    bytes: usize,
+    path: &std::path::Path,
+) -> AgentWriteOutput {
+    AgentWriteOutput {
+        modified_at: fs_modified_at(path),
+        id,
+        name: fm.name.as_deref().unwrap_or("").trim().to_string(),
+        description: fm
+            .description
+            .as_deref()
+            .map(str::trim)
+            .unwrap_or("")
+            .to_string(),
+        logo: fm.logo.map(|l| l.trim().to_string()),
+        bytes,
+    }
+}
+
+fn fs_modified_at(path: &std::path::Path) -> String {
+    std::fs::metadata(path)
+        .ok()
+        .and_then(|m| m.modified().ok())
+        .map(|t| chrono::DateTime::<chrono::Utc>::from(t).to_rfc3339())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::{Path, PathBuf};
+
+    const CAPTAIN: &str = "---\nname: Release Captain\ndescription: Cuts releases.\nlogo: \"🚢\"\nskills:\n  - iii-sandbox\n  - agent-memory/observe\ndelegates_to: [frontend-design]\nmodel: codex/gpt-5.4-mini\nicon: search\n---\nYou are the release captain.\n";
+
+    fn write_fixture(dir: &Path, rel: &str, contents: &str) {
+        let path = dir.join(rel);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, contents).unwrap();
+    }
+
+    fn cfg_for(dir: &Path) -> SkillsConfig {
+        SkillsConfig {
+            skills_folder: dir.to_string_lossy().into_owned(),
+            local_skills_folder: dir.join("local-empty").to_string_lossy().into_owned(),
+            ..SkillsConfig::default()
+        }
+    }
+
+    fn skill(id: &str) -> FsSkill {
+        FsSkill {
+            id: id.into(),
+            abs_path: PathBuf::from(format!("/x/{id}.md")),
+        }
+    }
+
+    #[test]
+    fn list_and_get_roundtrip() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_fixture(tmp.path(), "agents/release-captain.md", CAPTAIN);
+        let cfg = cfg_for(tmp.path());
+
+        let listed = list_agents(&cfg);
+        assert_eq!(listed.agents.len(), 1);
+        let row = &listed.agents[0];
+        assert_eq!(row.id, "release-captain");
+        assert_eq!(row.name, "Release Captain");
+        assert_eq!(row.logo.as_deref(), Some("🚢"));
+        assert_eq!(row.skill_count, Some(2));
+        assert_eq!(row.model.as_deref(), Some("codex/gpt-5.4-mini"));
+        assert_eq!(row.icon.as_deref(), Some("search"));
+        assert!(!row.leaf);
+
+        // `iii-sandbox` is known via the `<ns>/index` alias; the other id
+        // matches nothing.
+        let visible = vec![skill("iii-sandbox/index")];
+        let got = get_agent(
+            &cfg,
+            AgentGetInput {
+                id: "release-captain".into(),
+                raw: Some(true),
+            },
+            &visible,
+        )
+        .unwrap();
+        assert_eq!(got.system_prompt.trim(), "You are the release captain.");
+        assert_eq!(got.unknown_skills, vec!["agent-memory/observe".to_string()]);
+        assert_eq!(
+            got.delegates_to.as_deref(),
+            Some(&["frontend-design".to_string()][..])
+        );
+        assert!(!got.leaf);
+        assert_eq!(got.unknown_delegates, vec!["frontend-design".to_string()]);
+        assert_eq!(got.model.as_deref(), Some("codex/gpt-5.4-mini"));
+        assert_eq!(got.icon.as_deref(), Some("search"));
+        assert_eq!(got.raw.as_deref(), Some(CAPTAIN));
+    }
+
+    #[test]
+    fn get_reports_known_delegate_and_absent_lists() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_fixture(tmp.path(), "agents/architect.md", CAPTAIN);
+        write_fixture(
+            tmp.path(),
+            "agents/frontend-design.md",
+            "---\nname: Frontend\ndescription: UI work.\n---\nYou do frontend.\n",
+        );
+        let cfg = cfg_for(tmp.path());
+        let got = get_agent(
+            &cfg,
+            AgentGetInput {
+                id: "architect".into(),
+                raw: None,
+            },
+            &[],
+        )
+        .unwrap();
+        assert!(
+            got.unknown_delegates.is_empty(),
+            "{:?}",
+            got.unknown_delegates
+        );
+
+        // Absent skills / delegates_to on the second agent.
+        let plain = get_agent(
+            &cfg,
+            AgentGetInput {
+                id: "frontend-design".into(),
+                raw: None,
+            },
+            &[],
+        )
+        .unwrap();
+        assert!(plain.skills.is_empty());
+        assert!(plain.unknown_skills.is_empty());
+        assert!(plain.delegates_to.is_none());
+        assert!(plain.unknown_delegates.is_empty());
+    }
+
+    #[test]
+    fn get_miss_names_the_family_and_its_list() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_fixture(tmp.path(), "agents/real.md", CAPTAIN);
+        let cfg = cfg_for(tmp.path());
+        let err = get_agent(
+            &cfg,
+            AgentGetInput {
+                id: "reel".into(),
+                raw: None,
+            },
+            &[],
+        )
+        .unwrap_err();
+        assert!(err.starts_with("D410 not_found: agent"), "got: {err}");
+        assert!(err.contains("real"), "candidate missing: {err}");
+        assert!(err.contains("directory::agents::list"), "got: {err}");
+    }
+
+    #[test]
+    fn create_update_delete_lifecycle() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = cfg_for(tmp.path());
+
+        let out = create_agent(
+            &cfg,
+            &AgentCreateInput {
+                id: "captain".into(),
+                content: CAPTAIN.into(),
+            },
+        )
+        .unwrap();
+        assert_eq!(out.name, "Release Captain");
+        let dest = tmp.path().join("agents/captain.md");
+        assert!(dest.is_file());
+
+        // Duplicate create conflicts.
+        let err = create_agent(
+            &cfg,
+            &AgentCreateInput {
+                id: "captain".into(),
+                content: CAPTAIN.into(),
+            },
+        )
+        .unwrap_err();
+        assert!(err.starts_with("D414 invalid_input:"), "got: {err}");
+        assert!(err.contains("directory::agents::update"), "got: {err}");
+
+        let updated = update_agent(
+            &cfg,
+            &AgentUpdateInput {
+                id: "captain".into(),
+                content: "---\nname: Captain v2\ndescription: New.\n---\nNew prompt.\n".into(),
+            },
+        )
+        .unwrap();
+        assert_eq!(updated.name, "Captain v2");
+        assert!(std::fs::read_to_string(&dest)
+            .unwrap()
+            .contains("New prompt."));
+
+        delete_agent(
+            &cfg,
+            &AgentDeleteInput {
+                id: "captain".into(),
+            },
+        )
+        .unwrap();
+        assert!(!dest.exists());
+
+        let err = update_agent(
+            &cfg,
+            &AgentUpdateInput {
+                id: "captain".into(),
+                content: CAPTAIN.into(),
+            },
+        )
+        .unwrap_err();
+        assert!(err.starts_with("D410 not_found: agent"), "got: {err}");
+    }
+
+    #[test]
+    fn write_rejects_what_the_scanner_would_skip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = cfg_for(tmp.path());
+        for (content, needle) in [
+            ("no frontmatter\n", "missing YAML frontmatter"),
+            ("---\ndescription: x\n---\nbody\n", "non-empty `name`"),
+            ("---\nname: X\nlogo: ./x.png\n---\nbody\n", "emoji only"),
+            ("---\nname: X\nicon: rocket\n---\nbody\n", "`icon` must be one of"),
+            ("---\nname: X\ndescription: y\n---\n", "non-empty"),
+        ] {
+            let err = create_agent(
+                &cfg,
+                &AgentCreateInput {
+                    id: "bad".into(),
+                    content: content.into(),
+                },
+            )
+            .unwrap_err();
+            assert!(err.contains(needle), "content {content:?} → {err}");
+        }
+    }
+
+    #[test]
+    fn create_refuses_on_disk_but_skipped_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        // On disk but frontmatter-less → invisible to the scan, still a
+        // create conflict (create never clobbers).
+        write_fixture(tmp.path(), "agents/ghost.md", "no frontmatter\n");
+        let cfg = cfg_for(tmp.path());
+        let err = create_agent(
+            &cfg,
+            &AgentCreateInput {
+                id: "ghost".into(),
+                content: CAPTAIN.into(),
+            },
+        )
+        .unwrap_err();
+        assert!(err.contains("already exists at"), "got: {err}");
+    }
+}

--- a/iii-directory/src/functions/agents.rs
+++ b/iii-directory/src/functions/agents.rs
@@ -730,7 +730,10 @@ mod tests {
             ("no frontmatter\n", "missing YAML frontmatter"),
             ("---\ndescription: x\n---\nbody\n", "non-empty `name`"),
             ("---\nname: X\nlogo: ./x.png\n---\nbody\n", "emoji only"),
-            ("---\nname: X\nicon: rocket\n---\nbody\n", "`icon` must be one of"),
+            (
+                "---\nname: X\nicon: rocket\n---\nbody\n",
+                "`icon` must be one of",
+            ),
             ("---\nname: X\ndescription: y\n---\n", "non-empty"),
         ] {
             let err = create_agent(

--- a/iii-directory/src/functions/download.rs
+++ b/iii-directory/src/functions/download.rs
@@ -19,7 +19,7 @@ use serde_json::{json, Value};
 
 use crate::config::{SharedConfig, SkillsConfig};
 use crate::sources::{self, registry::VersionSpec, DownloadResult};
-use crate::trigger_types::{self, SubscriberSet};
+use crate::trigger_types;
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 pub struct DownloadInput {
@@ -87,6 +87,7 @@ struct DownloadOutput {
     skills_written: Vec<String>,
     prompts_written: Vec<String>,
     system_prompts_written: Vec<String>,
+    agents_written: Vec<String>,
     source: Value,
 }
 
@@ -121,24 +122,14 @@ pub fn register(iii: &Arc<IIIClient>, cfg: &SharedConfig, subscribers: &super::S
 async fn run_and_fan_out(
     iii: &IIIClient,
     cfg: &SkillsConfig,
-    skills_subs: &SubscriberSet,
-    prompts_subs: &SubscriberSet,
-    system_prompts_subs: &SubscriberSet,
+    subs: &super::Subscribers,
     input: DownloadInput,
 ) -> Result<DownloadOutput, Error> {
     let classified = classify_input(input).map_err(Error::Handler)?;
     let result = run_download(cfg, &classified)
         .await
         .map_err(Error::Handler)?;
-    fan_out(
-        iii,
-        skills_subs,
-        prompts_subs,
-        system_prompts_subs,
-        &classified,
-        &result,
-    )
-    .await;
+    fan_out(iii, subs, &classified, &result).await;
     Ok(build_output(&classified, result))
 }
 
@@ -149,28 +140,14 @@ async fn run_and_fan_out(
 fn register_download(iii: &Arc<IIIClient>, cfg: &SharedConfig, subscribers: &super::Subscribers) {
     let iii_inner = iii.clone();
     let cfg_inner = cfg.clone();
-    let skills_subs = subscribers.skills.clone();
-    let prompts_subs = subscribers.prompts.clone();
-    let system_prompts_subs = subscribers.system_prompts.clone();
+    let subs_outer = subscribers.clone();
     iii.register_function(
         "directory::skills::download",
         RegisterFunction::new_async(move |req: DownloadInput| {
             let iii = iii_inner.clone();
             let cfg = cfg_inner.load_full();
-            let skills_subs = skills_subs.clone();
-            let prompts_subs = prompts_subs.clone();
-            let system_prompts_subs = system_prompts_subs.clone();
-            async move {
-                run_and_fan_out(
-                    &iii,
-                    &cfg,
-                    &skills_subs,
-                    &prompts_subs,
-                    &system_prompts_subs,
-                    req,
-                )
-                .await
-            }
+            let subs = subs_outer.clone();
+            async move { run_and_fan_out(&iii, &cfg, &subs, req).await }
         })
         .description(
             "Download skills + prompts into skills_folder from EITHER source. Prefer the \
@@ -195,17 +172,13 @@ fn register_download_from_registry(
 ) {
     let iii_inner = iii.clone();
     let cfg_inner = cfg.clone();
-    let skills_subs = subscribers.skills.clone();
-    let prompts_subs = subscribers.prompts.clone();
-    let system_prompts_subs = subscribers.system_prompts.clone();
+    let subs_outer = subscribers.clone();
     iii.register_function(
         "directory::skills::download_from_registry",
         RegisterFunction::new_async(move |req: RegistryDownloadInput| {
             let iii = iii_inner.clone();
             let cfg = cfg_inner.load_full();
-            let skills_subs = skills_subs.clone();
-            let prompts_subs = prompts_subs.clone();
-            let system_prompts_subs = system_prompts_subs.clone();
+            let subs = subs_outer.clone();
             async move {
                 let input = DownloadInput {
                     worker: Some(req.worker),
@@ -213,15 +186,7 @@ fn register_download_from_registry(
                     tag: req.tag,
                     ..Default::default()
                 };
-                run_and_fan_out(
-                    &iii,
-                    &cfg,
-                    &skills_subs,
-                    &prompts_subs,
-                    &system_prompts_subs,
-                    input,
-                )
-                .await
+                run_and_fan_out(&iii, &cfg, &subs, input).await
             }
         })
         .description(
@@ -246,17 +211,13 @@ fn register_download_from_repo(
 ) {
     let iii_inner = iii.clone();
     let cfg_inner = cfg.clone();
-    let skills_subs = subscribers.skills.clone();
-    let prompts_subs = subscribers.prompts.clone();
-    let system_prompts_subs = subscribers.system_prompts.clone();
+    let subs_outer = subscribers.clone();
     iii.register_function(
         "directory::skills::download_from_repo",
         RegisterFunction::new_async(move |req: RepoDownloadInput| {
             let iii = iii_inner.clone();
             let cfg = cfg_inner.load_full();
-            let skills_subs = skills_subs.clone();
-            let prompts_subs = prompts_subs.clone();
-            let system_prompts_subs = system_prompts_subs.clone();
+            let subs = subs_outer.clone();
             async move {
                 let input = DownloadInput {
                     repo: Some(req.repo),
@@ -264,15 +225,7 @@ fn register_download_from_repo(
                     branch: req.branch,
                     ..Default::default()
                 };
-                run_and_fan_out(
-                    &iii,
-                    &cfg,
-                    &skills_subs,
-                    &prompts_subs,
-                    &system_prompts_subs,
-                    input,
-                )
-                .await
+                run_and_fan_out(&iii, &cfg, &subs, input).await
             }
         })
         .description(
@@ -404,19 +357,18 @@ fn build_output(classified: &ClassifiedInput, result: DownloadResult) -> Downloa
         skills_written: result.skills_written,
         prompts_written: result.prompts_written,
         system_prompts_written: result.system_prompts_written,
+        agents_written: result.agents_written,
         source,
     }
 }
 
 /// Fan out to subscribers. We fire `skills::on-change` only when at
 /// least one skill was written (and likewise for prompts / system
-/// prompts) so noisy no-op downloads don't churn MCP
+/// prompts / agents) so noisy no-op downloads don't churn MCP
 /// `notifications/list_changed`.
 async fn fan_out(
     iii: &IIIClient,
-    skills_subs: &SubscriberSet,
-    prompts_subs: &SubscriberSet,
-    system_prompts_subs: &SubscriberSet,
+    subs: &super::Subscribers,
     classified: &ClassifiedInput,
     result: &DownloadResult,
 ) {
@@ -429,13 +381,16 @@ async fn fan_out(
         },
     });
     if !result.skills_written.is_empty() {
-        trigger_types::dispatch(iii, skills_subs, payload.clone()).await;
+        trigger_types::dispatch(iii, &subs.skills, payload.clone()).await;
     }
     if !result.prompts_written.is_empty() {
-        trigger_types::dispatch(iii, prompts_subs, payload.clone()).await;
+        trigger_types::dispatch(iii, &subs.prompts, payload.clone()).await;
     }
     if !result.system_prompts_written.is_empty() {
-        trigger_types::dispatch(iii, system_prompts_subs, payload).await;
+        trigger_types::dispatch(iii, &subs.system_prompts, payload.clone()).await;
+    }
+    if !result.agents_written.is_empty() {
+        trigger_types::dispatch(iii, &subs.agents, payload).await;
     }
 }
 

--- a/iii-directory/src/functions/mod.rs
+++ b/iii-directory/src/functions/mod.rs
@@ -15,6 +15,7 @@
 //! `engine::workers::list`. See the harness `iii` skill for the
 //! recommended composition patterns.
 
+pub mod agents;
 pub mod download;
 pub mod engine_fn;
 pub mod error;
@@ -35,14 +36,15 @@ use crate::config::{SharedConfig, SkillsConfig};
 use crate::fs_source::{self, SourceKind};
 use crate::trigger_types::{RegisteredTriggerTypes, SubscriberSet};
 
-/// Trio of subscriber sets passed into `download::register` and
-/// `update::register` so those functions can fan out to
-/// `directory::skills::on-change`, `directory::prompts::on-change`, and
-/// `directory::system-prompts::on-change` after a successful write.
+/// Subscriber sets passed into the write modules (`download`, `update`,
+/// `agents`) so they can fan out the matching `directory::*::on-change`
+/// after a successful write.
+#[derive(Clone)]
 pub struct Subscribers {
     pub skills: SubscriberSet,
     pub prompts: SubscriberSet,
     pub system_prompts: SubscriberSet,
+    pub agents: SubscriberSet,
 }
 
 impl From<&RegisteredTriggerTypes> for Subscribers {
@@ -51,6 +53,7 @@ impl From<&RegisteredTriggerTypes> for Subscribers {
             skills: t.skills.clone(),
             prompts: t.prompts.clone(),
             system_prompts: t.system_prompts.clone(),
+            agents: t.agents.clone(),
         }
     }
 }
@@ -68,6 +71,7 @@ pub fn register_all(
     let subs = Subscribers::from(trigger_types);
     download::register(iii, cfg, &subs);
     update::register(iii, cfg, &subs, &cache);
+    agents::register(iii, cfg, &subs, &cache);
     registry::register(iii, cfg);
     engine_fn::register(iii);
     tracing::info!(
@@ -75,6 +79,7 @@ pub fn register_all(
          3 skills writes (update + create + delete), \
          5 directory::prompts::* (list + get + create + update + delete), \
          5 directory::system-prompts::* (list + get + create + update + delete), \
+         5 directory::agents::* (list + get + create + update + delete), \
          3 downloads, 2 directory::registry::workers::*, \
          and 1 directory::engine::functions::info"
     );
@@ -92,6 +97,7 @@ pub fn register_all_with_cache(
     let subs = Subscribers::from(trigger_types);
     download::register(iii, cfg, &subs);
     update::register(iii, cfg, &subs, cache);
+    agents::register(iii, cfg, &subs, cache);
     registry::register_with_cache(iii, cfg, registry_cache);
     engine_fn::register(iii);
     tracing::info!(
@@ -99,6 +105,7 @@ pub fn register_all_with_cache(
          3 skills writes (update + create + delete), \
          5 directory::prompts::* (list + get + create + update + delete), \
          5 directory::system-prompts::* (list + get + create + update + delete), \
+         5 directory::agents::* (list + get + create + update + delete), \
          3 downloads, 2 directory::registry::workers::*, \
          and 1 directory::engine::functions::info"
     );
@@ -114,6 +121,7 @@ pub fn log_fs_health(cfg: &SkillsConfig) {
         fs_source::scan_prompts(&folder, fs_source::PromptKind::Command);
     let (system_prompts, system_prompt_skipped) =
         fs_source::scan_prompts(&folder, fs_source::PromptKind::System);
+    let (agent_profiles, agent_skipped) = fs_source::scan_agents(&folder);
     let (agents_skills, agents_skipped) =
         fs_source::scan_agents_skills(&cfg.resolved_agents_skills_folder());
 
@@ -145,21 +153,31 @@ pub fn log_fs_health(cfg: &SkillsConfig) {
             "loaded fs-backed system prompt"
         );
     }
+    for a in &agent_profiles {
+        tracing::info!(
+            id = %a.name,
+            path = %a.abs_path.display(),
+            "loaded fs-backed agent profile"
+        );
+    }
 
     let total_skipped = skill_skipped.len()
         + prompt_skipped.len()
         + system_prompt_skipped.len()
+        + agent_skipped.len()
         + agents_skipped.len();
     for s in skill_skipped
         .iter()
         .chain(prompt_skipped.iter())
         .chain(system_prompt_skipped.iter())
+        .chain(agent_skipped.iter())
         .chain(agents_skipped.iter())
     {
         let kind = match s.kind {
             SourceKind::Skill => "skill",
             SourceKind::Prompt => "prompt",
             SourceKind::SystemPrompt => "system prompt",
+            SourceKind::Agent => "agent",
         };
         tracing::warn!(
             kind,
@@ -174,6 +192,7 @@ pub fn log_fs_health(cfg: &SkillsConfig) {
         agents_skills = agents_skills.len(),
         prompts = prompts.len(),
         system_prompts = system_prompts.len(),
+        agent_profiles = agent_profiles.len(),
         skipped = total_skipped,
         skills_folder = %folder.display(),
         "fs source scan complete"

--- a/iii-directory/src/lib.rs
+++ b/iii-directory/src/lib.rs
@@ -21,6 +21,11 @@
 //!     `<skills_folder>/<ns>/prompts/*.md` files with YAML frontmatter.
 //!     `directory::prompts::list` enumerates them;
 //!     `directory::prompts::get` reads one body + metadata.
+//!   * **Agents** (`directory::agents::*`): filesystem-backed agent
+//!     profiles under an `agents/` path segment — reusable session
+//!     identities whose file body is the system prompt, with display
+//!     name / emoji logo / skill filter / delegation fields in required
+//!     YAML frontmatter (see `harness/architecture/agents.md`).
 //!   * **Registry** (`directory::registry::*`): HTTP proxy over
 //!     `api.workers.iii.dev` with the same `workers::{list,info}` shape
 //!     as the engine's `engine::workers::*` so callers learn one
@@ -37,16 +42,17 @@
 //! defaults to `tag=latest`) or from a GitHub repo (`repo=URL
 //! skill=NAME branch?=main`) and writes the contents into
 //! `<skills_folder>/<namespace>/...`; `directory::skills::update` /
-//! `directory::prompts::update` / `directory::system-prompts::update`
-//! overwrite one existing file with edited full-file content;
-//! `directory::skills::{create,delete}`,
-//! `directory::prompts::{create,delete}` and
-//! `directory::system-prompts::{create,delete}` manage skill/prompt
+//! `directory::prompts::update` / `directory::system-prompts::update` /
+//! `directory::agents::update` overwrite one existing file with edited
+//! full-file content; `directory::skills::{create,delete}`,
+//! `directory::prompts::{create,delete}`,
+//! `directory::system-prompts::{create,delete}` and
+//! `directory::agents::{create,delete}` manage skill/prompt/agent
 //! files (never touching the read-only `agents_skills_folder`). After
-//! every successful write the worker fires `directory::skills::on-change`
-//! and/or `directory::prompts::on-change` and/or
-//! `directory::system-prompts::on-change` so subscribers can forward
-//! change notifications to their clients.
+//! every successful write the worker fires the matching family's
+//! `directory::*::on-change` (skills / prompts / system-prompts /
+//! agents) so subscribers can forward change notifications to their
+//! clients.
 //!
 //! The worker also ships an injectable console UI (see [`ui`]): a
 //! skills & prompts browser/editor page, a `directory::*`

--- a/iii-directory/src/main.rs
+++ b/iii-directory/src/main.rs
@@ -245,6 +245,7 @@ async fn main() -> Result<()> {
         skills: registered.skills.clone(),
         prompts: registered.prompts.clone(),
         system_prompts: registered.system_prompts.clone(),
+        agents: registered.agents.clone(),
     };
     let rt = tokio::runtime::Handle::current();
     let _fs_watch = match iii_directory::watch::spawn_fs_watch(watch_roots, move |kind| {
@@ -252,6 +253,7 @@ async fn main() -> Result<()> {
             iii_directory::fs_source::SourceKind::Skill => watch_sets.skills.clone(),
             iii_directory::fs_source::SourceKind::Prompt => watch_sets.prompts.clone(),
             iii_directory::fs_source::SourceKind::SystemPrompt => watch_sets.system_prompts.clone(),
+            iii_directory::fs_source::SourceKind::Agent => watch_sets.agents.clone(),
         };
         let iii = watch_iii.clone();
         rt.spawn(async move {
@@ -268,18 +270,18 @@ async fn main() -> Result<()> {
         }
     };
 
-    // 27 unconditional: 3 skills reads (list/get/index) + 6 skills writes
+    // 32 unconditional: 3 skills reads (list/get/index) + 6 skills writes
     // (update/create/delete + download/download_from_registry/download_from_repo)
     // + 5 prompts (get/list/create/update/delete) + 5 system-prompts
-    // (get/list/create/update/delete) + 2 registry proxy + 1
-    // engine-functions-info + 1 configuration-change handler (registered
-    // above, outside functions::register_all_with_cache) + 4 for the
-    // search surface (search_functions + pre-generate + on-functions-change
-    // + hint-preview).
+    // (get/list/create/update/delete) + 5 agents (get/list/create/update/delete)
+    // + 2 registry proxy + 1 engine-functions-info + 1 configuration-change
+    // handler (registered above, outside functions::register_all_with_cache)
+    // + 4 for the search surface (search_functions + pre-generate +
+    // on-functions-change + hint-preview).
     // +1 when auto_download also registers directory::__on_worker_added.
-    let fn_count = if auto_download { 28 } else { 27 };
+    let fn_count = if auto_download { 33 } else { 32 };
     tracing::info!(
-        "iii-directory ready: {} directory::* functions + 3 custom trigger types + \
+        "iii-directory ready: {} directory::* functions + 4 custom trigger types + \
          function search + pre-generate hint + configuration hot-reload",
         fn_count
     );

--- a/iii-directory/src/sources/git.rs
+++ b/iii-directory/src/sources/git.rs
@@ -233,6 +233,17 @@ fn copy_recursive(
                         result.prompts_written.push(stem);
                     }
                 }
+                crate::fs_source::SourceKind::Agent
+                    if next_rel.extension().is_some_and(|e| e == "md") =>
+                {
+                    if let Some(stem) = stem_of(&next_rel) {
+                        result.agents_written.push(stem);
+                    }
+                }
+                // Non-md support files under an agents/ dir must not be
+                // reported as written skills — they'd fire the wrong
+                // on-change and pollute the skills bucket.
+                crate::fs_source::SourceKind::Agent => {}
                 _ => result.skills_written.push(rel_str),
             }
         }

--- a/iii-directory/src/sources/mod.rs
+++ b/iii-directory/src/sources/mod.rs
@@ -40,6 +40,7 @@ pub struct DownloadResult {
     pub skills_written: Vec<String>,
     pub prompts_written: Vec<String>,
     pub system_prompts_written: Vec<String>,
+    pub agents_written: Vec<String>,
 }
 
 impl DownloadResult {
@@ -49,11 +50,15 @@ impl DownloadResult {
             skills_written: Vec::new(),
             prompts_written: Vec::new(),
             system_prompts_written: Vec::new(),
+            agents_written: Vec::new(),
         }
     }
 
     pub fn total_files(&self) -> usize {
-        self.skills_written.len() + self.prompts_written.len() + self.system_prompts_written.len()
+        self.skills_written.len()
+            + self.prompts_written.len()
+            + self.system_prompts_written.len()
+            + self.agents_written.len()
     }
 }
 

--- a/iii-directory/src/sources/registry.rs
+++ b/iii-directory/src/sources/registry.rs
@@ -270,6 +270,15 @@ fn write_response(
                     result.prompts_written.push(stem);
                 }
             }
+            crate::fs_source::SourceKind::Agent if rel.extension().is_some_and(|e| e == "md") => {
+                if let Some(stem) = super::git::stem_of(&rel) {
+                    result.agents_written.push(stem);
+                }
+            }
+            // Non-md support files under an agents/ dir are written but
+            // not reported — they'd fire the wrong on-change and pollute
+            // the skills bucket.
+            crate::fs_source::SourceKind::Agent => {}
             _ => result
                 .skills_written
                 .push(rel.to_string_lossy().replace('\\', "/")),

--- a/iii-directory/src/trigger_types.rs
+++ b/iii-directory/src/trigger_types.rs
@@ -43,6 +43,7 @@ use serde_json::Value;
 pub const SKILLS_ON_CHANGE: &str = "directory::skills::on-change";
 pub const PROMPTS_ON_CHANGE: &str = "directory::prompts::on-change";
 pub const SYSTEM_PROMPTS_ON_CHANGE: &str = "directory::system-prompts::on-change";
+pub const AGENTS_ON_CHANGE: &str = "directory::agents::on-change";
 
 /// Thread-safe subscriber registry keyed by trigger-instance id. Cloned
 /// into both the `TriggerHandler` (which mutates on register /
@@ -120,6 +121,7 @@ pub struct RegisteredTriggerTypes {
     pub skills: SubscriberSet,
     pub prompts: SubscriberSet,
     pub system_prompts: SubscriberSet,
+    pub agents: SubscriberSet,
 }
 
 pub fn register_all(iii: &Arc<IIIClient>) -> RegisteredTriggerTypes {
@@ -162,10 +164,23 @@ pub fn register_all(iii: &Arc<IIIClient>) -> RegisteredTriggerTypes {
         "registered trigger type"
     );
 
+    let agents = SubscriberSet::new();
+    let _ = iii.register_trigger_type(RegisterTriggerType::new(
+        AGENTS_ON_CHANGE.to_string(),
+        "Fires after a directory::skills::download that wrote at least one agent profile, \
+         or a directory::agents::update, create, or delete. Also fires with \
+         { op: \"external\" } when a watched agents file changes on disk outside this \
+         worker."
+            .to_string(),
+        SkillsTriggerHandler::new(AGENTS_ON_CHANGE, agents.clone()),
+    ));
+    tracing::info!(trigger_type = AGENTS_ON_CHANGE, "registered trigger type");
+
     RegisteredTriggerTypes {
         skills,
         prompts,
         system_prompts,
+        agents,
     }
 }
 

--- a/iii-directory/ui/src/function-trigger/AgentsViews.tsx
+++ b/iii-directory/ui/src/function-trigger/AgentsViews.tsx
@@ -1,0 +1,179 @@
+import { MarkdownPreview } from '@iii-dev/console-ui'
+import { formatBytes, formatRelativeTime } from '../lib/format'
+import {
+  ActionLine,
+  Card,
+  EmptyRow,
+  KvChip,
+  MetaRow,
+  PulseLine,
+  StatusPill,
+} from '../lib/widgets'
+import {
+  agentsGetRequestSchema,
+  agentsGetResponseSchema,
+  agentsListResponseSchema,
+  agentsUpdateRequestSchema,
+  agentsUpdateResponseSchema,
+  safeParseRequest,
+  safeParseResponse,
+} from './parsers'
+
+interface ViewProps {
+  input: unknown
+  output: unknown
+  running?: boolean
+}
+
+/* ---------------- directory::agents::list ---------------- */
+
+export function AgentsListView({ output, running }: ViewProps) {
+  if (running) {
+    return (
+      <Card>
+        <MetaRow>
+          <StatusPill label="listing…" variant="default" />
+        </MetaRow>
+        <PulseLine label="scanning agents…" />
+      </Card>
+    )
+  }
+
+  const resp = safeParseResponse(agentsListResponseSchema, output)
+  if (!resp) return null
+
+  const label =
+    resp.agents.length === 0
+      ? 'no agents'
+      : `${resp.agents.length} ${resp.agents.length === 1 ? 'agent' : 'agents'}`
+
+  return (
+    <Card>
+      <MetaRow>
+        <StatusPill
+          label={label}
+          variant={resp.agents.length === 0 ? 'warn' : 'accent'}
+        />
+      </MetaRow>
+      {resp.agents.length === 0 ? (
+        <EmptyRow label="no agents found" />
+      ) : (
+        <ul className="dir-ui-list">
+          {resp.agents.map((a) => (
+            <li key={a.id} className="dir-ui-row">
+              <span className="dir-ui-id">
+                {[a.logo, a.name || a.id].filter(Boolean).join(' ')}
+              </span>
+              {a.description ? (
+                <div className="dir-ui-desc">{a.description}</div>
+              ) : null}
+              <span className="dir-ui-fine">
+                {a.skill_count != null
+                  ? `${a.skill_count} skills · `
+                  : 'all skills · '}
+                {formatRelativeTime(a.modified_at)}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Card>
+  )
+}
+
+/* ---------------- directory::agents::get ---------------- */
+
+export function AgentsGetView({ input, output, running }: ViewProps) {
+  const req = safeParseRequest(agentsGetRequestSchema, input)
+
+  if (running) {
+    return (
+      <Card>
+        <MetaRow>
+          <StatusPill label="loading…" variant="default" />
+          {req ? <KvChip label="id">{req.id}</KvChip> : null}
+        </MetaRow>
+        <PulseLine label="fetching agent…" />
+      </Card>
+    )
+  }
+
+  const resp = safeParseResponse(agentsGetResponseSchema, output)
+  if (!resp) return null
+
+  return (
+    <Card>
+      <MetaRow>
+        <StatusPill label="agent" variant="accent" />
+        {resp.leaf ? <KvChip label="leaf">yes</KvChip> : null}
+        {resp.model ? <KvChip label="model">{resp.model}</KvChip> : null}
+        <KvChip label="skills">
+          {resp.skills.length === 0 ? 'all' : String(resp.skills.length)}
+        </KvChip>
+        {resp.unknown_skills.length > 0 ? (
+          <KvChip label="unknown skills">
+            {resp.unknown_skills.join(', ')}
+          </KvChip>
+        ) : null}
+        <KvChip label="modified">{formatRelativeTime(resp.modified_at)}</KvChip>
+      </MetaRow>
+      <ActionLine symbol="ƒ" tone="accent">
+        <div className="dir-ui-stack">
+          <span className="dir-ui-id lg">
+            {[resp.logo, resp.name || resp.id].filter(Boolean).join(' ')}
+          </span>
+          {resp.description ? (
+            <span className="dir-ui-desc">{resp.description}</span>
+          ) : null}
+        </div>
+      </ActionLine>
+      <MarkdownPreview markdown={resp.system_prompt} />
+    </Card>
+  )
+}
+
+/* ---------------- directory::agents::update / create ---------------- */
+
+export function AgentsUpdateView({
+  input,
+  output,
+  running,
+  verb = 'updated',
+}: ViewProps & { verb?: string }) {
+  const req = safeParseRequest(agentsUpdateRequestSchema, input)
+
+  if (running) {
+    return (
+      <Card>
+        <MetaRow>
+          <StatusPill label="saving…" variant="default" />
+          {req ? <KvChip label="id">{req.id}</KvChip> : null}
+        </MetaRow>
+        <PulseLine label="writing agent…" />
+      </Card>
+    )
+  }
+
+  const resp = safeParseResponse(agentsUpdateResponseSchema, output)
+  if (!resp) return null
+
+  return (
+    <Card>
+      <MetaRow>
+        <StatusPill label={verb} variant="accent" />
+        <KvChip label="bytes">{formatBytes(resp.bytes)}</KvChip>
+        <KvChip label="modified">{formatRelativeTime(resp.modified_at)}</KvChip>
+      </MetaRow>
+      <ActionLine symbol="✎" tone="accent">
+        <div className="dir-ui-stack">
+          <span className="dir-ui-id lg">
+            {[resp.logo, resp.name || resp.id].filter(Boolean).join(' ')}
+          </span>
+          {resp.description ? (
+            <span className="dir-ui-desc">{resp.description}</span>
+          ) : null}
+        </div>
+      </ActionLine>
+    </Card>
+  )
+}

--- a/iii-directory/ui/src/function-trigger/index.tsx
+++ b/iii-directory/ui/src/function-trigger/index.tsx
@@ -15,6 +15,7 @@ import type {
   FunctionTriggerRenderer,
 } from '@iii-dev/console-ui'
 import { isErrorOutput, unwrapEnvelope } from '../lib/envelope'
+import { AgentsGetView, AgentsListView, AgentsUpdateView } from './AgentsViews'
 import { SkillsDownloadView } from './DownloadView'
 import { isDirectoryFunction } from './parsers'
 import { PromptsGetView, PromptsListView } from './PromptsViews'
@@ -100,6 +101,25 @@ function render(
     case 'directory::system-prompts::create':
       return (
         <PromptsUpdateView
+          input={input}
+          output={output}
+          running={running}
+          verb="created"
+        />
+      )
+    case 'directory::agents::list':
+      return <AgentsListView input={input} output={output} running={running} />
+    case 'directory::agents::get':
+      return <AgentsGetView input={input} output={output} running={running} />
+    case 'directory::agents::update':
+      return (
+        <AgentsUpdateView input={input} output={output} running={running} />
+      )
+    /* create's wire shapes ({id, content} → {id, name, description, logo,
+       bytes, modified_at}) are identical to update's, so the update view fits. */
+    case 'directory::agents::create':
+      return (
+        <AgentsUpdateView
           input={input}
           output={output}
           running={running}

--- a/iii-directory/ui/src/function-trigger/parsers.ts
+++ b/iii-directory/ui/src/function-trigger/parsers.ts
@@ -37,6 +37,10 @@ export const DIRECTORY_FUNCTION_IDS = [
   'directory::system-prompts::get',
   'directory::system-prompts::update',
   'directory::system-prompts::create',
+  'directory::agents::list',
+  'directory::agents::get',
+  'directory::agents::update',
+  'directory::agents::create',
   'directory::registry::workers::list',
   'directory::registry::workers::info',
 ] as const
@@ -197,6 +201,70 @@ export const promptsUpdateResponseSchema = z.object({
   modified_at: z.string(),
 })
 export type PromptsUpdateResponse = z.infer<typeof promptsUpdateResponseSchema>
+
+/* ---------------- agents::list ---------------- */
+
+export const agentEntrySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  logo: z.string().nullable().optional(),
+  skill_count: z.number().nullable().optional(),
+  model: z.string().nullable().optional(),
+  icon: z.string().nullable().optional(),
+  leaf: z.boolean().optional(),
+  modified_at: z.string(),
+})
+export type AgentEntry = z.infer<typeof agentEntrySchema>
+
+export const agentsListResponseSchema = z.object({
+  agents: z.array(agentEntrySchema),
+})
+export type AgentsListResponse = z.infer<typeof agentsListResponseSchema>
+
+/* ---------------- agents::get ---------------- */
+
+export const agentsGetRequestSchema = z.object({
+  id: z.string(),
+  raw: z.boolean().optional(),
+})
+export type AgentsGetRequest = z.infer<typeof agentsGetRequestSchema>
+
+export const agentsGetResponseSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  logo: z.string().nullable().optional(),
+  system_prompt: z.string(),
+  skills: z.array(z.string()),
+  unknown_skills: z.array(z.string()),
+  delegates_to: z.array(z.string()).nullable().optional(),
+  leaf: z.boolean().optional(),
+  unknown_delegates: z.array(z.string()).optional(),
+  model: z.string().nullable().optional(),
+  icon: z.string().nullable().optional(),
+  raw: z.string().nullable().optional(),
+  modified_at: z.string(),
+})
+export type AgentsGetResponse = z.infer<typeof agentsGetResponseSchema>
+
+/* ---------------- agents::update / create ---------------- */
+
+export const agentsUpdateRequestSchema = z.object({
+  id: z.string(),
+  content: z.string(),
+})
+export type AgentsUpdateRequest = z.infer<typeof agentsUpdateRequestSchema>
+
+export const agentsUpdateResponseSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  logo: z.string().nullable().optional(),
+  bytes: z.number(),
+  modified_at: z.string(),
+})
+export type AgentsUpdateResponse = z.infer<typeof agentsUpdateResponseSchema>
 
 /* ---------------- registry::workers::list ---------------- */
 

--- a/iii-directory/ui/src/page/agent-fields.tsx
+++ b/iii-directory/ui/src/page/agent-fields.tsx
@@ -1,0 +1,541 @@
+/**
+ * The agent profile form (see `agentsAdapter.customForm` in index.tsx):
+ * a sectioned settings layout — Identity (avatar + name + description),
+ * Behavior & capabilities (skill selection; the markdown editor below
+ * the form is the system prompt), Execution (default model), and
+ * Delegation. Everything edits the draft's frontmatter through the same
+ * guarded `editDraft` the built-in fields use; empty selections remove
+ * their key (absent `skills` = every skill, absent `delegates_to` =
+ * every agent), matching the worker's semantics.
+ */
+
+import { Input, type Host } from '@iii-dev/console-ui'
+import type { ReactNode } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import { type FormContext, slugify } from './browser'
+import { TokenIcon } from './token-icons'
+import {
+  readFrontmatterField,
+  readFrontmatterStringList,
+  setFrontmatterField,
+  setFrontmatterStringList,
+  withoutFrontmatterFields,
+} from './frontmatter'
+
+interface PickItem {
+  id: string
+  label: string
+  sublabel?: string
+  desc?: string
+  /** Tree-icon token rendered as the row glyph (agents). */
+  iconToken?: string | null
+}
+
+/** One list-fn fetch per mounted collection; a failure leaves the picker
+ * in its "edit in Content" fallback while still marking draft entries. */
+function useCatalog(
+  host: Host,
+  fetch: (host: Host) => Promise<PickItem[]>,
+): { items: PickItem[] | null; error: boolean } {
+  const [items, setItems] = useState<PickItem[] | null>(null)
+  const [error, setError] = useState(false)
+  useEffect(() => {
+    let cancelled = false
+    fetch(host)
+      .then((next) => {
+        if (!cancelled) setItems(next)
+      })
+      .catch(() => {
+        if (!cancelled) setError(true)
+      })
+    return () => {
+      cancelled = true
+    }
+    // biome-ignore lint/correctness/useExhaustiveDependencies: fetch is a module-level constant per picker
+  }, [host])
+  return { items, error }
+}
+
+const fetchSkills = (host: Host) =>
+  host.iii
+    .trigger<{
+      skills: { id: string; title: string; description: string }[]
+    }>('directory::skills::list', { include_description: true })
+    .then((out) =>
+      (out.skills ?? []).map((s) => ({
+        id: s.id,
+        label: s.title && s.title !== s.id ? s.title : s.id,
+        sublabel: s.title && s.title !== s.id ? s.id : undefined,
+        desc: s.description || undefined,
+      })),
+    )
+
+const fetchAgents = (host: Host) =>
+  host.iii
+    .trigger<{
+      agents: {
+        id: string
+        name: string
+        logo: string | null
+        icon: string | null
+        description: string
+      }[]
+    }>('directory::agents::list', {})
+    .then((out) =>
+      (out.agents ?? []).map((a) => ({
+        id: a.id,
+        label: a.name || a.id,
+        sublabel: a.name && a.name !== a.id ? a.id : undefined,
+        desc: a.description || undefined,
+        iconToken: a.icon,
+      })),
+    )
+
+const fetchModels = (host: Host) =>
+  host.iii
+    .trigger<{ models: { id: string }[] }>('router::models::list', {})
+    .then((out) => (out.models ?? []).map((m) => ({ id: m.id, label: m.id })))
+
+/** Curated avatar presets, one per harness `SubagentIcon` token — picking
+ * one keeps the emoji↔icon mapping mechanical for spawn display
+ * identities. */
+const LOGO_PRESETS: { emoji: string; token: string }[] = [
+  { emoji: '🤖', token: 'agent' },
+  { emoji: '💻', token: 'code' },
+  { emoji: '🔍', token: 'search' },
+  { emoji: '📟', token: 'terminal' },
+  { emoji: '💾', token: 'database' },
+  { emoji: '🧪', token: 'test' },
+  { emoji: '🧐', token: 'review' },
+  { emoji: '📚', token: 'docs' },
+  { emoji: '🎨', token: 'design' },
+]
+
+// ─────────────────────────── building blocks ─────────────────────────
+
+function Section({
+  title,
+  hint,
+  children,
+}: {
+  title: string
+  hint: string
+  children: ReactNode
+}) {
+  return (
+    <section className="dir-ui-af-section">
+      <h3 className="dir-ui-af-title">{title}</h3>
+      <p className="dir-ui-af-hint">{hint}</p>
+      <div className="dir-ui-af-card">{children}</div>
+    </section>
+  )
+}
+
+function Row({
+  label,
+  hint,
+  children,
+}: {
+  label: string
+  hint?: string
+  children: ReactNode
+}) {
+  return (
+    <div className="dir-ui-af-row">
+      <span className="dir-ui-af-label">
+        {label}
+        {hint ? <span className="dir-ui-af-label-hint">{hint}</span> : null}
+      </span>
+      <div className="dir-ui-af-control">{children}</div>
+    </div>
+  )
+}
+
+/** Collapsed "N selected — click to edit" row expanding into a search +
+ * checkbox list, the reference pattern for skills and delegates. */
+function CollapsiblePicker({
+  noun,
+  emptyLabel,
+  items,
+  error,
+  selected,
+  missing,
+  isChecked,
+  toggle,
+  readOnly,
+}: {
+  noun: string
+  emptyLabel: string
+  items: PickItem[] | null
+  error: boolean
+  selected: string[]
+  missing: string[]
+  isChecked: (id: string) => boolean
+  toggle: (id: string) => void
+  readOnly: boolean
+}) {
+  const [open, setOpen] = useState(false)
+  const [filter, setFilter] = useState('')
+  const needle = filter.trim().toLowerCase()
+  const visible = (items ?? []).filter(
+    (s) =>
+      !needle ||
+      s.id.toLowerCase().includes(needle) ||
+      s.label.toLowerCase().includes(needle) ||
+      (s.desc ?? '').toLowerCase().includes(needle),
+  )
+  const summary =
+    selected.length === 0
+      ? emptyLabel
+      : `${selected.length} selected — click to edit${missing.length ? ` · ${missing.length} missing` : ''}`
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        className="dir-ui-af-collapsed"
+        onClick={() => setOpen(true)}
+      >
+        <span className="dir-ui-af-plus">＋</span>
+        <span>{summary}</span>
+        <span className="dir-ui-af-chev">⌄</span>
+      </button>
+    )
+  }
+  return (
+    <div className="dir-ui-af-picker">
+      <div className="dir-ui-af-picker-head">
+        <span className="dir-ui-af-picker-count">
+          {selected.length ? `${selected.length} selected` : summary}
+        </span>
+        <button
+          type="button"
+          className="dir-ui-linkish"
+          onClick={() => setOpen(false)}
+        >
+          ✕ Collapse
+        </button>
+      </div>
+      {missing.length > 0 ? (
+        <div className="dir-ui-agent-skill-missing" role="status">
+          {missing.map((id) => (
+            <span key={id} className="dir-ui-agent-missing-row">
+              <span className="dir-ui-agent-missing-badge">missing</span>
+              <span className="mono">{id}</span>
+              {!readOnly ? (
+                <button
+                  type="button"
+                  className="dir-ui-linkish quiet"
+                  onClick={() => toggle(id)}
+                >
+                  remove
+                </button>
+              ) : null}
+            </span>
+          ))}
+        </div>
+      ) : null}
+      {error ? (
+        <div className="dir-ui-agent-skill-empty">
+          The {noun} catalog could not be loaded; edit the list in the source
+          below instead.
+        </div>
+      ) : items === null ? (
+        <div className="dir-ui-agent-skill-empty">Loading {noun}s…</div>
+      ) : (
+        <>
+          <Input
+            value={filter}
+            onChange={setFilter}
+            placeholder={`Search ${noun}s…`}
+            aria-label={`search ${noun}s`}
+            spellCheck={false}
+            className="dir-ui-edit-input"
+          />
+          <ul className="dir-ui-agent-skill-list tall">
+            {visible.length === 0 ? (
+              <li className="dir-ui-agent-skill-empty">
+                {needle ? `No ${noun}s match.` : `No ${noun}s available.`}
+              </li>
+            ) : (
+              visible.map((s) => (
+                <li key={s.id}>
+                  <label className="dir-ui-checkrow dir-ui-af-pick-row">
+                    <input
+                      type="checkbox"
+                      checked={isChecked(s.id)}
+                      disabled={readOnly}
+                      onChange={() => toggle(s.id)}
+                    />
+                    <span className="dir-ui-af-pick-body">
+                      <span className="dir-ui-af-pick-name">
+                        {s.iconToken ? (
+                          <span className="dir-ui-nav-ico">
+                            <TokenIcon token={s.iconToken} size={14} />
+                          </span>
+                        ) : null}
+                        {s.label}
+                        {s.sublabel ? (
+                          <span className="dir-ui-agent-skill-id mono">
+                            {s.sublabel}
+                          </span>
+                        ) : null}
+                      </span>
+                      {s.desc ? (
+                        <span className="dir-ui-af-pick-desc">{s.desc}</span>
+                      ) : null}
+                    </span>
+                  </label>
+                </li>
+              ))
+            )}
+          </ul>
+        </>
+      )}
+    </div>
+  )
+}
+
+// ───────────────────────────── the form ──────────────────────────────
+
+export function AgentForm(ctx: FormContext) {
+  const {
+    host,
+    draft,
+    editDraft,
+    readOnly,
+    fieldId,
+    entryKey,
+    nameValue,
+    descriptionValue,
+    setName,
+    setDescription,
+    creating,
+  } = ctx
+
+  const skills = readFrontmatterStringList(draft, 'skills').values
+  const delegates = readFrontmatterStringList(draft, 'delegates_to')
+  const leaf = /^true$/i.test(readFrontmatterField(draft, ['leaf']).value)
+  const model = readFrontmatterField(draft, ['model']).value.trim()
+  const icon = readFrontmatterField(draft, ['icon']).value.trim()
+
+  const skillCatalog = useCatalog(host, fetchSkills)
+  const agentCatalog = useCatalog(host, fetchAgents)
+  const modelCatalog = useCatalog(host, fetchModels)
+  const delegateItems =
+    agentCatalog.items === null
+      ? null
+      : agentCatalog.items.filter((a) => a.id !== entryKey)
+  const modelKnown =
+    modelCatalog.items === null ||
+    model === '' ||
+    modelCatalog.items.some((m) => m.id === model)
+
+  const toggleIn = (key: 'skills' | 'delegates_to', current: string[]) => {
+    return (id: string) => {
+      const next = current.includes(id)
+        ? current.filter((s) => s !== id)
+        : [...current, id]
+      editDraft(setFrontmatterStringList(draft, key, next))
+    }
+  }
+  const setLeaf = (next: boolean) => {
+    editDraft(
+      next
+        ? setFrontmatterField(draft, 'leaf', 'true', true)
+        : withoutFrontmatterFields(draft, ['leaf']),
+    )
+  }
+  const setModel = (next: string) => {
+    editDraft(
+      next
+        ? setFrontmatterField(draft, 'model', next)
+        : withoutFrontmatterFields(draft, ['model']),
+    )
+  }
+  /** The avatar IS the tree icon: one pick writes `icon` (the harness
+   * token the session tree renders) and the matching emoji `logo` (what
+   * the agent list rows show) in lockstep; clearing removes both. One
+   * edit carrying both fields — two editDraft calls in a row would lose
+   * the first (both close over the same `draft`). */
+  const setAvatar = (preset: { emoji: string; token: string } | null) => {
+    if (preset === null) {
+      editDraft(withoutFrontmatterFields(draft, ['logo', 'icon']))
+      return
+    }
+    const withLogo = setFrontmatterField(draft, 'logo', preset.emoji)
+    editDraft(setFrontmatterField(withLogo, 'icon', preset.token, true))
+  }
+
+  const knownIn = (items: PickItem[] | null) => {
+    const ids = new Set((items ?? []).map((s) => s.id))
+    return (id: string) => ids.has(id) || ids.has(`${id}/index`)
+  }
+  const missingSkills =
+    skillCatalog.items === null
+      ? []
+      : skills.filter((id) => !knownIn(skillCatalog.items)(id))
+  const missingDelegates =
+    delegateItems === null
+      ? []
+      : delegates.values.filter((id) => !knownIn(delegateItems)(id))
+
+  const derived = useMemo(() => slugify(nameValue), [nameValue])
+
+  return (
+    <div className="dir-ui-af">
+      <Section
+        title="Identity"
+        hint="Give the agent a recognizable name and a concise purpose."
+      >
+        <Row
+          label="Avatar"
+          hint={
+            icon
+              ? `${icon} — shown on the session in the side panel`
+              : 'pick the icon this agent shows in the session tree'
+          }
+        >
+          <div
+            className="dir-ui-af-icon-grid"
+            role="radiogroup"
+            aria-label="agent avatar"
+          >
+            {LOGO_PRESETS.map((p) => (
+              <button
+                key={p.token}
+                type="button"
+                role="radio"
+                aria-checked={icon === p.token}
+                title={p.token}
+                aria-label={`avatar ${p.token}`}
+                disabled={readOnly}
+                className={`dir-ui-af-icon-tile${icon === p.token ? ' active' : ''}`}
+                onClick={() => setAvatar(icon === p.token ? null : p)}
+              >
+                <TokenIcon token={p.token} />
+              </button>
+            ))}
+          </div>
+        </Row>
+        <Row
+          label="Name"
+          hint={
+            creating
+              ? derived
+                ? `→ ${derived}.md`
+                : 'the file name derives from it'
+              : undefined
+          }
+        >
+          <Input
+            id={`${fieldId}-name`}
+            value={nameValue}
+            onChange={setName}
+            placeholder="e.g. Deep Research Agent"
+            aria-label="agent name"
+            preserveCase
+            required
+            spellCheck={false}
+            readOnly={readOnly}
+            className="dir-ui-edit-input"
+          />
+        </Row>
+        <Row label="Description">
+          <textarea
+            id={`${fieldId}-description`}
+            value={descriptionValue}
+            onChange={(event) => setDescription(event.currentTarget.value)}
+            placeholder="What does this agent do?"
+            readOnly={readOnly}
+            rows={2}
+            className="dir-ui-edit-textarea"
+          />
+        </Row>
+      </Section>
+
+      <Section
+        title="Behavior & capabilities"
+        hint="The markdown below this form is the system prompt; attach the skills it can rely on."
+      >
+        <Row label="Skills">
+          <CollapsiblePicker
+            noun="skill"
+            emptyLabel="Add skills — none selected means every skill"
+            items={skillCatalog.items}
+            error={skillCatalog.error}
+            selected={skills}
+            missing={missingSkills}
+            isChecked={(id) =>
+              skills.includes(id) ||
+              (id.endsWith('/index') &&
+                skills.includes(id.slice(0, -'/index'.length)))
+            }
+            toggle={toggleIn('skills', skills)}
+            readOnly={readOnly}
+          />
+        </Row>
+      </Section>
+
+      <Section
+        title="Execution"
+        hint="Optionally pin the default model sessions run as this agent."
+      >
+        <Row
+          label="Model"
+          hint={modelKnown ? undefined : 'not in the model catalog'}
+        >
+          <select
+            id={`${fieldId}-model`}
+            value={model}
+            disabled={readOnly}
+            onChange={(event) => setModel(event.currentTarget.value)}
+            className="dir-ui-edit-input dir-ui-agent-model"
+          >
+            <option value="">Default — the send decides</option>
+            {!modelKnown ? (
+              <option value={model}>{model} (unavailable)</option>
+            ) : null}
+            {(modelCatalog.items ?? []).map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.id}
+              </option>
+            ))}
+          </select>
+        </Row>
+      </Section>
+
+      <Section
+        title="Delegation"
+        hint="Which agents this one may hand work to when orchestrating."
+      >
+        <Row label="Leaf">
+          <label className="dir-ui-checkrow dir-ui-agent-leaf">
+            <input
+              type="checkbox"
+              checked={leaf}
+              disabled={readOnly}
+              onChange={(event) => setLeaf(event.currentTarget.checked)}
+            />
+            <span>May not delegate (leaf agent)</span>
+          </label>
+        </Row>
+        {leaf ? null : (
+          <Row label="Delegates">
+            <CollapsiblePicker
+              noun="agent"
+              emptyLabel="Add agents — none selected means every agent"
+              items={delegateItems}
+              error={agentCatalog.error}
+              selected={delegates.values}
+              missing={missingDelegates}
+              isChecked={(id) => delegates.values.includes(id)}
+              toggle={toggleIn('delegates_to', delegates.values)}
+              readOnly={readOnly}
+            />
+          </Row>
+        )}
+      </Section>
+    </div>
+  )
+}

--- a/iii-directory/ui/src/page/browser.tsx
+++ b/iii-directory/ui/src/page/browser.tsx
@@ -62,12 +62,38 @@ const NARROW_BELOW = 850
 export interface BrowserRow {
   /** Stable key + the id/name passed to load/save. */
   key: string
+  /** Optional leading glyph (agents: the tree-icon token). */
+  icon?: ReactNode
   title: string
   description: string
   /** Fine-print line (size · modified). */
   fine: string
   /** Built-in entries can be viewed and copied but not changed. */
   readOnly?: boolean
+}
+
+/** What an adapter's `extraFields` renderer gets to work with: the full
+ * draft document plus the same guarded editor the built-in fields use. */
+export interface ExtraFieldsContext {
+  host: Host
+  draft: string
+  editDraft: (next: string) => void
+  readOnly: boolean
+  fieldId: string
+  /** The opened entry's key; null while creating a new one. */
+  entryKey: string | null
+}
+
+/** Context for a full custom form (`adapter.customForm`), which replaces
+ * the built-in name/description grid entirely. Name and description stay
+ * managed frontmatter fields — the setters here write them the same way
+ * the built-in inputs would. */
+export interface FormContext extends ExtraFieldsContext {
+  nameValue: string
+  descriptionValue: string
+  setName: (next: string) => void
+  setDescription: (next: string) => void
+  creating: boolean
 }
 
 export interface BrowserAdapter {
@@ -90,6 +116,26 @@ export interface BrowserAdapter {
   nameHint?: string
   /** Prompt scanners reject an empty description; skills keep it optional. */
   descriptionRequired?: boolean
+  /** The entry's key is a slug SEPARATE from its free-text display name
+      (agents: the id is the file stem, frontmatter `name` is display
+      only). The name field stays free text; the id is derived from it
+      (slugified) at create time and shown as a hint, never typed. */
+  separateId?: { pattern: RegExp; hint: string }
+  /** The scanner rejects an empty display name (agents). */
+  nameRequired?: boolean
+  /** Starter document for a new entry (defaults to name+description). */
+  newTemplate?: string
+  /** Extra frontmatter keys managed by `extraFields` — hidden from the
+      content editor and restored verbatim on save, like name/description. */
+  extraManagedKeys?: readonly string[]
+  /** Adapter-specific form controls rendered under the built-in fields. */
+  extraFields?: (ctx: ExtraFieldsContext) => ReactNode
+  /** Full replacement for the built-in fields block (agents: the
+      sectioned Identity / Behavior / Execution form). Wins over
+      `extraFields`. */
+  customForm?: (ctx: FormContext) => ReactNode
+  /** Label for the source editor header (default "Content"). */
+  sourceLabel?: string
   /** Show the skill's model-invocation control. */
   modelInvocationOption?: boolean
   /** Workspace empty-state copy. */
@@ -113,6 +159,15 @@ export interface BrowserAdapter {
  *  a `description`, so scaffold both required keys rather than a blank page. */
 const NEW_TEMPLATE = '---\nname: \ndescription: ""\n---\n\n'
 const SLUG_NAME = /^[a-z0-9_-]+$/
+
+/** Derive a slug id from a free-text display name ("Release Captain" →
+ * "release-captain"), used to prefill the id field while creating. */
+export function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
 
 type EditorMode = 'edit' | 'split' | 'preview'
 
@@ -426,13 +481,13 @@ export function CollectionBrowser({
       setCreating(true)
       setSelected(null)
       setLoaded({ key: '', content: '' })
-      setDraft(NEW_TEMPLATE)
+      setDraft(adapter.newTemplate ?? NEW_TEMPLATE)
       setLoadError(null)
       setSaveError(null)
       setDeleteError(null)
       setStaleOnDisk(false)
     })
-  }, [storageKey, guardDirty])
+  }, [storageKey, guardDirty, adapter])
 
   // External change (download / update from anywhere): refresh the list;
   // reload the open entry only when the editor has no unsaved edits.
@@ -467,22 +522,37 @@ export function CollectionBrowser({
       adapter.nameKeys ?? ['name'],
       adapter.defaultNameKey,
     ).value.trim()
-    const effectiveName = name || (!creating ? loaded.key : '')
-    // namePattern governs the CREATE id only: on update the frontmatter
-    // name/title is a display field for skills (the id is the key), so a
-    // human-readable title must not block saving. Prompt updates keep the
-    // slug gate — there the frontmatter name IS a rename.
-    const pattern = creating
-      ? (adapter.namePattern ?? (adapter.slugName ? SLUG_NAME : null))
-      : adapter.slugName
-        ? SLUG_NAME
-        : null
-    if (pattern && !pattern.test(effectiveName)) {
-      setSaveError(
-        adapter.nameHint ??
-          'enter a name using lowercase letters, numbers, hyphens or underscores',
-      )
+    if (adapter.nameRequired && !name) {
+      setSaveError(`enter a display name for this ${adapter.noun}`)
       return
+    }
+    let effectiveName = name || (!creating ? loaded.key : '')
+    if (adapter.separateId) {
+      // The name is free-text display copy; the key is the slug id —
+      // derived from the name at create time, fixed to the file stem
+      // afterwards. A collision surfaces as the server's conflict error.
+      effectiveName = creating ? slugify(name) : loaded.key
+      if (creating && !adapter.separateId.pattern.test(effectiveName)) {
+        setSaveError(adapter.separateId.hint)
+        return
+      }
+    } else {
+      // namePattern governs the CREATE id only: on update the frontmatter
+      // name/title is a display field for skills (the id is the key), so a
+      // human-readable title must not block saving. Prompt updates keep the
+      // slug gate — there the frontmatter name IS a rename.
+      const pattern = creating
+        ? (adapter.namePattern ?? (adapter.slugName ? SLUG_NAME : null))
+        : adapter.slugName
+          ? SLUG_NAME
+          : null
+      if (pattern && !pattern.test(effectiveName)) {
+        setSaveError(
+          adapter.nameHint ??
+            'enter a name using lowercase letters, numbers, hyphens or underscores',
+        )
+        return
+      }
     }
     const description = readFrontmatterField(draft, ['description']).value
     if (adapter.descriptionRequired && !description.trim()) {
@@ -746,6 +816,11 @@ export function CollectionBrowser({
     ...(adapter.modelInvocationOption && modelInvocationSimple
       ? [{ ...modelInvocationField, bare: true }]
       : []),
+    // Extra keys an adapter's custom controls own (agents: logo, skills):
+    // hidden from the content editor, restored verbatim from `raw` on save.
+    ...(adapter.extraManagedKeys ?? []).map((key) =>
+      readFrontmatterField(draft, [key]),
+    ),
   ]
   const editorSource = withoutFrontmatterFields(
     draft,
@@ -922,6 +997,9 @@ export function CollectionBrowser({
                         onClick={() => open(r.key)}
                       >
                         <span className={`name${isTitled ? '' : ' mono'}`}>
+                          {r.icon ? (
+                            <span className="dir-ui-nav-ico">{r.icon}</span>
+                          ) : null}
                           {isTitled ? r.title : r.key}
                         </span>
                         {isTitled ? <span className="id">{r.key}</span> : null}
@@ -1126,6 +1204,36 @@ export function CollectionBrowser({
                         effMode === 'split' ? { flexGrow: split } : undefined
                       }
                     >
+                      {adapter.customForm ? (
+                        adapter.customForm({
+                          host,
+                          draft,
+                          editDraft,
+                          readOnly,
+                          fieldId,
+                          entryKey: creating ? null : (loaded?.key ?? selected),
+                          nameValue,
+                          descriptionValue,
+                          setName: (next) =>
+                            editDraft(
+                              setFrontmatterField(
+                                draft,
+                                nameField.key,
+                                adapter.slugName ? next.toLowerCase() : next,
+                                adapter.slugName,
+                              ),
+                            ),
+                          setDescription: (next) =>
+                            editDraft(
+                              setFrontmatterField(
+                                draft,
+                                descriptionField.key,
+                                next,
+                              ),
+                            ),
+                          creating,
+                        })
+                      ) : (
                       <div className="dir-ui-edit-fields">
                         <label
                           className="dir-ui-edit-field"
@@ -1136,6 +1244,12 @@ export function CollectionBrowser({
                             {adapter.slugName ? (
                               <span className="dir-ui-edit-hint">
                                 a–z · 0–9 · - · _
+                              </span>
+                            ) : adapter.separateId && creating ? (
+                              <span className="dir-ui-edit-hint">
+                                {slugify(nameValue)
+                                  ? `→ ${slugify(nameValue)}.md`
+                                  : 'the id derives from the name'}
                               </span>
                             ) : null}
                           </span>
@@ -1154,7 +1268,7 @@ export function CollectionBrowser({
                             }
                             placeholder={`${adapter.noun} name`}
                             preserveCase={!adapter.slugName}
-                            required={adapter.slugName}
+                            required={adapter.slugName || adapter.nameRequired}
                             pattern={
                               adapter.slugName ? '[a-z0-9_-]+' : undefined
                             }
@@ -1233,9 +1347,18 @@ export function CollectionBrowser({
                             </div>
                           )
                         ) : null}
+                        {adapter.extraFields?.({
+                          host,
+                          draft,
+                          editDraft,
+                          readOnly,
+                          fieldId,
+                          entryKey: creating ? null : (loaded?.key ?? selected),
+                        })}
                       </div>
+                      )}
                       <div className="dir-ui-source-head" aria-hidden>
-                        <span>Content</span>
+                        <span>{adapter.sourceLabel ?? 'Content'}</span>
                         <span>Markdown</span>
                       </div>
                       <CodeEditor

--- a/iii-directory/ui/src/page/frontmatter.ts
+++ b/iii-directory/ui/src/page/frontmatter.ts
@@ -45,12 +45,17 @@ function fieldRange(lines: string[], key: string): [number, number] | null {
   const start = lines.findIndex((line) => header.test(line))
   if (start === -1) return null
 
-  const raw = header.exec(lines[start])?.[1].trimStart() ?? ''
+  // Indented (or blank) continuation lines belong to the field whatever
+  // its style — block scalar, block list, nested map — so removing or
+  // replacing a field never orphans its item lines.
   let end = start + 1
-  if (/^[>|]/.test(raw)) {
-    while (end < lines.length && (lines[end].trim() === '' || /^[ \t]/.test(lines[end]))) {
-      end += 1
-    }
+  while (end < lines.length && (lines[end].trim() === '' || /^[ \t]/.test(lines[end]))) {
+    end += 1
+  }
+  // Trailing blank lines between this field and the next belong to
+  // neither; leave them in place.
+  while (end > start + 1 && lines[end - 1].trim() === '') {
+    end -= 1
   }
   return [start, end]
 }
@@ -168,6 +173,72 @@ export function restoreFrontmatterFields(source: string, fields: readonly Frontm
 
 export function frontmatterBody(content: string): string {
   return splitFrontmatter(content).body
+}
+
+/** Decode one list item scalar (bare, quoted, or ~/null). */
+function decodeItem(raw: string): string {
+  return decodeScalar(raw, [])
+}
+
+/** Read a top-level string-list field: flow style (`skills: [a, b]`) or
+ * block style (`skills:` + `  - a` lines). A scalar value yields a
+ * single-item list; `[]`, `~`, or an empty value yield `[]`. */
+export function readFrontmatterStringList(
+  content: string,
+  key: string,
+): { values: string[]; present: boolean } {
+  const { yaml } = splitFrontmatter(content)
+  const lines = yaml ? yaml.split(/\r?\n/) : []
+  const range = fieldRange(lines, key)
+  if (!range) return { values: [], present: false }
+  const [start, end] = range
+  const raw = lines[start].slice(lines[start].indexOf(':') + 1).trim()
+
+  if (raw.startsWith('[')) {
+    const inner = raw.replace(/^\[/, '').replace(/\]\s*$/, '')
+    const values = inner
+      .split(',')
+      .map((item) => decodeItem(item.trim()))
+      .filter((item) => item !== '')
+    return { values, present: true }
+  }
+  if (raw === '' || raw === '~' || raw === 'null') {
+    const values = lines
+      .slice(start + 1, end)
+      .map((line) => line.trim())
+      .filter((line) => line.startsWith('-'))
+      .map((line) => decodeItem(line.slice(1).trim()))
+      .filter((item) => item !== '')
+    return { values, present: true }
+  }
+  // Scalar where a list was expected — treat as one item.
+  return { values: [decodeItem(raw)].filter((item) => item !== ''), present: true }
+}
+
+/** Write a top-level string-list field in flow style
+ * (`skills: [a, b]`); an empty list removes the field entirely. */
+export function setFrontmatterStringList(
+  content: string,
+  key: string,
+  values: readonly string[],
+): string {
+  if (values.length === 0) return withoutFrontmatterFields(content, [key])
+  const encoded = values
+    .map((value) =>
+      /^[a-zA-Z0-9_/.-]+$/.test(value) ? value : JSON.stringify(value),
+    )
+    .join(', ')
+  const parts = splitFrontmatter(content)
+  const lines = parts.yaml ? parts.yaml.split(/\r?\n/) : []
+  const range = fieldRange(lines, key)
+  const replacement = `${key}: [${encoded}]`
+  if (range) lines.splice(range[0], range[1] - range[0], replacement)
+  else lines.push(replacement)
+  return joinFrontmatter({
+    ...parts,
+    hasFrontmatter: true,
+    yaml: lines.join(parts.eol),
+  })
 }
 
 /** Whether a top-level field is absent or a directly editable boolean. */

--- a/iii-directory/ui/src/page/index.tsx
+++ b/iii-directory/ui/src/page/index.tsx
@@ -19,6 +19,8 @@ import {
 import { useEffect, useRef, useState } from 'react'
 import { formatBytes, formatRelativeTime } from '../lib/format'
 import { MarkdownFileIcon } from '../lib/widgets'
+import { AgentForm } from './agent-fields'
+import { TokenIcon } from './token-icons'
 import { type BrowserAdapter, CollectionBrowser } from './browser'
 
 interface SkillRow {
@@ -32,6 +34,15 @@ interface SkillRow {
 interface PromptRow {
   name: string
   description: string
+  modified_at: string
+}
+
+interface AgentRow {
+  id: string
+  name: string
+  description: string
+  logo: string | null
+  icon: string | null
   modified_at: string
 }
 
@@ -216,18 +227,79 @@ export const systemPromptsAdapter: BrowserAdapter = {
   },
 }
 
-type Collection = 'skills' | 'prompts' | 'system-prompts'
+export const agentsAdapter: BrowserAdapter = {
+  noun: 'agent',
+  crumbRoot: 'agents',
+  // The id (file stem) and the display name are different things for an
+  // agent: "Release Captain" lives in frontmatter `name`, the file is
+  // `release-captain.md`.
+  separateId: {
+    pattern: /^[a-z0-9_-]+$/,
+    hint: 'enter a name containing at least one letter or number — it becomes the file name',
+  },
+  nameRequired: true,
+  newTemplate: '---\nname: \ndescription: ""\n---\n\n',
+  extraManagedKeys: ['logo', 'skills', 'delegates_to', 'leaf', 'model', 'icon'],
+  customForm: (ctx) => <AgentForm {...ctx} />,
+  sourceLabel: 'Instructions · system prompt',
+  onChangeType: 'directory::agents::on-change',
+  emptyTitle: 'Select an agent',
+  emptyBody:
+    'Choose an agent from the sidebar to view and edit its profile. The content below the fields is the system prompt the session runs as; name, logo and skill selection live in the fields above it.',
+  async list(host) {
+    const out = await host.iii.trigger<{ agents: AgentRow[] }>(
+      'directory::agents::list',
+    )
+    return (out.agents ?? []).map((a) => ({
+      key: a.id,
+      // The row glyph is the SAME token glyph the avatar picker and the
+      // console session tree render — one identity, one pictogram.
+      icon: a.icon ? <TokenIcon token={a.icon} size={14} /> : undefined,
+      title: a.name,
+      description: a.description,
+      fine: formatRelativeTime(a.modified_at),
+    }))
+  },
+  async load(host, id) {
+    const out = await host.iii.trigger<{
+      system_prompt: string
+      raw?: string | null
+    }>('directory::agents::get', { id, raw: true })
+    return out.raw ?? out.system_prompt
+  },
+  async save(host, id, content) {
+    const out = await host.iii.trigger<{ id: string }>(
+      'directory::agents::update',
+      { id, content },
+    )
+    return out.id ?? id
+  },
+  async create(host, id, content) {
+    const out = await host.iii.trigger<{ id: string }>(
+      'directory::agents::create',
+      { id, content },
+    )
+    return out.id ?? id
+  },
+  async remove(host, id) {
+    await host.iii.trigger('directory::agents::delete', { id })
+  },
+}
+
+type Collection = 'skills' | 'prompts' | 'system-prompts' | 'agents'
 
 const COLLECTIONS: { value: Collection; label: string }[] = [
   { value: 'skills', label: 'Skills' },
   { value: 'prompts', label: 'Prompts' },
   { value: 'system-prompts', label: 'System Prompts' },
+  { value: 'agents', label: 'Agents' },
 ]
 
 const ADAPTERS: Record<Collection, BrowserAdapter> = {
   skills: skillsAdapter,
   prompts: promptsAdapter,
   'system-prompts': systemPromptsAdapter,
+  agents: agentsAdapter,
 }
 
 export function DirectoryPage({
@@ -280,7 +352,7 @@ export function DirectoryPage({
       onChange={setCollection}
       options={COLLECTIONS}
       className="dir-ui-collection-tabs"
-      aria-label="Browse skills, prompts or system prompts"
+      aria-label="Browse skills, prompts, system prompts or agents"
     />
   )
 
@@ -289,7 +361,7 @@ export function DirectoryPage({
       <PageHeader
         icon={<MarkdownFileIcon />}
         title="Directory"
-        description="Filesystem-backed skills, prompts and system prompts"
+        description="Filesystem-backed skills, prompts, system prompts and agents"
         onClose={onRequestClose}
       />
       {COLLECTIONS.map((c) => (

--- a/iii-directory/ui/src/page/palette.ts
+++ b/iii-directory/ui/src/page/palette.ts
@@ -14,7 +14,11 @@ import type { Host, PaletteSourceRow } from '@iii-dev/console-ui'
 
 const ROWS = 30
 
-export type DirectoryCollection = 'skills' | 'prompts' | 'system-prompts'
+export type DirectoryCollection =
+  | 'skills'
+  | 'prompts'
+  | 'system-prompts'
+  | 'agents'
 
 const COLLECTIONS: {
   id: DirectoryCollection
@@ -28,6 +32,7 @@ const COLLECTIONS: {
     label: 'System prompts',
     listFn: 'directory::system-prompts::list',
   },
+  { id: 'agents', label: 'Agents', listFn: 'directory::agents::list' },
 ]
 
 interface Row {
@@ -47,8 +52,11 @@ async function listCollection(
     payload,
   )
   // Skills answer `{ skills }`; prompts and system prompts both answer
-  // `{ prompts }` (same shape, per PromptRow).
-  const items = (out.skills ?? out.prompts ?? []) as Record<string, unknown>[]
+  // `{ prompts }` (same shape, per PromptRow); agents answer `{ agents }`.
+  const items = (out.skills ??
+    out.prompts ??
+    out.agents ??
+    []) as Record<string, unknown>[]
   return items
     .map((item) => ({
       key: String(item.id ?? item.name ?? ''),
@@ -99,8 +107,8 @@ export function registerDirectoryPalette(host: Host): void {
     {
       id: 'open',
       title: 'Open Directory',
-      detail: 'Filesystem-backed skills, prompts and system prompts',
-      keywords: ['skills', 'prompts', 'system prompts'],
+      detail: 'Filesystem-backed skills, prompts, system prompts and agents',
+      keywords: ['skills', 'prompts', 'system prompts', 'agents'],
       run: () => host.panels?.open({ pageId: 'directory', context: {} }),
     },
   ])

--- a/iii-directory/ui/src/page/token-icons.tsx
+++ b/iii-directory/ui/src/page/token-icons.tsx
@@ -1,0 +1,57 @@
+/**
+ * The nine harness `SubagentIcon` glyphs, inlined from lucide
+ * (ISC license) so the agent form shows EXACTLY what the console's
+ * session tree renders for each token — the console maps
+ * agent→Bot, code→Code2, search→Search, terminal→Terminal,
+ * database→Database, test→FlaskConical, review→ClipboardCheck,
+ * docs→FileText, design→Palette (see console/web
+ * ActiveSubagentChips.tsx). Path data only; rendered as stroke icons
+ * with the standard lucide attributes.
+ */
+
+type IconNode = [string, Record<string, string | number>][]
+
+export const TOKEN_ICON_NODES: Record<string, IconNode> = {
+  agent: [["path", {"d": "M12 8V4H8", "key": "hb8ula"}], ["rect", {"width": "16", "height": "12", "x": "4", "y": "8", "rx": "2", "key": "enze0r"}], ["path", {"d": "M2 14h2", "key": "vft8re"}], ["path", {"d": "M20 14h2", "key": "4cs60a"}], ["path", {"d": "M15 13v2", "key": "1xurst"}], ["path", {"d": "M9 13v2", "key": "rq6x2g"}]],
+  code: [["path", {"d": "m18 16 4-4-4-4", "key": "1inbqp"}], ["path", {"d": "m6 8-4 4 4 4", "key": "15zrgr"}], ["path", {"d": "m14.5 4-5 16", "key": "e7oirm"}]],
+  search: [["path", {"d": "m21 21-4.34-4.34", "key": "14j7rj"}], ["circle", {"cx": "11", "cy": "11", "r": "8", "key": "4ej97u"}]],
+  terminal: [["path", {"d": "M12 19h8", "key": "baeox8"}], ["path", {"d": "m4 17 6-6-6-6", "key": "1yngyt"}]],
+  database: [["ellipse", {"cx": "12", "cy": "5", "rx": "9", "ry": "3", "key": "msslwz"}], ["path", {"d": "M3 5V19A9 3 0 0 0 21 19V5", "key": "1wlel7"}], ["path", {"d": "M3 12A9 3 0 0 0 21 12", "key": "mv7ke4"}]],
+  test: [["path", {"d": "M14 2v6a2 2 0 0 0 .245.96l5.51 10.08A2 2 0 0 1 18 22H6a2 2 0 0 1-1.755-2.96l5.51-10.08A2 2 0 0 0 10 8V2", "key": "18mbvz"}], ["path", {"d": "M6.453 15h11.094", "key": "3shlmq"}], ["path", {"d": "M8.5 2h7", "key": "csnxdl"}]],
+  review: [["rect", {"width": "8", "height": "4", "x": "8", "y": "2", "rx": "1", "ry": "1", "key": "tgr4d6"}], ["path", {"d": "M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2", "key": "116196"}], ["path", {"d": "m9 14 2 2 4-4", "key": "df797q"}]],
+  docs: [["path", {"d": "M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z", "key": "1oefj6"}], ["path", {"d": "M14 2v5a1 1 0 0 0 1 1h5", "key": "wfsgrz"}], ["path", {"d": "M10 9H8", "key": "b1mrlr"}], ["path", {"d": "M16 13H8", "key": "t4e002"}], ["path", {"d": "M16 17H8", "key": "z1uh3a"}]],
+  design: [["path", {"d": "M12 22a1 1 0 0 1 0-20 10 9 0 0 1 10 9 5 5 0 0 1-5 5h-2.25a1.75 1.75 0 0 0-1.4 2.8l.3.4a1.75 1.75 0 0 1-1.4 2.8z", "key": "e79jfc"}], ["circle", {"cx": "13.5", "cy": "6.5", "r": ".5", "fill": "currentColor", "key": "1okk4w"}], ["circle", {"cx": "17.5", "cy": "10.5", "r": ".5", "fill": "currentColor", "key": "f64h9f"}], ["circle", {"cx": "6.5", "cy": "12.5", "r": ".5", "fill": "currentColor", "key": "qy21gx"}], ["circle", {"cx": "8.5", "cy": "7.5", "r": ".5", "fill": "currentColor", "key": "fotxhn"}]],
+}
+
+export function TokenIcon({
+  token,
+  size = 16,
+  className,
+}: {
+  token: string
+  size?: number
+  className?: string
+}) {
+  const node = TOKEN_ICON_NODES[token]
+  if (!node) return null
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      className={className}
+    >
+      {node.map(([tag, attrs], i) => {
+        const Tag = tag as 'path'
+        // biome-ignore lint/suspicious/noArrayIndexKey: static path list
+        return <Tag key={i} {...attrs} />
+      })}
+    </svg>
+  )
+}

--- a/iii-directory/ui/styles.css
+++ b/iii-directory/ui/styles.css
@@ -1680,3 +1680,421 @@
   line-height: 1.55;
   overflow-wrap: anywhere;
 }
+
+/* ── agent profile fields: emoji logo + skill selection ─────────────────
+   Rendered by AgentExtraFields inside .dir-ui-edit-fields, so the grid,
+   label, and input styles above already apply; this only adds what the
+   picker needs — a full-width row, a bounded scrolling list, and the
+   missing-skill marker the ticket calls for. */
+[data-iii-ui="iii-directory"] .dir-ui-agent-logo {
+  max-width: 120px;
+  font-size: 16px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-agent-skills {
+  grid-column: 1 / -1;
+}
+[data-iii-ui="iii-directory"] .dir-ui-agent-skill-list {
+  margin: 0;
+  padding: 4px;
+  list-style: none;
+  max-height: 168px;
+  overflow-y: auto;
+  border: 1px solid var(--color-edge);
+  border-radius: 6px;
+  background: var(--color-surface);
+  display: flex;
+  flex-direction: column;
+}
+[data-iii-ui="iii-directory"] .dir-ui-agent-skill-row {
+  padding: 5px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  min-width: 0;
+}
+[data-iii-ui="iii-directory"] .dir-ui-agent-skill-row:hover {
+  background: var(--color-surface-hover);
+}
+[data-iii-ui="iii-directory"] .dir-ui-agent-skill-row:has(input:disabled) {
+  cursor: default;
+}
+[data-iii-ui="iii-directory"] .dir-ui-agent-skill-name {
+  font-size: 12.5px;
+  color: var(--color-ink);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+[data-iii-ui="iii-directory"] .dir-ui-agent-skill-id {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11px;
+  color: var(--color-ink-faint);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+[data-iii-ui="iii-directory"] .dir-ui-agent-skill-empty {
+  font-size: 12px;
+  color: var(--color-ink-faint);
+  padding: 6px 8px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-agent-skill-missing {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-agent-missing-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--color-ink);
+}
+[data-iii-ui="iii-directory"] .dir-ui-agent-missing-row .mono {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11.5px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-agent-missing-badge {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 9.5px;
+  line-height: 1;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-warning, #b58900);
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  padding: 3px 7px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-agent-leaf {
+  padding: 2px 0 4px;
+  font-size: 12.5px;
+  color: var(--color-ink);
+  cursor: pointer;
+}
+[data-iii-ui="iii-directory"] .dir-ui-agent-leaf:has(input:disabled) {
+  cursor: default;
+}
+[data-iii-ui="iii-directory"] .dir-ui-agent-model {
+  appearance: none;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: var(--color-surface);
+  color: var(--color-ink);
+  padding: 0 12px;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 12.5px;
+  cursor: pointer;
+}
+[data-iii-ui="iii-directory"] .dir-ui-agent-model:hover {
+  background: var(--color-surface-hover);
+}
+[data-iii-ui="iii-directory"] .dir-ui-agent-model:focus {
+  outline: none;
+  border-color: var(--color-rule-focus);
+  box-shadow: 0 0 0 3px var(--color-accent-muted);
+}
+[data-iii-ui="iii-directory"] .dir-ui-agent-model:disabled {
+  cursor: default;
+  opacity: 0.7;
+}
+[data-iii-ui="iii-directory"] .dir-ui-agent-logo-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+[data-iii-ui="iii-directory"] .dir-ui-agent-logo-preset {
+  appearance: none;
+  width: 36px;
+  height: 36px;
+  border: 1px solid var(--color-edge);
+  border-radius: 6px;
+  background: var(--color-surface);
+  font-size: 17px;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    border-color var(--motion-duration-control) var(--motion-ease-standard),
+    background-color var(--motion-duration-control) var(--motion-ease-standard);
+}
+[data-iii-ui="iii-directory"] .dir-ui-agent-logo-preset:hover {
+  background: var(--color-surface-hover);
+}
+[data-iii-ui="iii-directory"] .dir-ui-agent-logo-preset.active {
+  border-color: var(--color-rule-focus);
+  box-shadow: 0 0 0 3px var(--color-accent-muted);
+}
+[data-iii-ui="iii-directory"] .dir-ui-agent-logo-preset:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+/* ── agent form: sectioned settings layout (Identity / Behavior /
+   Execution / Delegation), the reference pattern. Sits where the flat
+   edit-fields grid sits for other collections, scrolling on its own so
+   the system-prompt editor below keeps its room. */
+[data-iii-ui="iii-directory"] .dir-ui-af {
+  flex-shrink: 0;
+  max-height: 55%;
+  overflow-y: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  background: var(--color-panel-raised);
+  border-bottom: 1px solid var(--color-edge);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-section {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-title {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-ink);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-hint {
+  margin: 0 0 6px;
+  font-size: 11.5px;
+  color: var(--color-ink-faint);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-card {
+  border: 1px solid var(--color-edge);
+  border-radius: 8px;
+  background: var(--color-surface);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-row {
+  display: grid;
+  grid-template-columns: minmax(110px, 150px) 1fr;
+  gap: 12px;
+  align-items: start;
+  padding: 12px 14px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-row + .dir-ui-af-row {
+  border-top: 1px solid var(--color-edge);
+}
+[data-iii-ui="iii-directory"] .dir-ui-browser.narrow .dir-ui-af-row {
+  grid-template-columns: minmax(0, 1fr);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-label {
+  padding-top: 8px;
+  font-size: 12.5px;
+  color: var(--color-ink);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-label-hint {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 10.5px;
+  color: var(--color-ink-faint);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-control {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+/* avatar + popover */
+[data-iii-ui="iii-directory"] .dir-ui-af-avatar-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-avatar {
+  appearance: none;
+  width: 44px;
+  height: 44px;
+  border: 1px solid var(--color-edge);
+  border-radius: 10px;
+  background: var(--color-panel-raised);
+  font-size: 22px;
+  line-height: 1;
+  cursor: pointer;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-avatar:hover {
+  background: var(--color-surface-hover);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-avatar-empty {
+  opacity: 0.35;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-avatar-note {
+  font-size: 11.5px;
+  color: var(--color-ink-faint);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-pop-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-pop {
+  position: absolute;
+  top: 50px;
+  left: 0;
+  z-index: 41;
+  width: max-content;
+  max-width: 320px;
+  padding: 10px;
+  border: 1px solid var(--color-edge);
+  border-radius: 10px;
+  background: var(--color-panel-raised);
+  box-shadow: 0 10px 32px rgba(0, 0, 0, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-pop-head {
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-ink-faint);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-pop-grid {
+  display: grid;
+  grid-template-columns: repeat(8, 32px);
+  gap: 4px;
+  justify-content: start;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-pop-grid .dir-ui-agent-logo-preset {
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  font-size: 16px;
+  line-height: 1;
+  font-family: 'Noto Color Emoji', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-pop-free {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* collapsed picker row + expanded panel */
+[data-iii-ui="iii-directory"] .dir-ui-af-collapsed {
+  appearance: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 9px 12px;
+  border: 1px solid var(--color-edge);
+  border-radius: 6px;
+  background: var(--color-panel-raised);
+  color: var(--color-ink-faint);
+  font-size: 12.5px;
+  cursor: pointer;
+  text-align: left;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-collapsed:hover {
+  background: var(--color-surface-hover);
+  color: var(--color-ink);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-plus {
+  font-size: 13px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-chev {
+  margin-left: auto;
+  opacity: 0.6;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-picker-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-picker-count {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 10.5px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-ink-faint);
+}
+[data-iii-ui="iii-directory"] .dir-ui-agent-skill-list.tall {
+  max-height: 240px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-pick-row {
+  align-items: flex-start;
+  padding: 7px 8px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-pick-row input {
+  margin-top: 2px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-pick-body {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-pick-name {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 12.5px;
+  color: var(--color-ink);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-pick-desc {
+  font-size: 11.5px;
+  color: var(--color-ink-faint);
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+/* Tree-icon tiles: the exact lucide glyphs the console tree renders,
+   one per SubagentIcon token. Same tile chrome as the emoji presets. */
+[data-iii-ui="iii-directory"] .dir-ui-af-icon-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-icon-tile {
+  appearance: none;
+  width: 34px;
+  height: 34px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 1px solid var(--color-edge);
+  border-radius: 6px;
+  background: var(--color-panel-raised);
+  color: var(--color-ink-faint);
+  cursor: pointer;
+  transition:
+    border-color var(--motion-duration-control) var(--motion-ease-standard),
+    color var(--motion-duration-control) var(--motion-ease-standard),
+    background-color var(--motion-duration-control) var(--motion-ease-standard);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-icon-tile:hover {
+  background: var(--color-surface-hover);
+  color: var(--color-ink);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-icon-tile.active {
+  border-color: var(--color-rule-focus);
+  color: var(--color-ink);
+  box-shadow: 0 0 0 3px var(--color-accent-muted);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-icon-tile:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+[data-iii-ui="iii-directory"] .dir-ui-nav-ico {
+  display: inline-flex;
+  align-items: center;
+  vertical-align: -2px;
+  margin-right: 6px;
+  color: var(--color-ink-faint);
+}

--- a/iii-directory/ui/tests/frontmatter.test.mjs
+++ b/iii-directory/ui/tests/frontmatter.test.mjs
@@ -165,3 +165,50 @@ Body
     /^disable-model-invocation: !!bool \|-$/m,
   )
 })
+
+test('string-list fields: flow and block styles round-trip', async () => {
+  const { readFrontmatterStringList, setFrontmatterStringList } = await import(
+    '../src/page/frontmatter.ts'
+  )
+  const flow = '---\nname: X\nskills: [iii-sandbox, agent-memory/observe]\n---\nBody.\n'
+  assert.deepEqual(readFrontmatterStringList(flow, 'skills'), {
+    values: ['iii-sandbox', 'agent-memory/observe'],
+    present: true,
+  })
+
+  const block = '---\nname: X\nskills:\n  - iii-sandbox\n  - "agent memory"\n---\nBody.\n'
+  assert.deepEqual(readFrontmatterStringList(block, 'skills').values, [
+    'iii-sandbox',
+    'agent memory',
+  ])
+
+  // Absent key, empty flow list.
+  assert.deepEqual(readFrontmatterStringList('---\nname: X\n---\nB\n', 'skills'), {
+    values: [],
+    present: false,
+  })
+  assert.deepEqual(
+    readFrontmatterStringList('---\nskills: []\n---\nB\n', 'skills').values,
+    [],
+  )
+
+  // Set writes flow style and replaces a block-style field wholesale.
+  const written = setFrontmatterStringList(block, 'skills', ['a', 'b c'])
+  assert.equal(written, '---\nname: X\nskills: [a, "b c"]\n---\nBody.\n')
+
+  // Empty selection removes the key entirely (absent = every skill).
+  const cleared = setFrontmatterStringList(flow, 'skills', [])
+  assert.equal(cleared, '---\nname: X\n---\nBody.\n')
+})
+
+test('hiding a block-list field never orphans its item lines', () => {
+  const content = '---\nname: X\nskills:\n  - a\n  - b\ndescription: d\n---\nBody.\n'
+  const source = withoutFrontmatterFields(content, ['skills'])
+  assert.equal(source, '---\nname: X\ndescription: d\n---\nBody.\n')
+
+  // Restore puts the raw block back verbatim.
+  const field = readFrontmatterField(content, ['skills'])
+  assert.equal(field.raw, 'skills:\n  - a\n  - b')
+  const restored = restoreFrontmatterFields(source, [field])
+  assert.ok(restored.includes('skills:\n  - a\n  - b'))
+})


### PR DESCRIPTION
## What

The agents feature family, end to end:

- **(MOT-4484) `directory::agents::*`** — filesystem-backed agent profiles: one markdown file per agent (frontmatter: name, description, emoji logo, tree icon, skills filter, `delegates_to`/`leaf`, default model; body = system prompt), list/get/create/update/delete + on-change trigger, and a console Agents tab for authoring.
- **(MOT-4485) native harness resolution** — `harness::send` `options.agent` runs a session as a profile: body as enrich prompt, skill filter, model fallback, sticky identity, and a `cfg.default_functions` dispatch-policy default when the send names none (deny-all otherwise made every agent session a plain chat loop). `harness::spawn` gains a top-level `agent` field for (typically leaf) profiles — child prompt/skills/model/display from the profile, `orchestrator` defaulting to non-leaf — and the spawning turn's frozen `delegates_to` gates which profiles it may name (`harness/delegation_denied`). The console picker now sends just the id; the client-side emulation is deleted.
- **(MOT-4486) console session tree** — subagent icon + color rendered from `subagent_display`, which spawn now defaults from the profile.

## Refusals & compat

- `options.agent` is refused on existing sessions, combined with either prompt field, and for `leaf` profiles (spawn targets). Unknown ids surface the directory's D410 hint.
- Identity resolves once and freezes (skills-baseline philosophy); directory edits never reach live sessions. Bare steers inherit it; an explicit prompt field sheds it.
- Profile-less spawns are unchanged and never delegation-gated. `SpawnOptions.orchestrator` is now `Option<bool>` (wire-compatible).

## Tests

- 438 harness lib tests (refusal matrix, policy default + ask-clamp, stickiness, delegation matrix, display merge, provider/model pairing), clippy/fmt clean, send/spawn goldens regenerated.
- New integration scenario **INT-026** `agent_identity_delegation` against a real stack: profile send with NO functions on the wire → shipped wildcard default lets it spawn; unlisted profile denied; listed leaf child runs on `You are Coder.` over the sub-agent identity. New DSL: `Send::agent/omit_functions`, `Scenario::skills_file`, `match_any_dispatch`.
- Console: tsc -b, biome (touched files), vitest incl. new `agentIdForSend` gates (the `willQueue` gate is load-bearing — queued mid-stream sends target sessions the harness now refuses `agent` on).

## Live verification (dev stack)

Profile sends freeze the enriched prompt; the full refusal matrix holds; a goal-only send to the `tech-leader` profile orchestrates researcher → coder → tester → reviewer **by profile** through the state-trigger wake pattern, each child with a narrowed policy and its profile icon in the session tree, producing working apps (todo CLI, safe AST calculator) with real test transcripts and review verdicts.

https://claude.ai/code/session_01RYM7qXtNYmQV82heBAhZry