### PR TITLE
fix(harness): allow controlled configuration access

### DIFF
--- a/approval-gate/tests/repository_permissions.rs
+++ b/approval-gate/tests/repository_permissions.rs
@@ -1,0 +1,65 @@
+use approval_gate::permissions::{parse_rules_from_config, Decision, Permissions};
+use approval_gate::types::PermissionMode;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+#[derive(Deserialize)]
+struct RepositoryPermissions {
+    rules: Vec<Value>,
+}
+
+fn repository_permissions() -> Permissions {
+    let config: RepositoryPermissions =
+        serde_yaml::from_str(include_str!("../../iii-permissions.yaml"))
+            .expect("repository permissions should be valid YAML");
+    let specs = parse_rules_from_config(&Value::Array(config.rules));
+    Permissions::compile(&specs).expect("repository permission rules should compile")
+}
+
+#[test]
+fn configuration_list_is_allowed() {
+    assert!(matches!(
+        repository_permissions().check("configuration::list", &json!({}), PermissionMode::Manual),
+        Decision::Allow { .. }
+    ));
+}
+
+#[test]
+fn configuration_schema_is_allowed() {
+    assert!(matches!(
+        repository_permissions().check("configuration::schema", &json!({}), PermissionMode::Manual),
+        Decision::Allow { .. }
+    ));
+}
+
+#[test]
+fn configuration_get_needs_approval() {
+    assert!(matches!(
+        repository_permissions().check(
+            "configuration::get",
+            &json!({ "id": "database", "raw": true }),
+            PermissionMode::Manual
+        ),
+        Decision::NeedsApproval
+    ));
+}
+
+#[test]
+fn configuration_set_is_denied() {
+    assert!(matches!(
+        repository_permissions().check("configuration::set", &json!({}), PermissionMode::Manual),
+        Decision::Deny { .. }
+    ));
+}
+
+#[test]
+fn configuration_register_is_denied() {
+    assert!(matches!(
+        repository_permissions().check(
+            "configuration::register",
+            &json!({}),
+            PermissionMode::Manual
+        ),
+        Decision::Deny { .. }
+    ));
+}

--- a/console/web/src/lib/backend/approval-gate-config.test.ts
+++ b/console/web/src/lib/backend/approval-gate-config.test.ts
@@ -26,7 +26,6 @@ describe('approval-gate-config', () => {
       deny: [
         'approval::*',
         'configuration::register',
-        'configuration::set',
         'shell::run',
         'state::set',
       ],
@@ -34,16 +33,13 @@ describe('approval-gate-config', () => {
     })
   })
 
-  it('denies configuration mutations without blocking reads', () => {
+  it('keeps configuration registration structurally denied', () => {
     const deny = deriveFunctionPolicy([]).deny
 
-    expect(deny).toEqual([
-      'approval::*',
-      'configuration::register',
-      'configuration::set',
-    ])
+    expect(deny).toEqual(['approval::*', 'configuration::register'])
     expect(deny).not.toContain('configuration::*')
     expect(deny).not.toContain('configuration::get')
+    expect(deny).not.toContain('configuration::set')
   })
 
   it.each([
@@ -51,5 +47,12 @@ describe('approval-gate-config', () => {
     ['structured', { function: 'configuration::get', action: 'deny' }],
   ])('preserves an explicit %s deny for configuration::get', (_, rule) => {
     expect(deriveFunctionPolicy([rule]).deny).toContain('configuration::get')
+  })
+
+  it.each([
+    ['shorthand', '!configuration::set'],
+    ['structured', { function: 'configuration::set', action: 'deny' }],
+  ])('preserves an explicit %s deny for configuration::set', (_, rule) => {
+    expect(deriveFunctionPolicy([rule]).deny).toContain('configuration::set')
   })
 })

--- a/console/web/src/lib/backend/approval-gate-config.test.ts
+++ b/console/web/src/lib/backend/approval-gate-config.test.ts
@@ -23,8 +23,33 @@ describe('approval-gate-config', () => {
       ]),
     ).toEqual({
       allow: ['*'],
-      deny: ['approval::*', 'configuration::*', 'shell::run', 'state::set'],
+      deny: [
+        'approval::*',
+        'configuration::register',
+        'configuration::set',
+        'shell::run',
+        'state::set',
+      ],
       expose: 'agent_trigger',
     })
+  })
+
+  it('denies configuration mutations without blocking reads', () => {
+    const deny = deriveFunctionPolicy([]).deny
+
+    expect(deny).toEqual([
+      'approval::*',
+      'configuration::register',
+      'configuration::set',
+    ])
+    expect(deny).not.toContain('configuration::*')
+    expect(deny).not.toContain('configuration::get')
+  })
+
+  it.each([
+    ['shorthand', '!configuration::get'],
+    ['structured', { function: 'configuration::get', action: 'deny' }],
+  ])('preserves an explicit %s deny for configuration::get', (_, rule) => {
+    expect(deriveFunctionPolicy([rule]).deny).toContain('configuration::get')
   })
 })

--- a/console/web/src/lib/backend/approval-gate-config.ts
+++ b/console/web/src/lib/backend/approval-gate-config.ts
@@ -52,11 +52,7 @@ export function autoAllowSeedFromRules(rules: JsonValue[]): string[] {
 export function deriveFunctionPolicy(
   rules: JsonValue[],
 ): HarnessFunctionPolicy {
-  const deny = new Set<string>([
-    'approval::*',
-    'configuration::register',
-    'configuration::set',
-  ])
+  const deny = new Set<string>(['approval::*', 'configuration::register'])
   for (const entry of rules) {
     if (typeof entry === 'string') {
       if (entry.startsWith('!')) deny.add(entry.slice(1))

--- a/console/web/src/lib/backend/approval-gate-config.ts
+++ b/console/web/src/lib/backend/approval-gate-config.ts
@@ -52,7 +52,11 @@ export function autoAllowSeedFromRules(rules: JsonValue[]): string[] {
 export function deriveFunctionPolicy(
   rules: JsonValue[],
 ): HarnessFunctionPolicy {
-  const deny = new Set<string>(['approval::*', 'configuration::*'])
+  const deny = new Set<string>([
+    'approval::*',
+    'configuration::register',
+    'configuration::set',
+  ])
   for (const entry of rules) {
     if (typeof entry === 'string') {
       if (entry.startsWith('!')) deny.add(entry.slice(1))

--- a/console/web/src/lib/backend/real-metadata.test.ts
+++ b/console/web/src/lib/backend/real-metadata.test.ts
@@ -30,6 +30,14 @@ describe('fallback function policy', () => {
   it('does not expose workspace picker functions to the agent', () => {
     expect(FALLBACK_FUNCTION_POLICY.deny).toContain('shell::workspace::*')
   })
+
+  it('denies configuration mutations without blocking reads', () => {
+    expect(FALLBACK_FUNCTION_POLICY.deny).toEqual(
+      expect.arrayContaining(['configuration::register', 'configuration::set']),
+    )
+    expect(FALLBACK_FUNCTION_POLICY.deny).not.toContain('configuration::*')
+    expect(FALLBACK_FUNCTION_POLICY.deny).not.toContain('configuration::get')
+  })
 })
 
 describe('model reasoning effort forwarding', () => {

--- a/console/web/src/lib/backend/real-metadata.test.ts
+++ b/console/web/src/lib/backend/real-metadata.test.ts
@@ -31,12 +31,11 @@ describe('fallback function policy', () => {
     expect(FALLBACK_FUNCTION_POLICY.deny).toContain('shell::workspace::*')
   })
 
-  it('denies configuration mutations without blocking reads', () => {
-    expect(FALLBACK_FUNCTION_POLICY.deny).toEqual(
-      expect.arrayContaining(['configuration::register', 'configuration::set']),
-    )
+  it('allows configuration updates without exposing registration', () => {
+    expect(FALLBACK_FUNCTION_POLICY.deny).toContain('configuration::register')
     expect(FALLBACK_FUNCTION_POLICY.deny).not.toContain('configuration::*')
     expect(FALLBACK_FUNCTION_POLICY.deny).not.toContain('configuration::get')
+    expect(FALLBACK_FUNCTION_POLICY.deny).not.toContain('configuration::set')
   })
 })
 

--- a/console/web/src/lib/backend/real.ts
+++ b/console/web/src/lib/backend/real.ts
@@ -72,17 +72,13 @@ interface RunParams {
 
 /**
  * The chat composer is a general-purpose agent surface: expose the whole bus
- * via `agent_trigger`. The approval-gate rules supply the structural floor;
- * the gate hook remains the human decision surface.
+ * via `agent_trigger`. When approval-gate configuration is unavailable, this
+ * fallback keeps registration and other control-plane functions hidden while
+ * allowing updates to already-registered configuration entries.
  */
 export const FALLBACK_FUNCTION_POLICY: HarnessFunctionPolicy = {
   allow: ['*'],
-  deny: [
-    'approval::*',
-    'configuration::register',
-    'configuration::set',
-    'shell::workspace::*',
-  ],
+  deny: ['approval::*', 'configuration::register', 'shell::workspace::*'],
   expose: 'agent_trigger',
 }
 

--- a/console/web/src/lib/backend/real.ts
+++ b/console/web/src/lib/backend/real.ts
@@ -77,7 +77,12 @@ interface RunParams {
  */
 export const FALLBACK_FUNCTION_POLICY: HarnessFunctionPolicy = {
   allow: ['*'],
-  deny: ['approval::*', 'configuration::*', 'shell::workspace::*'],
+  deny: [
+    'approval::*',
+    'configuration::register',
+    'configuration::set',
+    'shell::workspace::*',
+  ],
   expose: 'agent_trigger',
 }
 

--- a/docs/architecture/skills-and-permissions.md
+++ b/docs/architecture/skills-and-permissions.md
@@ -54,6 +54,13 @@ rules:
 Precedent: `session-manager` block — deny all writes and `session::store::*`;
 reads stay at default approval.
 
+For the configuration worker, `configuration::list` and
+`configuration::schema` are read-only and allowed. `configuration::get` is a
+sensitive read and needs approval by default. Agents cannot call
+`configuration::set` or `configuration::register`. Direct Console
+configuration pages and worker-to-worker configuration calls use privileged
+paths; this agent policy does not change them.
+
 Update [`iii-permissions.yaml`](../../iii-permissions.yaml) when adding a worker
 whose functions agents should or should not call without approval.
 

--- a/docs/architecture/skills-and-permissions.md
+++ b/docs/architecture/skills-and-permissions.md
@@ -56,10 +56,13 @@ reads stay at default approval.
 
 For the configuration worker, `configuration::list` and
 `configuration::schema` are read-only and allowed. `configuration::get` is a
-sensitive read and needs approval by default. Agents cannot call
-`configuration::set` or `configuration::register`. Direct Console
-configuration pages and worker-to-worker configuration calls use privileged
-paths; this agent policy does not change them.
+sensitive read and needs approval by default. When approval-gate configuration
+is unavailable, the Console fallback permits `configuration::set` for existing
+entries. With the gate configured, `configuration::set` follows its deployment
+rules; the repository default denies it. Agents cannot call
+`configuration::register`. Direct Console configuration pages and
+worker-to-worker configuration calls use privileged paths; this agent policy
+does not change them.
 
 Update [`iii-permissions.yaml`](../../iii-permissions.yaml) when adding a worker
 whose functions agents should or should not call without approval.

--- a/docs/architecture/skills-and-permissions.md
+++ b/docs/architecture/skills-and-permissions.md
@@ -56,10 +56,11 @@ reads stay at default approval.
 
 For the configuration worker, `configuration::list` and
 `configuration::schema` are read-only and allowed. `configuration::get` is a
-sensitive read and needs approval by default. When approval-gate configuration
-is unavailable, the Console fallback permits `configuration::set` for existing
-entries. With the gate configured, `configuration::set` follows its deployment
-rules; the repository default denies it. Agents cannot call
+sensitive read and needs approval by default when the gate is configured. When
+approval-gate configuration is unavailable, the Console fallback permits both
+`configuration::get` and `configuration::set` for existing entries. With the
+gate configured, `configuration::set` follows its deployment rules; the
+repository default denies it. Agents cannot call
 `configuration::register`. Direct Console configuration pages and
 worker-to-worker configuration calls use privileged paths; this agent policy
 does not change them.

--- a/harness/src/clients/engine.rs
+++ b/harness/src/clients/engine.rs
@@ -68,7 +68,8 @@ impl EngineClient {
         function_id: &str,
         payload: Value,
     ) -> Result<Value, DispatchError> {
-        let (payload, target_namespace) = self.compose.prepare(function_id, payload);
+        let (payload, prepared_namespace) = self.compose.prepare(function_id, payload);
+        let target_namespace = dispatch_namespace(function_id, prepared_namespace);
         // Capture the epoch immediately before the invocation instead of
         // comparing against process-global state. A global baseline becomes
         // stale when the engine restarts while this worker is idle and would
@@ -208,6 +209,17 @@ impl ComposeScope {
             }
         }
         (payload, self.namespace.as_deref())
+    }
+}
+
+fn dispatch_namespace<'a>(
+    function_id: &str,
+    prepared_namespace: Option<&'a str>,
+) -> Option<&'a str> {
+    if function_id.starts_with("configuration::") {
+        Some("default")
+    } else {
+        prepared_namespace
     }
 }
 
@@ -421,7 +433,7 @@ mod tests {
             namespace: Some("compose-daemon".to_string()),
             file: Some("/srv/app/worker-compose.yaml".to_string()),
         };
-        let (payload, namespace) = scope.prepare(
+        let (payload, prepared_namespace) = scope.prepare(
             "compose::add",
             json!({
                 "worker": "database",
@@ -429,6 +441,7 @@ mod tests {
                 "namespace": "other-daemon"
             }),
         );
+        let namespace = dispatch_namespace("compose::add", prepared_namespace);
 
         assert_eq!(namespace, Some("compose-daemon"));
         assert_eq!(payload["worker"], "database");
@@ -443,10 +456,23 @@ mod tests {
             file: Some("/srv/app/worker-compose.yaml".to_string()),
         };
         let payload = json!({ "path": "." });
-        let (prepared, namespace) = scope.prepare("shell::fs::ls", payload.clone());
+        let (prepared, prepared_namespace) = scope.prepare("shell::fs::ls", payload.clone());
+        let namespace = dispatch_namespace("shell::fs::ls", prepared_namespace);
 
         assert_eq!(prepared, payload);
         assert_eq!(namespace, None);
+    }
+
+    #[test]
+    fn configuration_calls_are_routed_to_default() {
+        for function_id in ["configuration::get", "configuration::list"] {
+            assert_eq!(dispatch_namespace(function_id, None), Some("default"));
+        }
+    }
+
+    #[test]
+    fn configuration_prefix_match_is_exact() {
+        assert_eq!(dispatch_namespace("configuration-extra::get", None), None);
     }
 
     #[test]

--- a/iii-permissions.yaml
+++ b/iii-permissions.yaml
@@ -23,9 +23,10 @@ rules:
   - '!stream::set'
   - '!iii::durable::publish'
   # Provider credentials live in the `llm-router` configuration entry. Agents
-  # must never resolve a secret, self-register a provider, poison the model
-  # catalog, or read/rewrite the configuration value (which carries plaintext
-  # api keys). Direct router spend (chat/complete) bypasses the harness
+  # must never resolve a secret through router internals, self-register a
+  # provider, poison the model catalog, or rewrite the configuration value
+  # (which carries plaintext api keys). Direct router spend (chat/complete)
+  # bypasses the harness
   # loop's accounting; the routing preview is orchestrator-internal. The
   # console edits config as a user-initiated SDK call, which bypasses this gate.
   - '!router::provider::resolve'
@@ -41,7 +42,9 @@ rules:
   # bypass the router's accounting, budgets, and retry policy. The router
   # invokes these worker-to-worker; agents never call them.
   - '!provider::*'
-  - '!configuration::get'
+  # configuration::get can expose stored secrets, so it has no default rule:
+  # no match means needs_approval. list/schema return no stored values and are
+  # safe read-only introspection. Mutations stay denied.
   - '!configuration::set'
   - '!configuration::register'
   - '!directory::pre-generate'
@@ -242,6 +245,8 @@ rules:
   - '!gantry::on-trigger-type-registration'
 
   # Read-only / introspection (extend below for your tools).
+  - configuration::list
+  - configuration::schema
   - state::get
   - state::list
   - router::models::list


### PR DESCRIPTION
## Summary

- route `configuration::*` dispatches from Harness to the engine-owned worker in the `default` namespace
- allow configuration reads while keeping sensitive reads subject to approval-gate rules
- allow `configuration::set` in the Console fallback when approval-gate configuration is unavailable
- keep `configuration::register` structurally denied and preserve explicit deployment denies
- update repository policy tests and security documentation

## Problem

Two independent checks blocked configuration access from a Harness running in a project namespace:

1. The Console turn policy denied the full `configuration::*` prefix before Harness could dispatch the call.
2. Generic Harness dispatch inherited the project namespace, but the engine-owned configuration worker is registered in `default`.

The broad deny also prevented local stacks without approval-gate from updating an existing worker configuration.

## Solution

Harness now applies an explicit `configuration::*` to `default` namespace rule after compose payload preparation. Compose calls still use `III_COMPOSE_NAMESPACE`, and ordinary calls still inherit the Harness worker namespace.

The Console fallback permits `configuration::set` when approval-gate configuration is unavailable. When gate configuration is present, deployment deny rules are copied into the Harness policy and the gate remains the decision surface. The repository default still contains `!configuration::set`, so the default gated deployment denies it.

`configuration::register` remains structurally denied in every mode. Explicit deployment denies, including `!configuration::get` and `!configuration::set`, remain effective.

The Engine, SDK namespace rules, and WebSocket protocol are unchanged. The explicit target belongs in Harness because namespace isolation is intentional and cross-namespace fallback would weaken that boundary.

## Security model

- Without approval-gate configuration, `configuration::get` and `configuration::set` are available through the Console fallback.
- With approval-gate configuration, `configuration::get` and `configuration::set` follow deployment rules. An unmatched call requires approval; the repository default denies `configuration::set`.
- `configuration::list` and `configuration::schema` are allowed read-only introspection calls.
- `configuration::register` remains denied to agents.

## Validation

- `cargo test --locked --manifest-path harness/Cargo.toml -p harness` — 456 passed
- `cargo test --locked --manifest-path approval-gate/Cargo.toml` — 183 passed
- focused Console policy tests — 15 passed
- `pnpm --dir console/web typecheck` — passed
- Biome check on the four changed Console files — passed
- Rust formatting and `git diff --check` — passed

## Local acceptance

The live Engine registers all five configuration functions in `default`, including `configuration::set`. An agent acceptance turn still requires rebuilding Console and starting a new conversation because existing turns keep their frozen function policy. No configuration value or credential was printed during validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only access to configuration listings and schemas by default.
  * Configuration updates for existing entries can proceed through approved Console fallback paths.
  * Configuration requests are consistently routed to the default configuration namespace.

* **Bug Fixes**
  * Configuration registration remains denied by default, while configuration reads and updates are no longer implicitly blocked.
  * Preserved explicit rules that deny configuration updates when configured.

* **Documentation**
  * Clarified permission guidance for configuration access, secret resolution, registration, and catalog changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->