### PR TITLE
(MOT-4574) fix(shell): stabilize tree collapse and workspace notice

### DIFF
--- a/shell/ui/src/page/FilesTab.tsx
+++ b/shell/ui/src/page/FilesTab.tsx
@@ -21,6 +21,7 @@ import {
   reactivateSelectedFile,
   shouldActivateTreeSelection,
 } from './tree-activation'
+import { expandedDirectoryPaths } from './tree-expansion'
 import { TREE_THEME, TREE_UNSAFE_CSS } from './tree-theme'
 
 /** Directory paths live in the model with a trailing slash; callers key
@@ -140,8 +141,10 @@ export function FilesTab({
   // Expansion state is read back through the dir handles (the model has
   // no expansion events on its public surface): every model notification
   // schedules a debounced snapshot over the known dir paths.
-  const expandedRef = useRef<readonly string[]>(expanded)
-  expandedRef.current = expanded
+  const liveExpandedRef = useRef<readonly string[]>(expanded)
+  useEffect(() => {
+    liveExpandedRef.current = expanded
+  }, [expanded])
   const lastReportedRef = useRef<string>('')
   useEffect(() => {
     if (!kinds) return
@@ -152,24 +155,15 @@ export function FilesTab({
     let timer: number | null = null
     const snapshot = () => {
       timer = null
-      const open: string[] = []
-      for (const path of dirPaths) {
-        const handle = model.getItem(path) ?? model.getItem(`${path}/`)
-        // A method call doesn't narrow the handle union — the literal
-        // `isDirectory(): true` return type needs the explicit cast.
-        if (
-          handle?.isDirectory() &&
-          (handle as FileTreeDirectoryHandle).isExpanded()
-        ) {
-          open.push(path)
-        }
-      }
+      const open = expandedDirectoryPaths(model, dirPaths)
+      liveExpandedRef.current = open
       const key = open.join('\n')
       if (key === lastReportedRef.current) return
       lastReportedRef.current = key
       onExpandedChange(open)
     }
     const unsubscribe = model.subscribe(() => {
+      liveExpandedRef.current = expandedDirectoryPaths(model, dirPaths)
       if (timer != null) window.clearTimeout(timer)
       timer = window.setTimeout(snapshot, EXPAND_SNAPSHOT_MS)
     })
@@ -190,7 +184,7 @@ export function FilesTab({
     lastPathsKeyRef.current = pathsKey
     // The model accepts dir ids in either spelling depending on how the
     // row materialized — hand it both.
-    const initialExpandedPaths = expandedRef.current.flatMap((p) => [
+    const initialExpandedPaths = liveExpandedRef.current.flatMap((p) => [
       p,
       `${p}/`,
     ])
@@ -205,7 +199,7 @@ export function FilesTab({
       const handle = model.getItem(path) ?? model.getItem(`${path}/`)
       if (handle?.isDirectory()) (handle as FileTreeDirectoryHandle).expand()
     }
-  }, [model, pathsKey, expanded])
+  }, [model, expanded])
 
   // Keep the Files tree's selection aligned with the file currently
   // visible in the main pane, including files opened by live follow.

--- a/shell/ui/src/page/__tests__/tree-expansion.test.ts
+++ b/shell/ui/src/page/__tests__/tree-expansion.test.ts
@@ -1,0 +1,42 @@
+import { FileTree, type FileTreeDirectoryHandle } from '@pierre/trees'
+import { describe, expect, it } from 'vitest'
+
+import { expandedDirectoryPaths } from '../tree-expansion'
+
+describe('expandedDirectoryPaths', () => {
+  it('does not restore expanded descendants beneath a collapsed folder', () => {
+    const paths = [
+      'skills/',
+      'skills/watch/',
+      'skills/watch/SKILL.md',
+      'tasklist/',
+      'tasklist/tasks.md',
+    ]
+    const directories = ['skills', 'skills/watch', 'tasklist']
+    const model = new FileTree({
+      paths,
+      initialExpandedPaths: directories,
+    })
+
+    const skills = model.getItem('skills') ?? model.getItem('skills/')
+    expect(skills?.isDirectory()).toBe(true)
+    ;(skills as FileTreeDirectoryHandle).collapse()
+
+    const expanded = expandedDirectoryPaths(model, directories)
+    expect(expanded).toEqual(['tasklist'])
+
+    model.resetPaths([...paths, 'README.md'], {
+      initialExpandedPaths: expanded.flatMap((path) => [path, `${path}/`]),
+    })
+
+    const refreshedSkills = model.getItem('skills') ?? model.getItem('skills/')
+    const refreshedTasklist =
+      model.getItem('tasklist') ?? model.getItem('tasklist/')
+    expect((refreshedSkills as FileTreeDirectoryHandle).isExpanded()).toBe(
+      false,
+    )
+    expect((refreshedTasklist as FileTreeDirectoryHandle).isExpanded()).toBe(
+      true,
+    )
+  })
+})

--- a/shell/ui/src/page/__tests__/working-dir-scope.test.ts
+++ b/shell/ui/src/page/__tests__/working-dir-scope.test.ts
@@ -31,10 +31,10 @@ describe('Shell and chat working-directory scope', () => {
 
   it('states both scopes clearly', () => {
     expect(workingDirectoryScopeMessage('/new', '/old')).toBe(
-      'Browsing /new; chat still works in /old.',
+      'Browsing /new. Chat still works in /old.',
     )
     expect(workingDirectoryScopeMessage('/new', null)).toBe(
-      'Browsing /new; chat has no working directory.',
+      'Browsing /new. Chat has no working directory yet.',
     )
   })
 })

--- a/shell/ui/src/page/tree-expansion.ts
+++ b/shell/ui/src/page/tree-expansion.ts
@@ -1,0 +1,31 @@
+import type { FileTree, FileTreeDirectoryHandle } from '@pierre/trees'
+
+export function expandedDirectoryPaths(
+  model: Pick<FileTree, 'getItem'>,
+  directoryPaths: Iterable<string>,
+): string[] {
+  const paths = [...directoryPaths]
+  const knownPaths = new Set(paths)
+  const expandedPaths = new Set<string>()
+
+  for (const path of paths) {
+    const handle = model.getItem(path) ?? model.getItem(`${path}/`)
+    if (
+      handle?.isDirectory() &&
+      (handle as FileTreeDirectoryHandle).isExpanded()
+    ) {
+      expandedPaths.add(path)
+    }
+  }
+
+  return paths.filter((path) => {
+    if (!expandedPaths.has(path)) return false
+
+    const segments = path.split('/')
+    for (let end = 1; end < segments.length; end++) {
+      const ancestor = segments.slice(0, end).join('/')
+      if (knownPaths.has(ancestor) && !expandedPaths.has(ancestor)) return false
+    }
+    return true
+  })
+}

--- a/shell/ui/src/page/working-dir-scope.ts
+++ b/shell/ui/src/page/working-dir-scope.ts
@@ -17,6 +17,6 @@ export function workingDirectoryScopeMessage(
   workingDir: string | null | undefined,
 ): string {
   return workingDir
-    ? `Browsing ${root}; chat still works in ${workingDir}.`
-    : `Browsing ${root}; chat has no working directory.`
+    ? `Browsing ${root}. Chat still works in ${workingDir}.`
+    : `Browsing ${root}. Chat has no working directory yet.`
 }

--- a/shell/ui/styles.css
+++ b/shell/ui/styles.css
@@ -1740,6 +1740,48 @@
   justify-content: flex-end;
   gap: 4px;
 }
+[data-iii-ui="shell"] .shui-review-message:has(.shui-review-inline-action) {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  margin: 8px 10px 0;
+  padding: 10px 12px;
+  color: var(--color-ink-faint);
+  font-family: var(--font-sans);
+  border: 1px solid var(--color-edge);
+  border-radius: 6px;
+  background: var(--color-surface);
+}
+[data-iii-ui="shell"]
+  .shui-review-message:has(.shui-review-inline-action)
+  > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+[data-iii-ui="shell"] .shui-review-inline-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 28px;
+  padding: 4px 9px;
+  color: var(--color-ink);
+  font: 500 12px / 16px var(--font-sans);
+  text-transform: capitalize;
+  white-space: nowrap;
+  border: 1px solid var(--color-edge);
+  border-radius: 5px;
+  background: var(--color-bg);
+  cursor: pointer;
+}
+[data-iii-ui="shell"] .shui-review-inline-action:hover {
+  background: var(--color-surface-hover);
+}
+[data-iii-ui="shell"] .shui-review-inline-action:focus-visible {
+  outline: 1px solid var(--color-rule-focus);
+  outline-offset: 1px;
+}
 [data-iii-ui="shell"] .shui-review-diff {
   display: block;
 }
@@ -2959,6 +3001,23 @@
 
   [data-iii-ui='shell'] .shui-browser-list {
     grid-template-columns: 1fr;
+  }
+
+  [data-iii-ui='shell']
+    .shui-review-message:has(.shui-review-inline-action) {
+    grid-template-columns: minmax(0, 1fr);
+    align-items: start;
+  }
+
+  [data-iii-ui='shell']
+    .shui-review-message:has(.shui-review-inline-action)
+    > span {
+    overflow-wrap: anywhere;
+    white-space: normal;
+  }
+
+  [data-iii-ui='shell'] .shui-review-inline-action {
+    justify-self: start;
   }
 }
 


### PR DESCRIPTION
## Summary

- keep collapsed folders closed when the Shell file tree refreshes after filesystem changes
- discard stale expanded descendants beneath a collapsed ancestor before replaying tree state
- replace the cramped Shell and chat working-directory warning with clearer copy and a responsive action card

## Root cause

The tree persisted expansion state on a debounce. A filesystem refresh could reset the tree before the latest collapse snapshot was reported, and nested directory handles could still carry expanded state that reopened their parent.

The fix tracks the live model state synchronously, normalizes descendants beneath collapsed folders, and uses that snapshot during `resetPaths`.

## Verification

- [x] Shell UI test suite: 34 files, 334 tests passed
- [x] Shell UI production build: TypeScript check and bundle passed
- [x] Harness Console: collapsing a folder followed by a real filesystem refresh leaves it collapsed
- [x] Harness Console: working-directory mismatch copy wraps cleanly and keeps `Use for chat` as a separate action at split-panel width
- [x] `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * File tree expansion state is now preserved more reliably when navigating, refreshing, or updating directory contents.
  * Collapsed folders remain collapsed while expanded folders continue to be restored appropriately.
  * Working-directory messages now use clearer, more consistent wording.

* **Style**
  * Review messages now support inline actions with improved borders, hover and focus states, truncation, and responsive stacking on smaller screens.

* **Tests**
  * Added coverage for directory expansion restoration and updated working-directory message expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->