### PR TITLE
feat: console configurable port

### DIFF
--- a/console/README.md
+++ b/console/README.md
@@ -188,25 +188,37 @@ proxies `/ws` to the iii engine. The browser only ever talks to one origin.
 
 ## Configuration
 
-### `config.yaml`
+Console registers a `console` entry with the central `configuration` worker.
+Its `http_port` value is authoritative after first registration: Console reads
+it before binding, watches `configuration:updated`, and moves the listener live
+when the port changes. The replacement port is bound and started before the old
+listener is gracefully drained; a failed bind keeps the previous listener and
+port active.
+
+The local `config.yaml` is a first-registration seed and a fallback for direct
+runs where the configuration worker is unavailable:
 
 ```yaml
-http_port: 3113       # port the UI + /ws are served on (default: 3113)
+http_port: 3113       # initial port seed for the UI + /ws (default: 3113)
 injectable_ui: true   # kill switch for runtime-injected worker UI (default: true)
 ```
 
 | Key | Default | Description |
 |---|---|---|
-| `http_port` | `3113` | TCP port the worker binds for `/`, `/assets/*`, and `/ws` |
+| `http_port` | `3113` | Initial TCP port seed for `/`, `/assets/*`, and `/ws`; the stored `console.http_port` wins thereafter |
 | `injectable_ui` | `true` | When `false`, skips the `console:script` / `console:style` / `console:assets` trigger types, the `/ui` + `/vendor` routes, and the SPA loader (`console::ui-manifest` answers `disabled: true`) |
+
+The configuration entry also stores UI preferences and
+`injectableUi.disabledWorkers`. Port and per-worker UI changes apply without a
+Console restart; the local `injectable_ui` kill switch remains startup-only.
 
 ### CLI flags
 
 | Flag | Default | Description |
 |---|---|---|
-| `--config <path>` | `./config.yaml` | Path to the YAML config |
+| `--config <path>` | `./config.yaml` | Path to the first-registration YAML seed/fallback |
 | `--url <ws://…>` | `ws://127.0.0.1:49134` | iii engine WebSocket URL (`DEFAULT_ENGINE_URL` in [`src/config.rs`](src/config.rs)) |
-| `--http-port <port>` | from config | Overrides `http_port` from the config file |
+| `--http-port <port>` | from seed | Overrides the YAML port seed; an existing configuration-worker value still wins |
 | `--manifest` | — | Print the publish manifest as JSON and exit (used by the registry pipeline) |
 
 ## Routes

--- a/console/config.yaml
+++ b/console/config.yaml
@@ -1,1 +1,3 @@
+# First-registration seed/fallback. After registration, the `console`
+# configuration worker entry is authoritative and port edits apply live.
 http_port: 3113

--- a/console/iii.worker.yaml
+++ b/console/iii.worker.yaml
@@ -7,3 +7,7 @@ license: Apache-2.0
 bin: console
 tags: [console, dashboard, ui, web, admin]
 description: Web console for iii — bundles the React UI and proxies the engine WebSocket on a single port.
+config:
+  http_port: 3113
+dependencies:
+  configuration: "0.x"

--- a/console/src/config.rs
+++ b/console/src/config.rs
@@ -1,9 +1,10 @@
-//! Runtime configuration for the `console` worker.
+//! Local seed/fallback configuration for the `console` worker.
 //!
 //! The YAML config file exposes two operator-facing knobs:
 //!
-//! - `http_port` — TCP port the worker binds for `/`, `/assets/*`, and
-//!   `/ws`. Defaults to `3113`.
+//! - `http_port` — first-registration seed/fallback for the TCP port serving
+//!   `/`, `/assets/*`, and `/ws`. Defaults to `3113`; after registration the
+//!   central `console.http_port` value is authoritative and hot-reloads.
 //! - `injectable_ui` — kill switch for runtime-injected worker UI
 //!   (`console:script` / `console:style` / `console:assets` trigger types,
 //!   the `/ui` + `/vendor` routes, and the SPA loader). Defaults to `true`.

--- a/console/src/configuration.rs
+++ b/console/src/configuration.rs
@@ -1,21 +1,17 @@
-//! Register the `console` configuration entry — the server-side home for
-//! console UI preferences (the Traces V2 saved views) and the injectable-UI
-//! per-worker toggles (`injectableUi.disabledWorkers`). The frontend
-//! reads/writes it with `configuration::get` / `configuration::set` over the
-//! `/ws` proxy; registration here just guarantees the entry and its schema
-//! exist before any browser connects.
+//! Integration with the builtin `configuration` worker. The `console` entry is
+//! the source of truth for the HTTP listener port as well as Console UI
+//! preferences and injectable-UI per-worker toggles.
 //!
-//! Unlike workers whose behavior depends on their configuration, the console
-//! serves fine without it — when the `configuration` worker is disabled or
-//! unreachable the UI degrades to in-browser defaults (and every worker's
-//! injected UI stays enabled). Registration is therefore best-effort and
-//! never blocks boot.
+//! The local YAML/CLI port is a first-registration seed and a fallback when the
+//! configuration worker is unavailable. Once stored, `http_port` is fetched
+//! before the listener binds and is applied live on `configuration:updated`.
+//! Port changes use the same bind-new-before-stop-old strategy as the HTTP
+//! worker: a failed bind leaves both the previous port snapshot and listener
+//! untouched; a successful bind starts the replacement before gracefully
+//! draining the old listener.
 //!
-//! [`start_injectable_ui_sync`] is the runtime half: apply the persisted
-//! `disabledWorkers` set to the [`crate::ui_assets`] registry at boot, then
-//! subscribe to `configuration:updated` events for this entry so saving the
-//! toggle form applies live — tabs drop/load the affected workers' assets
-//! without any restart (the state worker's `configuration.rs` precedent).
+//! Configuration integration remains best-effort so a directly-run Console
+//! can still serve when the configuration worker is disabled or unreachable.
 
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -25,8 +21,36 @@ use iii_sdk::errors::Error;
 use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
 use iii_sdk::{IIIClient, RegisterFunction};
 use serde_json::{json, Value};
+use tokio::sync::RwLock;
 
+use crate::server::{self, AppState, ServerControlCell};
 use crate::ui_assets::UiControl;
+
+/// Live port snapshot used by `console::status` and the rebind path.
+pub type PortCell = Arc<RwLock<u16>>;
+
+/// Serializes fetch → validate → bind → swap across overlapping update events.
+pub type ApplyLock = Arc<tokio::sync::Mutex<()>>;
+
+/// The runtime-owned slice of the broader Console configuration entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeConfig {
+    pub http_port: u16,
+    disabled_workers: HashSet<String>,
+}
+
+impl RuntimeConfig {
+    pub fn fallback(http_port: u16) -> Self {
+        Self {
+            http_port,
+            disabled_workers: HashSet::new(),
+        }
+    }
+}
+
+pub fn new_port_cell(http_port: u16) -> PortCell {
+    Arc::new(RwLock::new(http_port))
+}
 
 pub const DEFAULT_CONFIG_ID: &str = "console";
 
@@ -51,15 +75,22 @@ const CONFIG_TIMEOUT_MS: u64 = 5_000;
 const CONFIG_RETRIES: u32 = 3;
 const CONFIG_RETRY_BACKOFF_MS: u64 = 250;
 
-/// The `console` entry schema. Deliberately permissive below the top level:
-/// the UI owns the detailed view shape (grouping, filters, display, hidden
-/// functions) and must be able to evolve it without a console-worker
-/// redeploy. Only the envelope — `traces.views[]` entries carrying `id` and
-/// `name` — is pinned.
+/// The `console` entry schema. `http_port` is strictly bounded to a TCP port;
+/// the UI-owned preference sections stay deliberately permissive so their
+/// detailed shapes can evolve without a console-worker redeploy. Only the
+/// preference envelope — `traces.views[]` entries carrying `id` and `name` —
+/// is pinned.
 fn schema() -> Value {
     json!({
         "type": "object",
         "properties": {
+            "http_port": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 65535,
+                "default": 3113,
+                "description": "TCP port for the Console UI, injected assets, and /ws proxy. Changes rebind the listener live."
+            },
             "traces": {
                 "type": "object",
                 "description": "Traces V2 UI preferences.",
@@ -105,7 +136,7 @@ fn schema() -> Value {
     })
 }
 
-/// Out-of-the-box preferences seeded when the entry has never been
+/// Out-of-the-box port and preferences seeded when the entry has never been
 /// configured.
 ///
 /// - `views`: `view-sessions` groups traces by `iii.session.id` (stamped on
@@ -119,8 +150,9 @@ fn schema() -> Value {
 ///   (the frontend also defaults to on when the flag is absent).
 /// - `spanFilters`: detail-view funnel defaults — hide the chatty
 ///   `harness::send` span group and the session/context bookkeeping workers.
-fn default_value() -> Value {
+fn default_value(http_port: u16) -> Value {
     json!({
+        "http_port": http_port,
         "traces": {
             "views": [{
                 "id": "view-sessions",
@@ -143,122 +175,215 @@ fn default_value() -> Value {
     })
 }
 
-/// Best-effort registration of the `console` configuration entry. Seeds the
-/// default value only when nothing is stored yet (a re-register with
-/// `initial_value` would replace user-saved views). Failures are logged and
-/// swallowed — the console must serve even without the configuration worker.
-pub async fn register_console_config(iii: &IIIClient) {
-    let seed = match existing_value(iii).await {
-        Ok(existing) => existing.is_none(),
-        Err(e) => {
-            tracing::warn!(
-                error = %e,
-                "console configuration lookup failed; skipping registration \
-                 (UI preferences fall back to in-browser defaults)"
-            );
-            return;
+/// Register the `console` configuration entry. `seed_http_port` is included in
+/// `initial_value` only when no value is stored, so runtime edits survive
+/// restarts. Callers intentionally treat errors as best-effort fallbacks.
+pub async fn register_console_config(iii: &IIIClient, seed_http_port: u16) -> Result<(), String> {
+    let existing = existing_value(iii)
+        .await
+        .map_err(|error| format!("console configuration lookup failed: {error}"))?;
+    let seed = existing.is_none();
+    // Entries created by older Console versions already contain preferences
+    // but no port. Backfill the active local seed after the schema refresh so
+    // the configuration form displays the listener's real value and future
+    // restarts no longer depend on a possibly-changed local seed.
+    let backfill = existing.as_ref().and_then(|value| {
+        let mut value = value.as_object()?.clone();
+        if value.contains_key("http_port") {
+            return None;
         }
-    };
+        value.insert("http_port".to_string(), json!(seed_http_port));
+        Some(Value::Object(value))
+    });
 
     let mut payload = json!({
         "id": config_id(),
         "name": "Console",
-        "description": "Console UI preferences — Traces V2 saved views \
-                        (grouping, filters, display settings, hidden functions), \
-                        the selected view, and the per-worker injectable-UI \
-                        toggles.",
+        "description": "Console server and UI settings — live HTTP port binding, \
+                        Traces V2 saved views, and per-worker injectable-UI toggles.",
         "schema": schema(),
     });
     if seed {
-        payload["initial_value"] = default_value();
+        payload["initial_value"] = default_value(seed_http_port);
     }
 
-    match trigger_configuration_with_retry(iii, "configuration::register", payload).await {
-        Ok(_) => tracing::info!(id = config_id(), "console configuration registered"),
-        Err(e) => tracing::warn!(
-            error = %e,
-            "console configuration registration failed; skipping \
-             (UI preferences fall back to in-browser defaults)"
-        ),
+    trigger_configuration_with_retry(iii, "configuration::register", payload).await?;
+    if let Some(value) = backfill {
+        set_value(iii, value).await?;
+        tracing::info!(
+            id = config_id(),
+            http_port = seed_http_port,
+            "backfilled http_port in existing console configuration"
+        );
     }
+    tracing::info!(id = config_id(), "console configuration registered");
+    Ok(())
 }
 
 const CONFIG_CHANGE_FN_ID: &str = "console::on-config-change";
 
-/// Apply the persisted `injectableUi.disabledWorkers` set at boot, then
-/// subscribe to `configuration:updated` events for the `console` entry so
-/// toggle-form saves apply live. Best-effort like the registration above:
-/// with no configuration worker every injected UI simply stays enabled.
-pub async fn start_injectable_ui_sync(iii: &Arc<IIIClient>, control: UiControl) {
-    match fetch_disabled_workers(iii).await {
-        Ok(workers) => control.set_disabled_workers(workers).await,
-        Err(e) => tracing::warn!(
-            error = %e,
-            "injectable-ui toggles: initial configuration fetch failed; \
-             every worker's injected UI stays enabled until a config change arrives"
-        ),
-    }
+/// Fetch the runtime-owned fields from the authoritative entry. A missing
+/// `http_port` (including entries created by older Console versions) retains
+/// the supplied seed/fallback port.
+pub async fn fetch_runtime_config(
+    iii: &IIIClient,
+    fallback_http_port: u16,
+) -> Result<RuntimeConfig, String> {
+    let value = existing_value(iii).await?;
+    runtime_config_from(value.as_ref(), fallback_http_port)
+}
 
-    // Serialize fetch→apply across events: the SDK spawns each invocation on
-    // its own task, and a stale fetch applied after a fresh one would undo
-    // the newer toggle state (the state worker's ApplyLock precedent).
-    let apply_lock = Arc::new(tokio::sync::Mutex::new(()));
-    {
-        let iii_for_fn = iii.clone();
-        let control = control.clone();
-        iii.register_function(
-            CONFIG_CHANGE_FN_ID,
-            RegisterFunction::new_async(move |_: ConfigChangeRequest| {
-                let iii = iii_for_fn.clone();
-                let control = control.clone();
-                let apply_lock = apply_lock.clone();
-                async move {
-                    let _guard = apply_lock.lock().await;
-                    // Never trust the trigger payload — re-fetch the
-                    // authoritative value. A fetch failure keeps the
-                    // previous toggle state in place.
-                    match fetch_disabled_workers(&iii).await {
-                        Ok(workers) => control.set_disabled_workers(workers).await,
-                        Err(e) => tracing::warn!(
-                            error = %e,
-                            "injectable-ui toggles: config-change fetch failed; keeping previous state"
-                        ),
-                    }
-                    Ok::<_, Error>(ConfigChangeAck { ok: true })
-                }
-            })
-            .description(
-                "Internal: re-apply the console's injectable-UI per-worker toggles \
-                 when the console configuration entry changes.",
-            )
-            .metadata(json!({ "internal": true })),
-        );
-    }
+fn runtime_config_from(
+    value: Option<&Value>,
+    fallback_http_port: u16,
+) -> Result<RuntimeConfig, String> {
+    let http_port = match value.and_then(|value| value.get("http_port")) {
+        None => fallback_http_port,
+        Some(Value::Number(number)) => number
+            .as_u64()
+            .and_then(|port| u16::try_from(port).ok())
+            .ok_or_else(|| {
+                "stored `console.http_port` must be an integer from 0 to 65535".to_string()
+            })?,
+        Some(_) => {
+            return Err("stored `console.http_port` must be an integer from 0 to 65535".to_string())
+        }
+    };
 
-    if let Err(e) = iii.register_trigger(RegisterTriggerInput::new(
+    Ok(RuntimeConfig {
+        http_port,
+        disabled_workers: value.map(disabled_workers_from).unwrap_or_default(),
+    })
+}
+
+/// Apply the runtime UI slice fetched during boot.
+pub async fn apply_runtime_ui(config: &RuntimeConfig, control: Option<&UiControl>) {
+    if let Some(control) = control {
+        control
+            .set_disabled_workers(config.disabled_workers.clone())
+            .await;
+    }
+}
+
+/// Register the configuration update handler and subscription. Every delivery
+/// re-fetches the authoritative value under `apply_lock`; the discoverable
+/// handler never trusts caller-supplied payload data.
+pub fn register_config_trigger(
+    iii: &Arc<IIIClient>,
+    port: PortCell,
+    state: AppState,
+    server_control: ServerControlCell,
+    ui_control: Option<UiControl>,
+    apply_lock: ApplyLock,
+) -> Result<(), Error> {
+    let iii_for_fn = iii.clone();
+    iii.register_function(
+        CONFIG_CHANGE_FN_ID,
+        RegisterFunction::new_async(move |_: ConfigChangeRequest| {
+            let iii = iii_for_fn.clone();
+            let port = port.clone();
+            let state = state.clone();
+            let server_control = server_control.clone();
+            let ui_control = ui_control.clone();
+            let apply_lock = apply_lock.clone();
+            async move {
+                apply_current_config(
+                    &iii,
+                    &port,
+                    &state,
+                    &server_control,
+                    ui_control.as_ref(),
+                    &apply_lock,
+                )
+                .await;
+                Ok::<_, Error>(ConfigChangeAck { ok: true })
+            }
+        })
+        .description(
+            "Internal: re-apply the Console HTTP port and injectable-UI toggles \
+             when its configuration entry changes.",
+        )
+        .metadata(json!({ "internal": true })),
+    );
+
+    iii.register_trigger(RegisterTriggerInput::new(
         "configuration".to_string(),
         CONFIG_CHANGE_FN_ID.to_string(),
         json!({
             "configuration_id": config_id(),
             "event_types": ["configuration:updated"],
         }),
-    )) {
-        tracing::warn!(
-            error = %e,
-            "injectable-ui toggles: configuration trigger registration failed; \
-             toggle changes apply at the next console restart"
-        );
-    }
+    ))?;
+    Ok(())
 }
 
-/// Read `injectableUi.disabledWorkers` from the stored `console` entry.
-/// Missing entry / section / list ⇒ empty set (everything enabled).
-async fn fetch_disabled_workers(iii: &IIIClient) -> Result<HashSet<String>, String> {
-    let value = existing_value(iii).await?;
-    Ok(value
-        .as_ref()
-        .map(disabled_workers_from)
-        .unwrap_or_default())
+/// Catch up after trigger registration, and serve as the trigger handler body.
+/// Errors are logged and keep the previous listener/runtime state intact.
+pub async fn apply_current_config(
+    iii: &IIIClient,
+    port: &PortCell,
+    state: &AppState,
+    server_control: &ServerControlCell,
+    ui_control: Option<&UiControl>,
+    apply_lock: &ApplyLock,
+) {
+    let _guard = apply_lock.lock().await;
+    let current_port = *port.read().await;
+    let candidate = match fetch_runtime_config(iii, current_port).await {
+        Ok(config) => config,
+        Err(error) => {
+            tracing::error!(%error, "console config-change fetch failed; keeping previous state");
+            return;
+        }
+    };
+
+    if candidate.http_port != current_port {
+        if let Err(error) = rebind(port, state, server_control, candidate.http_port).await {
+            tracing::error!(
+                %error,
+                old = current_port,
+                new = candidate.http_port,
+                "console rebind failed; keeping previous port and listener"
+            );
+            return;
+        }
+        tracing::info!(
+            old = current_port,
+            new = candidate.http_port,
+            "console server rebound after configuration change; old port shutting down"
+        );
+    }
+
+    apply_runtime_ui(&candidate, ui_control).await;
+}
+
+/// Rebind the Console listener with the HTTP worker's bind-new-before-stop-old
+/// ordering. All fallible work completes before the live port snapshot or
+/// current-server slot changes.
+async fn rebind(
+    port: &PortCell,
+    state: &AppState,
+    control: &ServerControlCell,
+    new_port: u16,
+) -> anyhow::Result<()> {
+    let listener = server::bind_listener(new_port).await?;
+    let new_control = server::spawn_server(listener, state.clone());
+
+    let old = {
+        let mut current = control.lock().await;
+        if current.is_none() {
+            server::stop_old_server(new_control);
+            anyhow::bail!("console server is already shut down");
+        }
+
+        *port.write().await = new_port;
+        current.replace(new_control)
+    };
+
+    if let Some(old) = old {
+        server::stop_old_server(old);
+    }
+    Ok(())
 }
 
 /// Tolerant extraction: non-object sections and non-string entries are
@@ -378,25 +503,124 @@ mod tests {
     }
 
     #[test]
+    fn schema_exposes_the_live_http_port() {
+        let port = &schema()["properties"]["http_port"];
+        assert_eq!(port["type"], "integer");
+        assert_eq!(port["minimum"], 0);
+        assert_eq!(port["maximum"], 65_535);
+        assert_eq!(port["default"], 3113);
+    }
+
+    #[test]
+    fn runtime_port_uses_stored_value_or_fallback() {
+        let stored = json!({
+            "http_port": 9123,
+            "injectableUi": { "disabledWorkers": ["state"] }
+        });
+        let parsed = runtime_config_from(Some(&stored), 3113).unwrap();
+        assert_eq!(parsed.http_port, 9123);
+        assert!(parsed.disabled_workers.contains("state"));
+
+        assert_eq!(
+            runtime_config_from(Some(&json!({})), 4555)
+                .unwrap()
+                .http_port,
+            4555
+        );
+        assert_eq!(runtime_config_from(None, 4666).unwrap().http_port, 4666);
+        assert!(runtime_config_from(Some(&json!({ "http_port": 70_000 })), 3113).is_err());
+        assert!(runtime_config_from(Some(&json!({ "http_port": "3113" })), 3113).is_err());
+    }
+
+    #[test]
     fn seed_groups_sessions_by_id_not_name() {
         // Grouping must key on `iii.session.id` — the engine's `group_by`
         // drops spans lacking the attribute, and `iii.session.name` is only
         // stamped once a session has a title, which hid every untitled
         // session's traces from the default view.
-        let v = default_value();
+        let v = default_value(3113);
         let view = &v["traces"]["views"][0];
         assert_eq!(view["id"], "view-sessions");
         assert_eq!(view["groupBy"], "iii.session.id");
         assert_eq!(v["traces"]["activeViewId"], "view-sessions");
+        assert_eq!(v["http_port"], 3113);
     }
 
     #[test]
     fn seed_starts_with_no_disabled_workers() {
-        let v = default_value();
+        let v = default_value(3113);
         assert!(disabled_workers_from(&v).is_empty());
         assert!(v["injectableUi"]["disabledWorkers"]
             .as_array()
             .unwrap()
             .is_empty());
+    }
+
+    fn two_free_ports() -> (u16, u16) {
+        loop {
+            let first = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            let second = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            let ports = (
+                first.local_addr().unwrap().port(),
+                second.local_addr().unwrap().port(),
+            );
+            if ports.0 != ports.1 {
+                return ports;
+            }
+        }
+    }
+
+    async fn wait_for_connection(port: u16, expected: bool) -> bool {
+        for _ in 0..50 {
+            let connected = tokio::net::TcpStream::connect(("127.0.0.1", port))
+                .await
+                .is_ok();
+            if connected == expected {
+                return true;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        false
+    }
+
+    #[tokio::test]
+    async fn rebind_starts_new_port_before_stopping_old_listener() {
+        let (old_port, new_port) = two_free_ports();
+        let state = AppState::new(Arc::new("ws://127.0.0.1:1".to_string()), None, None);
+        let handle = server::start(old_port, state.clone()).await.unwrap();
+        let port = new_port_cell(old_port);
+
+        assert!(wait_for_connection(old_port, true).await);
+        rebind(&port, &state, &handle.control, new_port)
+            .await
+            .unwrap();
+
+        assert_eq!(*port.read().await, new_port);
+        assert_eq!(handle.current_addr().await.unwrap().port(), new_port);
+        assert!(wait_for_connection(new_port, true).await);
+        assert!(wait_for_connection(old_port, false).await);
+
+        handle.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn failed_rebind_keeps_old_port_and_listener() {
+        let (old_port, occupied_port) = two_free_ports();
+        let occupied = tokio::net::TcpListener::bind(("0.0.0.0", occupied_port))
+            .await
+            .unwrap();
+        let state = AppState::new(Arc::new("ws://127.0.0.1:1".to_string()), None, None);
+        let handle = server::start(old_port, state.clone()).await.unwrap();
+        let port = new_port_cell(old_port);
+
+        assert!(rebind(&port, &state, &handle.control, occupied_port)
+            .await
+            .is_err());
+        assert_eq!(*port.read().await, old_port);
+        assert_eq!(handle.current_addr().await.unwrap().port(), old_port);
+        assert!(wait_for_connection(old_port, true).await);
+
+        drop(occupied);
+        handle.shutdown().await;
     }
 }

--- a/console/src/functions/mod.rs
+++ b/console/src/functions/mod.rs
@@ -18,21 +18,21 @@ use iii_sdk::{IIIClient, RegisterFunction};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::config::ConsoleConfig;
+use crate::configuration::PortCell;
 use crate::ui_assets::{ManifestAsset, ManifestWorker, UiRegistry};
 use status::{StatusInput, StatusOutput};
 
 /// Register every `console::*` function. Called once from `main` after
 /// `register_worker` (and after `ui_assets::start`, which owns the
 /// trigger-type registrations — types register before functions). Each
-/// handler captures the runtime knobs without re-parsing the YAML.
+/// handler captures the live runtime state without re-parsing the YAML.
 pub fn register_all(
     iii: &Arc<IIIClient>,
-    config: &Arc<ConsoleConfig>,
+    port: PortCell,
     engine_url: &str,
     ui: Option<Arc<UiRegistry>>,
 ) {
-    register_status(iii, config, engine_url);
+    register_status(iii, port, engine_url);
     register_ui_manifest(iii, ui);
     working_directory::register(iii);
     if let Err(error) = working_directory::bind(iii) {
@@ -92,17 +92,16 @@ fn register_ui_manifest(iii: &Arc<IIIClient>, ui: Option<Arc<UiRegistry>>) {
     );
 }
 
-fn register_status(iii: &Arc<IIIClient>, config: &Arc<ConsoleConfig>, engine_url: &str) {
-    let cfg = config.clone();
+fn register_status(iii: &Arc<IIIClient>, port: PortCell, engine_url: &str) {
     let engine_url = engine_url.to_string();
     iii.register_function(
         "console::status",
         RegisterFunction::new_async(move |_: StatusInput| {
-            let cfg = cfg.clone();
+            let port = port.clone();
             let engine_url = engine_url.clone();
             async move {
                 Ok::<_, Error>(StatusOutput {
-                    http_port: cfg.http_port,
+                    http_port: *port.read().await,
                     engine_url,
                     version: env!("CARGO_PKG_VERSION").to_string(),
                 })

--- a/console/src/main.rs
+++ b/console/src/main.rs
@@ -1,12 +1,15 @@
 //! `console` worker entry point.
 //!
 //! Boot sequence:
-//!   1. Parse CLI / load YAML config (with fallback to defaults).
+//!   1. Parse CLI / load the optional YAML seed (with fallback to defaults).
 //!   2. Connect to the iii engine over WebSocket via the SDK.
-//!   3. Register `console::status` against the engine.
-//!   4. Bind the HTTP server on `http_port` and serve `/`, `/assets/*`,
+//!   3. Register the Console configuration schema and fetch its authoritative
+//!      `http_port` (falling back to the local seed if unavailable).
+//!   4. Register `console::status` against the engine.
+//!   5. Bind the HTTP server on `http_port` and serve `/`, `/assets/*`,
 //!      and `/ws` (WebSocket proxy back to the engine).
-//!   5. Wait for SIGINT or SIGTERM, then signal a graceful HTTP
+//!   6. Subscribe to configuration changes so port edits rebind live.
+//!   7. Wait for SIGINT or SIGTERM, then signal a graceful HTTP
 //!      shutdown and `iii.shutdown_async()`.
 
 use std::sync::Arc;
@@ -15,7 +18,6 @@ use anyhow::Result;
 use clap::Parser;
 use iii_sdk::runtime::WorkerMetadata;
 use iii_sdk::{register_worker, InitOptions};
-use tokio::sync::oneshot;
 
 use console::{config, configuration, functions, manifest, server, ui, ui_assets};
 
@@ -25,7 +27,7 @@ use console::{config, configuration, functions, manifest, server, ui, ui_assets}
     about = "Web console for iii — bundles the React UI and proxies the engine WebSocket on a single port."
 )]
 struct Cli {
-    /// Path to `config.yaml`.
+    /// Path to the YAML seed used on first configuration registration.
     #[arg(long, default_value = "./config.yaml")]
     config: String,
 
@@ -33,8 +35,8 @@ struct Cli {
     #[arg(long, env = "III_URL", default_value = config::DEFAULT_ENGINE_URL)]
     url: String,
 
-    /// TCP port for `/`, `/assets/*`, and `/ws`. Overrides `http_port`
-    /// from the config file when present.
+    /// TCP port seed for `/`, `/assets/*`, and `/ws`. Overrides `http_port`
+    /// from the seed file; an existing configuration-worker value still wins.
     #[arg(long)]
     http_port: Option<u16>,
 
@@ -78,14 +80,6 @@ async fn main() -> Result<()> {
 
     let engine_url = cli.url;
 
-    tracing::info!(
-        http_port = cfg.http_port,
-        engine_url = %redact_url(&engine_url),
-        "starting console worker"
-    );
-
-    let cfg = Arc::new(cfg);
-
     let iii = register_worker(
         &engine_url,
         InitOptions {
@@ -103,6 +97,36 @@ async fn main() -> Result<()> {
     );
     let iii = Arc::new(iii);
 
+    // Match the HTTP worker's configuration lifecycle: local config is only a
+    // first-registration seed/fallback; a stored value is authoritative and is
+    // fetched before binding the listener.
+    if let Err(error) = configuration::register_console_config(&iii, cfg.http_port).await {
+        tracing::warn!(
+            %error,
+            "console configuration registration failed; continuing with the local port seed"
+        );
+    }
+    let runtime_config = match configuration::fetch_runtime_config(&iii, cfg.http_port).await {
+        Ok(config) => config,
+        Err(error) => {
+            tracing::warn!(
+                %error,
+                "console configuration fetch failed; continuing with the local port seed"
+            );
+            configuration::RuntimeConfig::fallback(cfg.http_port)
+        }
+    };
+    cfg.http_port = runtime_config.http_port;
+
+    tracing::info!(
+        http_port = cfg.http_port,
+        engine_url = %redact_url(&engine_url),
+        "starting console worker"
+    );
+
+    let cfg = Arc::new(cfg);
+    let port = configuration::new_port_cell(cfg.http_port);
+
     // Trigger types register before functions (approval-gate/memory
     // ordering convention). `None` = injectable UI disabled via config.
     let (ui, ui_control) = if cfg.injectable_ui {
@@ -113,27 +137,15 @@ async fn main() -> Result<()> {
         (None, None)
     };
 
-    functions::register_all(&iii, &cfg, &engine_url, ui.clone());
+    functions::register_all(&iii, port.clone(), &engine_url, ui.clone());
 
-    // The console's own injected UI — the injectable-UI toggle form for the
-    // `console` configuration entry. Same mechanism as any worker's.
+    // The console's own injected UI — live port + injectable-UI controls for
+    // the `console` configuration entry. Same mechanism as any worker's.
     if cfg.injectable_ui {
         ui::register(&iii);
     }
 
-    // Best-effort: guarantee the `console` configuration entry exists for the
-    // UI's saved preferences, without delaying HTTP serve. With injectable UI
-    // on, also apply the persisted per-worker toggles and subscribe to
-    // configuration changes so toggles apply live.
-    {
-        let iii = iii.clone();
-        tokio::spawn(async move {
-            configuration::register_console_config(&iii).await;
-            if let Some(control) = ui_control {
-                configuration::start_injectable_ui_sync(&iii, control).await;
-            }
-        });
-    }
+    configuration::apply_runtime_ui(&runtime_config, ui_control.as_ref()).await;
 
     if !console::assets::has_bundle() {
         tracing::warn!(
@@ -142,30 +154,55 @@ async fn main() -> Result<()> {
         );
     }
 
-    let (http_shutdown_tx, http_shutdown_rx) = oneshot::channel::<()>();
     let engine_url_redacted = redact_url(&engine_url);
     let state = server::AppState::new(Arc::new(engine_url), iii.namespace(), ui);
-    let http_port = cfg.http_port;
-    let server_handle = tokio::spawn(async move {
-        if let Err(e) = server::serve(http_port, state, http_shutdown_rx, None).await {
-            tracing::error!(error = %e, "http server crashed");
-        }
-    });
+    let server_handle = server::start(cfg.http_port, state.clone()).await?;
+    let apply_lock: configuration::ApplyLock = Arc::new(tokio::sync::Mutex::new(()));
+
+    if let Err(error) = configuration::register_config_trigger(
+        &iii,
+        port.clone(),
+        state.clone(),
+        server_handle.control.clone(),
+        ui_control.clone(),
+        apply_lock.clone(),
+    ) {
+        tracing::warn!(
+            %error,
+            "console configuration trigger registration failed; live updates are disabled"
+        );
+    } else {
+        // Close the fetch→subscribe race: an edit that landed while the server
+        // was binding is reconciled through the same serialized apply path.
+        configuration::apply_current_config(
+            &iii,
+            &port,
+            &state,
+            &server_handle.control,
+            ui_control.as_ref(),
+            &apply_lock,
+        )
+        .await;
+    }
+
+    let ready_addr = server_handle
+        .current_addr()
+        .await
+        .unwrap_or(server_handle.local_addr);
 
     tracing::info!(
         "console ready — UI on http://127.0.0.1:{}/, /ws proxies to {}",
-        cfg.http_port,
+        ready_addr.port(),
         engine_url_redacted,
     );
 
     wait_for_shutdown_signal().await?;
     tracing::info!("console shutting down");
 
-    let _ = http_shutdown_tx.send(());
-    if let Err(e) = server_handle.await {
-        tracing::warn!(error = %e, "http server task join failed");
-    }
-
+    // Serialize shutdown with any in-flight rebind. `rebind` also refuses to
+    // install a replacement after the control slot becomes `None`.
+    let _apply_guard = apply_lock.lock().await;
+    server_handle.shutdown().await;
     iii.shutdown_async().await;
     Ok(())
 }

--- a/console/src/server.rs
+++ b/console/src/server.rs
@@ -7,6 +7,7 @@
 
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Context;
 use axum::extract::{FromRef, Path, State};
@@ -15,11 +16,52 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::{Json, Router};
 use tokio::net::TcpListener;
-use tokio::sync::oneshot;
+use tokio::sync::{oneshot, Mutex};
+use tokio::task::{AbortHandle, JoinHandle};
 use tower_http::set_header::SetResponseHeaderLayer;
 
 use crate::ui_assets::UiRegistry;
 use crate::{assets, proxy};
+
+/// Grace period before a superseded listener is hard-aborted. Graceful
+/// shutdown is the primary path; the abort only bounds how long a stuck
+/// connection can keep the old port occupied after a configuration rebind.
+/// This matches the HTTP worker's listener-rebind strategy.
+const OLD_SERVER_HARD_STOP_GRACE: Duration = Duration::from_secs(2);
+
+/// Control handle for the currently running HTTP listener.
+pub struct ServerControl {
+    pub graceful: oneshot::Sender<()>,
+    pub abort: AbortHandle,
+    pub local_addr: SocketAddr,
+    pub join: JoinHandle<()>,
+}
+
+/// Shared slot holding the current listener. A configuration change replaces
+/// this only after the new port has bound successfully.
+pub type ServerControlCell = Arc<Mutex<Option<ServerControl>>>;
+
+/// Handle returned once the initial listener is bound and serving.
+pub struct ServerHandle {
+    pub local_addr: SocketAddr,
+    pub control: ServerControlCell,
+}
+
+impl ServerHandle {
+    /// The address currently serving Console. This changes after a live port
+    /// rebind and becomes `None` after shutdown.
+    pub async fn current_addr(&self) -> Option<SocketAddr> {
+        self.control.lock().await.as_ref().map(|c| c.local_addr)
+    }
+
+    /// Gracefully stop the current listener and wait for it to finish.
+    pub async fn shutdown(self) {
+        if let Some(control) = self.control.lock().await.take() {
+            let _ = control.graceful.send(());
+            let _ = control.join.await;
+        }
+    }
+}
 
 /// Router state. `ui: None` means injectable UI is disabled (config kill
 /// switch) — the `/ui` and `/vendor` routes are not mounted at all.
@@ -179,30 +221,80 @@ pub async fn serve(
     shutdown: oneshot::Receiver<()>,
     bound: Option<oneshot::Sender<SocketAddr>>,
 ) -> anyhow::Result<()> {
-    let app = router(state);
-
-    let addr: SocketAddr = (std::net::Ipv4Addr::UNSPECIFIED, http_port).into();
-    let listener = TcpListener::bind(addr)
-        .await
-        .with_context(|| format!("binding TCP listener on {addr}"))?;
-    let local = listener
-        .local_addr()
-        .with_context(|| "reading bound listener local_addr")?;
-    tracing::info!(addr = %local, "console http listening");
+    let handle = start(http_port, state).await?;
 
     if let Some(tx) = bound {
-        let _ = tx.send(local);
+        let _ = tx.send(handle.local_addr);
     }
 
-    axum::serve(listener, app)
-        .with_graceful_shutdown(async move {
-            let _ = shutdown.await;
-        })
-        .await
-        .context("axum::serve loop exited with error")?;
-
-    tracing::info!("console http stopped");
+    let _ = shutdown.await;
+    handle.shutdown().await;
     Ok(())
+}
+
+/// Bind the initial listener and spawn its server task.
+pub async fn start(http_port: u16, state: AppState) -> anyhow::Result<ServerHandle> {
+    let listener = bind_listener(http_port).await?;
+    let local_addr = listener
+        .local_addr()
+        .with_context(|| "reading bound listener local_addr")?;
+    let control = spawn_server(listener, state);
+    Ok(ServerHandle {
+        local_addr,
+        control: Arc::new(Mutex::new(Some(control))),
+    })
+}
+
+/// Bind `0.0.0.0:<http_port>` without changing any live server state. Rebinds
+/// use this bind-new-before-stop-old step so a failed port change leaves the
+/// existing Console listener untouched.
+pub async fn bind_listener(http_port: u16) -> anyhow::Result<TcpListener> {
+    let addr: SocketAddr = (std::net::Ipv4Addr::UNSPECIFIED, http_port).into();
+    TcpListener::bind(addr)
+        .await
+        .with_context(|| format!("binding TCP listener on {addr}"))
+}
+
+/// Spawn a server over an already-bound listener. The same shared app state is
+/// reused when configuration moves the listener to a different port.
+pub fn spawn_server(listener: TcpListener, state: AppState) -> ServerControl {
+    let local_addr = listener
+        .local_addr()
+        .unwrap_or_else(|_| SocketAddr::from(([0, 0, 0, 0], 0)));
+    let (graceful_tx, graceful_rx) = oneshot::channel::<()>();
+    let app = router(state);
+
+    let join = tokio::spawn(async move {
+        tracing::info!(addr = %local_addr, "console http listening");
+        if let Err(error) = axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                let _ = graceful_rx.await;
+            })
+            .await
+        {
+            tracing::error!(%error, "console http server exited with error");
+        }
+        tracing::info!(addr = %local_addr, "console http stopped");
+    });
+
+    let abort = join.abort_handle();
+    ServerControl {
+        graceful: graceful_tx,
+        abort,
+        local_addr,
+        join,
+    }
+}
+
+/// Gracefully drain a superseded listener, with a bounded hard-stop fallback.
+/// The replacement listener is already serving before this is called.
+pub fn stop_old_server(old: ServerControl) {
+    let _ = old.graceful.send(());
+    let abort = old.abort;
+    tokio::spawn(async move {
+        tokio::time::sleep(OLD_SERVER_HARD_STOP_GRACE).await;
+        abort.abort();
+    });
 }
 
 #[cfg(test)]

--- a/console/src/ui.rs
+++ b/console/src/ui.rs
@@ -6,9 +6,10 @@
 //!
 //! - a custom configuration form for the `console` entry
 //!   (`host.configForms`), replacing the schema-generated JSON editor with
-//!   the injectable-UI toggle board — one bordered card per worker (title +
-//!   description + switch) flipping `injectableUi.disabledWorkers`, which
-//!   [`crate::configuration::start_injectable_ui_sync`] applies live;
+//!   the live HTTP port control and injectable-UI toggle board — one bordered
+//!   card per worker (title + description + switch) flipping
+//!   `injectableUi.disabledWorkers`; both settings apply live through
+//!   [`crate::configuration::register_config_trigger`];
 //! - the engine-catalogue pages (`host.pages`): functions and triggers,
 //!   reading `engine::functions::*` / `engine::triggers::*` /
 //!   `engine::registered-triggers::list`. They are engine-level views no
@@ -80,6 +81,10 @@ mod tests {
         assert!(
             CONFIG_FORM_JS.contains("export"),
             "built config-form.js looks wrong"
+        );
+        assert!(
+            CONFIG_FORM_JS.contains("http_port"),
+            "built config-form.js is missing the live HTTP port field"
         );
     }
 

--- a/console/tests/integration.rs
+++ b/console/tests/integration.rs
@@ -11,16 +11,21 @@ use std::process::{Child, Command, Stdio};
 use std::time::Duration;
 
 use futures_util::{SinkExt, StreamExt};
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::{register_worker, InitOptions};
 use tokio::net::TcpStream;
 use tokio::time::{sleep, timeout};
 use tokio_tungstenite::tungstenite::Message;
+use uuid::Uuid;
 
 const ENGINE_WS: &str = "ws://127.0.0.1:49134";
 const HTTP_PORT: u16 = 48217;
+const REBOUND_HTTP_PORT: u16 = 48218;
 
 struct Harness {
     iii: Child,
     worker: Child,
+    config_id: String,
 }
 
 impl Drop for Harness {
@@ -42,6 +47,13 @@ async fn boot() -> Option<Harness> {
         );
         return None;
     }
+    if TcpStream::connect(("127.0.0.1", REBOUND_HTTP_PORT))
+        .await
+        .is_ok()
+    {
+        eprintln!("skipping: rebound port {REBOUND_HTTP_PORT} already in use on 127.0.0.1");
+        return None;
+    }
 
     let iii = Command::new(&iii_bin)
         .arg("--use-default-config")
@@ -55,6 +67,7 @@ async fn boot() -> Option<Harness> {
     let worker_bin = env!("CARGO_BIN_EXE_console");
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let config_path = format!("{manifest_dir}/config.yaml");
+    let config_id = format!("console-integration-{}", Uuid::new_v4());
 
     let worker = Command::new(worker_bin)
         .args([
@@ -65,6 +78,7 @@ async fn boot() -> Option<Harness> {
             "--http-port",
             &HTTP_PORT.to_string(),
         ])
+        .env("III_CONFIG_NAME", &config_id)
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
@@ -74,7 +88,11 @@ async fn boot() -> Option<Harness> {
         return None;
     }
 
-    Some(Harness { iii, worker })
+    Some(Harness {
+        iii,
+        worker,
+        config_id,
+    })
 }
 
 async fn wait_for_listen(port: u16, max: Duration) -> bool {
@@ -89,8 +107,8 @@ async fn wait_for_listen(port: u16, max: Duration) -> bool {
 }
 
 #[tokio::test]
-async fn end_to_end_http_and_ws_proxy() {
-    let Some(_h) = boot().await else {
+async fn end_to_end_http_ws_proxy_and_configuration_rebind() {
+    let Some(harness) = boot().await else {
         eprintln!("skipping: prerequisites not met (see logs above)");
         return;
     };
@@ -178,6 +196,86 @@ async fn end_to_end_http_and_ws_proxy() {
     }
 
     let _ = ws.close(None).await;
+
+    // 5. Change the authoritative configuration entry and prove the same
+    // process moves to the new listener: replacement serves, status updates,
+    // and the original port stops accepting new connections.
+    let client = register_worker(ENGINE_WS, InitOptions::default());
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    let current = loop {
+        match client
+            .trigger(
+                TriggerRequest {
+                    function_id: "configuration::get".to_string(),
+                    payload: serde_json::json!({ "id": harness.config_id }),
+                    action: None,
+                    timeout_ms: Some(2_000),
+                }
+                .namespace("default"),
+            )
+            .await
+        {
+            Ok(value) => break value,
+            Err(error) => {
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "configuration::get never became callable: {error}"
+                );
+                sleep(Duration::from_millis(100)).await;
+            }
+        }
+    };
+    let mut value = current["value"].clone();
+    value["http_port"] = serde_json::json!(REBOUND_HTTP_PORT);
+    client
+        .trigger(
+            TriggerRequest {
+                function_id: "configuration::set".to_string(),
+                payload: serde_json::json!({
+                    "id": harness.config_id,
+                    "value": value,
+                }),
+                action: None,
+                timeout_ms: Some(5_000),
+            }
+            .namespace("default"),
+        )
+        .await
+        .expect("configuration::set failed");
+
+    assert!(
+        wait_for_listen(REBOUND_HTTP_PORT, Duration::from_secs(8)).await,
+        "rebound Console port never started listening"
+    );
+    let rebound = reqwest::get(format!("http://127.0.0.1:{REBOUND_HTTP_PORT}/"))
+        .await
+        .expect("GET / on rebound port failed");
+    assert!(rebound.status().is_success());
+
+    let status = client
+        .trigger(TriggerRequest {
+            function_id: "console::status".to_string(),
+            payload: serde_json::json!({}),
+            action: None,
+            timeout_ms: Some(5_000),
+        })
+        .await
+        .expect("console::status failed after rebind");
+    assert_eq!(status["http_port"], REBOUND_HTTP_PORT);
+
+    let old_deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if TcpStream::connect(("127.0.0.1", HTTP_PORT)).await.is_err() {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < old_deadline,
+            "original Console port kept accepting connections after rebind"
+        );
+        sleep(Duration::from_millis(100)).await;
+    }
+
+    client.shutdown_async().await;
 }
 
 fn parse_first_asset(html: &str) -> Option<String> {

--- a/console/ui/src/injectable-ui-form/index.tsx
+++ b/console/ui/src/injectable-ui-form/index.tsx
@@ -1,6 +1,6 @@
 /**
- * Custom configuration form for the `console` configuration entry — the
- * injectable-UI toggle board.
+ * Custom configuration form for the `console` configuration entry — the live
+ * HTTP port and injectable-UI toggle board.
  *
  * One bordered card per worker that ships injected console UI (or is
  * currently toggled off), showing the worker's title and description with a
@@ -22,7 +22,12 @@
  */
 
 import { useEffect, useMemo, useRef, useState } from 'react'
-import type { ConfigFormProps, Host, JsonValue } from '@iii-dev/console-ui'
+import {
+  Input,
+  type ConfigFormProps,
+  type Host,
+  type JsonValue,
+} from '@iii-dev/console-ui'
 
 type JsonObject = { [key: string]: JsonValue }
 
@@ -65,6 +70,13 @@ function disabledWorkersOf(value: JsonValue): string[] {
   return list.filter((w): w is string => typeof w === 'string')
 }
 
+function httpPortOf(value: JsonValue): string {
+  const port = asObject(value).http_port
+  return typeof port === 'number' || typeof port === 'string'
+    ? String(port)
+    : '3113'
+}
+
 export function InjectableUiConfigForm(
   props: ConfigFormProps & { host: Host },
 ) {
@@ -73,6 +85,7 @@ export function InjectableUiConfigForm(
   const [loadError, setLoadError] = useState<string | null>(null)
 
   const disabled = useMemo(() => disabledWorkersOf(props.value), [props.value])
+  const httpPort = httpPortOf(props.value)
 
   useEffect(() => {
     let cancelled = false
@@ -138,8 +151,14 @@ export function InjectableUiConfigForm(
     })
   }
 
-  // Deep-link focus (`#/workers/configuration/console/injectableUi`): a
-  // custom form honors `focusField` itself.
+  const changeHttpPort = (next: string) => {
+    const value = asObject(props.value)
+    const parsed = /^\d+$/.test(next) ? Number(next) : next
+    props.onChange({ ...value, http_port: parsed })
+  }
+
+  // Deep-link focus (`#/workers/configuration/console/<field>`): a custom
+  // form honors `focusField` itself.
   const rootRef = useRef<HTMLDivElement | null>(null)
   useEffect(() => {
     const field = props.focusField?.[0]
@@ -155,6 +174,32 @@ export function InjectableUiConfigForm(
       <span className="console-ui-form-caption">
         custom form · shipped by the console worker
       </span>
+
+      <div className="console-ui-form-section" data-field="http_port">
+        <label className="console-ui-form-title" htmlFor="console-http-port">
+          HTTP port
+        </label>
+        <span className="console-ui-form-hint">
+          serves the console UI, injected assets, and /ws proxy. saving a new
+          port starts the replacement listener before gracefully closing the
+          old one — no worker restart required.
+        </span>
+        <Input
+          id="console-http-port"
+          className="console-ui-port-input"
+          type="number"
+          inputMode="numeric"
+          min={0}
+          max={65535}
+          step={1}
+          value={httpPort}
+          onChange={changeHttpPort}
+          aria-describedby="console-http-port-hint"
+        />
+        <span id="console-http-port-hint" className="console-ui-form-field-hint">
+          0 asks the operating system to choose an available ephemeral port.
+        </span>
+      </div>
 
       <div className="console-ui-form-section" data-field="injectableUi">
         <span className="console-ui-form-title">Injectable worker UI</span>

--- a/console/ui/styles.css
+++ b/console/ui/styles.css
@@ -36,6 +36,16 @@
   color: var(--color-ink-faint);
   max-width: 60ch;
 }
+[data-iii-ui="console"] .console-ui-port-input {
+  width: min(100%, 180px);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-variant-numeric: tabular-nums;
+}
+[data-iii-ui="console"] .console-ui-form-field-hint {
+  font-size: 11px;
+  line-height: 1.4;
+  color: var(--color-ink-ghost);
+}
 
 /* ── the toggle board: one bordered card per worker ─────────────────── */
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized configuration for the console’s HTTP port and runtime UI preferences.
  * Console port changes now apply live without restarting, with safe fallback behavior if rebinding fails.
  * Added an HTTP port field to the injectable UI settings form, including validation guidance.
  * Console status now reports the currently active port.
* **Bug Fixes**
  * Improved listener replacement to preserve the existing connection when a new port cannot be bound.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->