### PR TITLE
feat(harness): migrate quickstart to the rc CLI channel and iii compose

### DIFF
--- a/.github/scripts/tests/test_verify_registry_lock.py
+++ b/.github/scripts/tests/test_verify_registry_lock.py
@@ -52,3 +52,57 @@ def test_rejects_stack_version_resolved_from_another_channel(tmp_path: Path):
     result = run_verify(tmp_path, {"harness": "1.8.0", "state": "0.23.0"})
     assert result.returncode != 0
     assert "state: expected 0.23.0, resolved 0.22.0" in result.stderr
+
+
+def run_verify_compose(
+    tmp_path: Path, version: str, required: list[str]
+) -> subprocess.CompletedProcess[str]:
+    compose = tmp_path / "worker-compose.yaml"
+    compose.write_text(
+        yaml.safe_dump(
+            {
+                "namespace": "default",
+                "containers": {
+                    "harness": {
+                        "worker": "package://api.workers.iii.dev/harness",
+                        "version": "1.8.7",
+                    },
+                    "console": {
+                        "worker": "package://api.workers.iii.dev/console",
+                        "version": "1.9.11",
+                    },
+                },
+            }
+        )
+    )
+    command = [
+        sys.executable,
+        str(SCRIPT),
+        "--lock",
+        str(compose),
+        "--worker",
+        "harness",
+        "--version",
+        version,
+    ]
+    for name in required:
+        command += ["--required", name]
+    return subprocess.run(command, text=True, capture_output=True, check=False)
+
+
+def test_accepts_compose_file_with_pinned_release(tmp_path: Path):
+    result = run_verify_compose(tmp_path, "1.8.7", ["harness", "console"])
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["actual_version"] == "1.8.7"
+
+
+def test_rejects_compose_file_missing_required_worker(tmp_path: Path):
+    result = run_verify_compose(tmp_path, "1.8.7", ["harness", "console", "shell"])
+    assert result.returncode != 0
+    assert "stack_incomplete" in result.stderr
+
+
+def test_rejects_compose_file_with_wrong_release_pin(tmp_path: Path):
+    result = run_verify_compose(tmp_path, "1.8.8", ["harness"])
+    assert result.returncode != 0
+    assert "artifact_mismatch" in result.stderr

--- a/.github/scripts/verify_registry_lock.py
+++ b/.github/scripts/verify_registry_lock.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
-"""Verify that iii.lock resolved the released worker and required stack."""
+"""Verify that the resolved worker file pins the released worker and stack.
+
+Accepts either shape a validator produces: an ``iii.lock`` (``workers:``
+mapping) or a ``worker-compose.yaml`` (``containers:`` mapping, one
+``version`` per container as written by ``compose::add``).
+"""
 
 from __future__ import annotations
 
@@ -29,12 +34,27 @@ def load_yaml(path: Path) -> dict:
     return value
 
 
+def resolved_workers(lock: dict) -> dict:
+    """The name → record mapping, whichever file shape carries it."""
+    if "workers" in lock:
+        workers = lock.get("workers") or {}
+        if not isinstance(workers, dict):
+            raise SystemExit("invalid_lock: workers must be a mapping")
+        return workers
+    containers = lock.get("containers")
+    if isinstance(containers, dict):
+        return {
+            name: entry
+            for name, entry in containers.items()
+            if isinstance(entry, dict)
+        }
+    raise SystemExit("invalid_lock: neither workers nor containers is a mapping")
+
+
 def main() -> None:
     args = parse_args()
     lock = load_yaml(args.lock)
-    workers = lock.get("workers") or {}
-    if not isinstance(workers, dict):
-        raise SystemExit("invalid_lock: workers must be a mapping")
+    workers = resolved_workers(lock)
 
     record = workers.get(args.worker)
     actual_version = record.get("version") if isinstance(record, dict) else None

--- a/.github/workflows/harness-quickstart.yml
+++ b/.github/workflows/harness-quickstart.yml
@@ -10,7 +10,9 @@ on:
       cli_channel:
         required: true
         type: choice
-        options: [latest, next]
+        # `rc` replaced the CLI's dead `next` prerelease channel; the compose
+        # flow the validator drives needs a 0.23.0-rc or newer CLI.
+        options: [latest, rc]
       registry_tag:
         required: true
         type: choice
@@ -95,12 +97,14 @@ jobs:
           HARNESS_QUICKSTART_RELEASE_VERSION: ${{ inputs.release_version != 'none' && inputs.release_version || '' }}
         run: harness/tests/quickstart/run-ci.sh
 
-      - name: Verify exact release in lock
+      - name: Verify exact release in compose file
         if: inputs.release_version != 'none'
+        # No --manifest here: compose only declares workers it can run, so
+        # engine-builtin dependencies (iii-stream, iii-observability) are
+        # deliberately absent from the compose file.
         run: >-
           python3 .github/scripts/verify_registry_lock.py
-          --lock target/harness-quickstart/iii.lock
-          --manifest harness/iii.worker.yaml
+          --lock target/harness-quickstart/worker-compose.yaml
           --required harness
           --required console
           --worker '${{ inputs.release_worker }}'

--- a/harness/Makefile
+++ b/harness/Makefile
@@ -28,7 +28,7 @@ STACK := $(BASE_STACK) eval
 PYTHON_WORKERS := scrapling
 RUST_WORKERS   := $(filter-out $(PYTHON_WORKERS),$(STACK))
 
-GOAL_ARGS        := $(filter-out help install-iii-next build install-local clean cargo-clean dev-run dev-up dev-down dev-restart \
+GOAL_ARGS        := $(filter-out help install-iii-rc build install-local clean cargo-clean dev-run dev-up dev-down dev-restart \
                     engine wait-engine wait-base wait-stack restart restart-worker stop stop-worker stop-work stop-engine status smoke logs attach \
                     ensure-session prepare-scrapling require-engine where integration-test integration-coverage integration-playground integration-validate quickstart-validate,$(MAKECMDGOALS))
 SELECTED_WORKERS := $(strip $(GOAL_ARGS))
@@ -40,7 +40,7 @@ RUN_FLAG   := $(if $(filter release,$(RUN_PROFILE)),--release,)
 
 .DEFAULT_GOAL := help
 
-.PHONY: help install-iii-next build install-local clean cargo-clean dev-run dev-up dev-down dev-restart engine wait-engine wait-base wait-stack \
+.PHONY: help install-iii-rc build install-local clean cargo-clean dev-run dev-up dev-down dev-restart engine wait-engine wait-base wait-stack \
         restart restart-worker stop stop-worker stop-work stop-engine status smoke logs attach ensure-session prepare-scrapling \
         require-engine where integration-test integration-coverage integration-playground integration-validate quickstart-validate $(STACK)
 
@@ -56,7 +56,7 @@ help:
 	  '  make stop harness shell             stop selected worker windows' \
 	  '  make stop-work                      stop all worker windows, keep engine' \
 	  '  make stop-engine                    stop the engine window only' \
-	  '  make install-iii-next               install the iii CLI @next channel' \
+	  '  make install-iii-rc               install the iii CLI @rc channel' \
 	  '  make status                         list registered workers' \
 	  '  make smoke                          run basic engine/harness/router probes' \
 	  '  make where                          print source roots, refs, and tmux panes' \
@@ -73,8 +73,8 @@ help:
 quickstart-validate:
 	@$(MAKEFILE_DIR)tests/quickstart/run-ci.sh
 
-install-iii-next:
-	@curl -fsSL https://install.iii.dev/iii/main/install.sh | sh -s -- --next
+install-iii-rc:
+	@curl -fsSL https://install.iii.dev/iii/main/install.sh | sh -s -- --rc
 
 $(SCRAPLING_STAMP): $(SCRAPLING_ROOT)/pyproject.toml
 	@test -x "$(SCRAPLING_VENV)/bin/python" || "$(PYTHON)" -m venv --without-pip "$(SCRAPLING_VENV)"

--- a/harness/tests/quickstart/README.md
+++ b/harness/tests/quickstart/README.md
@@ -6,8 +6,15 @@ home and project:
 ```bash
 printf 'workers: []\n' > config.yaml
 iii -c config.yaml
-iii worker add harness console
+iii compose --namespace default   # serves compose::* against the engine
+iii trigger compose::add --json '{"file":"worker-compose.yaml","worker":"harness"}'
+iii trigger compose::add --json '{"file":"worker-compose.yaml","worker":"console"}'
 ```
+
+The validator seeds a minimal `worker-compose.yaml` (`namespace: default`,
+empty `containers:`); each `compose::add` resolves the worker's registry
+graph, pins every container to an exact version in the file, and restarts
+the project.
 
 It verifies that:
 
@@ -27,7 +34,7 @@ It verifies that:
   conversation after a reload;
 - the capability call and its exact output are present in the durable session
   transcript; and
-- `config.yaml` and `iii.lock` contain the installed workers.
+- `worker-compose.yaml` declares harness and Console with pinned versions.
 
 Run it locally with:
 
@@ -43,21 +50,23 @@ Playwright binary directly, so Corepack cannot silently select a different
 pnpm version while the quickstart is running.
 The default engine and Console ports (`49134` and `3113`) must be available.
 The CLI installer and Registry worker selectors are independent:
-`III_CLI_CHANNEL` chooses `latest` or `next` for `iii`, while `III_WORKER_TAG`
+`III_CLI_CHANNEL` chooses `latest` or `rc` for `iii` (default `rc`; the CLI's
+`next` channel is dead, and `iii compose` needs 0.23.0-rc or newer — the
+validator refuses a CLI without the `compose` command), while `III_WORKER_TAG`
 chooses the Registry tag used by `harness` and `console`. The old combined
 `III_CHANNEL` variable is rejected to prevent a silent test against the wrong
 side of the split.
 Set `HARNESS_QUICKSTART_TRACE=1` to print only the important external commands
-(`iii worker add`, `iii trigger`, installer, and engine) and save the list as
-`commands.log`. Polling attempts, assignments, cleanup, and other shell internals
-are omitted.
+(`iii trigger compose::add`, `iii trigger`, installer, engine, and compose
+daemon) and save the list as `commands.log`. Polling attempts, assignments,
+cleanup, and other shell internals are omitted.
 
 The CI workflow preserves `result.json`, the generated project files, sanitized
 browser, terminal, and first-capability evidence, raw Playwright output, the
 command trace, and the provider-switch MP4. It scans every artifact for the
 literal Anthropic and OpenAI credentials before upload. Release-triggered runs
-replace the released worker with its exact candidate version and verify it in
-`iii.lock`.
+re-pin the released worker to its exact candidate version and verify the pin in
+`worker-compose.yaml`.
 
 After a successful `deploy_harness`, Release Control dispatches this check as a
 child observation. Its result and MP4 are appended to the release Slack thread,

--- a/harness/tests/quickstart/run-ci.sh
+++ b/harness/tests/quickstart/run-ci.sh
@@ -2,15 +2,16 @@
 set -Eeuo pipefail
 
 # Validate the published quickstart in an isolated home and project:
-# install iii, boot an empty engine, add harness + console, and complete the
-# first Console conversation, switch from Anthropic Sonnet 5 to OpenAI Luna,
-# start a second Luna conversation, and exercise one real Harness capability.
+# install iii, boot an empty engine, bring up harness + console through
+# `iii compose`, and complete the first Console conversation, switch from
+# Anthropic Sonnet 5 to OpenAI Luna, start a second Luna conversation, and
+# exercise one real Harness capability.
 
 script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 repo_root=$(cd -- "$script_dir/../../.." && pwd)
 artifact_dir=${HARNESS_QUICKSTART_ARTIFACTS_DIR:-"$repo_root/target/harness-quickstart"}
 install_url=${III_INSTALL_URL:-https://install.iii.dev/iii/main/install.sh}
-cli_channel=${III_CLI_CHANNEL:-latest}
+cli_channel=${III_CLI_CHANNEL:-rc}
 worker_tag=${III_WORKER_TAG:-latest}
 release_worker=${HARNESS_QUICKSTART_RELEASE_WORKER:-}
 release_version=${HARNESS_QUICKSTART_RELEASE_VERSION:-}
@@ -38,10 +39,13 @@ case "$trace_enabled" in
     ;;
 esac
 
+# The CLI's `next` prerelease channel died with iii/v0.21.8-next.4; the
+# prerelease channel is `rc` now, and `iii compose` only exists from
+# 0.23.0-rc onward.
 case "$cli_channel" in
-  latest | next) ;;
+  latest | rc) ;;
   *)
-    echo "III_CLI_CHANNEL must be 'latest' or 'next' (got: $cli_channel)" >&2
+    echo "III_CLI_CHANNEL must be 'latest' or 'rc' (got: $cli_channel)" >&2
     exit 2
     ;;
 esac
@@ -123,6 +127,7 @@ rm -f \
   "$artifact_dir/first-capability-evidence.json" \
   "$artifact_dir/config.yaml" \
   "$artifact_dir/iii.lock" \
+  "$artifact_dir/worker-compose.yaml" \
   "$artifact_dir/commands.log" \
   "$log_dir"/*.log
 rm -rf "$artifact_dir/playwright-output" "$artifact_dir/slack-evidence"
@@ -138,9 +143,11 @@ export PATH="$quickstart_home/.local/bin:$quickstart_home/.iii/bin:$PATH"
 unset ZAI_API_KEY DEEPSEEK_API_KEY OPENROUTER_API_KEY XAI_API_KEY KIMI_API_KEY
 
 engine_pid=""
+compose_pid=""
 iii_bin=""
 failure_reason=""
 cli_version="unknown"
+compose_file="$project_dir/worker-compose.yaml"
 started_at_seconds=$SECONDS
 
 log() {
@@ -238,16 +245,29 @@ stop_engine() {
 }
 
 snapshot_project() {
-  for output in config.yaml iii.lock; do
+  for output in config.yaml worker-compose.yaml; do
     [[ -f "$project_dir/$output" ]] && cp "$project_dir/$output" "$artifact_dir/$output"
   done
 }
 
-stop_managed_workers() {
-  [[ -n "$iii_bin" && -n "$engine_pid" ]] || return 0
-  kill -0 "$engine_pid" 2>/dev/null || return 0
-  (cd "$project_dir" && "$iii_bin" worker remove -y harness console) \
-    >"$log_dir/worker-remove.log" 2>&1 || true
+stop_compose() {
+  [[ -n "$compose_pid" ]] || return 0
+  # Ask the daemon to stop the project's children first; killing the daemon
+  # alone would leave them supervised by nothing until the orphan sweep.
+  if [[ -n "$iii_bin" && -n "$engine_pid" ]] \
+    && kill -0 "$engine_pid" 2>/dev/null && kill -0 "$compose_pid" 2>/dev/null; then
+    "$iii_bin" trigger compose::down --port "$engine_port" \
+      --json "$(jq -cn --arg file "$compose_file" '{file: $file}')" \
+      >"$log_dir/compose-down.log" 2>&1 || true
+  fi
+  kill -0 "$compose_pid" 2>/dev/null || return 0
+  kill -- "-$compose_pid" 2>/dev/null || kill "$compose_pid" 2>/dev/null || true
+  for _ in {1..20}; do
+    kill -0 "$compose_pid" 2>/dev/null || break
+    sleep 0.1
+  done
+  kill -KILL -- "-$compose_pid" 2>/dev/null || kill -KILL "$compose_pid" 2>/dev/null || true
+  wait "$compose_pid" 2>/dev/null || true
 }
 
 stop_owned_orphans() {
@@ -271,7 +291,7 @@ cleanup() {
   set +e
 
   snapshot_project
-  stop_managed_workers
+  stop_compose
   stop_engine
   stop_owned_orphans
 
@@ -550,14 +570,26 @@ assert_secret_safe_artifacts() {
   ok "artifacts do not contain provider credentials"
 }
 
-run_worker_add() {
-  log_command "iii worker add $*"
+# Declares one worker (and everything the registry resolves for it) in the
+# compose file, then lets the daemon restart the project. The call is
+# synchronous: it returns after installs finish and every container reports
+# ready, so it carries the old `worker add` timeout.
+run_compose_add() {
+  local spec=$1 payload response
+  payload=$(jq -cn --arg file "$compose_file" --arg worker "$spec" \
+    '{file: $file, worker: $worker}')
+  log_command "iii trigger compose::add --port $engine_port --json '$payload'"
   if command -v timeout >/dev/null 2>&1; then
-    timeout --signal=TERM --kill-after=15s "$add_timeout_seconds" \
-      "$iii_bin" worker add "$@"
+    response=$(timeout --signal=TERM --kill-after=15s "$add_timeout_seconds" \
+      "$iii_bin" trigger compose::add --port "$engine_port" --json "$payload")
   else
-    "$iii_bin" worker add "$@"
+    response=$("$iii_bin" trigger compose::add --port "$engine_port" --json "$payload")
   fi
+  printf '%s\n' "$response"
+  # A container that failed to start comes back as JSON with status "failed",
+  # not as a non-zero exit; the exit code alone proves nothing.
+  jq -e '.status == "ok"' <<<"$response" >/dev/null 2>&1 \
+    || die "compose::add $spec did not report ok"
 }
 
 start_engine() {
@@ -571,15 +603,47 @@ start_engine() {
   engine_pid=$!
 }
 
+# The daemon serves `compose::*` in the `default` namespace so the triggers
+# below reach it the same way every other function is reached. It runs in the
+# foreground by design; the script owns backgrounding it, like the engine.
+start_compose() {
+  local command=("$iii_bin" compose --engine "ws://127.0.0.1:$engine_port" --namespace default)
+  log_command "iii compose --engine ws://127.0.0.1:$engine_port --namespace default"
+  if command -v setsid >/dev/null 2>&1; then
+    setsid "${command[@]}" >"$log_dir/compose.log" 2>&1 &
+  else
+    "${command[@]}" >"$log_dir/compose.log" 2>&1 &
+  fi
+  compose_pid=$!
+}
+
+wait_for_compose() {
+  local response attempt
+  log "Waiting for the compose daemon (up to ${wait_seconds}s)"
+  log_command "iii trigger engine::functions::list --port $engine_port --json '{\"include_internal\":true}'"
+  for ((attempt = 0; attempt < wait_seconds; attempt++)); do
+    kill -0 "$compose_pid" 2>/dev/null || die "compose daemon exited before becoming ready"
+    response=$("$iii_bin" trigger engine::functions::list --port "$engine_port" \
+      --json '{"include_internal":true}' 2>>"$log_dir/discovery.log" || true)
+    if jq -e '(.functions // [] | map(.function_id)) | index("compose::add") != null' \
+      <<<"$response" >/dev/null 2>&1; then
+      ok "compose daemon ready after ${attempt}s"
+      return 0
+    fi
+    sleep 1
+  done
+  die "compose::add did not register within ${wait_seconds}s"
+}
+
 cd "$project_dir"
 
 log "Step 1/9: Install iii from $install_url (channel=$cli_channel)"
 log_command "curl -fsSL $install_url -o install.sh"
 curl -fsSL --retry 3 --retry-connrefused --retry-delay 5 \
   "$install_url" -o "$run_root/install.sh"
-if [[ "$cli_channel" == "next" ]]; then
-  log_command "sh install.sh --next"
-  sh "$run_root/install.sh" --next 2>&1 | tee "$log_dir/install.log"
+if [[ "$cli_channel" == "rc" ]]; then
+  log_command "sh install.sh --rc"
+  sh "$run_root/install.sh" --rc 2>&1 | tee "$log_dir/install.log"
 else
   log_command "sh install.sh"
   sh "$run_root/install.sh" 2>&1 | tee "$log_dir/install.log"
@@ -588,23 +652,38 @@ iii_bin=$(command -v iii || true)
 [[ -n "$iii_bin" && -x "$iii_bin" ]] || die "iii CLI was not installed"
 log_command "iii --version"
 cli_version=$("$iii_bin" --version 2>&1)
+"$iii_bin" compose --help >/dev/null 2>&1 \
+  || die "the installed iii CLI ($cli_version) has no compose command; the quickstart needs 0.23.0-rc or newer"
 printf '%s\n' "$cli_version" >"$artifact_dir/cli-version.txt"
 ok "installed $cli_version"
 
-log "Step 2/9: Start an empty engine"
+log "Step 2/9: Start an empty engine and the compose daemon"
 printf 'workers: []\n' >config.yaml
+# The seed only names the project: `compose::add` writes every container.
+# `namespace: default` is required — harness and Console must register beside
+# the engine builtins, exactly like the flow this validates.
+cat >"$compose_file" <<'COMPOSE'
+namespace: default
+startup_timeout: 5m
+stop_timeout: 10s
+
+containers:
+COMPOSE
 start_engine
 wait_for_engine
+start_compose
+wait_for_compose
 
-log "Step 3/9: Add harness and Console from worker tag $worker_tag"
-run_worker_add "harness@$worker_tag" "console@$worker_tag" 2>&1 | tee "$log_dir/worker-add.log"
-ok "iii worker add harness console exited successfully"
+log "Step 3/9: Add harness and Console from worker tag $worker_tag via compose"
+run_compose_add "harness@$worker_tag" 2>&1 | tee "$log_dir/compose-add-harness.log"
+run_compose_add "console@$worker_tag" 2>&1 | tee "$log_dir/compose-add-console.log"
+ok "compose declared and started harness + console"
 
 log "Step 4/9: Apply exact release candidate override"
 if [[ -n "$release_worker" ]]; then
-  run_worker_add "${release_worker}@${release_version}" --force \
+  run_compose_add "${release_worker}@${release_version}" \
     2>&1 | tee "$log_dir/candidate-override.log"
-  ok "installed exact candidate ${release_worker}@${release_version}"
+  ok "pinned exact candidate ${release_worker}@${release_version}"
 else
   ok "no release candidate override requested"
 fi
@@ -634,12 +713,15 @@ wait_for_terminal_turns
 verify_first_capability
 
 log "Step 9/9: Verify generated project files and secret-safe evidence"
-for output in config.yaml iii.lock; do
-  [[ -s "$output" ]] || die "worker add did not write $output"
-  grep -Eiq 'harness' "$output" || die "$output does not contain harness"
-  grep -Eiq 'console' "$output" || die "$output does not contain console"
+[[ -s "$project_dir/config.yaml" ]] || die "the engine config.yaml is missing"
+[[ -s "$compose_file" ]] || die "compose::add did not write worker-compose.yaml"
+for required in harness console; do
+  grep -Eiq "$required" "$compose_file" \
+    || die "worker-compose.yaml does not contain $required"
 done
-ok "config.yaml and iii.lock reference harness + console"
+grep -Eq '^[[:space:]]+version:' "$compose_file" \
+  || die "worker-compose.yaml has no pinned versions"
+ok "worker-compose.yaml declares harness + console with pinned versions"
 snapshot_project
 assert_secret_safe_artifacts
 


### PR DESCRIPTION
## Why

Every `next`-lane quickstart validation has failed at bootstrap since ~2026-08-11 with:

```
installing latest next release
error: no next release found
```

The CLI's `next` prerelease channel is dead — the last `-next.` release is `iii/v0.21.8-next.4` (2026-07-22); prereleases moved to `-rc.` — and the installer's `--next` path only scans the 20 most recent releases of `iii-hq/iii`. Harness 1.8.7's failed validation (run 32660063106) was this infrastructure failure, not a product regression. Full analysis in `harness/harness-quickstart-investigation.md`.

The rc CLI (0.23.0-rc.4+) also ships `iii compose`, the compose-era onboarding flow, so this migrates the validator to both at once.

## What

- **`run-ci.sh`**: install with `--rc` (`III_CLI_CHANNEL` accepts `latest | rc`, default `rc`); refuse a CLI without the `compose` command; seed a minimal `worker-compose.yaml` (`namespace: default`); background an `iii compose` daemon beside the engine; bring the stack up with `compose::add` (`harness@tag`, `console@tag`, then the exact candidate re-pin, replacing `worker add --force`); assert each add's JSON `status == "ok"` (a failed container returns exit 0); tear down via `compose::down`; step 9 asserts the pinned compose file instead of `config.yaml`/`iii.lock`.
- **`harness-quickstart.yml`**: `cli_channel` choices become `[latest, rc]` (`registry_tag` keeps `[latest, next]` — the workers tag is alive). The exact-release step verifies `worker-compose.yaml` and drops `--manifest`, since compose deliberately omits engine-builtin dependencies (`iii-stream`, `iii-observability`).
- **`verify_registry_lock.py`**: accepts the compose `containers:` shape next to the `iii.lock` `workers:` shape (candidate-smoke untouched), with tests.
- **Makefile**: `install-iii-next` → `install-iii-rc`. README rewritten for the compose flow.

## Validation

- `bash -n` on the validator; actionlint clean on the workflow.
- Full `.github/scripts` pytest suite: 255 passed (3 new compose-shape tests).

## Follow-ups outside this repo

1. **Release Control still dispatches `cli_channel=next`** — with the new choices that dispatch now fails fast at dispatch time; the channel mapping in iii-cloud must send `rc` before this lane goes green.
2. **The `latest` lane stays red until 0.23.0 goes stable** — CLI 0.22.1 has no `compose`; the runtime guard fails it with an actionable message.

https://claude.ai/code/session_01TKnhg98EHKxzFBuCjJdunX