### PR TITLE
fix(harness): expires_in_ms replacing expires_at in agent guidance

### DIFF
--- a/harness/prompts/default.txt
+++ b/harness/prompts/default.txt
@@ -231,10 +231,12 @@ Explicit `once` always wins, and the response echoes the effective value.
 
 Optional, on either shape:
 
-- `lifecycle: { max_fires: N }` / `{ expires_at: <epoch ms> }` — a delivery budget or a
+- `lifecycle: { max_fires: N }` / `{ expires_in_ms: <ms from now> }` — a delivery budget or a
   deadline. A deadline on a never-fired wake wakes you with an expiry notice instead of
   leaving the session parked forever — ALWAYS set one on any wake your run cannot finish
-  without.
+  without. Use `expires_in_ms`: it is a duration, resolved against the engine's clock. The
+  absolute form `expires_at: <epoch ms>` is still accepted, but you do not know what time it
+  is — a remembered date is in the past and the registration is refused.
 - `conditions: [{ function_id, config? }]` — gates evaluated in order before delivery.
   Each is an ordinary function answering `{ decision: "allow" | "skip", payload?, reason? }`;
   a returned `payload` replaces the event downstream. A condition that errors SKIPS the

--- a/harness/src/functions/subscribe.rs
+++ b/harness/src/functions/subscribe.rs
@@ -457,7 +457,7 @@ fn standing_binding_advisory(req: &SubscribeRequest, once: bool) -> Option<Strin
              dispatched call). This registration still SUCCEEDED. A deadline wants trigger_type \
              \"timer\" with {{ \"in_ms\": <ms> }} (fires once, exactly on time) — or keep this \
              cron and pass `once: true`; a bounded run sets lifecycle \
-             {{ max_fires | expires_at }}; a deliberate forever-cron must be unregistered by \
+             {{ max_fires | expires_in_ms }}; a deliberate forever-cron must be unregistered by \
              your teardown."
         ));
     }
@@ -465,7 +465,7 @@ fn standing_binding_advisory(req: &SubscribeRequest, once: bool) -> Option<Strin
         "note: this call binding is STANDING — it re-runs its call on EVERY future matching \
          event until unregistered. That is the default for a call target (per-event work is \
          what a call binding means); pass `once: true` for a one-shot, and give a standing \
-         binding a lifecycle bound ({ max_fires | expires_at }) or unregister it in your \
+         binding a lifecycle bound ({ max_fires | expires_in_ms }) or unregister it in your \
          teardown so it cannot fire forever."
             .to_string(),
     )
@@ -1004,7 +1004,7 @@ fn armed_wake_advisory(req: &SubscribeRequest, once: bool) -> Option<String> {
          state::delete) on that exact scope/key fires it — a database table or row with the \
          same name does NOT. Double-check that a task you spawned (worker/finalizer) \
          EXPLICITLY sets that exact scope/key when its condition is met, or this session \
-         sleeps forever and its cleanup never runs. Set lifecycle {{ expires_at: <epoch ms> }} \
+         sleeps forever and its cleanup never runs. Set lifecycle {{ expires_in_ms: <ms> }} \
          to be woken with an expiry notice instead if the write never comes."
     ))
 }
@@ -1415,7 +1415,9 @@ mod tests {
             note.contains("database table or row with the same name does NOT"),
             "the medium sentence is the advisory's whole point: {note}"
         );
-        assert!(note.contains("expires_at"), "got: {note}");
+        // The advisory names the field a caller can get right without a clock.
+        assert!(note.contains("expires_in_ms"), "got: {note}");
+        assert!(!note.contains("expires_at"), "got: {note}");
         assert!(note.contains("expiry notice"), "got: {note}");
         // Standing notifies and non-state types are not wakes.
         assert!(armed_wake_advisory(&mk("state", json!({ "key": "k" })), false).is_none());


### PR DESCRIPTION
`lifecycle.expires_in_ms` exists (added on the base branch), but every piece of text a model reads before making the call still said `expires_at`:

- `prompts/default.txt` — the lifecycle line under "Optional, on either shape"
- the unbounded-cron warning — *"a bounded run sets lifecycle `{ max_fires | expires_at }`"*
- the standing-binding note — *"give a standing binding a lifecycle bound (`{ max_fires | expires_at }`)"*
- the one-shot-wake note — *"Set lifecycle `{ expires_at: <epoch ms> }`"*

A model copies the shape it is shown, so it kept sending an absolute epoch. An agent has no clock, so that value is a remembered date — five months stale in the report that prompted this:

```
harness/invalid_request: `lifecycle.expires_at` must be in the future:
1774738800000 is not after 1787778411587 (epoch ms, now).
```

`1774738800000` is 2026-03-28; `now` was 2026-08-26.

## What changes

All four now name `expires_in_ms`. The prompt keeps one sentence on the absolute form — it is still accepted, and anyone reading a stored binding will meet it — but says why not to reach for it: *you do not know what time it is*.

No logic changes. `expires_at` still works, and the seconds rescue and clock-aware refusal on the base branch are untouched.

## Base

Stacked on `feat/agent-terminal-workers`, which is where `expires_in_ms` is introduced (PR #937). Retarget to `main` once that lands, or merge them in order.

## Checks

`cargo test --lib` in `harness/`: 441 pass. One advisory test now asserts the note names `expires_in_ms` and no longer names `expires_at`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)