### PR TITLE
feat(console): workers page drives compose-supervised lifecycle

### DIFF
--- a/console/web/src/pages/Workers/api/workers.ts
+++ b/console/web/src/pages/Workers/api/workers.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod'
 import {
   type WorkerInfoResponse,
   type WorkersListResponse,
@@ -9,9 +10,11 @@ import {
   type WorkerListResponse,
   workerListResponseSchema,
 } from '@/components/chat/worker/parsers'
+import { errText } from '@/lib/errors'
 import { getIiiClient } from '@/lib/iii-client'
 import type { ConfigurationSchemaView } from '@/pages/Configuration/tabs/WorkersTab/api'
 import { listConfigurations } from '@/pages/Configuration/tabs/WorkersTab/api'
+import type { ComposeAction } from '../types'
 
 export const WORKERS_RPC = {
   engineList: 'engine::workers::list',
@@ -19,7 +22,50 @@ export const WORKERS_RPC = {
   supervisorList: 'worker::list',
   supervisorStop: 'worker::stop',
   configList: 'configuration::list',
+  composeStatus: 'compose::status',
+  composeUp: 'compose::up',
+  composeDown: 'compose::down',
+  composeRestart: 'compose::restart',
 } as const
+
+export const composeContainerSchema = z.object({
+  container: z.string(),
+  state: z.enum(['starting', 'ready', 'failed', 'stopped']),
+  owned: z.boolean().optional(),
+  pid: z.number().nullable().optional(),
+  last_error: z.string().nullable().optional(),
+})
+export type ComposeContainer = z.infer<typeof composeContainerSchema>
+
+export const composeStatusSchema = z.object({
+  namespace: z.string().nullable().optional(),
+  file: z.string().nullable().optional(),
+  state_dir: z.string().nullable().optional(),
+  daemon_pid: z.number().nullable().optional(),
+  containers: z.array(composeContainerSchema).default([]),
+})
+export type ComposeStatus = z.infer<typeof composeStatusSchema>
+
+const composeOpResultSchema = z.object({
+  status: z.string().optional(),
+  changed: z.boolean().optional(),
+  containers: z
+    .array(
+      z.object({
+        container: z.string(),
+        changed: z.boolean().optional(),
+        state: z.string().optional(),
+        error: z.unknown().optional(),
+      }),
+    )
+    .optional(),
+})
+
+const composeAnswerSchema = composeOpResultSchema.extend({
+  restarted: composeOpResultSchema.nullable().optional(),
+  up: composeOpResultSchema.nullable().optional(),
+  down: composeOpResultSchema.nullable().optional(),
+})
 
 export async function fetchEngineWorkersList(): Promise<WorkersListResponse> {
   const client = await getIiiClient()
@@ -50,9 +96,53 @@ export async function fetchConfigurationIds(): Promise<
   return listConfigurations()
 }
 
+export async function fetchComposeStatus(): Promise<ComposeStatus | null> {
+  const client = await getIiiClient()
+  try {
+    const raw = await client.trigger<unknown>(
+      WORKERS_RPC.composeStatus,
+      {},
+      { timeoutMs: 10_000 },
+    )
+    const parsed = composeStatusSchema.safeParse(raw)
+    return parsed.success ? parsed.data : null
+  } catch {
+    return null
+  }
+}
+
 export async function stopSupervisorWorker(name: string): Promise<void> {
   const client = await getIiiClient()
   await client.trigger(WORKERS_RPC.supervisorStop, { name, yes: true })
+}
+
+const COMPOSE_FN: Record<ComposeAction, string> = {
+  start: WORKERS_RPC.composeUp,
+  stop: WORKERS_RPC.composeDown,
+  restart: WORKERS_RPC.composeRestart,
+}
+
+export async function composeContainerAction(
+  action: ComposeAction,
+  container: string,
+): Promise<void> {
+  const client = await getIiiClient()
+  const raw = await client.trigger<unknown>(
+    COMPOSE_FN[action],
+    { container },
+    { timeoutMs: 600_000 },
+  )
+  const answer = composeAnswerSchema.safeParse(raw)
+  if (!answer.success) return
+  const { restarted, up, down, ...top } = answer.data
+  const failures = [top, restarted, up, down]
+    .flatMap((result) => result?.containers ?? [])
+    .filter((entry) => entry.error)
+    .map((entry) => `${entry.container}: ${errText(entry.error)}`)
+  if (failures.length > 0) throw new Error(failures.join('\n'))
+  if (top.status === 'failed') {
+    throw new Error(`compose ${action} ${container} failed`)
+  }
 }
 
 export interface RawWorkersSnapshot {
@@ -60,6 +150,7 @@ export interface RawWorkersSnapshot {
   supervisorWorkers: WorkerEntry[]
   configurations: ConfigurationSchemaView[]
   infoByName: Map<string, WorkerInfoResponse['worker']>
+  compose: ComposeStatus | null
 }
 
 /** Bounded parallel map — avoids stampeding the engine on large fleets. */
@@ -86,17 +177,19 @@ export async function mapWithConcurrency<T, R>(
 }
 
 export async function fetchRawWorkersSnapshot(): Promise<RawWorkersSnapshot> {
-  // Supervisor and configuration reads are enrichment: an engine without
-  // worker::list (a compose-managed engine, or one booted with no
+  // Supervisor, configuration, and compose reads are enrichment: an engine
+  // without worker::list (a compose-managed engine, or one booted with no
   // supervisor) must not blank the whole page - the connected fleet from
   // engine::workers::list still renders, just without stop/config detail.
-  const [engineList, supervisorList, configurations] = await Promise.all([
-    fetchEngineWorkersList(),
-    fetchSupervisorWorkersList().catch(
-      (): WorkerListResponse => ({ workers: [] }),
-    ),
-    fetchConfigurationIds().catch((): ConfigurationSchemaView[] => []),
-  ])
+  const [engineList, supervisorList, configurations, compose] =
+    await Promise.all([
+      fetchEngineWorkersList(),
+      fetchSupervisorWorkersList().catch(
+        (): WorkerListResponse => ({ workers: [] }),
+      ),
+      fetchConfigurationIds().catch((): ConfigurationSchemaView[] => []),
+      fetchComposeStatus(),
+    ])
 
   const connected = engineList.workers.filter(
     (w) => w.status.toLowerCase() === 'connected' && w.name,
@@ -120,5 +213,6 @@ export async function fetchRawWorkersSnapshot(): Promise<RawWorkersSnapshot> {
     supervisorWorkers: supervisorList.workers,
     configurations,
     infoByName,
+    compose,
   }
 }

--- a/console/web/src/pages/Workers/components/WorkersFilters.tsx
+++ b/console/web/src/pages/Workers/components/WorkersFilters.tsx
@@ -1,8 +1,17 @@
 import { Search, X } from 'lucide-react'
 import { Input } from '@/components/ui/Input'
 import { cn } from '@/lib/utils'
-import type { WorkerRow, WorkersFilterState } from '../types'
-import { distinctRuntimes, distinctTags } from '../types'
+import type {
+  WorkerManagementKind,
+  WorkerRow,
+  WorkersFilterState,
+} from '../types'
+import {
+  distinctManagement,
+  distinctRuntimes,
+  distinctTags,
+  MANAGEMENT_LABEL,
+} from '../types'
 
 interface WorkersFiltersProps {
   rows: WorkerRow[]
@@ -21,10 +30,12 @@ export function WorkersFilters({
 }: WorkersFiltersProps) {
   const tags = distinctTags(rows)
   const runtimes = distinctRuntimes(rows)
+  const management = distinctManagement(rows)
   const hasActive =
     filters.search.trim() !== '' ||
     filters.tag !== null ||
-    filters.runtime !== null
+    filters.runtime !== null ||
+    filters.management !== null
 
   return (
     <div className={cn('flex flex-col gap-3', className)}>
@@ -54,8 +65,26 @@ export function WorkersFilters({
           </button>
         ) : null}
       </div>
-      {(tags.length > 0 || runtimes.length > 0) && (
+      {(management.length > 1 || tags.length > 0 || runtimes.length > 0) && (
         <div className="flex flex-wrap items-center gap-2">
+          {management.length > 1 ? (
+            <FilterChipGroup
+              label="managed by"
+              options={management}
+              labelFor={(kind) =>
+                MANAGEMENT_LABEL[kind as WorkerManagementKind]
+              }
+              selected={filters.management}
+              onSelect={(kind) =>
+                onFilterChange({
+                  management:
+                    filters.management === kind
+                      ? null
+                      : (kind as WorkerManagementKind),
+                })
+              }
+            />
+          ) : null}
           {tags.length > 0 ? (
             <FilterChipGroup
               label="tag"
@@ -89,6 +118,7 @@ interface FilterChipGroupProps {
   options: string[]
   selected: string | null
   onSelect: (value: string) => void
+  labelFor?: (value: string) => string
 }
 
 function FilterChipGroup({
@@ -96,6 +126,7 @@ function FilterChipGroup({
   options,
   selected,
   onSelect,
+  labelFor = (value) => value,
 }: FilterChipGroupProps) {
   return (
     <div className="flex flex-wrap items-center gap-1.5">
@@ -117,7 +148,7 @@ function FilterChipGroup({
                 : 'bg-bg text-ink-faint border-rule hover:border-ink hover:text-ink',
             )}
           >
-            {opt}
+            {labelFor(opt)}
           </button>
         )
       })}

--- a/console/web/src/pages/Workers/components/WorkersTable.stories.tsx
+++ b/console/web/src/pages/Workers/components/WorkersTable.stories.tsx
@@ -4,10 +4,12 @@ import { useMemo, useState } from 'react'
 import { TooltipProvider } from '@/components/ui/Tooltip'
 import {
   WORKER_SURFACE_FIXTURE,
+  WORKERS_FIXTURE_COMPOSE_ROWS,
   WORKERS_FIXTURE_EMPTY,
   WORKERS_FIXTURE_ROWS,
 } from '../fixtures/workers-fixtures'
-import type { WorkerRow } from '../types'
+import type { PendingComposeAction } from '../hooks/useWorkersLive'
+import type { ComposeAction, WorkerRow } from '../types'
 import { filterWorkerRows, type WorkersFilterState } from '../types'
 import { workerSurfaceKeys } from './WorkerSurface'
 import { WorkersFilters } from './WorkersFilters'
@@ -35,19 +37,26 @@ function WorkersHarness({
   rows,
   isLoading,
   initialTag,
+  initialManagement,
+  pendingCompose,
   onStop,
+  onComposeAction,
   onConfigure,
 }: {
   rows: WorkerRow[]
   isLoading?: boolean
   initialTag?: string | null
+  initialManagement?: WorkersFilterState['management']
+  pendingCompose?: PendingComposeAction | null
   onStop?: (name: string) => void
+  onComposeAction?: (action: ComposeAction, container: string) => void
   onConfigure?: (configurationId: string) => void
 }) {
   const [filters, setFilters] = useState<WorkersFilterState>({
     search: '',
     tag: initialTag ?? null,
     runtime: null,
+    management: initialManagement ?? null,
   })
   const filtered = useMemo(
     () => filterWorkerRows(rows, filters),
@@ -68,14 +77,21 @@ function WorkersHarness({
                 setFilters((cur) => ({ ...cur, ...next }))
               }
               onClear={() =>
-                setFilters({ search: '', tag: null, runtime: null })
+                setFilters({
+                  search: '',
+                  tag: null,
+                  runtime: null,
+                  management: null,
+                })
               }
             />
           ) : null}
           <WorkersTable
             rows={filtered}
             isLoading={isLoading}
+            pendingCompose={pendingCompose}
             onStop={onStop}
+            onComposeAction={onComposeAction}
             onConfigure={onConfigure}
           />
         </div>
@@ -136,6 +152,30 @@ export const StopEnabled: Story = {
 export const StandaloneNoStop: Story = {
   args: {
     rows: WORKERS_FIXTURE_ROWS.filter((r) => r.managementKind === 'standalone'),
+  },
+}
+
+/**
+ * A compose-supervised fleet: a ready container, one still starting, one the
+ * daemon reports as failed with its last error, and a declared container
+ * that is stopped and therefore absent from the engine. Start / stop /
+ * restart route through `compose::up` / `compose::down` / `compose::restart`;
+ * stop and restart confirm first because stop cascades to dependents.
+ */
+export const ComposeManaged: Story = {
+  args: {
+    rows: [...WORKERS_FIXTURE_COMPOSE_ROWS, ...WORKERS_FIXTURE_ROWS],
+    initialManagement: 'compose',
+    onComposeAction: () => undefined,
+    onConfigure: () => undefined,
+  },
+}
+
+export const ComposeActionPending: Story = {
+  args: {
+    rows: WORKERS_FIXTURE_COMPOSE_ROWS,
+    pendingCompose: { container: 'llm-router', action: 'restart' },
+    onComposeAction: () => undefined,
   },
 }
 

--- a/console/web/src/pages/Workers/components/WorkersTable.tsx
+++ b/console/web/src/pages/Workers/components/WorkersTable.tsx
@@ -1,8 +1,10 @@
-import { ChevronRight, Settings, Square } from 'lucide-react'
+import { ChevronRight, Play, RotateCw, Settings, Square } from 'lucide-react'
 import { useState } from 'react'
 import { Badge } from '@/components/ui/Badge'
 import { Button } from '@/components/ui/Button'
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
 import { EmptyState } from '@/components/ui/EmptyState'
+import { IconButton } from '@/components/ui/IconButton'
 import { Skeleton } from '@/components/ui/Skeleton'
 import { StatusDot } from '@/components/ui/StatusDot'
 import {
@@ -11,41 +13,50 @@ import {
   TooltipTrigger,
 } from '@/components/ui/Tooltip'
 import { cn } from '@/lib/utils'
-import type { WorkerManagementKind, WorkerRow } from '../types'
+import type { PendingComposeAction } from '../hooks/useWorkersLive'
+import {
+  type ComposeAction,
+  composeActions,
+  MANAGEMENT_LABEL,
+  type WorkerManagementKind,
+  type WorkerRow,
+} from '../types'
 import { WorkerSurface } from './WorkerSurface'
 
 interface WorkersTableProps {
   rows: WorkerRow[]
   isLoading?: boolean
   stoppingName?: string | null
+  pendingCompose?: PendingComposeAction | null
   onStop?: (name: string) => void
+  onComposeAction?: (action: ComposeAction, container: string) => void
   onConfigure?: (configurationId: string) => void
   className?: string
-}
-
-const MANAGEMENT_LABEL: Record<WorkerManagementKind, string> = {
-  config: 'config',
-  supervisor: 'managed',
-  standalone: 'standalone',
-  internal: 'internal',
 }
 
 const MANAGEMENT_VARIANT: Record<
   WorkerManagementKind,
   'default' | 'accent' | 'warn'
 > = {
+  compose: 'accent',
   config: 'default',
   supervisor: 'accent',
   standalone: 'warn',
   internal: 'default',
 }
 
-function statusTone(
-  status: WorkerRow['status'],
-): 'accent' | 'alert' | 'warn' | 'ink' {
-  if (status === 'connected') return 'accent'
-  if (status === 'stopped') return 'ink'
-  return 'warn'
+const STATUS_STYLE: Record<
+  WorkerRow['status'],
+  {
+    tone: 'accent' | 'alert' | 'warn' | 'ink'
+    badge: 'default' | 'warn' | 'alert'
+  }
+> = {
+  connected: { tone: 'accent', badge: 'warn' },
+  starting: { tone: 'warn', badge: 'warn' },
+  failed: { tone: 'alert', badge: 'alert' },
+  disconnected: { tone: 'warn', badge: 'warn' },
+  stopped: { tone: 'ink', badge: 'default' },
 }
 
 function formatCell(value: string | number | null | undefined): string {
@@ -53,11 +64,18 @@ function formatCell(value: string | number | null | undefined): string {
   return String(value)
 }
 
+interface ComposeConfirm {
+  action: Exclude<ComposeAction, 'start'>
+  container: string
+}
+
 export function WorkersTable({
   rows,
   isLoading,
   stoppingName,
+  pendingCompose,
   onStop,
+  onComposeAction,
   onConfigure,
   className,
 }: WorkersTableProps) {
@@ -70,14 +88,22 @@ export function WorkersTable({
       <EmptyState
         icon={Square}
         title="no workers"
-        description="no workers match the current filters. workers appear here when they connect to the engine or are installed via the supervisor."
+        description="no workers match the current filters. workers appear here when they connect to the engine, when compose declares them, or when the supervisor installs them."
       />
     )
   }
 
   return (
     <WorkersTableBody
-      {...{ rows, stoppingName, onStop, onConfigure, className }}
+      {...{
+        rows,
+        stoppingName,
+        pendingCompose,
+        onStop,
+        onComposeAction,
+        onConfigure,
+        className,
+      }}
     />
   )
 }
@@ -85,13 +111,16 @@ export function WorkersTable({
 function WorkersTableBody({
   rows,
   stoppingName,
+  pendingCompose,
   onStop,
+  onComposeAction,
   onConfigure,
   className,
 }: Omit<WorkersTableProps, 'isLoading'>) {
   // Only connected workers have a surface to show: `engine::workers::info`
   // answers for the live bus, not for a stopped supervisor entry.
   const [expanded, setExpanded] = useState<string | null>(null)
+  const [confirm, setConfirm] = useState<ComposeConfirm | null>(null)
 
   return (
     <div
@@ -136,17 +165,54 @@ function WorkersTableBody({
                 key={row.id}
                 row={row}
                 stopping={stoppingName === row.name}
+                pendingAction={
+                  pendingCompose?.container === row.name
+                    ? pendingCompose.action
+                    : null
+                }
                 expanded={expanded === row.name}
                 onToggle={() =>
                   setExpanded((prev) => (prev === row.name ? null : row.name))
                 }
                 onStop={onStop}
+                onComposeAction={
+                  onComposeAction
+                    ? (action) => {
+                        if (action === 'start')
+                          onComposeAction(action, row.name)
+                        else setConfirm({ action, container: row.name })
+                      }
+                    : undefined
+                }
                 onConfigure={onConfigure}
               />
             ))}
           </tbody>
         </table>
       </div>
+      <ConfirmDialog
+        open={confirm !== null}
+        onOpenChange={(open) => {
+          if (!open) setConfirm(null)
+        }}
+        title={
+          confirm?.action === 'restart'
+            ? `Restart ${confirm.container}?`
+            : `Stop ${confirm?.container ?? ''}?`
+        }
+        description={
+          confirm?.action === 'restart'
+            ? 'Compose restarts this container in place without touching its dependency graph.'
+            : 'Compose stops this container and every container that depends on it, in reverse dependency order.'
+        }
+        confirmLabel={confirm?.action === 'restart' ? 'Restart' : 'Stop'}
+        onConfirm={() => {
+          if (confirm && onComposeAction) {
+            onComposeAction(confirm.action, confirm.container)
+          }
+          setConfirm(null)
+        }}
+      />
     </div>
   )
 }
@@ -154,21 +220,32 @@ function WorkersTableBody({
 interface WorkerTableRowProps {
   row: WorkerRow
   stopping: boolean
+  pendingAction: ComposeAction | null
   expanded: boolean
   onToggle: () => void
   onStop?: (name: string) => void
+  onComposeAction?: (action: ComposeAction) => void
   onConfigure?: (configurationId: string) => void
+}
+
+const COMPOSE_ICON: Record<ComposeAction, typeof Play> = {
+  start: Play,
+  stop: Square,
+  restart: RotateCw,
 }
 
 function WorkerTableRow({
   row,
   stopping,
+  pendingAction,
   expanded,
   onToggle,
   onStop,
+  onComposeAction,
   onConfigure,
 }: WorkerTableRowProps) {
   const expandable = row.status === 'connected'
+  const composeVerbs = composeActions(row)
   const configureButton = row.configurationId ? (
     <Button
       variant="icon"
@@ -185,6 +262,33 @@ function WorkerTableRow({
     </Button>
   ) : null
 
+  const composeButtons =
+    composeVerbs.length > 0
+      ? composeVerbs.map((action) => {
+          const Icon = COMPOSE_ICON[action]
+          const busy = pendingAction !== null
+          return (
+            <IconButton
+              key={action}
+              variant="icon"
+              label={`${action} ${row.name}`}
+              disabled={busy || !onComposeAction}
+              onClick={() => onComposeAction?.(action)}
+            >
+              <Icon
+                className={cn(
+                  'size-4',
+                  pendingAction === action &&
+                    action === 'restart' &&
+                    'animate-spin',
+                )}
+                aria-hidden
+              />
+            </IconButton>
+          )
+        })
+      : null
+
   const stopButton = (
     <Button
       variant="ghost"
@@ -197,17 +301,37 @@ function WorkerTableRow({
     </Button>
   )
 
+  const fallbackStop =
+    composeVerbs.length > 0 ? null : row.stopEnabled ||
+      !row.stopDisabledReason ? (
+      stopButton
+    ) : (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="inline-block">{stopButton}</span>
+        </TooltipTrigger>
+        <TooltipContent>{row.stopDisabledReason}</TooltipContent>
+      </Tooltip>
+    )
+
   // A span, not a div: this nests inside the expand <button>, which only
   // allows phrasing content.
   const nameCell = (
     <span className="flex items-center gap-2">
       <StatusDot
-        tone={statusTone(row.status)}
-        pulse={row.status === 'connected'}
+        tone={STATUS_STYLE[row.status].tone}
+        pulse={row.status === 'connected' || row.status === 'starting'}
       />
       <span className="font-mono text-[13px] text-ink lowercase">
         {row.name}
       </span>
+      {pendingAction ? (
+        <Badge
+          variant={STATUS_STYLE[row.status].badge}
+        >{`${pendingAction}…`}</Badge>
+      ) : row.status !== 'connected' ? (
+        <Badge variant={STATUS_STYLE[row.status].badge}>{row.status}</Badge>
+      ) : null}
     </span>
   )
   const detailId = `worker-detail-${row.name}`
@@ -237,6 +361,14 @@ function WorkerTableRow({
           ) : (
             <div className="pl-[18px]">{nameCell}</div>
           )}
+          {row.lastError ? (
+            <p
+              className="mt-1 max-w-[32rem] whitespace-normal pl-[18px] font-mono text-[11.5px] leading-relaxed text-alert"
+              title={row.lastError}
+            >
+              {row.lastError}
+            </p>
+          ) : null}
         </td>
         <td className="py-2.5 pr-4 font-mono text-[13px] text-ink-faint lowercase">
           {formatCell(row.runtime)}
@@ -259,18 +391,10 @@ function WorkerTableRow({
           {formatCell(row.tag)}
         </td>
         <td className="py-2.5 text-right">
-          <div className="flex items-center justify-end gap-2">
+          <div className="flex items-center justify-end gap-1">
             {configureButton}
-            {row.stopEnabled || !row.stopDisabledReason ? (
-              stopButton
-            ) : (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span className="inline-block">{stopButton}</span>
-                </TooltipTrigger>
-                <TooltipContent>{row.stopDisabledReason}</TooltipContent>
-              </Tooltip>
-            )}
+            {composeButtons}
+            {fallbackStop}
           </div>
         </td>
       </tr>

--- a/console/web/src/pages/Workers/fixtures/workers-fixtures.ts
+++ b/console/web/src/pages/Workers/fixtures/workers-fixtures.ts
@@ -15,6 +15,8 @@ export const WORKERS_FIXTURE_ROWS: WorkerRow[] = [
     stopEnabled: false,
     stopDisabledReason:
       'workers declared in config.yaml are managed by the engine',
+    composeState: null,
+    lastError: null,
   },
   {
     id: '00000000-0000-0000-0000-000000000aaa',
@@ -29,6 +31,8 @@ export const WORKERS_FIXTURE_ROWS: WorkerRow[] = [
     configurationId: null,
     stopEnabled: true,
     stopDisabledReason: null,
+    composeState: null,
+    lastError: null,
   },
   {
     id: '11111111-2222-3333-4444-555555555555',
@@ -44,6 +48,8 @@ export const WORKERS_FIXTURE_ROWS: WorkerRow[] = [
     stopEnabled: false,
     stopDisabledReason:
       'standalone workers must be stopped from the process that started them',
+    composeState: null,
+    lastError: null,
   },
   {
     id: '22222222-3333-4444-5555-666666666666',
@@ -59,6 +65,8 @@ export const WORKERS_FIXTURE_ROWS: WorkerRow[] = [
     stopEnabled: false,
     stopDisabledReason:
       'internal engine workers cannot be stopped from the console',
+    composeState: null,
+    lastError: null,
   },
   {
     id: '33333333-4444-5555-6666-777777777777',
@@ -73,6 +81,76 @@ export const WORKERS_FIXTURE_ROWS: WorkerRow[] = [
     configurationId: null,
     stopEnabled: false,
     stopDisabledReason: 'worker is not running',
+    composeState: null,
+    lastError: null,
+  },
+]
+
+export const WORKERS_FIXTURE_COMPOSE_ROWS: WorkerRow[] = [
+  {
+    id: '44444444-5555-6666-7777-888888888888',
+    name: 'llm-router',
+    runtime: 'rust',
+    ipAddress: '127.0.0.1',
+    version: '1.4.14',
+    pid: 27610,
+    tag: 'platform',
+    managementKind: 'compose',
+    status: 'connected',
+    configurationId: 'llm-router',
+    stopEnabled: false,
+    stopDisabledReason: null,
+    composeState: 'ready',
+    lastError: null,
+  },
+  {
+    id: '55555555-6666-7777-8888-999999999999',
+    name: 'provider-openai',
+    runtime: 'rust',
+    ipAddress: '127.0.0.1',
+    version: '1.2.8',
+    pid: 27638,
+    tag: 'provider',
+    managementKind: 'compose',
+    status: 'starting',
+    configurationId: null,
+    stopEnabled: false,
+    stopDisabledReason: null,
+    composeState: 'starting',
+    lastError: null,
+  },
+  {
+    id: 'compose:provider-anthropic',
+    name: 'provider-anthropic',
+    runtime: null,
+    ipAddress: null,
+    version: null,
+    pid: null,
+    tag: null,
+    managementKind: 'compose',
+    status: 'failed',
+    configurationId: null,
+    stopEnabled: false,
+    stopDisabledReason: null,
+    composeState: 'failed',
+    lastError:
+      'CHILD_EXITED_BEFORE_REGISTRATION: provider-anthropic exited with status 1 before registering',
+  },
+  {
+    id: 'compose:web',
+    name: 'web',
+    runtime: null,
+    ipAddress: null,
+    version: null,
+    pid: null,
+    tag: null,
+    managementKind: 'compose',
+    status: 'stopped',
+    configurationId: null,
+    stopEnabled: false,
+    stopDisabledReason: null,
+    composeState: 'stopped',
+    lastError: null,
   },
 ]
 

--- a/console/web/src/pages/Workers/hooks/useComposeChanged.ts
+++ b/console/web/src/pages/Workers/hooks/useComposeChanged.ts
@@ -1,0 +1,51 @@
+import { useEffect, useId, useRef } from 'react'
+import { getIiiClient } from '@/lib/iii-client'
+
+export const COMPOSE_CHANGED_TRIGGER = 'compose-ui::changed'
+
+export interface UseComposeChangedOptions {
+  enabled: boolean
+  fnId: string
+  onEvent: () => void
+}
+
+export function useComposeChanged(opts: UseComposeChangedOptions): void {
+  const { enabled, fnId, onEvent } = opts
+  const onEventRef = useRef(onEvent)
+  onEventRef.current = onEvent
+  const instanceId = useId().replace(/[^a-zA-Z0-9]/g, '')
+
+  useEffect(() => {
+    if (!enabled) return
+    let cancelled = false
+    let offHandler: (() => void) | undefined
+    let offTrigger: (() => void) | undefined
+
+    void (async () => {
+      const client = await getIiiClient()
+      if (cancelled) return
+      const localFnId = `${fnId}::${instanceId}`
+      try {
+        offHandler = client.on(localFnId, () => {
+          onEventRef.current()
+        })
+        offTrigger = client.registerTrigger({
+          type: COMPOSE_CHANGED_TRIGGER,
+          function_id: `${localFnId}::${client.browserId}`,
+          config: {},
+        })
+      } catch {
+        offTrigger?.()
+        offHandler?.()
+        offTrigger = undefined
+        offHandler = undefined
+      }
+    })()
+
+    return () => {
+      cancelled = true
+      offTrigger?.()
+      offHandler?.()
+    }
+  }, [enabled, fnId, instanceId])
+}

--- a/console/web/src/pages/Workers/hooks/useWorkersLive.ts
+++ b/console/web/src/pages/Workers/hooks/useWorkersLive.ts
@@ -2,10 +2,15 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useMemo, useState } from 'react'
 import { useWorkerLifecycle } from '@/hooks/use-worker-lifecycle'
 import { getDefaultBackend } from '@/lib/backend'
-import { stopSupervisorWorker } from '../api/workers'
-import { fetchMergedWorkers } from '../lib/merge-workers'
+import { composeContainerAction, stopSupervisorWorker } from '../api/workers'
+import { fetchWorkersView } from '../lib/merge-workers'
 import { takePendingWorkerSearch } from '../pending-selection'
-import { filterWorkerRows, type WorkersFilterState } from '../types'
+import {
+  type ComposeAction,
+  filterWorkerRows,
+  type WorkersFilterState,
+} from '../types'
+import { useComposeChanged } from './useComposeChanged'
 
 export const workersKeys = {
   all: ['workers'] as const,
@@ -13,6 +18,7 @@ export const workersKeys = {
 }
 
 const WORKERS_RUNTIME_WATCH_FN = 'iii::console::workers_runtime'
+const COMPOSE_WATCH_FN = 'iii::console::workers_compose'
 
 const RUNTIME_OPERATIONS = [
   'add',
@@ -25,6 +31,11 @@ const RUNTIME_OPERATIONS = [
 
 const RUNTIME_STAGES = ['done', 'failed'] as const
 
+export interface PendingComposeAction {
+  container: string
+  action: ComposeAction
+}
+
 export function useWorkersLive() {
   const qc = useQueryClient()
   const enabled = getDefaultBackend().id === 'real'
@@ -34,27 +45,38 @@ export function useWorkersLive() {
     search: takePendingWorkerSearch() ?? '',
     tag: null,
     runtime: null,
+    management: null,
   }))
   const [stoppingName, setStoppingName] = useState<string | null>(null)
+  const [pendingCompose, setPendingCompose] =
+    useState<PendingComposeAction | null>(null)
 
   const query = useQuery({
     queryKey: workersKeys.runtime(),
-    queryFn: fetchMergedWorkers,
+    queryFn: fetchWorkersView,
     enabled,
   })
+
+  const invalidate = () => {
+    void qc.invalidateQueries({ queryKey: workersKeys.runtime() })
+  }
 
   useWorkerLifecycle({
     enabled,
     fnId: WORKERS_RUNTIME_WATCH_FN,
     operations: RUNTIME_OPERATIONS,
     stages: RUNTIME_STAGES,
-    onEvent: () => {
-      void qc.invalidateQueries({ queryKey: workersKeys.runtime() })
-    },
+    onEvent: invalidate,
+  })
+
+  useComposeChanged({
+    enabled,
+    fnId: COMPOSE_WATCH_FN,
+    onEvent: invalidate,
   })
 
   const rows = useMemo(() => {
-    const source = query.data ?? []
+    const source = query.data?.rows ?? []
     return filterWorkerRows(source, filters)
   }, [query.data, filters])
 
@@ -65,7 +87,19 @@ export function useWorkersLive() {
     },
     onSettled: () => {
       setStoppingName(null)
-      void qc.invalidateQueries({ queryKey: workersKeys.runtime() })
+      invalidate()
+    },
+  })
+
+  const composeMutation = useMutation({
+    mutationFn: ({ action, container }: PendingComposeAction) =>
+      composeContainerAction(action, container),
+    onMutate: (pending) => {
+      setPendingCompose(pending)
+    },
+    onSettled: () => {
+      setPendingCompose(null)
+      invalidate()
     },
   })
 
@@ -74,16 +108,21 @@ export function useWorkersLive() {
   }
 
   function clearFilters() {
-    setFilters({ search: '', tag: null, runtime: null })
+    setFilters({ search: '', tag: null, runtime: null, management: null })
   }
 
   function stopWorker(name: string) {
     stopMutation.mutate(name)
   }
 
+  function composeAction(action: ComposeAction, container: string) {
+    composeMutation.mutate({ action, container })
+  }
+
   return {
     rows,
-    allRows: query.data ?? [],
+    allRows: query.data?.rows ?? [],
+    compose: query.data?.compose ?? null,
     filters,
     updateFilters,
     clearFilters,
@@ -94,5 +133,9 @@ export function useWorkersLive() {
     stoppingName,
     stopWorker,
     stopError: stopMutation.error,
+    pendingCompose,
+    composeAction,
+    composeError: composeMutation.error,
+    clearComposeError: composeMutation.reset,
   }
 }

--- a/console/web/src/pages/Workers/index.tsx
+++ b/console/web/src/pages/Workers/index.tsx
@@ -1,16 +1,20 @@
-import { AlertCircle, Blocks, RefreshCw } from 'lucide-react'
+import { AlertCircle, Blocks, Layers, RefreshCw } from 'lucide-react'
 import { useEffect, useRef } from 'react'
 import { Button } from '@/components/ui/Button'
 import { PageHeader, PageShell } from '@/components/ui/PageChrome'
 import { StatusPanel } from '@/components/ui/StatusPanel'
 import { TooltipProvider } from '@/components/ui/Tooltip'
 import { useWorkersConfigurationRoute } from '@/hooks/use-hash-route'
+import { requestPanelOpen } from '@/lib/panel-context'
+import { useExtPages } from '@/lib/ui-slots'
 import { cn } from '@/lib/utils'
 import type { PageCommandsApi } from '@/types/injectable-ui'
 import { WorkerConfigurationPanel } from './components/WorkerConfigurationPanel'
 import { WorkersFilters } from './components/WorkersFilters'
 import { WorkersTable } from './components/WorkersTable'
 import { useWorkersLive } from './hooks/useWorkersLive'
+
+const COMPOSE_PAGE_ID = 'compose'
 
 interface WorkersProps {
   /** Close the hosting pane — the header's standard ✕ when present. */
@@ -25,6 +29,7 @@ export function Workers({ onRequestClose, commands }: WorkersProps) {
   const {
     rows,
     allRows,
+    compose,
     filters,
     updateFilters,
     clearFilters,
@@ -34,7 +39,11 @@ export function Workers({ onRequestClose, commands }: WorkersProps) {
     refetch,
     stoppingName,
     stopWorker,
+    pendingCompose,
+    composeAction,
+    composeError,
   } = useWorkersLive()
+  const composePage = useExtPages().some((page) => page.id === COMPOSE_PAGE_ID)
   const rootRef = useRef<HTMLDivElement>(null)
   useEffect(
     () =>
@@ -58,11 +67,23 @@ export function Workers({ onRequestClose, commands }: WorkersProps) {
               ?.querySelector<HTMLElement>('[aria-label="search workers"]')
               ?.focus(),
         },
+        {
+          id: 'compose',
+          title: 'Open Compose',
+          detail: 'Containers, lifecycle, worker packages, and logs',
+          keywords: ['compose', 'containers', 'daemon', 'logs'],
+          shortcut: 'C',
+          enabled: () => composePage,
+          run: () => requestPanelOpen({ pageId: COMPOSE_PAGE_ID, context: {} }),
+        },
       ]),
-    [commands, refetch],
+    [commands, refetch, composePage],
   )
 
   const countLabel = isLoading ? '…' : String(allRows.length)
+  const description = compose
+    ? `${countLabel} connected or declared · compose${compose.namespace ? ` ${compose.namespace}` : ''} ${compose.ready}/${compose.total} ready`
+    : `${countLabel} connected or installed`
 
   return (
     <TooltipProvider>
@@ -77,22 +98,37 @@ export function Workers({ onRequestClose, commands }: WorkersProps) {
           <PageHeader
             icon={<Blocks />}
             title="Workers"
-            description={`${countLabel} connected or installed`}
+            description={description}
             onClose={onRequestClose}
             actions={
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => void refetch()}
-                disabled={isLoading}
-                className="gap-1.5"
-              >
-                <RefreshCw
-                  className={cn('size-4', isLoading && 'animate-spin')}
-                  aria-hidden
-                />
-                refresh
-              </Button>
+              <>
+                {composePage ? (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() =>
+                      requestPanelOpen({ pageId: COMPOSE_PAGE_ID, context: {} })
+                    }
+                    className="gap-1.5"
+                  >
+                    <Layers className="size-4" aria-hidden />
+                    compose
+                  </Button>
+                ) : null}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => void refetch()}
+                  disabled={isLoading}
+                  className="gap-1.5"
+                >
+                  <RefreshCw
+                    className={cn('size-4', isLoading && 'animate-spin')}
+                    aria-hidden
+                  />
+                  refresh
+                </Button>
+              </>
             }
           />
           <div className="flex-1 overflow-y-auto px-4 sm:px-6 lg:px-8 py-4 space-y-4">
@@ -109,6 +145,19 @@ export function Workers({ onRequestClose, commands }: WorkersProps) {
               />
             ) : null}
 
+            {composeError ? (
+              <StatusPanel
+                variant="alert"
+                icon={<AlertCircle className="w-full h-full" />}
+                headline="compose action failed"
+                detail={
+                  composeError instanceof Error
+                    ? composeError.message
+                    : String(composeError)
+                }
+              />
+            ) : null}
+
             <WorkersFilters
               rows={allRows}
               filters={filters}
@@ -120,7 +169,9 @@ export function Workers({ onRequestClose, commands }: WorkersProps) {
               rows={rows}
               isLoading={isLoading}
               stoppingName={stoppingName}
+              pendingCompose={pendingCompose}
               onStop={stopWorker}
+              onComposeAction={composeAction}
               onConfigure={(configurationId) =>
                 navigateConfiguration(configurationId)
               }

--- a/console/web/src/pages/Workers/lib/merge-workers.compose.test.ts
+++ b/console/web/src/pages/Workers/lib/merge-workers.compose.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest'
+import type { RawWorkersSnapshot } from '../api/workers'
+import type { WorkerRow } from '../types'
+import { composeActions, distinctManagement, filterWorkerRows } from '../types'
+import {
+  mergeWorkers,
+  mergeWorkersView,
+  summarizeCompose,
+} from './merge-workers'
+
+function row(rows: WorkerRow[], name: string): WorkerRow {
+  const found = rows.find((r) => r.name === name)
+  if (!found) throw new Error(`no row named ${name}`)
+  return found
+}
+
+function snapshot(partial: Partial<RawWorkersSnapshot>): RawWorkersSnapshot {
+  return {
+    engineWorkers: [],
+    supervisorWorkers: [],
+    configurations: [],
+    infoByName: new Map(),
+    compose: null,
+    ...partial,
+  }
+}
+
+const engineWorker = (name: string, status = 'connected') => ({
+  id: `id-${name}`,
+  name,
+  status,
+  function_count: 1,
+  connected_at_ms: 0,
+  active_invocations: 0,
+})
+
+const compose: RawWorkersSnapshot['compose'] = {
+  namespace: 'my-project',
+  file: '/proj/worker-compose.yaml',
+  state_dir: '/home/me/.iii/compose/my-project/proj-1',
+  daemon_pid: 27045,
+  containers: [
+    { container: 'llm-router', state: 'ready', owned: true, pid: 27610 },
+    {
+      container: 'provider-openai',
+      state: 'starting',
+      owned: true,
+      pid: 27638,
+    },
+    {
+      container: 'provider-anthropic',
+      state: 'failed',
+      owned: false,
+      pid: 27640,
+      last_error: 'exited with status 1',
+    },
+    { container: 'web', state: 'stopped', owned: false, pid: 69884 },
+  ],
+}
+
+describe('mergeWorkers with compose', () => {
+  it('marks connected containers as compose-supervised and keeps the engine pid', () => {
+    const rows = mergeWorkers(
+      snapshot({
+        engineWorkers: [engineWorker('llm-router')],
+        infoByName: new Map([
+          [
+            'llm-router',
+            { ...engineWorker('llm-router'), internal: false, pid: 27610 },
+          ],
+        ]),
+        compose,
+      }),
+    )
+    const found = row(rows, 'llm-router')
+    expect(found).toMatchObject({
+      managementKind: 'compose',
+      status: 'connected',
+      composeState: 'ready',
+      pid: 27610,
+      stopEnabled: false,
+      stopDisabledReason: null,
+    })
+    expect(composeActions(found)).toEqual(['stop', 'restart'])
+  })
+
+  it('compose wins over supervisor and config classification', () => {
+    const rows = mergeWorkers(
+      snapshot({
+        engineWorkers: [engineWorker('llm-router')],
+        supervisorWorkers: [
+          { name: 'llm-router', running: true, pid: 1, version: '1' },
+        ],
+        configurations: [
+          { id: 'llm-router', name: 'llm-router', description: '', schema: {} },
+        ],
+        compose,
+      }),
+    )
+    expect(rows.find((r) => r.name === 'llm-router')).toMatchObject({
+      managementKind: 'compose',
+      configurationId: 'llm-router',
+    })
+  })
+
+  it('adds declared containers the engine does not know as synthetic rows', () => {
+    const rows = mergeWorkers(snapshot({ compose }))
+    expect(rows.map((r) => r.name)).toEqual([
+      'llm-router',
+      'provider-anthropic',
+      'provider-openai',
+      'web',
+    ])
+    expect(rows.find((r) => r.name === 'provider-anthropic')).toMatchObject({
+      id: 'compose:provider-anthropic',
+      status: 'failed',
+      composeState: 'failed',
+      lastError: 'exited with status 1',
+      pid: null,
+    })
+    expect(rows.find((r) => r.name === 'provider-openai')).toMatchObject({
+      status: 'starting',
+      pid: 27638,
+    })
+    expect(rows.find((r) => r.name === 'web')).toMatchObject({
+      status: 'stopped',
+      pid: null,
+    })
+  })
+
+  it('offers start for stopped and failed containers, stop while running', () => {
+    const rows = mergeWorkers(snapshot({ compose }))
+    expect(composeActions(row(rows, 'web'))).toEqual(['start', 'restart'])
+    expect(composeActions(row(rows, 'provider-anthropic'))).toEqual([
+      'start',
+      'restart',
+    ])
+    expect(composeActions(row(rows, 'provider-openai'))).toEqual([
+      'stop',
+      'restart',
+    ])
+  })
+
+  it('offers no compose actions to rows compose does not supervise', () => {
+    const rows = mergeWorkers(
+      snapshot({
+        engineWorkers: [engineWorker('todo-app')],
+        compose,
+      }),
+    )
+    expect(composeActions(row(rows, 'todo-app'))).toEqual([])
+  })
+
+  it('summarizes the compose project for the page header', () => {
+    expect(summarizeCompose(compose)).toEqual({
+      namespace: 'my-project',
+      file: '/proj/worker-compose.yaml',
+      daemonPid: 27045,
+      ready: 1,
+      total: 4,
+    })
+    expect(summarizeCompose(null)).toBeNull()
+    expect(mergeWorkersView(snapshot({ compose })).compose?.total).toBe(4)
+  })
+
+  it('filters by management kind and lists the kinds present in a fixed order', () => {
+    const rows = mergeWorkers(
+      snapshot({
+        engineWorkers: [engineWorker('todo-app')],
+        compose,
+      }),
+    )
+    expect(distinctManagement(rows)).toEqual(['compose', 'standalone'])
+    expect(
+      filterWorkerRows(rows, {
+        search: '',
+        tag: null,
+        runtime: null,
+        management: 'compose',
+      }).map((r) => r.name),
+    ).toEqual(['llm-router', 'provider-anthropic', 'provider-openai', 'web'])
+    expect(
+      filterWorkerRows(rows, {
+        search: 'failed',
+        tag: null,
+        runtime: null,
+        management: null,
+      }).map((r) => r.name),
+    ).toEqual(['provider-anthropic'])
+  })
+})

--- a/console/web/src/pages/Workers/lib/merge-workers.test.ts
+++ b/console/web/src/pages/Workers/lib/merge-workers.test.ts
@@ -8,6 +8,7 @@ function snapshot(partial: Partial<RawWorkersSnapshot>): RawWorkersSnapshot {
     supervisorWorkers: [],
     configurations: [],
     infoByName: new Map(),
+    compose: null,
     ...partial,
   }
 }

--- a/console/web/src/pages/Workers/lib/merge-workers.ts
+++ b/console/web/src/pages/Workers/lib/merge-workers.ts
@@ -1,11 +1,12 @@
 import type { WorkerSummary } from '@/components/chat/engine/parsers'
 import type { WorkerEntry } from '@/components/chat/worker/parsers'
 import type { ConfigurationSchemaView } from '@/pages/Configuration/tabs/WorkersTab/api'
-import type { RawWorkersSnapshot } from '../api/workers'
-import type {
-  WorkerConnectionStatus,
-  WorkerManagementKind,
-  WorkerRow,
+import type { ComposeContainer, RawWorkersSnapshot } from '../api/workers'
+import {
+  isComposeRunning,
+  type WorkerConnectionStatus,
+  type WorkerManagementKind,
+  type WorkerRow,
 } from '../types'
 
 const STOP_REASON = {
@@ -19,6 +20,19 @@ const STOP_REASON = {
 interface ConfigurationLookup {
   byId: Map<string, string>
   byName: Map<string, string>
+}
+
+export interface ComposeSummary {
+  namespace: string | null
+  file: string | null
+  daemonPid: number | null
+  ready: number
+  total: number
+}
+
+export interface WorkersView {
+  rows: WorkerRow[]
+  compose: ComposeSummary | null
 }
 
 function configurationLookup(
@@ -48,12 +62,24 @@ function supervisorMap(entries: WorkerEntry[]): Map<string, WorkerEntry> {
   return map
 }
 
+function composeMap(
+  compose: RawWorkersSnapshot['compose'],
+): Map<string, ComposeContainer> {
+  const map = new Map<string, ComposeContainer>()
+  for (const container of compose?.containers ?? []) {
+    map.set(container.container, container)
+  }
+  return map
+}
+
 function deriveManagementKind(
   internal: boolean,
   configurationId: string | null,
   supervisor?: WorkerEntry,
+  compose?: ComposeContainer,
 ): WorkerManagementKind {
   if (internal) return 'internal'
+  if (compose) return 'compose'
   if (configurationId) return 'config'
   if (supervisor) return 'supervisor'
   return 'standalone'
@@ -62,8 +88,15 @@ function deriveManagementKind(
 function deriveConnectionStatus(
   engineStatus: string | undefined,
   supervisor: WorkerEntry | undefined,
+  compose: ComposeContainer | undefined,
 ): WorkerConnectionStatus {
   if (engineStatus?.toLowerCase() === 'connected') return 'connected'
+  if (compose) {
+    if (compose.state === 'ready') return 'connected'
+    if (compose.state === 'starting') return 'starting'
+    if (compose.state === 'failed') return 'failed'
+    return 'stopped'
+  }
   if (supervisor?.running) return 'connected'
   if (supervisor && !supervisor.running) return 'stopped'
   return 'disconnected'
@@ -74,6 +107,9 @@ function deriveStopState(
   status: WorkerConnectionStatus,
   supervisor: WorkerEntry | undefined,
 ): Pick<WorkerRow, 'stopEnabled' | 'stopDisabledReason'> {
+  if (kind === 'compose') {
+    return { stopEnabled: false, stopDisabledReason: null }
+  }
   if (kind === 'supervisor' && status === 'connected' && supervisor?.running) {
     return { stopEnabled: true, stopDisabledReason: null }
   }
@@ -89,10 +125,25 @@ function deriveStopState(
   return { stopEnabled: false, stopDisabledReason: STOP_REASON.notRunning }
 }
 
+function composeFields(
+  compose: ComposeContainer | undefined,
+): Pick<WorkerRow, 'composeState' | 'lastError'> {
+  return {
+    composeState: compose?.state ?? null,
+    lastError: compose?.last_error ?? null,
+  }
+}
+
+function composePid(compose: ComposeContainer | undefined): number | null {
+  if (!compose || !isComposeRunning(compose.state)) return null
+  return compose.pid ?? null
+}
+
 function engineRowToWorkerRow(
   summary: WorkerSummary,
   configurations: ConfigurationLookup,
   supervisors: Map<string, WorkerEntry>,
+  composes: Map<string, ComposeContainer>,
   infoByName: Map<
     string,
     { pid?: number; internal: boolean; tag?: string | null }
@@ -102,13 +153,15 @@ function engineRowToWorkerRow(
   const info = infoByName.get(name)
   const internal = info?.internal ?? false
   const supervisor = supervisors.get(name)
+  const compose = composes.get(name)
   const configurationId = resolveConfigurationId(name, configurations)
   const managementKind = deriveManagementKind(
     internal,
     configurationId,
     supervisor,
+    compose,
   )
-  const status = deriveConnectionStatus(summary.status, supervisor)
+  const status = deriveConnectionStatus(summary.status, supervisor, compose)
   const stop = deriveStopState(managementKind, status, supervisor)
 
   return {
@@ -117,12 +170,13 @@ function engineRowToWorkerRow(
     runtime: summary.runtime ?? null,
     ipAddress: summary.ip_address ?? null,
     version: summary.version ?? null,
-    pid: info?.pid ?? supervisor?.pid ?? null,
+    pid: info?.pid ?? composePid(compose) ?? supervisor?.pid ?? null,
     tag: info?.tag ?? summary.tag ?? null,
     managementKind,
     status,
     configurationId,
     ...stop,
+    ...composeFields(compose),
   }
 }
 
@@ -147,13 +201,53 @@ function syntheticSupervisorRow(
     status,
     configurationId,
     ...stop,
+    ...composeFields(undefined),
   }
 }
 
-/** Merge engine catalogue, supervisor list, and configuration registry into table rows. */
+function syntheticComposeRow(
+  container: ComposeContainer,
+  configurations: ConfigurationLookup,
+): WorkerRow {
+  const name = container.container
+  const status = deriveConnectionStatus(undefined, undefined, container)
+
+  return {
+    id: `compose:${name}`,
+    name,
+    runtime: null,
+    ipAddress: null,
+    version: null,
+    pid: composePid(container),
+    tag: null,
+    managementKind: 'compose',
+    status,
+    configurationId: resolveConfigurationId(name, configurations),
+    stopEnabled: false,
+    stopDisabledReason: null,
+    ...composeFields(container),
+  }
+}
+
+export function summarizeCompose(
+  compose: RawWorkersSnapshot['compose'],
+): ComposeSummary | null {
+  if (!compose) return null
+  const containers = compose.containers
+  return {
+    namespace: compose.namespace ?? null,
+    file: compose.file ?? null,
+    daemonPid: compose.daemon_pid ?? null,
+    ready: containers.filter((c) => c.state === 'ready').length,
+    total: containers.length,
+  }
+}
+
+/** Merge engine catalogue, supervisor list, compose status, and configuration registry into table rows. */
 export function mergeWorkers(snapshot: RawWorkersSnapshot): WorkerRow[] {
   const configurations = configurationLookup(snapshot.configurations)
   const supervisors = supervisorMap(snapshot.supervisorWorkers)
+  const composes = composeMap(snapshot.compose)
   const seen = new Set<string>()
   const rows: WorkerRow[] = []
 
@@ -165,9 +259,16 @@ export function mergeWorkers(snapshot: RawWorkersSnapshot): WorkerRow[] {
         engineWorker,
         configurations,
         supervisors,
+        composes,
         snapshot.infoByName,
       ),
     )
+  }
+
+  for (const [name, container] of composes) {
+    if (seen.has(name)) continue
+    rows.push(syntheticComposeRow(container, configurations))
+    seen.add(name)
   }
 
   for (const [name, entry] of supervisors) {
@@ -180,8 +281,18 @@ export function mergeWorkers(snapshot: RawWorkersSnapshot): WorkerRow[] {
   return rows
 }
 
-export async function fetchMergedWorkers(): Promise<WorkerRow[]> {
+export function mergeWorkersView(snapshot: RawWorkersSnapshot): WorkersView {
+  return {
+    rows: mergeWorkers(snapshot),
+    compose: summarizeCompose(snapshot.compose),
+  }
+}
+
+export async function fetchWorkersView(): Promise<WorkersView> {
   const { fetchRawWorkersSnapshot } = await import('../api/workers')
-  const snapshot = await fetchRawWorkersSnapshot()
-  return mergeWorkers(snapshot)
+  return mergeWorkersView(await fetchRawWorkersSnapshot())
+}
+
+export async function fetchMergedWorkers(): Promise<WorkerRow[]> {
+  return (await fetchWorkersView()).rows
 }

--- a/console/web/src/pages/Workers/types.test.ts
+++ b/console/web/src/pages/Workers/types.test.ts
@@ -15,6 +15,8 @@ const rows: WorkerRow[] = [
     configurationId: 'harness',
     stopEnabled: false,
     stopDisabledReason: null,
+    composeState: null,
+    lastError: null,
   },
   {
     id: '2',
@@ -29,6 +31,8 @@ const rows: WorkerRow[] = [
     configurationId: null,
     stopEnabled: false,
     stopDisabledReason: 'standalone',
+    composeState: null,
+    lastError: null,
   },
 ]
 
@@ -38,6 +42,7 @@ describe('filterWorkerRows', () => {
       search: '',
       tag: 'dev',
       runtime: null,
+      management: null,
     })
     expect(filtered).toHaveLength(1)
     expect(filtered[0]?.name).toBe('todo-app')
@@ -48,6 +53,7 @@ describe('filterWorkerRows', () => {
       search: '127.0.0.1',
       tag: null,
       runtime: null,
+      management: null,
     })
     expect(filtered).toHaveLength(1)
     expect(filtered[0]?.name).toBe('harness')

--- a/console/web/src/pages/Workers/types.ts
+++ b/console/web/src/pages/Workers/types.ts
@@ -1,12 +1,22 @@
-/** How the worker is managed — drives badge copy and stop affordance. */
+/** How the worker is managed — drives badge copy and lifecycle affordances. */
 export type WorkerManagementKind =
+  | 'compose'
   | 'config'
   | 'supervisor'
   | 'standalone'
   | 'internal'
 
 /** Connection / liveness status shown in the table. */
-export type WorkerConnectionStatus = 'connected' | 'disconnected' | 'stopped'
+export type WorkerConnectionStatus =
+  | 'connected'
+  | 'starting'
+  | 'failed'
+  | 'disconnected'
+  | 'stopped'
+
+export type ComposeContainerState = 'starting' | 'ready' | 'failed' | 'stopped'
+
+export type ComposeAction = 'start' | 'stop' | 'restart'
 
 /** View-model row for the runtime workers table (no transport types). */
 export interface WorkerRow {
@@ -22,16 +32,46 @@ export interface WorkerRow {
   status: WorkerConnectionStatus
   /** Configuration registry id for rows with editable worker configuration. */
   configurationId: string | null
-  /** When true the stop action is enabled (supervisor-managed + running). */
+  /** When true the supervisor stop action is enabled (supervisor-managed + running). */
   stopEnabled: boolean
   /** Shown when stop is disabled. */
   stopDisabledReason: string | null
+  composeState: ComposeContainerState | null
+  lastError: string | null
 }
 
 export interface WorkersFilterState {
   search: string
   tag: string | null
   runtime: string | null
+  management: WorkerManagementKind | null
+}
+
+export const MANAGEMENT_ORDER: readonly WorkerManagementKind[] = [
+  'compose',
+  'config',
+  'supervisor',
+  'standalone',
+  'internal',
+]
+
+export const MANAGEMENT_LABEL: Record<WorkerManagementKind, string> = {
+  compose: 'compose',
+  config: 'config',
+  supervisor: 'managed',
+  standalone: 'standalone',
+  internal: 'internal',
+}
+
+export function isComposeRunning(state: ComposeContainerState): boolean {
+  return state === 'ready' || state === 'starting'
+}
+
+export function composeActions(row: WorkerRow): ComposeAction[] {
+  if (row.managementKind !== 'compose' || row.composeState === null) return []
+  return isComposeRunning(row.composeState)
+    ? ['stop', 'restart']
+    : ['start', 'restart']
 }
 
 export function filterWorkerRows(
@@ -42,6 +82,8 @@ export function filterWorkerRows(
   return rows.filter((row) => {
     if (filters.tag && row.tag !== filters.tag) return false
     if (filters.runtime && row.runtime !== filters.runtime) return false
+    if (filters.management && row.managementKind !== filters.management)
+      return false
     if (!q) return true
     const haystack = [
       row.name,
@@ -50,6 +92,7 @@ export function filterWorkerRows(
       row.version,
       row.tag,
       row.managementKind,
+      row.status,
       row.pid?.toString(),
     ]
       .filter(Boolean)
@@ -73,4 +116,9 @@ export function distinctRuntimes(rows: WorkerRow[]): string[] {
     if (row.runtime) runtimes.add(row.runtime)
   }
   return [...runtimes].sort()
+}
+
+export function distinctManagement(rows: WorkerRow[]): WorkerManagementKind[] {
+  const present = new Set(rows.map((row) => row.managementKind))
+  return MANAGEMENT_ORDER.filter((kind) => present.has(kind))
 }

--- a/console/web/vite.config.ts
+++ b/console/web/vite.config.ts
@@ -48,6 +48,10 @@ export default defineConfig({
         target: process.env.III_CONSOLE_URL ?? 'http://127.0.0.1:3113',
         changeOrigin: true,
       },
+      '/runtime': {
+        target: process.env.III_CONSOLE_URL ?? 'http://127.0.0.1:3113',
+        changeOrigin: true,
+      },
     },
   },
 })

--- a/docs/sops/console-ui-conformance.md
+++ b/docs/sops/console-ui-conformance.md
@@ -98,7 +98,7 @@ owns; the registry refuses those at registration. See the injectable-UI SOP,
 | Page | Commands (render time unless noted) | Keys | Palette source |
 |---|---|---|---|
 | chat (first-party) | focus composer, next / previous message, approve / deny the pending call, expand, copy, latest, switch model, stop, new chat, search conversations | `I`, `J` / `K`, `A` / `D`, `O`, `Y`, `End`, `M`, `Escape`, `N`, `/` | chats (built in) |
-| workers (first-party) | refresh, search | `R`, `/` | workers, functions (built in) |
+| workers (first-party) | refresh, search, open Compose (when the compose-ui page is registered); start / stop / restart on compose-supervised rows | `R`, `/`, `C` | workers, functions (built in) |
 | traces (first-party) | search, follow turns, clear filters, close detail | `/`, `F`, `Escape` | |
 | shell | open file…, search in files, file tree, toggle sidebar, toggle terminal, next / previous tab, close tab, next / previous change; setup: open file…, open | `P`, `F`, `E`, `B`, `` ` ``, `Alt+←` / `Alt+→`, `W`, `J` / `K` | files (`coder::search`, `#`) |
 | database | focus SQL, refresh, focus tables; setup: open | `S`, `R`, `/` | tables (`database::listTables`) |


### PR DESCRIPTION
## What

The Workers page now merges `compose::status` into the fleet table so a compose-supervised worker is managed where the operator already is.

- Containers the daemon supervises show management kind `compose` with the daemon's state (`starting`, `ready` as connected, `failed`, `stopped`), the last recorded error under the name, and start / stop / restart actions that call `compose::up`, `compose::down`, and `compose::restart` for that container. Stop and restart confirm through `ConfirmDialog` because stop cascades to dependents in reverse dependency order.
- Declared containers the engine does not know (stopped or crashed before registration) appear as synthetic rows, so a down worker is still visible and startable.
- The header names the compose namespace with a ready count and offers a `compose` button (and a `C` command) that opens the Compose page when the `compose-ui` worker has registered it; a `managed by` chip group joins the tag and runtime filters.
- Live updates ride the `compose-ui::changed` trigger while that worker is connected (registration is dropped silently otherwise) and fall back to a refetch after each action. No polling.
- `compose::status` is enrichment like the supervisor and configuration reads: an engine without a daemon still renders the connected fleet.

The Vite dev server now proxies `/runtime` to the console worker alongside `/ws` and `/ui`, so the dev SPA joins the compose namespace instead of `default` (without it every namespaced function, `compose::status` included, is "not found" in development).

## Why

Compose supervises the fleet now; `worker::stop` only reaches supervisor-managed workers. Operators were seeing 16 `standalone` rows with disabled stop buttons for containers the daemon could start, stop, and restart.

## Changes

`pages/Workers/{types,api/workers,lib/merge-workers,hooks/useWorkersLive,hooks/useComposeChanged,components/WorkersTable,components/WorkersFilters,index}` plus fixtures, stories (`ComposeManaged`, `ComposeActionPending`), and tests (`merge-workers.compose.test.ts`, 7 cases: classification precedence, synthetic rows, action derivation, header summary, management filter). Workers commands row updated in `docs/sops/console-ui-conformance.md`.

## Verified

- Dev console against the local compose rig (16 containers): rows classified `compose`, header `compose my-project 16/16 ready`, restart from a row went dialog, `restart...` badge, new PID in the table without a manual refresh.
- `tsc -b`, `biome ci src/pages/Workers vite.config.ts`, `vitest run src/pages/Workers` (20 tests), `npm run build`, `build-storybook` green. The three failing tests in the full suite (`icon-size-conformance`, `redact-raw`, `TriggerActivityCard`) and the biome errors elsewhere fail identically on `main`.

## Depends on

Pairs with the `compose-ui` worker PR for the live trigger and the Compose page link; the table works without it.
