### PR TITLE
fix(release): commit Registry channels after verification

### DIFF
--- a/.github/scripts/build_skills_payload.py
+++ b/.github/scripts/build_skills_payload.py
@@ -8,15 +8,13 @@ the workers-registry endpoint. Skill paths map to keys as:
     <worker>/skills/SKILL.md      -> "SKILL.md"
     <worker>/skills/<rel>.md      -> "skills/<rel>.md"  (except SKILL.md)
 
-If no non-empty markdown is found the script writes ``skip=true`` to
-``$GITHUB_OUTPUT`` (so the calling workflow can gate the POST step off) and
-exits cleanly; the API rejects payloads that omit both ``skills`` and
-``prompts``, and ``skills: {}`` would be a destructive "clear all" call which is
-wrong on a fresh publish.
+The payload always carries the complete skills snapshot, including
+``skills: {}`` when no non-empty markdown exists. Publishing that explicit
+empty snapshot is idempotent and lets retries prove that the exact version has
+no attached skills before a mutable Registry channel is assigned.
 """
 import argparse
 import json
-import os
 import pathlib
 import re
 import sys
@@ -68,14 +66,6 @@ def collect_skills(worker_root: pathlib.Path) -> dict[str, str]:
     return skills
 
 
-def _signal_skip(worker: str) -> None:
-    gha_out = os.environ.get("GITHUB_OUTPUT")
-    if gha_out:
-        with open(gha_out, "a", encoding="utf-8") as f:
-            f.write("skip=true\n")
-    print(f"::notice::no skills found for {worker}; skipping POST /w/.../skills")
-
-
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--worker", required=True, help="Worker folder name in the repo root")
@@ -99,13 +89,8 @@ def main() -> int:
         print(f"::error::{exc}", file=sys.stderr)
         return 1
 
-    out_path = pathlib.Path(args.out)
-    if not skills:
-        out_path.write_text("{}\n", encoding="utf-8")
-        _signal_skip(args.worker)
-        return 0
-
     payload = {"version": args.version, "skills": skills}
+    out_path = pathlib.Path(args.out)
     out_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
     print(f"::notice::collected {len(skills)} skill file(s) for {args.worker}")
     return 0

--- a/.github/scripts/registry_publication.py
+++ b/.github/scripts/registry_publication.py
@@ -1,0 +1,647 @@
+#!/usr/bin/env python3
+"""Publish a Registry version, its skills, and its channel without partial visibility.
+
+The mutable Registry tag is the commit point and is intentionally handled by a
+separate command so the workflow can keep it after immutable publication and
+skills verification. Mutating requests retry at most three times. A timeout or
+5xx is always followed by an exact readback before another write is attempted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Literal
+
+
+MAX_ATTEMPTS = 3
+
+
+class RegistryPublicationError(RuntimeError):
+    pass
+
+
+class TransportError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class Readback:
+    state: Literal["equivalent", "absent", "unavailable", "divergent"]
+    detail: str
+
+
+def request_json(
+    method: str,
+    url: str,
+    payload: dict[str, Any] | None = None,
+    *,
+    api_key: str | None = None,
+) -> tuple[int, dict[str, Any]]:
+    body = json.dumps(payload, separators=(",", ":")).encode() if payload is not None else None
+    headers = {"Accept": "application/json"}
+    if payload is not None:
+        headers["Content-Type"] = "application/json"
+    if api_key:
+        headers["X-API-Key"] = api_key
+    request = urllib.request.Request(url, data=body, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            raw = response.read().decode()
+            return response.status, json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as error:
+        raw = error.read().decode(errors="replace")
+        try:
+            response = json.loads(raw) if raw else {}
+        except json.JSONDecodeError:
+            response = {"error": raw or f"HTTP {error.code}"}
+        return error.code, response
+    except (TimeoutError, urllib.error.URLError, OSError) as error:
+        raise TransportError(str(error)) from error
+    except (json.JSONDecodeError, UnicodeDecodeError) as error:
+        raise TransportError(f"invalid JSON response: {error}") from error
+
+
+def _json_file(path: pathlib.Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise RegistryPublicationError(f"cannot read JSON payload {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise RegistryPublicationError(f"JSON payload {path} must be an object")
+    return value
+
+
+def _write_receipt(path: pathlib.Path, value: dict[str, Any]) -> None:
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _required_string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise RegistryPublicationError(f"{field} must be a non-empty string")
+    return value
+
+
+def _object(value: Any, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise RegistryPublicationError(f"{field} must be an object")
+    return value
+
+
+def _array(value: Any, field: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise RegistryPublicationError(f"{field} must be an array")
+    return value
+
+
+def _sorted_named_rows(value: Any, field: str) -> list[dict[str, Any]]:
+    rows = _array(value, field)
+    normalized: list[dict[str, Any]] = []
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            raise RegistryPublicationError(f"{field}[{index}] must be an object")
+        _required_string(row.get("name"), f"{field}[{index}].name")
+        normalized.append(row)
+    return sorted(normalized, key=lambda row: (str(row["name"]), json.dumps(row, sort_keys=True)))
+
+
+def _dependencies(value: Any, field: str) -> list[dict[str, str]]:
+    rows = _array(value, field)
+    normalized: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            raise RegistryPublicationError(f"{field}[{index}] must be an object")
+        name = _required_string(row.get("name"), f"{field}[{index}].name")
+        version = row.get("version")
+        if not isinstance(version, str):
+            raise RegistryPublicationError(f"{field}[{index}].version must be a string")
+        if name in seen:
+            raise RegistryPublicationError(f"{field} contains duplicate dependency {name}")
+        seen.add(name)
+        normalized.append({"name": name, "version": version})
+    return sorted(normalized, key=lambda row: (row["name"], row["version"]))
+
+
+def _dependency_map(value: Any, field: str) -> dict[str, str]:
+    return {row["name"]: row["version"] for row in _dependencies(value, field)}
+
+
+def _validate_publish_payload(payload: dict[str, Any], worker: str, version: str) -> None:
+    allowed = {
+        "worker_name",
+        "version",
+        "type",
+        "readme",
+        "repo",
+        "description",
+        "license",
+        "tags",
+        "dependencies",
+        "config",
+        "functions",
+        "triggers",
+        "experimental",
+        "binaries",
+        "image_tag",
+        "archive_url",
+        "sha256",
+    }
+    unknown = sorted(set(payload) - allowed)
+    if unknown:
+        raise RegistryPublicationError(f"publish payload contains unprovable fields: {', '.join(unknown)}")
+    if payload.get("worker_name") != worker or payload.get("version") != version:
+        raise RegistryPublicationError("publish payload identity does not match requested worker/version")
+    if payload.get("type") not in {"binary", "image", "bundle"}:
+        raise RegistryPublicationError("publish payload type must be binary, image, or bundle")
+    if "tag" in payload:
+        raise RegistryPublicationError("immutable publish payload must not assign a Registry tag")
+
+
+def _expected_detail(payload: dict[str, Any]) -> dict[str, Any]:
+    expected = {
+        "name": payload["worker_name"],
+        "version": payload["version"],
+        "type": payload["type"],
+        "description": payload.get("description", ""),
+        "license": payload.get("license", ""),
+        "repo": payload.get("repo", ""),
+        "config": payload.get("config") or {},
+        "readme": payload.get("readme", ""),
+        "dependencies": _dependencies(payload.get("dependencies", []), "payload.dependencies"),
+        "functions": _sorted_named_rows(payload.get("functions", []), "payload.functions"),
+        "triggers": _sorted_named_rows(payload.get("triggers", []), "payload.triggers"),
+        "experimental": payload.get("experimental") is True,
+    }
+    if "tags" in payload:
+        tags = _array(payload["tags"], "payload.tags")
+        if not all(isinstance(tag, str) for tag in tags):
+            raise RegistryPublicationError("payload.tags must contain only strings")
+        expected["tags"] = sorted(tags)
+    if payload["type"] == "binary":
+        expected["supported_targets"] = sorted(_object(payload.get("binaries"), "payload.binaries"))
+    elif payload["type"] == "image":
+        expected["image"] = _required_string(payload.get("image_tag"), "payload.image_tag")
+    return expected
+
+
+def _actual_detail(body: dict[str, Any], *, compare_tags: bool) -> dict[str, Any]:
+    worker = _object(body.get("worker"), "detail.worker")
+    required = {
+        "name",
+        "version",
+        "type",
+        "description",
+        "license",
+        "repo",
+        "config",
+        "readme",
+        "dependencies",
+        "functions",
+        "triggers",
+    }
+    missing = sorted(required - set(worker))
+    if missing:
+        raise RegistryPublicationError(f"detail.worker hides required fields: {', '.join(missing)}")
+    actual = {
+        "name": worker.get("name"),
+        "version": worker.get("version"),
+        "type": worker.get("type"),
+        "description": worker.get("description", ""),
+        "license": worker.get("license", ""),
+        "repo": worker.get("repo", ""),
+        "config": worker.get("config") or {},
+        "readme": worker.get("readme", ""),
+        "dependencies": _dependencies(worker.get("dependencies", []), "detail.worker.dependencies"),
+        "functions": _sorted_named_rows(worker.get("functions", []), "detail.worker.functions"),
+        "triggers": _sorted_named_rows(worker.get("triggers", []), "detail.worker.triggers"),
+        "experimental": worker.get("experimental") is True,
+    }
+    if compare_tags:
+        if "tags" not in worker:
+            raise RegistryPublicationError("detail.worker hides required field: tags")
+        tags = worker.get("tags", [])
+        if not isinstance(tags, list) or not all(isinstance(tag, str) for tag in tags):
+            raise RegistryPublicationError("detail.worker.tags must be an array of strings")
+        actual["tags"] = sorted(tags)
+    if worker.get("type") == "binary":
+        targets = worker.get("supported_targets")
+        if not isinstance(targets, list) or not all(isinstance(target, str) for target in targets):
+            raise RegistryPublicationError("detail.worker.supported_targets must be an array of strings")
+        actual["supported_targets"] = sorted(targets)
+    elif worker.get("type") == "image":
+        actual["image"] = worker.get("image")
+    return actual
+
+
+def _expected_resolved(payload: dict[str, Any]) -> dict[str, Any]:
+    expected: dict[str, Any] = {
+        "name": payload["worker_name"],
+        "version": payload["version"],
+        "type": payload["type"],
+        "repo": payload.get("repo", ""),
+        "config": payload.get("config") or {},
+        "dependencies": _dependency_map(payload.get("dependencies", []), "payload.dependencies"),
+    }
+    if payload["type"] == "binary":
+        expected["binaries"] = _object(payload.get("binaries"), "payload.binaries")
+    elif payload["type"] == "image":
+        expected["image"] = _required_string(payload.get("image_tag"), "payload.image_tag")
+    elif payload["type"] == "bundle":
+        expected["archive_url"] = _required_string(payload.get("archive_url"), "payload.archive_url")
+        expected["sha256"] = _required_string(payload.get("sha256"), "payload.sha256")
+    else:
+        raise RegistryPublicationError(f"unsupported payload type {payload['type']!r}")
+    return expected
+
+
+def _actual_resolved(body: dict[str, Any], worker: str, version: str) -> dict[str, Any]:
+    root = _object(body.get("root"), "resolve.root")
+    if root.get("name") != worker or root.get("version") != version:
+        raise RegistryPublicationError("resolve.root does not match the exact worker/version")
+    graph = _array(body.get("graph"), "resolve.graph")
+    matches = [node for node in graph if isinstance(node, dict) and node.get("name") == worker]
+    if len(matches) != 1 or matches[0].get("version") != version:
+        raise RegistryPublicationError("resolve.graph has no unique exact root node")
+    node = matches[0]
+    actual: dict[str, Any] = {
+        "name": node.get("name"),
+        "version": node.get("version"),
+        "type": node.get("type"),
+        "repo": node.get("repo"),
+        "config": node.get("config"),
+        "dependencies": node.get("dependencies"),
+    }
+    kind = node.get("type")
+    if kind == "binary":
+        actual["binaries"] = node.get("binaries")
+    elif kind == "image":
+        actual["image"] = node.get("image")
+    elif kind == "bundle":
+        actual["archive_url"] = node.get("archive_url")
+        actual["sha256"] = node.get("sha256")
+    return actual
+
+
+def _difference(expected: dict[str, Any], actual: dict[str, Any]) -> str | None:
+    for field in sorted(expected):
+        if field not in actual:
+            return f"field {field} is unavailable"
+        if actual[field] != expected[field]:
+            return (
+                f"field {field} differs: expected "
+                f"{json.dumps(expected[field], sort_keys=True)}, got {json.dumps(actual[field], sort_keys=True)}"
+            )
+    return None
+
+
+def prove_version(api_url: str, worker: str, version: str, payload: dict[str, Any]) -> Readback:
+    encoded_worker = urllib.parse.quote(worker, safe="")
+    encoded_version = urllib.parse.quote(version, safe="")
+    try:
+        detail_status, detail_body = request_json(
+            "GET", f"{api_url.rstrip('/')}/w/{encoded_worker}?version={encoded_version}"
+        )
+        resolve_status, resolve_body = request_json(
+            "POST", f"{api_url.rstrip('/')}/resolve", {"worker": worker, "version": version}
+        )
+    except TransportError as error:
+        return Readback("unavailable", f"version readback transport failed: {error}")
+
+    resolve_error = resolve_body.get("error")
+    resolve_error_code = resolve_error.get("code") if isinstance(resolve_error, dict) else None
+    resolve_absent = resolve_status == 404 or (
+        resolve_status == 422 and resolve_error_code in {"version_not_found", "worker_not_found"}
+    )
+    if detail_status == 404 and resolve_absent:
+        return Readback("absent", "exact version is absent from both read surfaces")
+    if detail_status != 200 or resolve_status != 200:
+        return Readback(
+            "unavailable",
+            f"exact version readback returned detail={detail_status}, resolve={resolve_status}",
+        )
+
+    try:
+        detail_difference = _difference(
+            _expected_detail(payload),
+            _actual_detail(detail_body, compare_tags="tags" in payload),
+        )
+        if detail_difference:
+            return Readback("divergent", f"detail {detail_difference}")
+        resolve_difference = _difference(
+            _expected_resolved(payload),
+            _actual_resolved(resolve_body, worker, version),
+        )
+        if resolve_difference:
+            return Readback("divergent", f"resolve {resolve_difference}")
+    except RegistryPublicationError as error:
+        return Readback("divergent", str(error))
+    return Readback("equivalent", "detail and exact resolved root match the publish payload")
+
+
+def _retry_delay(attempt: int) -> None:
+    time.sleep(attempt)
+
+
+def publish_version(
+    api_url: str,
+    api_key: str,
+    worker: str,
+    version: str,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    _validate_publish_payload(payload, worker, version)
+    last = "publication did not run"
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        transport_error: str | None = None
+        try:
+            status, body = request_json("POST", f"{api_url.rstrip('/')}/publish", payload, api_key=api_key)
+        except TransportError as error:
+            status, body = 0, {}
+            transport_error = str(error)
+
+        if status == 200:
+            response_version = _object(body.get("version"), "publish response.version")
+            if response_version.get("version") != version:
+                raise RegistryPublicationError("publish response returned a different version")
+        elif status == 409:
+            proof = prove_version(api_url, worker, version, payload)
+            if proof.state == "equivalent":
+                return {"state": "unchanged", "attempt": attempt, "proof": proof.detail}
+            raise RegistryPublicationError(f"409 duplicate publish is not provably equivalent: {proof.detail}")
+        elif status != 0 and not 500 <= status <= 599:
+            raise RegistryPublicationError(f"publish failed with HTTP {status}: {json.dumps(body, sort_keys=True)}")
+
+        proof = prove_version(api_url, worker, version, payload)
+        if proof.state == "equivalent":
+            return {
+                "state": "changed" if status == 200 else "recovered",
+                "attempt": attempt,
+                "proof": proof.detail,
+            }
+        if proof.state == "divergent":
+            raise RegistryPublicationError(f"published version diverges from the payload: {proof.detail}")
+        if proof.state == "unavailable":
+            raise RegistryPublicationError(f"published version cannot be proved: {proof.detail}")
+        last = proof.detail if transport_error is None else f"{transport_error}; {proof.detail}"
+        if attempt < MAX_ATTEMPTS:
+            _retry_delay(attempt)
+    raise RegistryPublicationError(f"publish was not verified after {MAX_ATTEMPTS} attempts: {last}")
+
+
+def _skills_map(payload: dict[str, Any], version: str) -> dict[str, str]:
+    if set(payload) != {"version", "skills"} or payload.get("version") != version:
+        raise RegistryPublicationError("skills payload must contain only the exact version and full skills snapshot")
+    skills = _object(payload.get("skills"), "skills payload.skills")
+    if not all(isinstance(path, str) and isinstance(content, str) and content for path, content in skills.items()):
+        raise RegistryPublicationError("skills payload must map paths to non-empty strings")
+    return skills
+
+
+def read_skills(api_url: str, worker: str, version: str, expected: dict[str, str]) -> Readback:
+    encoded_worker = urllib.parse.quote(worker, safe="")
+    encoded_version = urllib.parse.quote(version, safe="")
+    try:
+        status, body = request_json(
+            "GET", f"{api_url.rstrip('/')}/w/{encoded_worker}/skills?version={encoded_version}"
+        )
+    except TransportError as error:
+        return Readback("unavailable", f"skills readback transport failed: {error}")
+    if status == 404:
+        return Readback("absent", "skills snapshot or exact version is absent")
+    if status != 200:
+        return Readback("unavailable", f"skills readback returned HTTP {status}")
+    if body.get("name") != worker or body.get("version") != version:
+        return Readback("divergent", "skills readback identity differs")
+    rows = body.get("skills")
+    if not isinstance(rows, list):
+        return Readback("divergent", "skills readback has no skills array")
+    actual: dict[str, str] = {}
+    for index, row in enumerate(rows):
+        if (
+            not isinstance(row, dict)
+            or not isinstance(row.get("path"), str)
+            or not isinstance(row.get("content"), str)
+        ):
+            return Readback("divergent", f"skills[{index}] is malformed")
+        if row["path"] in actual:
+            return Readback("divergent", f"skills readback repeats path {row['path']}")
+        actual[row["path"]] = row["content"]
+    if actual != expected:
+        return Readback("divergent", "skills readback does not match the full requested snapshot")
+    return Readback("equivalent", "exact skills snapshot matches")
+
+
+def publish_skills(
+    api_url: str,
+    api_key: str,
+    worker: str,
+    version: str,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    expected = _skills_map(payload, version)
+    last = "skills publication did not run"
+    encoded_worker = urllib.parse.quote(worker, safe="")
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        transport_error: str | None = None
+        try:
+            status, body = request_json(
+                "POST",
+                f"{api_url.rstrip('/')}/w/{encoded_worker}/skills",
+                payload,
+                api_key=api_key,
+            )
+        except TransportError as error:
+            status, body = 0, {}
+            transport_error = str(error)
+        if status == 200 and body.get("version") != version:
+            raise RegistryPublicationError("skills response returned a different version")
+        if status != 200 and status != 0 and not 500 <= status <= 599:
+            raise RegistryPublicationError(
+                f"skills publish failed with HTTP {status}: {json.dumps(body, sort_keys=True)}"
+            )
+
+        proof = read_skills(api_url, worker, version, expected)
+        if proof.state == "equivalent":
+            return {
+                "state": "changed" if status == 200 else "recovered",
+                "attempt": attempt,
+                "proof": proof.detail,
+                "skills": len(expected),
+            }
+        if proof.state == "divergent":
+            raise RegistryPublicationError(f"skills snapshot diverges: {proof.detail}")
+        if proof.state == "unavailable":
+            raise RegistryPublicationError(f"skills snapshot cannot be proved: {proof.detail}")
+        last = proof.detail if transport_error is None else f"{transport_error}; {proof.detail}"
+        if attempt < MAX_ATTEMPTS:
+            _retry_delay(attempt)
+    raise RegistryPublicationError(f"skills were not verified after {MAX_ATTEMPTS} attempts: {last}")
+
+
+def read_channel(api_url: str, worker: str, tag: str) -> Readback:
+    encoded_worker = urllib.parse.quote(worker, safe="")
+    try:
+        status, body = request_json("GET", f"{api_url.rstrip('/')}/w/{encoded_worker}/versions")
+    except TransportError as error:
+        return Readback("unavailable", f"channel readback transport failed: {error}")
+    if status == 404:
+        return Readback("absent", "worker has no versions")
+    if status != 200:
+        return Readback("unavailable", f"channel readback returned HTTP {status}")
+    versions = body.get("versions")
+    if not isinstance(versions, list):
+        return Readback("divergent", "versions readback has no versions array")
+    targets: list[str] = []
+    for index, entry in enumerate(versions):
+        if not isinstance(entry, dict) or not isinstance(entry.get("version"), str):
+            return Readback("divergent", f"versions[{index}] is malformed")
+        tags = entry.get("tags")
+        if not isinstance(tags, list) or not all(isinstance(value, str) for value in tags):
+            return Readback("divergent", f"versions[{index}].tags is unavailable")
+        if tag in tags:
+            targets.append(entry["version"])
+    if len(targets) > 1:
+        return Readback("divergent", f"channel {tag} points to multiple versions")
+    if not targets:
+        return Readback("absent", f"channel {tag} is unassigned")
+    return Readback("equivalent", targets[0])
+
+
+def assign_channel(
+    api_url: str,
+    api_key: str,
+    worker: str,
+    version: str,
+    tag: str,
+    expected_current_version: str,
+) -> dict[str, Any]:
+    if tag == "none":
+        return {"state": "skipped", "proof": "immutable version has no channel commit"}
+
+    expected = expected_current_version
+    if not expected:
+        observed = read_channel(api_url, worker, tag)
+        if observed.state == "equivalent":
+            expected = observed.detail
+        elif observed.state == "absent":
+            expected = "none"
+        else:
+            raise RegistryPublicationError(f"cannot snapshot current channel for CAS: {observed.detail}")
+
+    payload: dict[str, Any] = {"version": version}
+    payload["expected_current_version"] = None if expected == "none" else expected
+    encoded_worker = urllib.parse.quote(worker, safe="")
+    encoded_tag = urllib.parse.quote(tag, safe="")
+    last = "channel assignment did not run"
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        transport_error: str | None = None
+        try:
+            status, body = request_json(
+                "PUT",
+                f"{api_url.rstrip('/')}/w/{encoded_worker}/tags/{encoded_tag}",
+                payload,
+                api_key=api_key,
+            )
+        except TransportError as error:
+            status, body = 0, {}
+            transport_error = str(error)
+        if status == 200:
+            response_tag = body.get("tag")
+            if not isinstance(response_tag, dict) or response_tag.get("version") != version:
+                raise RegistryPublicationError("channel response returned a different version")
+        elif status == 409:
+            current = read_channel(api_url, worker, tag)
+            if current.state == "equivalent" and current.detail == version:
+                return {
+                    "state": "unchanged",
+                    "attempt": attempt,
+                    "proof": f"raw {tag} pointer already equals {version}",
+                    "expected_previous": expected,
+                }
+            raise RegistryPublicationError(f"channel CAS conflict; current pointer: {current.detail}")
+        elif status != 0 and not 500 <= status <= 599:
+            raise RegistryPublicationError(
+                f"channel assignment failed with HTTP {status}: {json.dumps(body, sort_keys=True)}"
+            )
+
+        current = read_channel(api_url, worker, tag)
+        if current.state == "equivalent" and current.detail == version:
+            changed = body.get("changed") if status == 200 else None
+            return {
+                "state": "unchanged" if changed is False else ("changed" if status == 200 else "recovered"),
+                "attempt": attempt,
+                "proof": f"raw {tag} pointer equals {version}",
+                "expected_previous": expected,
+            }
+        if current.state == "equivalent" and current.detail != version:
+            raise RegistryPublicationError(f"channel {tag} points to {current.detail}, expected {version}")
+        if current.state == "divergent":
+            raise RegistryPublicationError(current.detail)
+        if current.state == "unavailable":
+            raise RegistryPublicationError(f"channel pointer cannot be proved: {current.detail}")
+        last = current.detail if transport_error is None else f"{transport_error}; {current.detail}"
+        if attempt < MAX_ATTEMPTS:
+            _retry_delay(attempt)
+    raise RegistryPublicationError(f"channel was not verified after {MAX_ATTEMPTS} attempts: {last}")
+
+
+def _api_key() -> str:
+    value = os.environ.get("WORKERS_REGISTRY_API_KEY", "")
+    if not value:
+        raise RegistryPublicationError("WORKERS_REGISTRY_API_KEY is required")
+    return value
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    def common(command: str) -> argparse.ArgumentParser:
+        sub = subparsers.add_parser(command)
+        sub.add_argument("--api-url", required=True)
+        sub.add_argument("--worker", required=True)
+        sub.add_argument("--version", required=True)
+        sub.add_argument("--out", type=pathlib.Path, required=True)
+        return sub
+
+    version_parser = common("publish-version")
+    version_parser.add_argument("--payload", type=pathlib.Path, required=True)
+    skills_parser = common("publish-skills")
+    skills_parser.add_argument("--payload", type=pathlib.Path, required=True)
+    channel_parser = common("assign-channel")
+    channel_parser.add_argument("--registry-tag", required=True)
+    channel_parser.add_argument("--expected-current-version", default="")
+    args = parser.parse_args()
+
+    try:
+        if args.command == "publish-version":
+            result = publish_version(args.api_url, _api_key(), args.worker, args.version, _json_file(args.payload))
+        elif args.command == "publish-skills":
+            result = publish_skills(args.api_url, _api_key(), args.worker, args.version, _json_file(args.payload))
+        else:
+            result = assign_channel(
+                args.api_url,
+                _api_key(),
+                args.worker,
+                args.version,
+                args.registry_tag,
+                args.expected_current_version,
+            )
+        _write_receipt(args.out, result)
+        print(json.dumps(result, sort_keys=True))
+        return 0
+    except RegistryPublicationError as error:
+        print(f"::error::{error}")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_build_skills_payload.py
+++ b/.github/scripts/tests/test_build_skills_payload.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+import sys
+
+import build_skills_payload
+
+
+def test_empty_worker_emits_explicit_empty_skills_snapshot(tmp_path, monkeypatch) -> None:
+    worker = tmp_path / "smoke"
+    worker.mkdir()
+    output = tmp_path / "skills.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "build_skills_payload.py",
+            "--worker",
+            "smoke",
+            "--version",
+            "1.2.3",
+            "--repo-root",
+            str(tmp_path),
+            "--out",
+            str(output),
+        ],
+    )
+
+    assert build_skills_payload.main() == 0
+    assert json.loads(output.read_text()) == {"version": "1.2.3", "skills": {}}
+
+
+def test_worker_emits_complete_nonempty_snapshot(tmp_path, monkeypatch) -> None:
+    skills = tmp_path / "smoke" / "skills"
+    nested = skills / "usage"
+    nested.mkdir(parents=True)
+    (skills / "SKILL.md").write_text("# Smoke\n")
+    (nested / "run.md").write_text("Run it\n")
+    output = tmp_path / "skills.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "build_skills_payload.py",
+            "--worker",
+            "smoke",
+            "--version",
+            "1.2.3",
+            "--repo-root",
+            str(tmp_path),
+            "--out",
+            str(output),
+        ],
+    )
+
+    assert build_skills_payload.main() == 0
+    assert json.loads(output.read_text()) == {
+        "version": "1.2.3",
+        "skills": {"SKILL.md": "# Smoke\n", "skills/usage/run.md": "Run it\n"},
+    }

--- a/.github/scripts/tests/test_registry_publication.py
+++ b/.github/scripts/tests/test_registry_publication.py
@@ -1,0 +1,433 @@
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+import registry_publication
+from registry_publication import RegistryPublicationError, TransportError
+
+
+API = "https://registry.test"
+KEY = "secret"
+WORKER = "smoke"
+VERSION = "1.2.3"
+
+
+def payload() -> dict[str, object]:
+    return {
+        "worker_name": WORKER,
+        "version": VERSION,
+        "type": "binary",
+        "readme": "# Smoke\n",
+        "repo": "https://github.com/iii-hq/workers",
+        "description": "Smoke worker",
+        "license": "Apache-2.0",
+        "tags": ["test", "smoke"],
+        "dependencies": [{"name": "configuration", "version": "^1.0.0"}],
+        "config": {"mode": "safe"},
+        "functions": [
+            {
+                "name": "smoke::run",
+                "description": "Run smoke",
+                "request_schema": {"type": "object"},
+                "response_schema": {"type": "object"},
+                "metadata": {},
+            }
+        ],
+        "triggers": [
+            {
+                "name": "smoke-event",
+                "description": "Smoke event",
+                "invocation_schema": {"type": "object"},
+                "return_schema": {"type": "object"},
+                "metadata": {},
+            }
+        ],
+        "experimental": False,
+        "binaries": {
+            "x86_64-unknown-linux-gnu": {
+                "url": "https://example.test/smoke.tar.gz",
+                "sha256": "a" * 64,
+            }
+        },
+    }
+
+
+def detail_body(source: dict[str, object] | None = None) -> dict[str, object]:
+    source = source or payload()
+    worker: dict[str, object] = {
+        "name": source["worker_name"],
+        "version": source["version"],
+        "type": source["type"],
+        "readme": source["readme"],
+        "repo": source["repo"],
+        "description": source["description"],
+        "license": source["license"],
+        "tags": list(reversed(source["tags"])),
+        "dependencies": source["dependencies"],
+        "config": source["config"],
+        "functions": source["functions"],
+        "triggers": source["triggers"],
+        "supported_targets": list(reversed(source["binaries"])),
+        "total_downloads": 42,
+        "author": {"name": "ignored"},
+    }
+    return {"worker": worker}
+
+
+def resolve_body(source: dict[str, object] | None = None) -> dict[str, object]:
+    source = source or payload()
+    node = {
+        "name": source["worker_name"],
+        "version": source["version"],
+        "type": source["type"],
+        "repo": source["repo"],
+        "config": source["config"],
+        "dependencies": {row["name"]: row["version"] for row in source["dependencies"]},
+        "binaries": source["binaries"],
+    }
+    return {
+        "root": {"name": source["worker_name"], "version": source["version"]},
+        "graph": [node],
+        "edges": [],
+    }
+
+
+def exact_readback(method: str, url: str, _body=None, **_kwargs):
+    if method == "GET" and "?version=" in url:
+        return 200, detail_body()
+    if method == "POST" and url.endswith("/resolve"):
+        return 200, resolve_body()
+    raise AssertionError((method, url))
+
+
+def no_sleep(monkeypatch) -> None:
+    monkeypatch.setattr(registry_publication, "_retry_delay", lambda _attempt: None)
+
+
+def test_fresh_publish_requires_exact_detail_and_resolve_readback(monkeypatch) -> None:
+    calls: list[tuple[str, str]] = []
+
+    def request(method, url, body=None, **kwargs):
+        calls.append((method, url))
+        if url.endswith("/publish"):
+            assert body == payload()
+            assert kwargs["api_key"] == KEY
+            return 200, {"version": {"version": VERSION}}
+        return exact_readback(method, url, body, **kwargs)
+
+    monkeypatch.setattr(registry_publication, "request_json", request)
+    result = registry_publication.publish_version(API, KEY, WORKER, VERSION, payload())
+    assert result["state"] == "changed"
+    assert [method for method, _url in calls] == ["POST", "GET", "POST"]
+
+
+def test_409_continues_only_when_every_public_field_and_artifact_matches(monkeypatch) -> None:
+    def request(method, url, body=None, **kwargs):
+        if url.endswith("/publish"):
+            return 409, {"error": "exists"}
+        return exact_readback(method, url, body, **kwargs)
+
+    monkeypatch.setattr(registry_publication, "request_json", request)
+    result = registry_publication.publish_version(API, KEY, WORKER, VERSION, payload())
+    assert result["state"] == "unchanged"
+
+
+@pytest.mark.parametrize("failure", ["hidden", "divergent", "artifact"])
+def test_409_fails_closed_when_equivalence_cannot_be_proved(monkeypatch, failure: str) -> None:
+    def request(method, url, body=None, **_kwargs):
+        if url.endswith("/publish"):
+            return 409, {"error": "exists"}
+        if method == "GET":
+            if failure == "hidden":
+                return 404, {"error": "not found"}
+            detail = detail_body()
+            if failure == "divergent":
+                detail["worker"]["description"] = "different"
+            return 200, detail
+        resolved = resolve_body()
+        if failure == "artifact":
+            resolved["graph"][0]["binaries"]["x86_64-unknown-linux-gnu"]["sha256"] = "b" * 64
+        return 200, resolved
+
+    monkeypatch.setattr(registry_publication, "request_json", request)
+    with pytest.raises(RegistryPublicationError, match="not provably equivalent"):
+        registry_publication.publish_version(API, KEY, WORKER, VERSION, payload())
+
+
+def test_409_fails_when_detail_hides_license(monkeypatch) -> None:
+    def request(method, url, body=None, **kwargs):
+        if url.endswith("/publish"):
+            return 409, {}
+        if method == "GET":
+            detail = detail_body()
+            del detail["worker"]["license"]
+            return 200, detail
+        return exact_readback(method, url, body, **kwargs)
+
+    monkeypatch.setattr(registry_publication, "request_json", request)
+    with pytest.raises(RegistryPublicationError, match="hides required fields: license"):
+        registry_publication.publish_version(API, KEY, WORKER, VERSION, payload())
+
+
+def test_5xx_reads_back_before_each_of_at_most_three_publish_attempts(monkeypatch) -> None:
+    calls: list[str] = []
+    no_sleep(monkeypatch)
+
+    def request(method, url, _body=None, **_kwargs):
+        calls.append(f"{method} {url.split('/')[-1].split('?')[0]}")
+        if url.endswith("/publish"):
+            return 503, {"error": "retry"}
+        if method == "GET":
+            return 404, {"error": {"code": "version_not_found"}}
+        return 422, {"error": {"code": "version_not_found"}}
+
+    monkeypatch.setattr(registry_publication, "request_json", request)
+    with pytest.raises(RegistryPublicationError, match="after 3 attempts"):
+        registry_publication.publish_version(API, KEY, WORKER, VERSION, payload())
+    assert calls == [
+        "POST publish", "GET smoke", "POST resolve",
+        "POST publish", "GET smoke", "POST resolve",
+        "POST publish", "GET smoke", "POST resolve",
+    ]
+
+
+def test_worker_not_found_on_both_read_surfaces_is_absent_for_initial_publish(monkeypatch) -> None:
+    attempts = 0
+    no_sleep(monkeypatch)
+
+    def request(method, url, _body=None, **_kwargs):
+        nonlocal attempts
+        if url.endswith("/publish"):
+            attempts += 1
+            return 503, {}
+        return 404, {"error": {"code": "worker_not_found"}}
+
+    monkeypatch.setattr(registry_publication, "request_json", request)
+    with pytest.raises(RegistryPublicationError, match="after 3 attempts"):
+        registry_publication.publish_version(API, KEY, WORKER, VERSION, payload())
+    assert attempts == 3
+
+
+@pytest.mark.parametrize("readback", ["unavailable", "divergent"])
+def test_publish_does_not_repeat_when_readback_is_not_absent(monkeypatch, readback: str) -> None:
+    attempts = 0
+
+    def request(method, url, _body=None, **_kwargs):
+        nonlocal attempts
+        if url.endswith("/publish"):
+            attempts += 1
+            return 503, {}
+        if readback == "unavailable":
+            return 503, {}
+        if method == "GET":
+            detail = detail_body()
+            detail["worker"]["description"] = "different"
+            return 200, detail
+        return 200, resolve_body()
+
+    monkeypatch.setattr(registry_publication, "request_json", request)
+    error = "cannot be proved" if readback == "unavailable" else "diverges"
+    with pytest.raises(RegistryPublicationError, match=error):
+        registry_publication.publish_version(API, KEY, WORKER, VERSION, payload())
+    assert attempts == 1
+
+
+def test_timeout_is_recovered_when_version_readback_is_exact(monkeypatch) -> None:
+    def request(method, url, body=None, **kwargs):
+        if url.endswith("/publish"):
+            raise TransportError("timeout")
+        return exact_readback(method, url, body, **kwargs)
+
+    monkeypatch.setattr(registry_publication, "request_json", request)
+    result = registry_publication.publish_version(API, KEY, WORKER, VERSION, payload())
+    assert result["state"] == "recovered"
+    assert result["attempt"] == 1
+
+
+def skills_response(skills: dict[str, str]) -> dict[str, object]:
+    return {
+        "name": WORKER,
+        "version": VERSION,
+        "skills": [{"path": path, "content": content} for path, content in sorted(skills.items())],
+        "prompts": [],
+    }
+
+
+@pytest.mark.parametrize("skills", [{}, {"SKILL.md": "# Smoke\n", "skills/run.md": "Run\n"}])
+def test_skills_replace_and_read_back_the_full_snapshot(monkeypatch, skills: dict[str, str]) -> None:
+    desired = {"version": VERSION, "skills": skills}
+    calls: list[str] = []
+
+    def request(method, url, body=None, **_kwargs):
+        calls.append(method)
+        if method == "POST":
+            assert body == desired
+            return 200, {"version": VERSION}
+        return 200, skills_response(skills)
+
+    monkeypatch.setattr(registry_publication, "request_json", request)
+    result = registry_publication.publish_skills(API, KEY, WORKER, VERSION, desired)
+    assert result["skills"] == len(skills)
+    assert calls == ["POST", "GET"]
+
+
+def test_skills_5xx_is_recovered_only_after_matching_readback(monkeypatch) -> None:
+    desired = {"version": VERSION, "skills": {"SKILL.md": "# Smoke\n"}}
+
+    def request(method, _url, _body=None, **_kwargs):
+        if method == "POST":
+            return 500, {}
+        return 200, skills_response(desired["skills"])
+
+    monkeypatch.setattr(registry_publication, "request_json", request)
+    result = registry_publication.publish_skills(API, KEY, WORKER, VERSION, desired)
+    assert result["state"] == "recovered"
+
+
+def test_skills_5xx_repeats_only_while_snapshot_is_absent(monkeypatch) -> None:
+    desired = {"version": VERSION, "skills": {}}
+    attempts = 0
+    no_sleep(monkeypatch)
+
+    def request(method, _url, _body=None, **_kwargs):
+        nonlocal attempts
+        if method == "POST":
+            attempts += 1
+            return 503, {}
+        return 404, {}
+
+    monkeypatch.setattr(registry_publication, "request_json", request)
+    with pytest.raises(RegistryPublicationError, match="after 3 attempts"):
+        registry_publication.publish_skills(API, KEY, WORKER, VERSION, desired)
+    assert attempts == 3
+
+
+@pytest.mark.parametrize("readback", ["unavailable", "divergent"])
+def test_skills_does_not_repeat_when_readback_is_not_absent(monkeypatch, readback: str) -> None:
+    desired = {"version": VERSION, "skills": {"SKILL.md": "# Smoke\n"}}
+    attempts = 0
+
+    def request(method, _url, _body=None, **_kwargs):
+        nonlocal attempts
+        if method == "POST":
+            attempts += 1
+            return 503, {}
+        if readback == "unavailable":
+            return 503, {}
+        return 200, skills_response({"SKILL.md": "different\n"})
+
+    monkeypatch.setattr(registry_publication, "request_json", request)
+    error = "cannot be proved" if readback == "unavailable" else "diverges"
+    with pytest.raises(RegistryPublicationError, match=error):
+        registry_publication.publish_skills(API, KEY, WORKER, VERSION, desired)
+    assert attempts == 1
+
+
+def versions_response(tag: str, version: str) -> dict[str, object]:
+    return {"versions": [{"version": version, "tag": tag, "tags": [tag], "dependencies": []}]}
+
+
+def test_channel_cas_is_last_state_change_and_uses_raw_pointer_readback(monkeypatch) -> None:
+    calls: list[tuple[str, str, object]] = []
+
+    def request(method, url, body=None, **_kwargs):
+        calls.append((method, url, copy.deepcopy(body)))
+        if method == "PUT":
+            assert body == {"version": VERSION, "expected_current_version": "1.2.2"}
+            return 200, {"tag": {"version": VERSION}, "changed": True}
+        return 200, versions_response("next", VERSION)
+
+    monkeypatch.setattr(registry_publication, "request_json", request)
+    result = registry_publication.assign_channel(API, KEY, WORKER, VERSION, "next", "1.2.2")
+    assert result["state"] == "changed"
+    assert [call[0] for call in calls] == ["PUT", "GET"]
+    assert calls[1][1].endswith("/w/smoke/versions")
+
+
+def test_legacy_blank_precondition_snapshots_once_then_uses_cas(monkeypatch) -> None:
+    reads = 0
+
+    def request(method, _url, body=None, **_kwargs):
+        nonlocal reads
+        if method == "GET":
+            reads += 1
+            return 200, versions_response("latest", "1.2.2" if reads == 1 else VERSION)
+        assert body == {"version": VERSION, "expected_current_version": "1.2.2"}
+        return 200, {"tag": {"version": VERSION}, "changed": True}
+
+    monkeypatch.setattr(registry_publication, "request_json", request)
+    result = registry_publication.assign_channel(API, KEY, WORKER, VERSION, "latest", "")
+    assert result["expected_previous"] == "1.2.2"
+    assert reads == 2
+
+
+def test_channel_5xx_is_recovered_when_raw_pointer_already_matches(monkeypatch) -> None:
+    def request(method, _url, _body=None, **_kwargs):
+        if method == "PUT":
+            return 503, {}
+        return 200, versions_response("next", VERSION)
+
+    monkeypatch.setattr(registry_publication, "request_json", request)
+    result = registry_publication.assign_channel(API, KEY, WORKER, VERSION, "next", "1.2.2")
+    assert result["state"] == "recovered"
+
+
+def test_channel_5xx_repeats_only_while_raw_pointer_is_absent(monkeypatch) -> None:
+    attempts = 0
+    no_sleep(monkeypatch)
+
+    def request(method, _url, _body=None, **_kwargs):
+        nonlocal attempts
+        if method == "PUT":
+            attempts += 1
+            return 503, {}
+        return 200, {"versions": []}
+
+    monkeypatch.setattr(registry_publication, "request_json", request)
+    with pytest.raises(RegistryPublicationError, match="after 3 attempts"):
+        registry_publication.assign_channel(API, KEY, WORKER, VERSION, "next", "1.2.2")
+    assert attempts == 3
+
+
+def test_channel_409_is_idempotent_when_raw_pointer_already_matches(monkeypatch) -> None:
+    def request(method, _url, _body=None, **_kwargs):
+        if method == "PUT":
+            return 409, {"error": "stale"}
+        return 200, versions_response("next", VERSION)
+
+    monkeypatch.setattr(registry_publication, "request_json", request)
+    result = registry_publication.assign_channel(API, KEY, WORKER, VERSION, "next", "1.2.2")
+    assert result["state"] == "unchanged"
+
+
+@pytest.mark.parametrize("readback", ["unavailable", "divergent"])
+def test_channel_does_not_repeat_when_raw_pointer_is_not_absent(monkeypatch, readback: str) -> None:
+    attempts = 0
+
+    def request(method, _url, _body=None, **_kwargs):
+        nonlocal attempts
+        if method == "PUT":
+            attempts += 1
+            return 503, {}
+        if readback == "unavailable":
+            return 503, {}
+        return 200, {"versions": "hidden"}
+
+    monkeypatch.setattr(registry_publication, "request_json", request)
+    error = "cannot be proved" if readback == "unavailable" else "no versions array"
+    with pytest.raises(RegistryPublicationError, match=error):
+        registry_publication.assign_channel(API, KEY, WORKER, VERSION, "next", "1.2.2")
+    assert attempts == 1
+
+
+def test_channel_409_fails_even_when_a_readback_is_available(monkeypatch) -> None:
+    def request(method, _url, _body=None, **_kwargs):
+        if method == "PUT":
+            return 409, {"error": "stale"}
+        return 200, versions_response("next", "1.2.4")
+
+    monkeypatch.setattr(registry_publication, "request_json", request)
+    with pytest.raises(RegistryPublicationError, match="CAS conflict"):
+        registry_publication.assign_channel(API, KEY, WORKER, VERSION, "next", "1.2.2")

--- a/.github/scripts/tests/test_release_workflows.py
+++ b/.github/scripts/tests/test_release_workflows.py
@@ -257,6 +257,27 @@ def test_registry_publish_keeps_stdio_workers_alive_for_interface_collection() -
     assert "signal.signal(signal.SIGTERM" in body
 
 
+def test_registry_publication_builds_every_payload_before_commit_last_writes() -> None:
+    path = WORKFLOWS / "_publish-registry.yml"
+    body = path.read_text()
+    steps = workflow(path)["jobs"]["publish"]["steps"]
+    names = [step.get("name") for step in steps]
+
+    build_payload = names.index("Build payload")
+    build_skills = names.index("Build skills payload")
+    publish_version = names.index("Publish and verify immutable Registry version")
+    publish_skills = names.index("Publish and verify exact Registry skills")
+    commit_channel = names.index("Commit and verify Registry channel with exact CAS")
+
+    assert build_payload < publish_version
+    assert build_skills < publish_version < publish_skills < commit_channel
+    assert steps[commit_channel]["if"] == "inputs.registry_tag != 'none'"
+    assert body.count("registry_publication.py") == 3
+    assert '-X POST "$API_URL/publish"' not in body
+    assert '-X POST "$API_URL/w/$WORKER/skills"' not in body
+    assert '-X PUT "$API_URL/w/$WORKER/tags/$REGISTRY_TAG"' not in body
+
+
 def test_rust_binary_cache_is_keyed_by_frontend_bundle_digest() -> None:
     jobs = workflow(WORKFLOWS / "_rust-binary.yml")["jobs"]
     web_build = jobs["web-build"]

--- a/.github/workflows/_publish-registry.yml
+++ b/.github/workflows/_publish-registry.yml
@@ -378,85 +378,7 @@ jobs:
             --image-tag "$IMAGE_TAG" \
             --out payload.json
 
-      - name: POST /publish
-        env:
-          API_URL: https://api.workers.iii.dev
-          API_KEY: ${{ secrets.WORKERS_REGISTRY_API_KEY }}
-          WORKER: ${{ inputs.worker }}
-          VERSION: ${{ inputs.version }}
-          REGISTRY_TAG: ${{ inputs.registry_tag }}
-        run: |
-          set -euo pipefail
-          if [[ -z "$API_KEY" ]]; then
-            echo "::error::WORKERS_REGISTRY_API_KEY secret is not set"
-            exit 1
-          fi
-          http=$(curl -sS -o response.json -w '%{http_code}' \
-            -H "X-API-Key: $API_KEY" \
-            -H "Content-Type: application/json" \
-            -X POST "$API_URL/publish" \
-            --data-binary @payload.json)
-          echo "HTTP $http"
-          cat response.json
-          if [[ "$http" == "409" ]]; then
-            resolve_http=$(curl -sS -o resolve-response.json -w '%{http_code}' \
-              -H "Content-Type: application/json" \
-              -X POST "$API_URL/resolve" \
-              --data "$(jq -cn --arg worker "$WORKER" --arg version "$VERSION" \
-                '{worker: $worker, version: $version}')")
-            resolved=$(jq -r '.root.version // empty' resolve-response.json)
-            if [[ "$resolve_http" == "200" && "$resolved" == "$VERSION" ]]; then
-              echo "::notice::$WORKER@$VERSION already exists; continuing idempotently"
-            else
-              echo "::error::duplicate publish is not a safe retry: $WORKER@$VERSION resolved ${resolved:-nothing} (HTTP $resolve_http), expected $VERSION"
-              cat resolve-response.json
-              exit 1
-            fi
-          elif [[ "$http" != "200" ]]; then
-            echo "::error::publish failed with HTTP $http"
-            exit 1
-          fi
-
-      - name: Assign Registry tag with existing CAS
-        if: inputs.registry_tag != 'none'
-        env:
-          API_URL: https://api.workers.iii.dev
-          API_KEY: ${{ secrets.WORKERS_REGISTRY_API_KEY }}
-          WORKER: ${{ inputs.worker }}
-          VERSION: ${{ inputs.version }}
-          REGISTRY_TAG: ${{ inputs.registry_tag }}
-          EXPECTED_CURRENT_VERSION: ${{ inputs.expected_current_version }}
-        run: |
-          set -euo pipefail
-          if [[ -z "$API_KEY" ]]; then
-            echo "::error::WORKERS_REGISTRY_API_KEY secret is not set"
-            exit 1
-          fi
-          if [[ "$EXPECTED_CURRENT_VERSION" == "none" ]]; then
-            payload=$(jq -cn --arg version "$VERSION" \
-              '{version:$version,expected_current_version:null}')
-          elif [[ -n "$EXPECTED_CURRENT_VERSION" ]]; then
-            payload=$(jq -cn --arg version "$VERSION" --arg expected "$EXPECTED_CURRENT_VERSION" \
-              '{version:$version,expected_current_version:$expected}')
-          else
-            payload=$(jq -cn --arg version "$VERSION" '{version:$version}')
-          fi
-          http=$(curl -sS -o tag-response.json -w '%{http_code}' \
-            -H "X-API-Key: $API_KEY" \
-            -H "Content-Type: application/json" \
-            -X PUT "$API_URL/w/$WORKER/tags/$REGISTRY_TAG" \
-            --data "$payload")
-          echo "HTTP $http"
-          cat tag-response.json
-          if [[ "$http" != "200" ]]; then
-            echo "::error::Registry tag assignment failed with HTTP $http"
-            exit 1
-          fi
-          assigned=$(jq -r '.tag.version // empty' tag-response.json)
-          test "$assigned" = "$VERSION"
-
       - name: Build skills payload
-        id: skills_payload
         env:
           WORKER: ${{ inputs.worker }}
           VERSION: ${{ inputs.version }}
@@ -466,29 +388,54 @@ jobs:
             --version "$VERSION" \
             --out skills-payload.json
 
-      - name: POST /w/<worker>/skills
-        if: steps.skills_payload.outputs.skip != 'true'
+      - name: Publish and verify immutable Registry version
         env:
           API_URL: https://api.workers.iii.dev
-          API_KEY: ${{ secrets.WORKERS_REGISTRY_API_KEY }}
+          WORKERS_REGISTRY_API_KEY: ${{ secrets.WORKERS_REGISTRY_API_KEY }}
           WORKER: ${{ inputs.worker }}
+          VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          if [[ -z "$API_KEY" ]]; then
-            echo "::error::WORKERS_REGISTRY_API_KEY secret is not set"
-            exit 1
-          fi
-          http=$(curl -sS -o skills-response.json -w '%{http_code}' \
-            -H "X-API-Key: $API_KEY" \
-            -H "Content-Type: application/json" \
-            -X POST "$API_URL/w/$WORKER/skills" \
-            --data-binary @skills-payload.json)
-          echo "HTTP $http"
-          cat skills-response.json
-          if [[ "$http" != "200" ]]; then
-            echo "::error::publish skills failed with HTTP $http"
-            exit 1
-          fi
+          python3 .github/scripts/registry_publication.py publish-version \
+            --api-url "$API_URL" \
+            --worker "$WORKER" \
+            --version "$VERSION" \
+            --payload payload.json \
+            --out registry-version.json
+
+      - name: Publish and verify exact Registry skills
+        env:
+          API_URL: https://api.workers.iii.dev
+          WORKERS_REGISTRY_API_KEY: ${{ secrets.WORKERS_REGISTRY_API_KEY }}
+          WORKER: ${{ inputs.worker }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/registry_publication.py publish-skills \
+            --api-url "$API_URL" \
+            --worker "$WORKER" \
+            --version "$VERSION" \
+            --payload skills-payload.json \
+            --out registry-skills.json
+
+      - name: Commit and verify Registry channel with exact CAS
+        if: inputs.registry_tag != 'none'
+        env:
+          API_URL: https://api.workers.iii.dev
+          WORKERS_REGISTRY_API_KEY: ${{ secrets.WORKERS_REGISTRY_API_KEY }}
+          WORKER: ${{ inputs.worker }}
+          VERSION: ${{ inputs.version }}
+          REGISTRY_TAG: ${{ inputs.registry_tag }}
+          EXPECTED_CURRENT_VERSION: ${{ inputs.expected_current_version }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/registry_publication.py assign-channel \
+            --api-url "$API_URL" \
+            --worker "$WORKER" \
+            --version "$VERSION" \
+            --registry-tag "$REGISTRY_TAG" \
+            --expected-current-version "$EXPECTED_CURRENT_VERSION" \
+            --out registry-channel.json
 
       - name: Dump III logs
         if: failure()


### PR DESCRIPTION
## Summary

- publish and verify the immutable Registry version before assigning a mutable channel
- publish and read back the complete skills snapshot, including an explicit empty snapshot
- recover ambiguous writes only from exact evidence and keep the Registry CAS as the final effect

## Validation

- `python3 -m pytest -q .github/scripts/tests`
- `actionlint` v1.7.12
- `python3 -m py_compile .github/scripts/registry_publication.py .github/scripts/build_skills_payload.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated registry publication for versions, skills snapshots, and release channels.
  * Added validation, readback verification, retry handling, idempotent updates, and publication receipts.
  * Ensured skills payloads are generated consistently, including when no skills are available.

* **Bug Fixes**
  * Improved handling of transient publication failures and prevented channel updates when verification fails.

* **Tests**
  * Added coverage for empty payloads, retries, idempotency, verification failures, and release workflow ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->