### PR TITLE
fix(shell): keep gitignored workspace writes out of the live review

### DIFF
--- a/shell/src/events.rs
+++ b/shell/src/events.rs
@@ -185,11 +185,17 @@ pub(crate) async fn git_ignored<'a>(
     else {
         return HashSet::new();
     };
-    if let Some(mut stdin) = child.stdin.take() {
-        use tokio::io::AsyncWriteExt;
-        let _ = stdin.write_all(&input).await;
-    }
-    let Ok(out) = child.wait_with_output().await else {
+    let stdin = child.stdin.take();
+    let writer = tokio::spawn(async move {
+        if let Some(mut stdin) = stdin {
+            use tokio::io::AsyncWriteExt;
+            let _ = stdin.write_all(&input).await;
+            let _ = stdin.shutdown().await;
+        }
+    });
+    let output = child.wait_with_output().await;
+    let _ = writer.await;
+    let Ok(out) = output else {
         return HashSet::new();
     };
     out.stdout

--- a/shell/src/events.rs
+++ b/shell/src/events.rs
@@ -13,8 +13,9 @@
 //! short window before emitting. Emission is best-effort: a slow or
 //! absent subscriber must never delay anything.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::process::Stdio;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -53,6 +54,10 @@ pub struct ChangedEvent {
     /// files must skip these. Deleted paths can't be probed and report
     /// false.
     pub dir: bool,
+    /// True when git ignores the path under `root` — build output, a
+    /// dependency tree, a worker's own store. A root that is not a
+    /// repository reports false for everything.
+    pub ignored: bool,
 }
 
 struct WatchEntry {
@@ -155,6 +160,46 @@ pub(crate) fn merge_kinds(prev: &'static str, next: &'static str) -> &'static st
     }
 }
 
+/// The subset of root-relative `paths` git ignores under `root`. A root
+/// that is not a repository, or a host without git, ignores nothing.
+pub(crate) async fn git_ignored<'a>(
+    root: &Path,
+    paths: impl Iterator<Item = &'a String>,
+) -> HashSet<String> {
+    let mut input = Vec::new();
+    for rel in paths {
+        input.extend_from_slice(rel.as_bytes());
+        input.push(0);
+    }
+    if input.is_empty() {
+        return HashSet::new();
+    }
+    let Ok(mut child) = tokio::process::Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["check-ignore", "--stdin", "-z"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+    else {
+        return HashSet::new();
+    };
+    if let Some(mut stdin) = child.stdin.take() {
+        use tokio::io::AsyncWriteExt;
+        let _ = stdin.write_all(&input).await;
+    }
+    let Ok(out) = child.wait_with_output().await else {
+        return HashSet::new();
+    };
+    out.stdout
+        .split(|b| *b == 0)
+        .filter_map(|chunk| std::str::from_utf8(chunk).ok())
+        .filter(|rel| !rel.is_empty())
+        .map(str::to_owned)
+        .collect()
+}
+
 /// Relative to the watched root; `None` for the root itself or paths
 /// outside it.
 fn rel_to(root: &Path, path: &Path) -> Option<String> {
@@ -212,13 +257,16 @@ async fn pump(
                 () = &mut window => break,
             }
         }
+        let ignored_paths = git_ignored(&root, batch.keys()).await;
         for (path, kind) in batch.drain() {
             let dir = kind != "deleted" && root.join(&path).is_dir();
+            let ignored = ignored_paths.contains(&path);
             let event = ChangedEvent {
                 path,
                 kind: kind.to_string(),
                 root: root_str.clone(),
                 dir,
+                ignored,
             };
             let payload = match serde_json::to_value(&event) {
                 Ok(v) => v,
@@ -329,6 +377,48 @@ pub fn register_changed_trigger(iii: &IIIClient, resolver: ResolverCell) {
 
 #[cfg(test)]
 mod tests {
+    #[tokio::test]
+    async fn git_ignored_reports_only_the_ignored_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let git = |args: &[&str]| {
+            let status = std::process::Command::new("git")
+                .arg("-C")
+                .arg(root)
+                .args(args)
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status()
+                .unwrap();
+            assert!(status.success(), "git {args:?}");
+        };
+        git(&["init", "-q"]);
+        std::fs::write(
+            root.join(".gitignore"),
+            "data/
+*.log
+",
+        )
+        .unwrap();
+        let paths = [
+            "data/session-manager/a.jsonl".to_string(),
+            "build.log".to_string(),
+            "src/main.rs".to_string(),
+        ];
+        let ignored = super::git_ignored(root, paths.iter()).await;
+        assert!(ignored.contains("data/session-manager/a.jsonl"));
+        assert!(ignored.contains("build.log"));
+        assert!(!ignored.contains("src/main.rs"));
+    }
+
+    #[tokio::test]
+    async fn git_ignored_is_empty_outside_a_repository() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = ["data/a.jsonl".to_string()];
+        let ignored = super::git_ignored(dir.path(), paths.iter()).await;
+        assert!(ignored.is_empty());
+    }
+
     use super::*;
     use serde_json::json;
 

--- a/shell/src/turn_observe.rs
+++ b/shell/src/turn_observe.rs
@@ -17,13 +17,14 @@
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::process::Stdio;
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 
 use notify::{RecursiveMode, Watcher};
 
-use crate::events::{is_git_internal, is_noise_kind, is_own_temp, kind_of, merge_kinds};
+use crate::events::{
+    git_ignored, is_git_internal, is_noise_kind, is_own_temp, kind_of, merge_kinds,
+};
 use crate::turns::TurnLog;
 
 /// Raw OS events batch this long before folding into the record.
@@ -236,38 +237,9 @@ async fn ignored_set<'a>(root: &Path, paths: impl Iterator<Item = &'a String>) -
                 .map(|rel| (rel.to_string_lossy().into_owned(), abs))
         })
         .collect();
-    if rels.is_empty() {
-        return HashSet::new();
-    }
-    let Ok(mut child) = tokio::process::Command::new("git")
-        .arg("-C")
-        .arg(root)
-        .args(["check-ignore", "--stdin", "-z"])
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-    else {
-        return HashSet::new();
-    };
-    if let Some(mut stdin) = child.stdin.take() {
-        use tokio::io::AsyncWriteExt;
-        let mut input = Vec::new();
-        for (rel, _) in &rels {
-            input.extend_from_slice(rel.as_bytes());
-            input.push(0);
-        }
-        let _ = stdin.write_all(&input).await;
-    }
-    let Ok(out) = child.wait_with_output().await else {
-        return HashSet::new();
-    };
-    let by_rel: HashMap<&str, &String> =
-        rels.iter().map(|(rel, abs)| (rel.as_str(), *abs)).collect();
-    out.stdout
-        .split(|b| *b == 0)
-        .filter_map(|chunk| std::str::from_utf8(chunk).ok())
-        .filter(|rel| !rel.is_empty())
-        .filter_map(|rel| by_rel.get(rel).map(|abs| (*abs).clone()))
+    let ignored = git_ignored(root, rels.iter().map(|(rel, _)| rel)).await;
+    rels.into_iter()
+        .filter(|(rel, _)| ignored.contains(rel))
+        .map(|(_, abs)| abs.clone())
         .collect()
 }

--- a/shell/ui/src/page/__tests__/live-review-ignore.test.ts
+++ b/shell/ui/src/page/__tests__/live-review-ignore.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { onlyIgnoredChanges } from '../live-review'
+import { type ReviewEntry, sameReviewEntry } from '../review'
+
+describe('onlyIgnoredChanges', () => {
+  it('is true only when a non-empty burst is entirely ignored', () => {
+    const ignored = new Set(['/w/data/a.jsonl', '/w/data/b.json'])
+    expect(onlyIgnoredChanges(['/w/data/a.jsonl', '/w/data/b.json'], ignored)).toBe(
+      true,
+    )
+    expect(onlyIgnoredChanges(['/w/data/a.jsonl', '/w/src/main.rs'], ignored)).toBe(
+      false,
+    )
+    expect(onlyIgnoredChanges([], ignored)).toBe(false)
+  })
+})
+
+describe('sameReviewEntry', () => {
+  const entry: ReviewEntry = {
+    path: 'src/main.rs',
+    change: { path: 'src/main.rs', status: 'modified', staged: false },
+    baseline: null,
+    before: { kind: 'head', path: 'src/main.rs' },
+    after: { kind: 'worktree', path: 'src/main.rs' },
+  }
+
+  it('is true for an entry git reported identically', () => {
+    expect(
+      sameReviewEntry({ ...entry, change: { ...entry.change } }, entry),
+    ).toBe(true)
+  })
+
+  it('is false without a previous entry or when status, staging, or sources move', () => {
+    expect(sameReviewEntry(undefined, entry)).toBe(false)
+    expect(
+      sameReviewEntry(
+        { ...entry, change: { ...entry.change, staged: true } },
+        entry,
+      ),
+    ).toBe(false)
+    expect(
+      sameReviewEntry(
+        { ...entry, change: { ...entry.change, status: 'added' } },
+        entry,
+      ),
+    ).toBe(false)
+    expect(
+      sameReviewEntry({ ...entry, before: { kind: 'empty' } }, entry),
+    ).toBe(false)
+    expect(
+      sameReviewEntry(
+        {
+          ...entry,
+          before: { kind: 'revision', revision: 'abc', path: 'src/main.rs' },
+        },
+        {
+          ...entry,
+          before: { kind: 'revision', revision: 'def', path: 'src/main.rs' },
+        },
+      ),
+    ).toBe(false)
+  })
+})

--- a/shell/ui/src/page/__tests__/live-review-ignore.test.ts
+++ b/shell/ui/src/page/__tests__/live-review-ignore.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { onlyIgnoredChanges } from '../live-review'
+import { onlyIgnoredChanges, trackIgnoredPath } from '../live-review'
 import { type ReviewEntry, sameReviewEntry } from '../review'
 
 describe('onlyIgnoredChanges', () => {
@@ -12,6 +12,18 @@ describe('onlyIgnoredChanges', () => {
       false,
     )
     expect(onlyIgnoredChanges([], ignored)).toBe(false)
+  })
+})
+
+describe('trackIgnoredPath', () => {
+  it('keeps the latest verdict when a path flips within one burst', () => {
+    const ignored = new Set<string>()
+    trackIgnoredPath(ignored, '/w/data/a.jsonl', true)
+    expect(ignored.has('/w/data/a.jsonl')).toBe(true)
+    trackIgnoredPath(ignored, '/w/data/a.jsonl', false)
+    expect(ignored.has('/w/data/a.jsonl')).toBe(false)
+    trackIgnoredPath(ignored, '/w/src/main.rs', false)
+    expect(ignored.size).toBe(0)
   })
 })
 

--- a/shell/ui/src/page/index.tsx
+++ b/shell/ui/src/page/index.tsx
@@ -114,7 +114,11 @@ import {
 } from './git'
 import { HoverTip } from './HoverTip'
 import { useWorkspaceChanges } from './live'
-import { normalizeLiveReviewEvent, onlyIgnoredChanges } from './live-review'
+import {
+  normalizeLiveReviewEvent,
+  onlyIgnoredChanges,
+  trackIgnoredPath,
+} from './live-review'
 import { parseShellPanelContext } from './panel-context'
 import {
   createTabUiStateSaver,
@@ -1929,7 +1933,7 @@ export function ShellExplorerPage({
     if (isShellUiStatePath(event.path)) return
     const eventAbs = joinPath(event.root, event.path)
     changedAbsRef.current.set(eventAbs, event.kind)
-    if (event.ignored === true) ignoredAbsRef.current.add(eventAbs)
+    trackIgnoredPath(ignoredAbsRef.current, eventAbs, event.ignored === true)
     // Directories refresh the tree but must never open as files —
     // reading one is a C210.
     if (event.dir === true) {

--- a/shell/ui/src/page/index.tsx
+++ b/shell/ui/src/page/index.tsx
@@ -114,7 +114,7 @@ import {
 } from './git'
 import { HoverTip } from './HoverTip'
 import { useWorkspaceChanges } from './live'
-import { normalizeLiveReviewEvent } from './live-review'
+import { normalizeLiveReviewEvent, onlyIgnoredChanges } from './live-review'
 import { parseShellPanelContext } from './panel-context'
 import {
   createTabUiStateSaver,
@@ -144,6 +144,7 @@ import {
   mergeReviewEntry,
   reviewContentsRepresentChange,
   type ReviewEntry,
+  sameReviewEntry,
 } from './review'
 import {
   DEFAULT_REVIEW_SCOPE,
@@ -1309,6 +1310,7 @@ export function ShellExplorerPage({
   const changedAbsRef = useRef<Map<string, string>>(new Map())
   const reviewEligibleAbsRef = useRef<Set<string>>(new Set())
   const changedDirsRef = useRef<Set<string>>(new Set())
+  const ignoredAbsRef = useRef<Set<string>>(new Set())
 
   const reloadActiveFile = useCallback(() => {
     const currentRoot = rootRef.current
@@ -1527,10 +1529,11 @@ export function ShellExplorerPage({
     (
       scope: Exclude<ReviewScopeSelection, { kind: 'last-turn' }>,
       preferredPath?: string | null,
+      options?: { touched: ReadonlySet<string> },
     ) => {
       if (root === null) return
       const seq = ++scopeLoadSeqRef.current
-      setScopeLoading(true)
+      if (options === undefined) setScopeLoading(true)
       setScopeError(null)
       setTurnOutside(0)
       setTurnOutsideRoot(null)
@@ -1693,6 +1696,7 @@ export function ShellExplorerPage({
             return
           }
           const next = reviewEntriesFromGit(state.changes)
+          const previousEntries = scopeEntriesRef.current
           scopeEntriesRef.current = next
           setScopeEntries(next)
           if (isLiveGitReviewScope(scope)) {
@@ -1708,8 +1712,14 @@ export function ShellExplorerPage({
             (preferredPath === undefined
               ? next.values().next().value
               : undefined)
-          if (entry) openReviewEntry(entry)
-          else {
+          if (entry) {
+            const settled =
+              options !== undefined &&
+              entry.path === activePath &&
+              !options.touched.has(entry.path) &&
+              sameReviewEntry(previousEntries.get(entry.path), entry)
+            if (!settled) openReviewEntry(entry)
+          } else {
             diffRequestRef.current += 1
             setDiff(null)
           }
@@ -1919,6 +1929,7 @@ export function ShellExplorerPage({
     if (isShellUiStatePath(event.path)) return
     const eventAbs = joinPath(event.root, event.path)
     changedAbsRef.current.set(eventAbs, event.kind)
+    if (event.ignored === true) ignoredAbsRef.current.add(eventAbs)
     // Directories refresh the tree but must never open as files —
     // reading one is a C210.
     if (event.dir === true) {
@@ -1965,7 +1976,7 @@ export function ShellExplorerPage({
           treeRef.current === null ? null : new Set(treeRef.current.paths)
         const kindsBefore = treeRef.current?.kinds
         reloadActiveFile()
-        const follow = followRef.current
+        const pendingFollow = followRef.current
         followRef.current = null
         const changed = changedAbsRef.current
         changedAbsRef.current = new Map()
@@ -1973,25 +1984,29 @@ export function ShellExplorerPage({
         reviewEligibleAbsRef.current = new Set()
         const changedDirs = changedDirsRef.current
         changedDirsRef.current = new Set()
+        const ignoredAbs = ignoredAbsRef.current
+        ignoredAbsRef.current = new Set()
         const currentRoot = rootRef.current
         if (currentRoot === null) return
 
         const prefix = currentRoot.endsWith('/')
           ? currentRoot
           : `${currentRoot}/`
-        const fileEvents = [...changed]
-          .filter(
-            ([abs]) =>
-              reviewEligible.has(abs) &&
-              !changedDirs.has(abs) &&
-              abs.startsWith(prefix),
-          )
+        const changedFiles = [...changed]
+          .filter(([abs]) => !changedDirs.has(abs) && abs.startsWith(prefix))
           .map(([abs, rawKind]) => ({
             abs,
             rawKind,
             rel: abs.slice(prefix.length),
           }))
           .filter(({ rel }) => reviewablePath(rel))
+        const fileEvents = changedFiles.filter(
+          ({ abs }) => reviewEligible.has(abs) && !ignoredAbs.has(abs),
+        )
+        const follow =
+          pendingFollow !== null && !ignoredAbs.has(prefix + pendingFollow.rel)
+            ? pendingFollow
+            : null
 
         // A lazily fetched subtree with a change under it is stale —
         // drop it; the load effect refetches while it stays expanded.
@@ -2010,6 +2025,13 @@ export function ShellExplorerPage({
           return next ?? prev
         })
         refreshTree()
+        if (
+          onlyIgnoredChanges(
+            changedFiles.map(({ abs }) => abs),
+            ignoredAbs,
+          )
+        )
+          return
         const followTicket = diffRequestRef.current
         void Promise.all([
           coderStatFiles(
@@ -2130,7 +2152,9 @@ export function ShellExplorerPage({
             return
           }
           if (isLiveGitReviewScope(activeScope)) {
-            loadReviewScope(activeScope, follow?.rel ?? null)
+            loadReviewScope(activeScope, follow?.rel ?? null, {
+              touched: new Set(fileEvents.map(({ rel }) => rel)),
+            })
             return
           }
           if (

--- a/shell/ui/src/page/live-review.ts
+++ b/shell/ui/src/page/live-review.ts
@@ -68,6 +68,15 @@ export function normalizeLiveReviewEvent(input: LiveReviewEventInput): LiveRevie
     : { action: 'modified', path: input.path, baseline: undefined }
 }
 
+export function trackIgnoredPath(
+  ignored: Set<string>,
+  abs: string,
+  isIgnored: boolean,
+): void {
+  if (isIgnored) ignored.add(abs)
+  else ignored.delete(abs)
+}
+
 export function onlyIgnoredChanges(
   paths: readonly string[],
   ignored: ReadonlySet<string>,

--- a/shell/ui/src/page/live-review.ts
+++ b/shell/ui/src/page/live-review.ts
@@ -67,3 +67,10 @@ export function normalizeLiveReviewEvent(input: LiveReviewEventInput): LiveRevie
     ? { action: 'created', path: input.path, baseline: '' }
     : { action: 'modified', path: input.path, baseline: undefined }
 }
+
+export function onlyIgnoredChanges(
+  paths: readonly string[],
+  ignored: ReadonlySet<string>,
+): boolean {
+  return paths.length > 0 && paths.every((path) => ignored.has(path))
+}

--- a/shell/ui/src/page/live.ts
+++ b/shell/ui/src/page/live.ts
@@ -25,6 +25,9 @@ export interface WorkspaceChangedEvent {
   /** True for directories — they refresh the tree but must never open
       as files. Absent on older workers: treat as false. */
   dir?: boolean
+  /** True when git ignores the path under `root`. Absent on older
+      workers: treat as false. */
+  ignored?: boolean
 }
 
 export function useWorkspaceChanges(

--- a/shell/ui/src/page/review.ts
+++ b/shell/ui/src/page/review.ts
@@ -64,6 +64,43 @@ export function diffForReviewEntry(entry: ReviewEntry): ReviewDiff {
   }
 }
 
+function sameGitChange(a: GitChange, b: GitChange): boolean {
+  return (
+    a.path === b.path &&
+    a.status === b.status &&
+    a.staged === b.staged &&
+    a.from === b.from
+  )
+}
+
+function sameContentSource(
+  a?: GitContentSource,
+  b?: GitContentSource,
+): boolean {
+  if (a === undefined || b === undefined) return a === b
+  if (a.kind !== b.kind) return false
+  if (a.kind === 'empty' || b.kind === 'empty') return true
+  if (a.path !== b.path) return false
+  return a.kind === 'revision' && b.kind === 'revision'
+    ? a.revision === b.revision
+    : true
+}
+
+export function sameReviewEntry(
+  a: ReviewEntry | undefined,
+  b: ReviewEntry,
+): boolean {
+  if (a === undefined) return false
+  return (
+    a.path === b.path &&
+    sameGitChange(a.change, b.change) &&
+    a.baseline === b.baseline &&
+    a.gitDir === b.gitDir &&
+    sameContentSource(a.before, b.before) &&
+    sameContentSource(a.after, b.after)
+  )
+}
+
 export function statusForLiveKind(kind: string): GitFileStatus {
   if (kind === 'created') return 'untracked'
   if (kind === 'deleted') return 'deleted'
@@ -125,9 +162,8 @@ export function mergeGitReviewEntries(
     }
     if (
       !hasRenameSource &&
-      existing?.change.status === change.status &&
-      existing.change.staged === change.staged &&
-      existing.change.from === change.from
+      existing !== undefined &&
+      sameGitChange(existing.change, change)
     ) {
       continue
     }


### PR DESCRIPTION
## Problem

When the browsed root is a compose project directory, the workers running in it write their stores under `data/` (session-manager `.jsonl` appends, the shell turn store, the queue store). Those paths are gitignored, and the turn observer already keeps them out of the durable turn record. The page's live review path did not: `shell::changed` carried no ignore signal, the page folded every watcher event into the review with only a static noise list, and it reloaded the live Git scope on every burst.

Two visible effects:

- `data/session-manager/*.jsonl` and `data/shell/turns/sessions/*.json` showed up as Current Turn changes, and the auto-follow rule from #941 switched into Current Turn on them.
- A manually selected Uncommitted, Unstaged, or Staged view flipped between `loading` and its file list on every burst while a turn ran, because each reload set the loading state and reopened the diff. The shell rewriting its own turn store on every fold kept the loop going.

## Change

Worker (`shell/src`):

- `events.rs`: `ChangedEvent` gains `ignored: bool`. The watcher pump asks `git check-ignore --stdin -z` once per coalesced burst, in process, through the new `git_ignored` helper. A root that is not a repository, or a host without git, reports false for everything. Events still fan out for ignored paths, so a tree keeps listing them; the flag lets a subscriber decide.
- `turn_observe.rs`: `ignored_set` now delegates to the same helper instead of carrying its own copy of the check-ignore plumbing.

Page (`shell/ui/src/page`):

- `live.ts`: `WorkspaceChangedEvent.ignored?: boolean` (absent on older workers, treated as false).
- `index.tsx`: the burst handler drops ignored paths from the review fold and from the follow target, and returns after the tree refresh when every changed file in the burst is ignored, so neither the review nor the Git view reloads for store writes. `loadReviewScope` takes an optional `{ touched }`: the burst handler passes it for live Git scopes so the reload does not flip the loading state and only reopens the open diff when its entry changed or the burst touched that path. Manual scope selection and the other callers are unchanged.
- `live-review.ts`: `onlyIgnoredChanges`.
- `review.ts`: `sameReviewEntry`, and `mergeGitReviewEntries` shares the same `sameGitChange` comparison instead of an inline copy.

## Verification

- `cargo fmt`, `cargo clippy --all-targets --all-features -D warnings`, `cargo test` (shell crate, two new tests for `git_ignored`).
- `tsc --noEmit` clean, `vitest` 336 passing (3 new).
- Live on a compose rig with the shell rooted at the project directory, Uncommitted selected, while writing to gitignored files under `data/` for 8 seconds (DOM mutations on the review pane): 1286 before the change, close to the idle baseline after. The scope header stayed on `Uncommitted 3 files` throughout.
- A new untracked file still appears in Uncommitted within a burst and disappears when deleted, with and without an active turn.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace change events now identify files ignored by Git.
  * Live reviews skip ignored-only changes and avoid reopening unchanged review entries.
  * Older workers remain supported when the ignored-file indicator is unavailable.

* **Bug Fixes**
  * Prevented unnecessary loading states and review updates when workspace changes do not affect the active review.

* **Tests**
  * Added coverage for ignored changes, mixed change bursts, and review-entry comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->