### PR TITLE
fix(tailscale): sign in from the Overview when the node needs login

### DIFF
--- a/tailscale/Cargo.lock
+++ b/tailscale/Cargo.lock
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "tailscale"
-version = "0.1.1-experimental"
+version = "0.1.2-experimental"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/tailscale/Cargo.toml
+++ b/tailscale/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "tailscale"
-version = "0.1.1-experimental"
+version = "0.1.2-experimental"
 edition = "2021"
 publish = false
 description = "Tailscale worker for iii — the tailscale CLI as tailscale::* functions (connectivity, peers, exit nodes, preferences, Serve and Funnel publishing, Taildrop, certificates, accounts, updates) with an injected Console page"

--- a/tailscale/src/functions/node.rs
+++ b/tailscale/src/functions/node.rs
@@ -13,6 +13,7 @@ use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tokio::time::timeout;
 
+use super::peers::{parse_prefs, up_args};
 use super::share::{normalize_routes, serve_status, Route};
 use super::{
     bool_at, register_fn, run, run_json, run_text, spec, string_at, strings_at, EmptyInput,
@@ -507,7 +508,10 @@ async fn connect_output(
 }
 
 async fn connect(config: &WorkerConfig, _: EmptyInput) -> Result<ConnectOutput, String> {
-    let authorization_url = run_with_login_watch(config, &["up"], CONNECT_TIMEOUT_SECS).await?;
+    let prefs = parse_prefs(&run_json(config, &["debug", "prefs"]).await?);
+    let args = up_args(&prefs);
+    let refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    let authorization_url = run_with_login_watch(config, &refs, CONNECT_TIMEOUT_SECS).await?;
     connect_output(config, authorization_url).await
 }
 

--- a/tailscale/src/functions/peers.rs
+++ b/tailscale/src/functions/peers.rs
@@ -439,6 +439,57 @@ pub fn prefs_set_args(input: &PrefsSetInput) -> Result<Vec<String>, String> {
     Ok(args)
 }
 
+const DEFAULT_CONTROL_URL: &str = "https://controlplane.tailscale.com";
+
+pub fn up_args(prefs: &Prefs) -> Vec<String> {
+    let mut args = vec!["up".to_string()];
+    if let Some(url) = &prefs.control_url {
+        if !url.is_empty() && url != DEFAULT_CONTROL_URL {
+            args.push(format!("--login-server={url}"));
+        }
+    }
+    if prefs.accept_routes {
+        args.push("--accept-routes".to_string());
+    }
+    if !prefs.accept_dns {
+        args.push("--accept-dns=false".to_string());
+    }
+    if let Some(exit_node) = prefs.exit_node_ip.as_ref().or(prefs.exit_node_id.as_ref()) {
+        args.push(format!("--exit-node={exit_node}"));
+    }
+    if prefs.exit_node_allow_lan_access {
+        args.push("--exit-node-allow-lan-access".to_string());
+    }
+    if prefs.ssh {
+        args.push("--ssh".to_string());
+    }
+    if prefs.shields_up {
+        args.push("--shields-up".to_string());
+    }
+    if let Some(hostname) = &prefs.hostname {
+        args.push(format!("--hostname={hostname}"));
+    }
+    if !prefs.advertise_routes.is_empty() {
+        args.push(format!(
+            "--advertise-routes={}",
+            prefs.advertise_routes.join(",")
+        ));
+    }
+    if prefs.advertise_exit_node {
+        args.push("--advertise-exit-node".to_string());
+    }
+    if !prefs.advertise_tags.is_empty() {
+        args.push(format!(
+            "--advertise-tags={}",
+            prefs.advertise_tags.join(",")
+        ));
+    }
+    if prefs.app_connector {
+        args.push("--advertise-connector".to_string());
+    }
+    args
+}
+
 async fn prefs_set(config: &WorkerConfig, input: PrefsSetInput) -> Result<Prefs, String> {
     let args = prefs_set_args(&input)?;
     let refs: Vec<&str> = args.iter().map(String::as_str).collect();
@@ -497,6 +548,48 @@ mod tests {
         assert!(prefs.advertise_exit_node);
         assert!(prefs.auto_update_apply);
         assert!(!serde_json::to_string(&prefs).unwrap().contains("privkey"));
+    }
+
+    #[test]
+    fn up_args_restate_non_default_prefs_and_nothing_else() {
+        let prefs = parse_prefs(&serde_json::json!({
+            "ControlURL": "https://controlplane.tailscale.com", "RouteAll": true, "CorpDNS": true,
+            "ExitNodeID": "", "ExitNodeIP": "", "RunSSH": false, "ShieldsUp": false, "Hostname": "",
+            "AdvertiseRoutes": ["10.0.0.0/8", "0.0.0.0/0", "::/0"], "AdvertiseTags": ["tag:ci"]
+        }));
+        assert_eq!(
+            up_args(&prefs),
+            vec![
+                "up",
+                "--accept-routes",
+                "--advertise-routes=10.0.0.0/8",
+                "--advertise-exit-node",
+                "--advertise-tags=tag:ci"
+            ]
+        );
+
+        let bare = parse_prefs(
+            &serde_json::json!({"ControlURL": "https://controlplane.tailscale.com", "CorpDNS": true}),
+        );
+        assert_eq!(up_args(&bare), vec!["up"]);
+
+        let custom = parse_prefs(&serde_json::json!({
+            "ControlURL": "https://headscale.example", "CorpDNS": false, "ExitNodeIP": "100.64.0.9",
+            "ExitNodeAllowLANAccess": true, "RunSSH": true, "ShieldsUp": true, "Hostname": "lab"
+        }));
+        assert_eq!(
+            up_args(&custom),
+            vec![
+                "up",
+                "--login-server=https://headscale.example",
+                "--accept-dns=false",
+                "--exit-node=100.64.0.9",
+                "--exit-node-allow-lan-access",
+                "--ssh",
+                "--shields-up",
+                "--hostname=lab"
+            ]
+        );
     }
 
     #[test]

--- a/tailscale/ui/src/page/index.tsx
+++ b/tailscale/ui/src/page/index.tsx
@@ -169,6 +169,19 @@ const conflictOptions = [
   { value: 'rename', label: 'Rename incoming files' },
 ]
 
+const BACKEND_STATE_LABEL: Record<string, string> = {
+  NeedsLogin: 'Needs sign-in',
+  NeedsMachineAuth: 'Needs device approval',
+  Starting: 'Starting',
+  Stopped: 'Stopped',
+  NoState: 'Not running',
+}
+
+function backendStateLabel(state: string | null | undefined): string {
+  if (!state) return 'Not running'
+  return BACKEND_STATE_LABEL[state] ?? state
+}
+
 function describe(cause: unknown): string {
   const text = (() => {
     if (cause instanceof Error) return cause.message
@@ -307,6 +320,7 @@ export function TailscalePage({ host, onRequestClose, panelSide, commands }: Pro
   )
 
   const online = status?.online ?? false
+  const needsLogin = status?.backend_state === 'NeedsLogin'
 
   const connect = useCallback(
     () =>
@@ -333,7 +347,7 @@ export function TailscalePage({ host, onRequestClose, panelSide, commands }: Pro
       ? 'Tailscale CLI not found'
       : online
         ? 'Connected'
-        : (status.backend_state ?? 'Not running')
+        : backendStateLabel(status.backend_state)
 
   const [share, setShare] = useState<Share | null>(null)
   const [mode, setMode] = useState<Mode>('serve')
@@ -850,13 +864,15 @@ export function TailscalePage({ host, onRequestClose, panelSide, commands }: Pro
               ) : (
                 <LoadingRows rows={4} />
               )}
-              {loginUrl && (
+              {loginUrl ? (
                 <StatusPanel variant="info" headline="This node needs a Tailscale sign-in" detail="Open the sign-in page, finish the login, then connect again." />
-              )}
+              ) : needsLogin ? (
+                <StatusPanel variant="info" headline="This device is signed out" detail="Sign in to add it to a tailnet; the sign-in page opens in a new tab." />
+              ) : null}
               <div className="ts-actions">
                 {status?.installed && !online && (
-                  <Button variant="primary" disabled={busy} data-autofocus="" onClick={() => void connect()}>
-                    {busy ? 'Working…' : 'Connect to tailnet'}
+                  <Button variant="primary" disabled={busy} data-autofocus="" onClick={() => void (needsLogin ? login() : connect())}>
+                    {busy ? 'Working…' : needsLogin ? 'Sign in to Tailscale' : 'Connect to tailnet'}
                   </Button>
                 )}
                 {loginUrl && (

--- a/tailscale/ui/styles.css
+++ b/tailscale/ui/styles.css
@@ -296,6 +296,10 @@
 }
 
 @container (max-width: 44rem) {
+  [data-iii-ui='tailscale'] .ts-card-header {
+    flex-wrap: wrap;
+  }
+
   [data-iii-ui='tailscale'] .ts-columns,
   [data-iii-ui='tailscale'] .ts-facts-grid,
   [data-iii-ui='tailscale'] .ts-fields {


### PR DESCRIPTION
## What

When the node's backend state is `NeedsLogin`, the Overview's primary action is now **Sign in to Tailscale** (`tailscale::login`) instead of **Connect to tailnet** (`tailscale::connect`), with an info panel saying the device is signed out and that the sign-in page opens in a new tab. The connection chip reads `Needs sign-in` (and `Needs device approval`, `Starting`, `Stopped`, `Not running`) instead of the raw backend state.

`tailscale::connect` now restates the node's current preferences as `up` flags (`--accept-routes`, `--accept-dns=false`, `--exit-node`, `--ssh`, `--shields-up`, `--hostname`, `--advertise-routes`, `--advertise-exit-node`, `--advertise-tags`, `--advertise-connector`, `--login-server`), read from `tailscale debug prefs` through the existing `parse_prefs`. A configured node reconnects without the CLI refusing or `--reset` wiping settings.

## Why

A signed-out node showed `NeedsLogin` in the chip and `You are logged out.` under Health, but the only button ran `tailscale up`, which just produced an auth URL and a second button to click. The Account section already had a sign-in path; the Overview, where the operator lands, did not offer it.

Clicking the old button on a node with `accept-routes` set failed with: changing settings via 'tailscale up' requires mentioning all non-default flags. Bare `tailscale up` is only valid on a node with default preferences.

## Verified

- `cargo fmt`, `cargo clippy --all-targets -D warnings`, `cargo test` (28 tests, including `up_args_restate_non_default_prefs_and_nothing_else`), `pnpm --dir tailscale/ui build` green.
- Patched worker run against the local rig on a signed-in node with `RouteAll: true`: `tailscale::connect` answered `connected: true`, `backend_state: Running`, prefs unchanged; the same call failed on the shipped 0.1.1 build.
- Patch version bumped to 0.1.2-experimental.
