### PR TITLE
Improve Harness tool contract recovery

### DIFF
--- a/harness/prompts/default.txt
+++ b/harness/prompts/default.txt
@@ -108,6 +108,10 @@ WRONG is a string. RIGHT is an object. Always send an object.
 - `function_not_found` → the id is wrong. Find the replacement through the active discovery path from Step 1.
   Do not retry the bad id.
 - An error with a `code` and a `fix` hint → do what the `fix` says.
+- A result that comes back `rejected` with field-level guidance (exact field
+  names and formats) → apply the guidance in exactly ONE corrective call to the
+  SAME function. Do not re-list the registry or re-fetch the contract to recover
+  from a rejection; the guidance is the correction.
 - A timeout or transport error that repeats → stop retrying the same way. Make the call
   simpler, split the work, or report the blocker and stop.
 

--- a/harness/prompts/subagent.txt
+++ b/harness/prompts/subagent.txt
@@ -53,7 +53,10 @@ RIGHT  payload: { "scope": "run-a1", "key": "result", "value": { "n": 42 } }
 
 On an error: read it, change something, call again. Never resend the same `function` +
 `payload` unchanged. `invalid_arguments` / `missing field` → fix the payload against the
-contract. `function_not_found` → re-check the id with `engine::functions::list`.
+contract. `function_not_found` → re-check the id with `engine::functions::list`. A
+`rejected` result with field-level guidance → apply the guidance in one
+corrective call to the same function; do not re-list the registry or re-fetch
+the contract.
 
 # The deliverable
 

--- a/harness/src/discovery.rs
+++ b/harness/src/discovery.rs
@@ -107,23 +107,30 @@ pub async fn apply(cell: &FunctionsCell, functions: Vec<FunctionDescriptor>) {
     });
 }
 
-/// The already-hydrated `id -> parameters` map from the current snapshot,
-/// used to carry schemas forward across a reload without re-fetching.
-async fn prev_params(cell: &FunctionsCell) -> HashMap<String, Value> {
+/// The already-known `id -> descriptor` map from the current snapshot, used to
+/// carry schemas forward across a reload without re-fetching — and to spot a
+/// tool whose list-visible descriptor changed since the last reload (a
+/// mid-session contract mutation), whose cached schema must be invalidated
+/// instead of carried forward.
+async fn prev_descriptors(cell: &FunctionsCell) -> HashMap<String, FunctionDescriptor> {
     cell.read()
         .await
         .functions
         .iter()
-        .filter_map(|d| d.parameters.clone().map(|p| (d.function_id.clone(), p)))
+        .map(|d| (d.function_id.clone(), d.clone()))
         .collect()
 }
 
-/// Carry a prior `parameters` forward for any id still `None`; report the ids
-/// that need an `engine::functions::info` fan-out. Every descriptor is retained
-/// in the output — a still-`None` one is flagged for fetch, never dropped.
+/// Carry a prior `parameters` forward for any id still `None` whose list-visible
+/// descriptor is unchanged since the last reload; report the ids that need an
+/// `engine::functions::info` fan-out — new ids, still-schema-less ids, and ids
+/// whose descriptor changed (a mid-session contract mutation: the cached
+/// contract metadata is stale and must be invalidated, so the next `info`
+/// returns the live required fields). Every descriptor is retained in the
+/// output — a still-`None` one is flagged for fetch, never dropped.
 fn plan_hydration(
     functions: Vec<FunctionDescriptor>,
-    prev: &HashMap<String, Value>,
+    prev: &HashMap<String, FunctionDescriptor>,
 ) -> (Vec<FunctionDescriptor>, Vec<String>) {
     let mut needs_fetch = Vec::new();
     let carried = functions
@@ -131,8 +138,20 @@ fn plan_hydration(
         .map(|mut d| {
             if d.parameters.is_none() {
                 match prev.get(&d.function_id) {
-                    Some(p) => d.parameters = Some(p.clone()),
-                    None => needs_fetch.push(d.function_id.clone()),
+                    // Same id survived the reload with an unchanged list-visible
+                    // descriptor AND a cached schema: the contract is still
+                    // live — carry the parameters forward without a re-fetch.
+                    Some(p) if p.description == d.description => {
+                        if let Some(params) = &p.parameters {
+                            d.parameters = Some(params.clone());
+                        } else {
+                            needs_fetch.push(d.function_id.clone());
+                        }
+                    }
+                    // New id, previously schema-less, or a changed descriptor
+                    // (list-visible mutation): the cached parameters — if any —
+                    // may be stale; invalidate them and fetch the live contract.
+                    _ => needs_fetch.push(d.function_id.clone()),
                 }
             }
             d
@@ -145,17 +164,17 @@ fn plan_hydration(
 const INFO_BATCH_MAX: usize = 32;
 
 /// Fill each descriptor's `parameters`, carrying already-hydrated schemas
-/// forward and fetching only new/unresolved ids — one `engine::functions::info`
-/// `function_ids` batch per 32 ids, with a per-id fallback for engines that
-/// predate batch support. A per-id failure keeps the descriptor with
-/// `parameters: None`.
+/// forward for unchanged ids and fetching new, unresolved, or mutated ids — one
+/// `engine::functions::info` `function_ids` batch per 32 ids, with a per-id
+/// fallback for engines that predate batch support. A per-id failure keeps the
+/// descriptor with `parameters: None`.
 // ponytail: engine include_schemas-on-list would replace this with the one list call reload already makes
 async fn hydrate(
     engine: &EngineClient,
     cell: &FunctionsCell,
     functions: Vec<FunctionDescriptor>,
 ) -> Vec<FunctionDescriptor> {
-    let prev = prev_params(cell).await;
+    let prev = prev_descriptors(cell).await;
     let (mut carried, needs_fetch) = plan_hydration(functions, &prev);
     if needs_fetch.is_empty() {
         return carried;
@@ -359,9 +378,12 @@ mod tests {
 
     #[test]
     fn plan_hydration_carries_forward_and_retains_unresolved() {
-        let prev: HashMap<String, Value> = [("a::b".to_string(), json!({ "type": "object" }))]
-            .into_iter()
-            .collect();
+        let prev: HashMap<String, FunctionDescriptor> = [(
+            "a::b".to_string(),
+            desc("a::b", Some(json!({ "type": "object" }))),
+        )]
+        .into_iter()
+        .collect();
         let (carried, needs_fetch) =
             plan_hydration(vec![desc("a::b", None), desc("c::d", None)], &prev);
 
@@ -373,5 +395,34 @@ mod tests {
         let c = carried.iter().find(|d| d.function_id == "c::d").unwrap();
         assert_eq!(c.parameters, None);
         assert_eq!(needs_fetch, vec!["c::d".to_string()]);
+    }
+
+    #[test]
+    fn plan_hydration_invalidates_a_mutated_tool_s_cached_contract() {
+        // Same id, changed list-visible descriptor (a mid-session contract
+        // mutation, e.g. a migration resolver registering a new tool version):
+        // the cached parameters must NOT be carried forward — the id is flagged
+        // for a live `engine::functions::info` re-fetch so the next read gets
+        // the live required fields instead of the stale schema.
+        let prev: HashMap<String, FunctionDescriptor> = [(
+            "calendar::schedule".to_string(),
+            desc("calendar::schedule", Some(json!({ "type": "object" }))),
+        )]
+        .into_iter()
+        .collect();
+        let mut mutated = desc("calendar::schedule", None);
+        mutated.description = Some("v2 migrated scheduler".to_string());
+
+        let (carried, needs_fetch) = plan_hydration(vec![mutated], &prev);
+
+        let out = carried
+            .iter()
+            .find(|d| d.function_id == "calendar::schedule")
+            .unwrap();
+        assert_eq!(
+            out.parameters, None,
+            "stale cached contract must be invalidated, not carried forward"
+        );
+        assert_eq!(needs_fetch, vec!["calendar::schedule".to_string()]);
     }
 }

--- a/harness/src/policy.rs
+++ b/harness/src/policy.rs
@@ -198,7 +198,7 @@ pub fn agent_trigger_schema() -> AgentFunction {
                       Only when it is absent, discover what is callable at runtime via engine::functions::list. \
                       Before first use, get selected contracts with engine::functions::info. Ordinary calls in one \
                       assistant response execute sequentially in content order. For independent same-function \
-                      work, use that function's supported bulk input."
+                      work, use that function's supported bulk input. When a target returns a rejected result carrying field-level guidance, apply that guidance in exactly one corrective call to the same target; do not re-list the registry or re-fetch its contract."
                 .to_string(),
         parameters: json!({
             "type": "object",
@@ -640,6 +640,18 @@ mod tests {
         );
         assert!(description.contains("independent same-function work"));
         assert!(description.contains("supported bulk input"));
+    }
+
+    #[test]
+    fn agent_trigger_schema_maps_rejection_guidance_to_one_corrective_call() {
+        // A rejected result carrying field-level guidance is a payload
+        // correction, not a discovery failure: apply it in exactly one
+        // corrective call to the same target instead of re-listing the registry
+        // or re-fetching the contract (the rejection/refetch churn loop).
+        let description = agent_trigger_schema().description;
+        assert!(description.contains("rejected result carrying field-level guidance"));
+        assert!(description.contains("exactly one corrective call to the same target"));
+        assert!(description.contains("do not re-list the registry"));
     }
 
     #[test]

--- a/harness/src/prompt/tests.rs
+++ b/harness/src/prompt/tests.rs
@@ -252,6 +252,20 @@ fn error_driven_correction() {
     assert!(out.contains("function_not_found"));
     assert!(out.contains("A timeout or transport error that repeats"));
 }
+#[test]
+fn rejected_result_guidance_maps_to_one_corrective_call() {
+    // A rejected result carrying field-level guidance is a payload
+    // correction, not a discovery failure: apply it in exactly one
+    // corrective call to the same function instead of re-listing the
+    // registry or re-fetching the contract (the rejection/refetch churn
+    // loop). Both identities must teach it.
+    for out in [variants::DEFAULT, variants::SUBAGENT] {
+        let normalized = out.replace('\n', " ").to_lowercase();
+        assert!(normalized.contains("field-level guidance"));
+        assert!(normalized.contains("corrective call"));
+        assert!(normalized.contains("do not re-list the registry"));
+    }
+}
 
 #[test]
 fn registry_flow() {

--- a/harness/src/turn_loop.rs
+++ b/harness/src/turn_loop.rs
@@ -3096,7 +3096,7 @@ fn patch_orphaned_calls(messages: &mut Vec<Value>) -> usize {
 
 /// The single-line notice delivered as a tail message when the registry
 /// changed under a session that had already acknowledged an earlier generation.
-const REGISTRY_CHANGED_NOTICE: &str = "NOTE: the function registry changed during this conversation. Function contracts fetched earlier may be stale — re-fetch the contracts you rely on (engine::functions::info) before calling those functions again.";
+const REGISTRY_CHANGED_NOTICE: &str = "NOTE: the function registry changed during this conversation. A contract you fetched earlier may be stale for the affected function — before calling it again, re-fetch ONLY that function's contract (engine::functions::info; batch several ids in one call if needed); do not re-list the whole registry. If a call returns a rejected result carrying field-level guidance, apply that guidance in exactly one corrective call to the same function — never re-send an unchanged rejected call.";
 
 /// Wrap the notice as an ephemeral tail user message for the generate request.
 /// `timestamp` is mandatory — the router's message types have no serde default


### PR DESCRIPTION
## Summary

- rehydrate the exact discovered tool contract when its visible registry descriptor changes during a session
- narrow registry-mutation recovery to the affected tool instead of repeating registry-wide discovery
- guide the Harness to apply field-level rejected-result feedback with one corrective call to the same function
- add prompt and policy regression coverage for the recovery behavior

## Deterministic validation

The protected improvement supervisor produced this exact commit from workers base cfe281a6a39d6b22d1b0ed4d9a2c280f78a654de. The candidate passed:

- cargo fmt --all
- cargo clippy --workspace --all-targets --exclude harness-e2e -- -D warnings
- cargo test --workspace --exclude harness-e2e
- cargo build --release -p harness
- diff policy: 6 files, 105 additions, 21 deletions

The first check round found one case-sensitive assertion; the bounded repair round fixed it and all checks then passed.

## Live five-sample comparison

For tool_contract_recovery, baseline to candidate medians changed as follows:

- function calls: 10 to 7 (-30%)
- turns: 10 to 7 (-30%)
- wall time: 139.4s to 50.8s (-63.6%)
- total tokens: 22,473 to 14,452 (-35.7%)
- work amplification: 3.33 to 2.33 (-30%)
- structural integrity: 40% to 40%

## Blocking regression — do not merge

The deterministic supervisor rejected this candidate because secret_hygiene regressed:

- structural integrity: 60% to 20%
- median function calls: 3 to 4 (+33.3%)
- median work amplification: 2.33 to 3.0 (+28.6%)

This draft preserves the candidate for review and follow-up. It must not be made ready or merged until the regression is corrected and the same frozen five-sample cohort passes again. Judge and Advisor output were consultative; the rejection came from deterministic gates and longitudinal metrics.