### PR TITLE
fix(console): narrow PageSidebar opens as a drawer instead of splitting the pane

### DIFF
--- a/console/SKILL.md
+++ b/console/SKILL.md
@@ -271,8 +271,10 @@ transitions. The Console host keeps a single stable `aside`, leaves children
 mounted while collapsed, synchronizes instances sharing a storage key, and
 owns motion plus reduced-motion behavior. Pass `narrow` when the page already
 has a drill-in state; use `narrowBelow` when only shared sidebar chrome needs
-to react to its parent width. Neither responsive mode overwrites the saved
-wide preference.
+to react to its parent width. With host-owned collapse state the narrow
+presentation is a rail whose toggle opens a drawer over `PageMain`; a page
+that controls `collapsed` gets the full-width aside and owns what shows
+beside it. Neither responsive mode overwrites the saved wide preference.
 
 The pieces own the surface hierarchy (header on `--color-panel-raised`
 with a hairline `--color-edge` border, sidebar on `--color-sidebar`, main

--- a/console/web/src/components/ui/PageSidebar.stories.tsx
+++ b/console/web/src/components/ui/PageSidebar.stories.tsx
@@ -63,12 +63,10 @@ function SidebarExample({
         >
           <Navigation />
         </PageSidebar>
-        <PageMain
-          className={`items-center justify-center p-6 font-sans text-sm text-ink-faint${
-            narrowBelow === undefined ? '' : ' max-[700px]:hidden'
-          }`}
-        >
-          Resize the separator, then collapse and expand the shared sidebar.
+        <PageMain className="items-center justify-center p-6 font-sans text-sm text-ink-faint">
+          {narrowBelow === undefined
+            ? 'Resize the separator, then collapse and expand the shared sidebar.'
+            : 'Below 700px the sidebar is a rail; expand it to open the drawer over this column.'}
         </PageMain>
       </PageBody>
     </PageShell>

--- a/console/web/src/components/ui/PageSidebar.test.tsx
+++ b/console/web/src/components/ui/PageSidebar.test.tsx
@@ -64,9 +64,25 @@ describe('PageSidebar', () => {
     expect(html).toContain('inert=""')
   })
 
-  it('forces the responsive presentation open without changing preference', () => {
+  it('narrows a host-owned sidebar to a closed drawer rail', () => {
     const html = renderSidebar(
-      <PageSidebar label="files" collapsible defaultCollapsed narrow>
+      <PageSidebar label="files" collapsible narrow>
+        file tree
+      </PageSidebar>,
+    )
+
+    expect(html).toContain('style="width:36px"')
+    expect(html).toContain('data-narrow=""')
+    expect(html).toContain('data-drawer="closed"')
+    expect(html).toContain('data-collapsed=""')
+    expect(html).toContain('file tree')
+    expect(html).toContain('aria-label="expand files"')
+    expect(html).not.toContain('aria-label="close files"')
+  })
+
+  it('keeps the full-width presentation for a page that controls collapse', () => {
+    const html = renderSidebar(
+      <PageSidebar label="files" collapsible collapsed={false} narrow>
         file tree
       </PageSidebar>,
     )
@@ -74,6 +90,7 @@ describe('PageSidebar', () => {
     expect(html).toContain('style="width:100%"')
     expect(html).toContain('file tree')
     expect(html).not.toContain('data-collapsed')
+    expect(html).not.toContain('data-drawer')
     expect(html).not.toContain('aria-label="expand files"')
   })
 })

--- a/console/web/src/components/ui/PageSidebar.tsx
+++ b/console/web/src/components/ui/PageSidebar.tsx
@@ -9,6 +9,7 @@ import { cn } from '@/lib/utils'
 import { IconButton } from './IconButton'
 
 const COLLAPSED_WIDTH = 36
+const DRAWER_MAX_WIDTH = 320
 const DEFAULT_WIDTH = 280
 const DEFAULT_MIN_WIDTH = 160
 const DEFAULT_MAX_WIDTH = 560
@@ -62,8 +63,10 @@ export interface PageSidebarProps
    */
   storageKey?: string
   /**
-   * Full-width responsive presentation. It hides collapse/resize affordances
-   * without overwriting the saved wide-layout preference.
+   * Responsive presentation. With host-owned collapse state the sidebar
+   * becomes a rail that opens as a drawer over the main column; a page that
+   * controls `collapsed` gets the full-width aside and owns what shows beside
+   * it. Neither overwrites the saved wide-layout preference.
    */
   narrow?: boolean
   /**
@@ -200,19 +203,21 @@ export function PageSidebar({
 
   const asideRef = React.useRef<HTMLElement>(null)
   const [containerNarrow, setContainerNarrow] = React.useState(false)
+  const [containerWidth, setContainerWidth] = React.useState(0)
+  const [drawerOpen, setDrawerOpen] = React.useState(false)
 
   React.useLayoutEffect(() => {
-    if (narrow || narrowBelow === undefined) {
-      setContainerNarrow(false)
-      return
-    }
+    const breakpoint = narrow || narrowBelow === undefined ? null : narrowBelow
+    if (breakpoint === null) setContainerNarrow(false)
 
     const container = asideRef.current?.parentElement
     if (!container) return
 
-    const update = (containerWidth: number) => {
-      if (containerWidth <= 0) return
-      const next = containerWidth <= narrowBelow
+    const update = (width: number) => {
+      if (width <= 0) return
+      setContainerWidth((current) => (current === width ? current : width))
+      if (breakpoint === null) return
+      const next = width <= breakpoint
       setContainerNarrow((current) => (current === next ? current : next))
     }
 
@@ -227,18 +232,31 @@ export function PageSidebar({
   }, [narrow, narrowBelow])
 
   const effectiveNarrow = narrow || containerNarrow
+  const hostDrawer = effectiveNarrow && controlledCollapsed === undefined
   const expandedWidth = clampWidth(
     controlledWidth ?? internalWidth,
     bounds.min,
     bounds.max,
   )
   const preferredCollapsed = controlledCollapsed ?? internalCollapsed
-  const effectiveCollapsed =
-    collapsible && !effectiveNarrow && preferredCollapsed
-  const effectiveWidth: number | string = effectiveNarrow
-    ? '100%'
-    : effectiveCollapsed
-      ? COLLAPSED_WIDTH
+  const effectiveCollapsed = hostDrawer
+    ? !drawerOpen
+    : collapsible && !effectiveNarrow && preferredCollapsed
+  const effectiveWidth: number | string = hostDrawer
+    ? COLLAPSED_WIDTH
+    : effectiveNarrow
+      ? '100%'
+      : effectiveCollapsed
+        ? COLLAPSED_WIDTH
+        : expandedWidth
+  const drawerWidth =
+    containerWidth > 0
+      ? Math.min(DRAWER_MAX_WIDTH, containerWidth)
+      : DRAWER_MAX_WIDTH
+  const panelWidth: number | string = hostDrawer
+    ? drawerWidth
+    : effectiveNarrow
+      ? '100%'
       : expandedWidth
 
   const expandedRef = React.useRef<HTMLDivElement>(null)
@@ -403,7 +421,8 @@ export function PageSidebar({
     }
     if (
       active instanceof Node &&
-      collapsedActionsRef.current?.contains(active)
+      (collapsedActionsRef.current?.contains(active) ||
+        (hostDrawer && active === toggleRef.current))
     ) {
       const target = expandedRef.current
         ? (firstFocusable(expandedRef.current) ?? expandedRef.current)
@@ -411,14 +430,17 @@ export function PageSidebar({
       target?.focus({ preventScroll: true })
       chromeFocusRef.current = false
     }
-  }, [effectiveCollapsed])
+  }, [effectiveCollapsed, hostDrawer])
 
   const previousNarrowRef = React.useRef(effectiveNarrow)
   React.useLayoutEffect(() => {
     if (previousNarrowRef.current === effectiveNarrow) return
     previousNarrowRef.current = effectiveNarrow
     setAnimateToggle(false)
-    if (!effectiveNarrow) return
+    if (!effectiveNarrow) {
+      setDrawerOpen(false)
+      return
+    }
     const active = document.activeElement
     const chromeHadFocus =
       active === toggleRef.current ||
@@ -458,6 +480,18 @@ export function PageSidebar({
     if (controlledCollapsed === undefined) persist({ collapsed: next })
   }, [controlledCollapsed, onCollapsedChange, persist, preferredCollapsed])
 
+  const setDrawer = React.useCallback((next: boolean) => {
+    setAnimateToggle(true)
+    if (motionTimerRef.current !== null)
+      window.clearTimeout(motionTimerRef.current)
+    motionTimerRef.current = window.setTimeout(() => {
+      motionTimerRef.current = null
+      setAnimateToggle(false)
+    }, MOTION_CLEANUP_MS)
+    setDrawerOpen(next)
+    if (!next) toggleRef.current?.focus({ preventScroll: true })
+  }, [])
+
   // Preserve the original zero-behavior primitive for existing consumers.
   if (!managed) {
     return (
@@ -479,6 +513,9 @@ export function PageSidebar({
   }
 
   const showResize = resizable && !effectiveNarrow && !effectiveCollapsed
+  const showToggle = (collapsible && !effectiveNarrow) || hostDrawer
+  const drawerToggleOffset =
+    hostDrawer && drawerOpen ? drawerWidth - COLLAPSED_WIDTH : undefined
   const enterFrom = side === 'left' ? '-translate-x-1' : 'translate-x-1'
   const ExpandedIcon = side === 'left' ? PanelLeftClose : PanelRightClose
   const CollapsedIcon = side === 'left' ? PanelLeftOpen : PanelRightOpen
@@ -489,10 +526,14 @@ export function PageSidebar({
       aria-label={rest['aria-label'] ?? label}
       data-collapsed={effectiveCollapsed ? '' : undefined}
       data-resizing={isResizing ? '' : undefined}
+      data-narrow={effectiveNarrow ? '' : undefined}
+      data-drawer={hostDrawer ? (drawerOpen ? 'open' : 'closed') : undefined}
       style={{ ...style, width: effectiveWidth }}
       className={cn(
-        'relative shrink-0 min-h-0 overflow-hidden bg-sidebar',
-        effectiveNarrow && 'flex-1 min-w-0',
+        'relative shrink-0 min-h-0 bg-sidebar',
+        hostDrawer ? 'overflow-visible' : 'overflow-hidden',
+        hostDrawer && drawerOpen && 'z-10',
+        effectiveNarrow && !hostDrawer && 'flex-1 min-w-0',
         animateToggle && !isResizing && 'transition-[width]',
         animateToggle &&
           !isResizing &&
@@ -508,17 +549,42 @@ export function PageSidebar({
         }
         rest.onBlurCapture?.(event)
       }}
+      onKeyDown={(event) => {
+        if (hostDrawer && drawerOpen && event.key === 'Escape') {
+          event.stopPropagation()
+          setDrawer(false)
+        }
+        rest.onKeyDown?.(event)
+      }}
     >
+      {hostDrawer && drawerOpen ? (
+        <button
+          type="button"
+          tabIndex={-1}
+          aria-label={`close ${label}`}
+          className={cn(
+            'absolute inset-y-0 z-10 cursor-default bg-ink/25',
+            side === 'left' ? 'left-0' : 'right-0',
+          )}
+          style={{ width: containerWidth > 0 ? containerWidth : '100vw' }}
+          onClick={() => setDrawer(false)}
+        />
+      ) : null}
       <div
         ref={expandedRef}
         id={contentId}
         tabIndex={-1}
         inert={effectiveCollapsed || undefined}
         aria-hidden={effectiveCollapsed || undefined}
-        style={{ width: effectiveNarrow ? '100%' : expandedWidth }}
+        style={{ width: panelWidth }}
         className={cn(
           'absolute inset-y-0 flex min-h-0 flex-col overflow-hidden',
           side === 'left' ? 'left-0' : 'right-0',
+          hostDrawer &&
+            cn(
+              'z-20 bg-sidebar',
+              side === 'left' ? 'border-r border-edge' : 'border-l border-edge',
+            ),
           effectiveCollapsed
             ? cn('pointer-events-none opacity-0', enterFrom)
             : 'opacity-100 translate-x-0',
@@ -531,13 +597,23 @@ export function PageSidebar({
         onFocusCapture={() => {
           chromeFocusRef.current = false
         }}
+        onClickCapture={(event) => {
+          if (!hostDrawer || !drawerOpen) return
+          const target = event.target
+          if (
+            target instanceof Element &&
+            target.closest(
+              'button, a, [role="button"], [role="option"], [role="tab"]',
+            )
+          ) {
+            setDrawer(false)
+          }
+        }}
       >
         <div
           className={cn(
             'flex min-h-11 shrink-0 items-center gap-2 px-3',
-            collapsible &&
-              !effectiveNarrow &&
-              (side === 'left' ? 'pr-11' : 'pl-11'),
+            showToggle && (side === 'left' ? 'pr-11' : 'pl-11'),
           )}
         >
           {header ?? (
@@ -571,20 +647,28 @@ export function PageSidebar({
         {collapsedActions}
       </div>
 
-      {collapsible && !effectiveNarrow ? (
+      {showToggle ? (
         <IconButton
           ref={toggleRef}
           label={`${effectiveCollapsed ? 'expand' : 'collapse'} ${label}`}
           tooltipSide={side === 'left' ? 'right' : 'left'}
           aria-expanded={!effectiveCollapsed}
           aria-controls={contentId}
-          onClick={toggle}
+          onClick={hostDrawer ? () => setDrawer(!drawerOpen) : toggle}
           onFocus={() => {
             chromeFocusRef.current = true
           }}
+          style={
+            drawerToggleOffset === undefined
+              ? undefined
+              : side === 'left'
+                ? { left: drawerToggleOffset + 4 }
+                : { right: drawerToggleOffset + 4 }
+          }
           className={cn(
-            'absolute top-2 z-20 size-7',
-            side === 'left' ? 'right-1' : 'left-1',
+            'absolute top-2 z-30 size-7',
+            drawerToggleOffset === undefined &&
+              (side === 'left' ? 'right-1' : 'left-1'),
           )}
         >
           <span className="relative block size-4" aria-hidden>

--- a/docs/sops/injectable-console-ui.md
+++ b/docs/sops/injectable-console-ui.md
@@ -407,9 +407,13 @@ the 220 ms width transition, content fade/offset, reduced-motion behavior,
 accessible toggle, pointer/keyboard resize, and best-effort persistence.
 Instances with the same `storageKey` share one preference. Pass `narrow` when
 your page's own drill-in state already knows the pane is narrow, or
-`narrowBelow` when only the sidebar chrome needs a container breakpoint; both
-temporarily force the full-width presentation without overwriting the saved
-wide preference. Drag resize and wide↔narrow changes remain instant.
+`narrowBelow` when only the sidebar chrome needs a container breakpoint. In
+the narrow presentation a sidebar with host-owned collapse state becomes a
+rail; its toggle opens the content as a drawer over the main column (scrim,
+Escape, and activating any control inside close it), so the page keeps
+rendering `PageMain` unchanged. A page that controls `collapsed` keeps the
+full-width aside and decides what shows beside it. Neither overwrites the
+saved wide preference. Drag resize and wide↔narrow changes remain instant.
 
 All human-facing chrome uses sans and authored sentence/title case; do not use
 CSS case transforms on tabs, buttons, menus, fields, or labels. Reserve mono

--- a/packages/console-ui/index.d.ts
+++ b/packages/console-ui/index.d.ts
@@ -1056,7 +1056,7 @@ export interface PageSidebarProps extends React.HTMLAttributes<HTMLElement> {
   resizable?: boolean
   /** Host-owned persistence/synchronization key; no storage logic ships in worker bundles. */
   storageKey?: string
-  /** Full-width responsive presentation without changing the wide preference. */
+  /** Responsive presentation: a rail that opens as a drawer over the main column when the host owns collapse state, the full-width aside when the page controls `collapsed`; never changes the wide preference. */
   narrow?: boolean
   /** Host-owned PageBody breakpoint for the responsive presentation. */
   narrowBelow?: number


### PR DESCRIPTION
## What

`PageSidebar`'s narrow presentation no longer splits the pane with the main column. When the sidebar's collapse state is host-owned (every page that passes `narrowBelow` and leaves `collapsed` uncontrolled: compose, tailscale, state, directory, and the rest), the narrow presentation is now:

- a 36 px rail in the flow, so `PageMain` keeps the full pane width;
- the existing toggle opens the sidebar content as a drawer over the main column (`min(320px, pane width)`), with a scrim, Escape, and activation of any control inside closing it and returning focus to the toggle;
- the wide preference is untouched, drag resize and wide/narrow changes stay instant, reduced motion is honored through the existing motion tokens.

A page that controls `collapsed` (shell) keeps the previous full-width aside and continues to own what shows beside it, so its local overlay is unchanged.

`data-narrow` and `data-drawer="open|closed"` on the aside expose the state for styling and tests.

## Why

Below `narrowBelow` the aside was `width:100%; flex:1` inside `PageBody`'s flex row, so it and `PageMain` shared the pane about 50/50. On a phone the tailscale page measured sidebar 179 px / main 211 px at 390 px, and the Compose page looked the same; card headers overlapped and facts wrapped per character. The SOP already promised the host owns this presentation; workers were not supposed to ship overlay CSS to get a usable phone layout.

## Verified

- `PageSidebar` tests updated for both contracts (host-owned rail vs page-controlled full width); `console-ui-conformance` test, `tsc -b`, biome green.
- Dev console against the local rig at 390 px on the tailscale page: rail 36 px with main at 353 px; toggle opens a 320 px drawer with scrim; selecting "Devices" switches the section and closes the drawer.
- Storybook `PageSidebar/Responsive` story now shows the rail and drawer instead of hiding main.

Docs: `docs/sops/injectable-console-ui.md`, `console/SKILL.md`, and the `narrow` typings describe the two presentations.
