### PR TITLE
fix(shell): keep the review toolbar and file rows on one line in narrow panes

### DIFF
--- a/shell/ui/styles.css
+++ b/shell/ui/styles.css
@@ -1295,7 +1295,9 @@
   color: var(--color-warn);
 }
 [data-iii-ui="shell"] .shui-review-count {
+  flex: none;
   color: var(--color-ink-faint);
+  white-space: nowrap;
 }
 [data-iii-ui="shell"] .shui-review-scope-error {
   max-width: 130px;
@@ -2902,6 +2904,16 @@
 /* Narrow panels — phones, and desktop panels split small ------------------- */
 
 @container shui-page (max-width: 720px) {
+  [data-iii-ui='shell'] .shui-review-toolbar {
+    gap: 6px;
+    padding: 0 6px;
+  }
+
+  [data-iii-ui='shell'] .shui-review-file-head {
+    gap: 6px;
+    padding: 0 6px;
+  }
+
   [data-iii-ui='shell'] .shui-review-notice {
     grid-template-columns: 32px minmax(0, 1fr);
   }


### PR DESCRIPTION
## What

In panes narrower than 720 px the review toolbar's file count (`3 files`) wrapped onto two lines and the toolbar and file heads kept desktop spacing, pushing the path and stat chips off the row. The count is now `flex: none; white-space: nowrap`, and the existing `@container shui-page (max-width: 720px)` block tightens toolbar and file-head gap/padding.

## Why

Phone screenshots of the review pane (390 to 560 px) showed the count wrapping and the file path truncating early while the trailing icon actions kept their desktop gaps.

## Verified

`pnpm --dir shell/ui build` green; staged on the local rig with the other narrow-pane fixes.