### PR TITLE
feat(compose-ui): topology map of engine, namespace, and containers

### DIFF
--- a/compose-ui/README.md
+++ b/compose-ui/README.md
@@ -1,6 +1,6 @@
 # compose-ui
 
-The compose daemon in the Console. A **Compose** page lists every container the
+The compose daemon in the Console. A **Compose** page opens on a topology map (engine, namespace group, containers laid out by `start_after`, ports and sources on the cards, upstream/downstream tracing on select) and lists every container the
 daemon supervises with live state, PID, and last error; starts, stops, and
 restarts containers or the whole project in dependency order; adds, updates,
 and removes declared worker packages; and tails each container's log. Every

--- a/compose-ui/skills/SKILL.md
+++ b/compose-ui/skills/SKILL.md
@@ -9,7 +9,8 @@ description: >-
 # compose-ui
 
 The compose-ui worker puts the compose daemon in the Console. Its page (Compose,
-`#/ext/compose`) shows every container the daemon supervises with its live
+`#/ext/compose`) opens on a topology map of the engine, the namespace, and the
+containers laid out by `start_after`, and shows every container the daemon supervises with its live
 state, PID, and last error; starts, stops, and restarts containers or the whole
 project in dependency order; adds, updates, and removes declared worker
 packages; and tails each container's log. Every lifecycle action is the

--- a/compose-ui/tests/topology.test.ts
+++ b/compose-ui/tests/topology.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+import {
+  assignLevels,
+  layoutTopology,
+  related,
+  TOPO,
+  type TopologyContainer,
+  type TopologyInput,
+} from '../ui/src/page/topology-layout.js'
+
+function container(name: string, startAfter: string[] = [], state = 'ready'): TopologyContainer {
+  return {
+    name,
+    state,
+    pid: 1,
+    source: 'path',
+    ref: `../${name}`,
+    version: null,
+    ports: [],
+    startAfter,
+    lastError: null,
+  }
+}
+
+const input: TopologyInput = {
+  namespace: 'my-project',
+  file: '/proj/worker-compose.yaml',
+  engine: { url: 'ws://127.0.0.1:49134', host: '127.0.0.1', port: 49134, pid: 27045 },
+  containers: [
+    container('harness', ['state', 'llm-router', 'console']),
+    container('state'),
+    container('console'),
+    container('llm-router', ['state']),
+    container('provider-openai', ['llm-router', 'state']),
+    container('web'),
+  ],
+}
+
+describe('assignLevels', () => {
+  it('places a container one level after its deepest dependency', () => {
+    const levels = assignLevels(input.containers)
+    expect(levels.get('state')).toBe(0)
+    expect(levels.get('console')).toBe(0)
+    expect(levels.get('llm-router')).toBe(1)
+    expect(levels.get('provider-openai')).toBe(2)
+    expect(levels.get('harness')).toBe(2)
+  })
+
+  it('ignores unknown and self dependencies and survives a cycle', () => {
+    const levels = assignLevels([container('a', ['b', 'ghost', 'a']), container('b', ['a'])])
+    expect(levels.get('b')).toBe(1)
+    expect(levels.get('a')).toBe(2)
+  })
+})
+
+describe('layoutTopology', () => {
+  it('lays columns left to right by level with the engine feeding level zero', () => {
+    const layout = layoutTopology(input)
+    const x = (name: string) => layout.nodes.find((n) => n.container.name === name)?.x ?? Number.NaN
+    expect(x('state')).toBe(x('console'))
+    expect(x('llm-router')).toBeGreaterThan(x('state'))
+    expect(x('harness')).toBeGreaterThan(x('llm-router'))
+    expect(x('harness')).toBe(x('provider-openai'))
+    expect(layout.engine.x).toBe(TOPO.pad)
+    expect(layout.group.x).toBeGreaterThan(layout.engine.x + layout.engine.w)
+    expect(layout.width).toBeGreaterThan(layout.group.x + layout.group.w)
+    expect(layout.nodes.map((n) => n.container.name)).toEqual([
+      'console',
+      'state',
+      'web',
+      'llm-router',
+      'harness',
+      'provider-openai',
+    ])
+  })
+
+  it('draws one edge per declared dependency and engine edges for roots', () => {
+    const layout = layoutTopology(input)
+    const keys = layout.edges.map((e) => e.key).sort()
+    expect(keys).toEqual(
+      [
+        'engine→console',
+        'engine→state',
+        'engine→web',
+        'state→llm-router',
+        'state→harness',
+        'llm-router→harness',
+        'console→harness',
+        'llm-router→provider-openai',
+        'state→provider-openai',
+      ].sort(),
+    )
+    const edge = layout.edges.find((e) => e.key === 'state→llm-router')
+    const from = layout.nodes.find((n) => n.container.name === 'state')
+    const to = layout.nodes.find((n) => n.container.name === 'llm-router')
+    expect(edge?.start).toEqual({ x: from!.x + from!.w, y: from!.y + from!.h / 2 })
+    expect(edge?.end).toEqual({ x: to!.x, y: to!.y + to!.h / 2 })
+    expect(edge!.midX).toBeGreaterThan(edge!.start.x)
+    expect(edge!.midX).toBeLessThan(edge!.end.x)
+  })
+
+  it('handles an empty project', () => {
+    const layout = layoutTopology({ ...input, containers: [] })
+    expect(layout.nodes).toEqual([])
+    expect(layout.edges).toEqual([])
+    expect(layout.width).toBeGreaterThan(0)
+  })
+})
+
+describe('related', () => {
+  it('walks transitive upstream and downstream containers', () => {
+    const { upstream, downstream } = related(input.containers, 'llm-router')
+    expect([...upstream]).toEqual(['state'])
+    expect([...downstream].sort()).toEqual(['harness', 'provider-openai'])
+  })
+
+  it('never includes the container itself', () => {
+    const r = related([container('a', ['b']), container('b', ['a'])], 'a')
+    expect(r.upstream.has('a')).toBe(false)
+    expect(r.downstream.has('a')).toBe(false)
+  })
+})

--- a/compose-ui/ui/src/page/Topology.tsx
+++ b/compose-ui/ui/src/page/Topology.tsx
@@ -1,12 +1,51 @@
-import { StatusDot } from '@iii-dev/console-ui'
-import { type KeyboardEvent, useMemo } from 'react'
+import { Button, StatusDot } from '@iii-dev/console-ui'
+import { type KeyboardEvent, type PointerEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Layers } from './icons'
-import { layoutTopology, related, type TopologyContainer, type TopologyInput } from './topology-layout'
+import { type Box, layoutTopology, related, TOPO, type TopologyContainer, type TopologyInput } from './topology-layout'
 
 interface TopologyProps {
   input: TopologyInput
   selected: string | null
   onSelect: (name: string | null) => void
+}
+
+type Offset = { x: number; y: number }
+type Offsets = Record<string, Offset>
+
+const ENGINE = 'engine'
+const DRAG_THRESHOLD = 3
+const NUDGE = 8
+const STORAGE_PREFIX = 'compose-ui:topology:'
+const STACK_BELOW = 560
+
+function storageKey(input: TopologyInput): string {
+  return `${STORAGE_PREFIX}${input.namespace ?? ''}:${input.file ?? ''}`
+}
+
+function readOffsets(key: string): Offsets {
+  try {
+    const raw = window.localStorage.getItem(key)
+    if (!raw) return {}
+    const parsed: unknown = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object') return {}
+    const out: Offsets = {}
+    for (const [name, value] of Object.entries(parsed as Record<string, unknown>)) {
+      if (value && typeof value === 'object') {
+        const { x, y } = value as { x?: unknown; y?: unknown }
+        if (typeof x === 'number' && typeof y === 'number') out[name] = { x, y }
+      }
+    }
+    return out
+  } catch {
+    return {}
+  }
+}
+
+function writeOffsets(key: string, offsets: Offsets) {
+  try {
+    if (Object.keys(offsets).length === 0) window.localStorage.removeItem(key)
+    else window.localStorage.setItem(key, JSON.stringify(offsets))
+  } catch {}
 }
 
 function dotTone(state: string): 'accent' | 'alert' | 'warn' | 'ink' {
@@ -27,23 +66,120 @@ function sourceLabel(c: TopologyContainer): string | null {
   return c.ref || null
 }
 
-function edgePath(edge: { start: { x: number; y: number }; end: { x: number; y: number } }): string {
-  const dx = Math.max(32, (edge.end.x - edge.start.x) / 2)
-  return `M ${edge.start.x} ${edge.start.y} C ${edge.start.x + dx} ${edge.start.y}, ${edge.end.x - dx} ${edge.end.y}, ${edge.end.x - 1} ${edge.end.y}`
+function edgePath(from: Box, to: Box): string {
+  const sx = from.x + from.w
+  const sy = from.y + from.h / 2
+  const ex = to.x
+  const ey = to.y + to.h / 2
+  const dx = Math.max(32, Math.abs(ex - sx) / 2)
+  return `M ${sx} ${sy} C ${sx + dx} ${sy}, ${ex - dx} ${ey}, ${ex - 1} ${ey}`
 }
+
+function shifted(box: Box, offset: Offset | undefined): Box {
+  if (!offset) return box
+  return { ...box, x: box.x + offset.x, y: box.y + offset.y }
+}
+
+type Drag = { name: string; pointerId: number; startX: number; startY: number; origin: Offset; moved: boolean }
 
 export function Topology({ input, selected, onSelect }: TopologyProps) {
   const layout = useMemo(() => layoutTopology(input), [input])
   const relation = useMemo(() => (selected ? related(input.containers, selected) : null), [input.containers, selected])
+  const key = storageKey(input)
+  const [offsets, setOffsets] = useState<Offsets>(() => readOffsets(key))
+  const keyRef = useRef(key)
+  useEffect(() => {
+    if (keyRef.current === key) return
+    keyRef.current = key
+    setOffsets(readOffsets(key))
+  }, [key])
+
+  const dragRef = useRef<Drag | null>(null)
+  const [dragging, setDragging] = useState<string | null>(null)
+  const suppressClickRef = useRef(false)
+  const frameRef = useRef<HTMLDivElement>(null)
+  const [stacked, setStacked] = useState(false)
+  useEffect(() => {
+    const frame = frameRef.current
+    if (!frame || typeof ResizeObserver === 'undefined') return
+    const update = (width: number) => {
+      if (width > 0) setStacked((current) => (current === width < STACK_BELOW ? current : width < STACK_BELOW))
+    }
+    update(frame.getBoundingClientRect().width)
+    const observer = new ResizeObserver(([entry]) => {
+      if (entry) update(entry.contentRect.width)
+    })
+    observer.observe(frame)
+    return () => observer.disconnect()
+  }, [])
+
+  const commit = useCallback(
+    (next: Offsets) => {
+      setOffsets(next)
+      writeOffsets(key, next)
+    },
+    [key],
+  )
+
+  const boxes = useMemo(() => {
+    const map = new Map<string, Box>()
+    map.set(ENGINE, shifted(layout.engine, offsets[ENGINE]))
+    for (const node of layout.nodes) map.set(node.container.name, shifted(node, offsets[node.container.name]))
+    return map
+  }, [layout, offsets])
+
+  const bounds = useMemo(() => {
+    let width = layout.width
+    let height = layout.height
+    for (const box of boxes.values()) {
+      width = Math.max(width, box.x + box.w + TOPO.pad)
+      height = Math.max(height, box.y + box.h + TOPO.pad)
+    }
+    return { width, height }
+  }, [boxes, layout])
+
+  const baseBox = useCallback(
+    (name: string): Box | undefined =>
+      name === ENGINE ? layout.engine : layout.nodes.find((n) => n.container.name === name),
+    [layout],
+  )
+
+  const clamp = useCallback(
+    (name: string, offset: Offset): Offset => {
+      const base = baseBox(name)
+      if (!base) return offset
+      return { x: Math.max(TOPO.pad - base.x, offset.x), y: Math.max(TOPO.pad - base.y, offset.y) }
+    },
+    [baseBox],
+  )
 
   const order = layout.nodes.map((n) => n.container.name)
-  const moveFocus = (event: KeyboardEvent<HTMLButtonElement>, name: string) => {
+
+  const onKeyDown = (event: KeyboardEvent<HTMLElement>, name: string) => {
+    const arrows: Record<string, [number, number]> = {
+      ArrowUp: [0, -1],
+      ArrowDown: [0, 1],
+      ArrowLeft: [-1, 0],
+      ArrowRight: [1, 0],
+    }
+    const arrow = arrows[event.key]
+    if (arrow && event.shiftKey) {
+      event.preventDefault()
+      const current = offsets[name] ?? { x: 0, y: 0 }
+      commit({ ...offsets, [name]: clamp(name, { x: current.x + arrow[0] * NUDGE, y: current.y + arrow[1] * NUDGE }) })
+      return
+    }
+    if (event.key === 'Escape') {
+      onSelect(null)
+      return
+    }
+    if (!arrow || name === ENGINE) return
     const index = order.indexOf(name)
     if (index < 0) return
     let next: number | null = null
     if (event.key === 'ArrowDown') next = Math.min(order.length - 1, index + 1)
     else if (event.key === 'ArrowUp') next = Math.max(0, index - 1)
-    else if (event.key === 'ArrowRight' || event.key === 'ArrowLeft') {
+    else {
       const current = layout.nodes[index]
       const dir = event.key === 'ArrowRight' ? 1 : -1
       const candidates = layout.nodes
@@ -51,17 +187,61 @@ export function Topology({ input, selected, onSelect }: TopologyProps) {
         .filter(({ n }) => n.level === current.level + dir)
         .sort((a, b) => Math.abs(a.n.y - current.y) - Math.abs(b.n.y - current.y))
       next = candidates[0]?.i ?? null
-    } else if (event.key === 'Escape') {
-      onSelect(null)
-      return
     }
     if (next === null) return
     event.preventDefault()
-    const target = event.currentTarget.parentElement?.querySelector<HTMLButtonElement>(`[data-node="${order[next]}"]`)
+    const target = event.currentTarget.parentElement?.querySelector<HTMLElement>(`[data-node="${order[next]}"]`)
     target?.focus()
   }
 
-  if (layout.nodes.length === 0) return null
+  const onPointerDown = (event: PointerEvent<HTMLElement>, name: string) => {
+    if (event.button !== 0) return
+    dragRef.current = {
+      name,
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      origin: offsets[name] ?? { x: 0, y: 0 },
+      moved: false,
+    }
+    try {
+      event.currentTarget.setPointerCapture(event.pointerId)
+    } catch {}
+  }
+
+  const onPointerMove = (event: PointerEvent<HTMLElement>) => {
+    const drag = dragRef.current
+    if (!drag || drag.pointerId !== event.pointerId) return
+    const dx = event.clientX - drag.startX
+    const dy = event.clientY - drag.startY
+    if (!drag.moved && Math.hypot(dx, dy) < DRAG_THRESHOLD) return
+    if (!drag.moved) {
+      drag.moved = true
+      setDragging(drag.name)
+    }
+    const next = clamp(drag.name, { x: drag.origin.x + dx, y: drag.origin.y + dy })
+    setOffsets((prev) => ({ ...prev, [drag.name]: next }))
+  }
+
+  const endDrag = (event: PointerEvent<HTMLElement>, cancelled: boolean) => {
+    const drag = dragRef.current
+    if (!drag || drag.pointerId !== event.pointerId) return
+    dragRef.current = null
+    setDragging(null)
+    try {
+      event.currentTarget.releasePointerCapture(event.pointerId)
+    } catch {}
+    if (!drag.moved) return
+    suppressClickRef.current = true
+    if (cancelled) {
+      setOffsets((prev) => ({ ...prev, [drag.name]: drag.origin }))
+      return
+    }
+    setOffsets((prev) => {
+      writeOffsets(key, prev)
+      return prev
+    })
+  }
 
   const edgeState = (from: string, to: string): string | undefined => {
     if (!selected || !relation) return undefined
@@ -82,99 +262,186 @@ export function Topology({ input, selected, onSelect }: TopologyProps) {
     return 'dim'
   }
 
-  const edges = [...layout.edges].sort((a, b) => {
-    const rank = (rel: string | undefined) => (rel === 'up' || rel === 'down' ? 1 : 0)
-    return rank(edgeState(a.from, a.to)) - rank(edgeState(b.from, b.to))
+  if (layout.nodes.length === 0) return null
+
+  const rank = (rel: string | undefined) => (rel === 'up' || rel === 'down' ? 1 : 0)
+  const edges = [...layout.edges].sort((a, b) => rank(edgeState(a.from, a.to)) - rank(edgeState(b.from, b.to)))
+  const moved = Object.keys(offsets).length > 0
+  const dragProps = (name: string) => ({
+    onPointerDown: (event: PointerEvent<HTMLElement>) => onPointerDown(event, name),
+    onPointerMove,
+    onPointerUp: (event: PointerEvent<HTMLElement>) => endDrag(event, false),
+    onPointerCancel: (event: PointerEvent<HTMLElement>) => endDrag(event, true),
+    onLostPointerCapture: (event: PointerEvent<HTMLElement>) => endDrag(event, false),
   })
+  const engineBox = boxes.get(ENGINE) ?? layout.engine
+
+  const card = (c: TopologyContainer, box: Box | null) => {
+    const source = sourceLabel(c)
+    return (
+      <button
+        key={c.name}
+        type="button"
+        data-node={c.name}
+        data-state={c.state}
+        data-rel={nodeState(c.name)}
+        data-dragging={dragging === c.name ? '' : undefined}
+        aria-pressed={selected === c.name}
+        className="cu-topo-node"
+        style={box ? { left: box.x, top: box.y, width: box.w, height: box.h } : undefined}
+        onClick={() => {
+          if (suppressClickRef.current) {
+            suppressClickRef.current = false
+            return
+          }
+          onSelect(selected === c.name ? null : c.name)
+        }}
+        onKeyDown={(event) => onKeyDown(event, c.name)}
+        title={c.lastError ?? undefined}
+        {...(box ? dragProps(c.name) : {})}
+      >
+        <span className="cu-topo-title">
+          <StatusDot tone={dotTone(c.state)} pulse={c.state === 'starting'} aria-hidden />
+          <span className="cu-mono cu-topo-name">{c.name}</span>
+          {c.ports.length ? <span className="cu-mono cu-topo-ports">:{c.ports.join(' :')}</span> : null}
+        </span>
+        <span className="cu-topo-sub" data-state={c.state}>
+          {c.state === 'ready' ? `pid ${c.pid ?? '–'}` : c.state}
+          {source ? (
+            <span className="cu-mono cu-topo-source" title={c.ref ?? undefined}>
+              {source}
+            </span>
+          ) : null}
+        </span>
+      </button>
+    )
+  }
+
+  const levels = new Map<number, TopologyContainer[]>()
+  for (const node of layout.nodes) {
+    const list = levels.get(node.level)
+    if (list) list.push(node.container)
+    else levels.set(node.level, [node.container])
+  }
+
+  const stack = (
+    <div className="cu-topo-stack">
+      <div className="cu-topo-engine cu-topo-engine-static">
+        <span className="cu-topo-title">
+          <Layers />
+          engine
+        </span>
+        <span className="cu-mono cu-topo-sub">
+          {input.engine.host ?? '127.0.0.1'}
+          {input.engine.port ? `:${input.engine.port}` : ''}
+          {input.engine.pid ? ` · daemon pid ${input.engine.pid}` : ''}
+        </span>
+      </div>
+      <span className="cu-topo-group-label cu-topo-group-label-static">
+        <span className="cu-topo-group-kind">namespace</span>
+        <span className="cu-mono">{input.namespace ?? '–'}</span>
+      </span>
+      {[...levels.entries()]
+        .sort((a, b) => a[0] - b[0])
+        .map(([level, containers]) => (
+          <section key={level} className="cu-topo-level">
+            <h3 className="cu-topo-level-head">
+              {level === 0 ? 'Starts with the engine' : `Start level ${level}`}
+              <span className="cu-topo-level-count">{containers.length}</span>
+            </h3>
+            <div className="cu-topo-level-grid">{containers.map((c) => card(c, null))}</div>
+          </section>
+        ))}
+    </div>
+  )
+
+  const canvas = (
+    <>
+      <div className="cu-topo-toolbar">
+        <span className="cu-topo-hint">Drag a card to rearrange; Shift+arrows nudge the focused one.</span>
+        {moved ? (
+          <Button variant="ghost" size="sm" onClick={() => commit({})}>
+            Reset layout
+          </Button>
+        ) : null}
+      </div>
+      <div className="cu-topo-scroll">
+        <div
+          className="cu-topo"
+          style={{ width: bounds.width, height: bounds.height }}
+          data-dragging={dragging ? '' : undefined}
+        >
+          <svg aria-hidden="true" className="cu-topo-svg" width={bounds.width} height={bounds.height}>
+            <defs>
+              <marker
+                id="cu-topo-arrow"
+                viewBox="0 0 8 8"
+                refX="7"
+                refY="4"
+                markerWidth="8"
+                markerHeight="8"
+                orient="auto"
+              >
+                <path d="M0 0 L8 4 L0 8 Z" />
+              </marker>
+            </defs>
+            {edges.map((edge) => {
+              const from = boxes.get(edge.from)
+              const to = boxes.get(edge.to)
+              if (!from || !to) return null
+              return (
+                <path
+                  key={edge.key}
+                  className="cu-topo-edge"
+                  data-rel={edgeState(edge.from, edge.to)}
+                  data-running={input.containers.find((c) => c.name === edge.to)?.state === 'ready' ? '' : undefined}
+                  d={edgePath(from, to)}
+                  markerEnd="url(#cu-topo-arrow)"
+                />
+              )
+            })}
+          </svg>
+
+          <div
+            className="cu-topo-group"
+            style={{ left: layout.group.x, top: layout.group.y, width: layout.group.w, height: layout.group.h }}
+          >
+            <span className="cu-topo-group-label">
+              <span className="cu-topo-group-kind">namespace</span>
+              <span className="cu-mono">{input.namespace ?? '–'}</span>
+              {input.file ? <span className="cu-topo-group-file cu-mono">{input.file.split('/').pop()}</span> : null}
+            </span>
+          </div>
+
+          <div
+            className="cu-topo-engine"
+            data-node={ENGINE}
+            data-dragging={dragging === ENGINE ? '' : undefined}
+            style={{ left: engineBox.x, top: engineBox.y, width: engineBox.w, height: engineBox.h }}
+            {...dragProps(ENGINE)}
+          >
+            <span className="cu-topo-title">
+              <Layers />
+              engine
+            </span>
+            <span className="cu-mono cu-topo-sub">
+              {input.engine.host ?? '127.0.0.1'}
+              {input.engine.port ? `:${input.engine.port}` : ''}
+            </span>
+            <span className="cu-topo-sub">
+              {input.engine.pid ? `daemon pid ${input.engine.pid}` : 'compose daemon'}
+            </span>
+          </div>
+
+          {layout.nodes.map((node) => card(node.container, boxes.get(node.container.name) ?? node))}
+        </div>
+      </div>
+    </>
+  )
 
   return (
-    <div className="cu-topo-scroll">
-      <div className="cu-topo" style={{ width: layout.width, height: layout.height }}>
-        <svg aria-hidden="true" className="cu-topo-svg" width={layout.width} height={layout.height}>
-          <defs>
-            <marker
-              id="cu-topo-arrow"
-              viewBox="0 0 8 8"
-              refX="7"
-              refY="4"
-              markerWidth="8"
-              markerHeight="8"
-              orient="auto"
-            >
-              <path d="M0 0 L8 4 L0 8 Z" />
-            </marker>
-          </defs>
-          {edges.map((edge) => (
-            <path
-              key={edge.key}
-              className="cu-topo-edge"
-              data-rel={edgeState(edge.from, edge.to)}
-              data-running={input.containers.find((c) => c.name === edge.to)?.state === 'ready' ? '' : undefined}
-              d={edgePath(edge)}
-              markerEnd="url(#cu-topo-arrow)"
-            />
-          ))}
-        </svg>
-
-        <div
-          className="cu-topo-group"
-          style={{ left: layout.group.x, top: layout.group.y, width: layout.group.w, height: layout.group.h }}
-        >
-          <span className="cu-topo-group-label">
-            <span className="cu-topo-group-kind">namespace</span>
-            <span className="cu-mono">{input.namespace ?? '–'}</span>
-            {input.file ? <span className="cu-topo-group-file cu-mono">{input.file.split('/').pop()}</span> : null}
-          </span>
-        </div>
-
-        <div
-          className="cu-topo-engine"
-          style={{ left: layout.engine.x, top: layout.engine.y, width: layout.engine.w, height: layout.engine.h }}
-        >
-          <span className="cu-topo-title">
-            <Layers />
-            engine
-          </span>
-          <span className="cu-mono cu-topo-sub">
-            {input.engine.host ?? '127.0.0.1'}
-            {input.engine.port ? `:${input.engine.port}` : ''}
-          </span>
-          <span className="cu-topo-sub">{input.engine.pid ? `daemon pid ${input.engine.pid}` : 'compose daemon'}</span>
-        </div>
-
-        {layout.nodes.map((node) => {
-          const c = node.container
-          return (
-            <button
-              key={c.name}
-              type="button"
-              data-node={c.name}
-              data-state={c.state}
-              data-rel={nodeState(c.name)}
-              aria-pressed={selected === c.name}
-              className="cu-topo-node"
-              style={{ left: node.x, top: node.y, width: node.w, height: node.h }}
-              onClick={() => onSelect(selected === c.name ? null : c.name)}
-              onKeyDown={(event) => moveFocus(event, c.name)}
-              title={c.lastError ?? undefined}
-            >
-              <span className="cu-topo-title">
-                <StatusDot tone={dotTone(c.state)} pulse={c.state === 'starting'} aria-hidden />
-                <span className="cu-mono cu-topo-name">{c.name}</span>
-                {c.ports.length ? <span className="cu-mono cu-topo-ports">:{c.ports.join(' :')}</span> : null}
-              </span>
-              <span className="cu-topo-sub" data-state={c.state}>
-                {c.state === 'ready' ? `pid ${c.pid ?? '–'}` : c.state}
-                {sourceLabel(c) ? (
-                  <span className="cu-mono cu-topo-source" title={c.ref ?? undefined}>
-                    {sourceLabel(c)}
-                  </span>
-                ) : null}
-              </span>
-            </button>
-          )
-        })}
-      </div>
+    <div className="cu-topo-frame" ref={frameRef}>
+      {stacked ? stack : canvas}
     </div>
   )
 }

--- a/compose-ui/ui/src/page/Topology.tsx
+++ b/compose-ui/ui/src/page/Topology.tsx
@@ -16,13 +16,20 @@ function dotTone(state: string): 'accent' | 'alert' | 'warn' | 'ink' {
   return 'ink'
 }
 
-function sourceLabel(c: TopologyContainer): string {
+function sourceLabel(c: TopologyContainer): string | null {
   if (c.source === 'package') return `${(c.ref ?? '').split('/').pop() ?? ''}${c.version ? `@${c.version}` : ''}`
   if (c.source === 'path') {
-    const parts = (c.ref ?? '').split('/').filter(Boolean)
-    return `path ${parts.length > 2 ? `…/${parts.slice(-2).join('/')}` : (c.ref ?? '')}`
+    const ref = c.ref ?? ''
+    if (ref === '.' || ref === './' || ref === `../${c.name}` || ref === `./${c.name}`) return null
+    const parts = ref.split('/').filter(Boolean)
+    return parts.length > 2 ? `…/${parts.slice(-2).join('/')}` : ref
   }
-  return c.ref ?? ''
+  return c.ref || null
+}
+
+function edgePath(edge: { start: { x: number; y: number }; end: { x: number; y: number } }): string {
+  const dx = Math.max(32, (edge.end.x - edge.start.x) / 2)
+  return `M ${edge.start.x} ${edge.start.y} C ${edge.start.x + dx} ${edge.start.y}, ${edge.end.x - dx} ${edge.end.y}, ${edge.end.x - 1} ${edge.end.y}`
 }
 
 export function Topology({ input, selected, onSelect }: TopologyProps) {
@@ -75,6 +82,11 @@ export function Topology({ input, selected, onSelect }: TopologyProps) {
     return 'dim'
   }
 
+  const edges = [...layout.edges].sort((a, b) => {
+    const rank = (rel: string | undefined) => (rel === 'up' || rel === 'down' ? 1 : 0)
+    return rank(edgeState(a.from, a.to)) - rank(edgeState(b.from, b.to))
+  })
+
   return (
     <div className="cu-topo-scroll">
       <div className="cu-topo" style={{ width: layout.width, height: layout.height }}>
@@ -92,13 +104,13 @@ export function Topology({ input, selected, onSelect }: TopologyProps) {
               <path d="M0 0 L8 4 L0 8 Z" />
             </marker>
           </defs>
-          {layout.edges.map((edge) => (
+          {edges.map((edge) => (
             <path
               key={edge.key}
               className="cu-topo-edge"
               data-rel={edgeState(edge.from, edge.to)}
               data-running={input.containers.find((c) => c.name === edge.to)?.state === 'ready' ? '' : undefined}
-              d={`M ${edge.start.x} ${edge.start.y} H ${edge.midX} V ${edge.end.y} H ${edge.end.x - 1}`}
+              d={edgePath(edge)}
               markerEnd="url(#cu-topo-arrow)"
             />
           ))}
@@ -151,12 +163,13 @@ export function Topology({ input, selected, onSelect }: TopologyProps) {
                 <span className="cu-mono cu-topo-name">{c.name}</span>
                 {c.ports.length ? <span className="cu-mono cu-topo-ports">:{c.ports.join(' :')}</span> : null}
               </span>
-              <span className="cu-mono cu-topo-sub" title={c.ref ?? undefined}>
-                {sourceLabel(c) || c.state}
-              </span>
-              <span className="cu-topo-sub">
-                {c.state}
-                {c.pid ? ` · pid ${c.pid}` : ''}
+              <span className="cu-topo-sub" data-state={c.state}>
+                {c.state === 'ready' ? `pid ${c.pid ?? '–'}` : c.state}
+                {sourceLabel(c) ? (
+                  <span className="cu-mono cu-topo-source" title={c.ref ?? undefined}>
+                    {sourceLabel(c)}
+                  </span>
+                ) : null}
               </span>
             </button>
           )

--- a/compose-ui/ui/src/page/Topology.tsx
+++ b/compose-ui/ui/src/page/Topology.tsx
@@ -1,0 +1,167 @@
+import { StatusDot } from '@iii-dev/console-ui'
+import { type KeyboardEvent, useMemo } from 'react'
+import { Layers } from './icons'
+import { layoutTopology, related, type TopologyContainer, type TopologyInput } from './topology-layout'
+
+interface TopologyProps {
+  input: TopologyInput
+  selected: string | null
+  onSelect: (name: string | null) => void
+}
+
+function dotTone(state: string): 'accent' | 'alert' | 'warn' | 'ink' {
+  if (state === 'ready') return 'accent'
+  if (state === 'failed') return 'alert'
+  if (state === 'starting') return 'warn'
+  return 'ink'
+}
+
+function sourceLabel(c: TopologyContainer): string {
+  if (c.source === 'package') return `${(c.ref ?? '').split('/').pop() ?? ''}${c.version ? `@${c.version}` : ''}`
+  if (c.source === 'path') {
+    const parts = (c.ref ?? '').split('/').filter(Boolean)
+    return `path ${parts.length > 2 ? `…/${parts.slice(-2).join('/')}` : (c.ref ?? '')}`
+  }
+  return c.ref ?? ''
+}
+
+export function Topology({ input, selected, onSelect }: TopologyProps) {
+  const layout = useMemo(() => layoutTopology(input), [input])
+  const relation = useMemo(() => (selected ? related(input.containers, selected) : null), [input.containers, selected])
+
+  const order = layout.nodes.map((n) => n.container.name)
+  const moveFocus = (event: KeyboardEvent<HTMLButtonElement>, name: string) => {
+    const index = order.indexOf(name)
+    if (index < 0) return
+    let next: number | null = null
+    if (event.key === 'ArrowDown') next = Math.min(order.length - 1, index + 1)
+    else if (event.key === 'ArrowUp') next = Math.max(0, index - 1)
+    else if (event.key === 'ArrowRight' || event.key === 'ArrowLeft') {
+      const current = layout.nodes[index]
+      const dir = event.key === 'ArrowRight' ? 1 : -1
+      const candidates = layout.nodes
+        .map((n, i) => ({ n, i }))
+        .filter(({ n }) => n.level === current.level + dir)
+        .sort((a, b) => Math.abs(a.n.y - current.y) - Math.abs(b.n.y - current.y))
+      next = candidates[0]?.i ?? null
+    } else if (event.key === 'Escape') {
+      onSelect(null)
+      return
+    }
+    if (next === null) return
+    event.preventDefault()
+    const target = event.currentTarget.parentElement?.querySelector<HTMLButtonElement>(`[data-node="${order[next]}"]`)
+    target?.focus()
+  }
+
+  if (layout.nodes.length === 0) return null
+
+  const edgeState = (from: string, to: string): string | undefined => {
+    if (!selected || !relation) return undefined
+    if (from === selected || relation.upstream.has(from)) {
+      if (to === selected || relation.upstream.has(to)) return 'up'
+    }
+    if (from === selected || relation.downstream.has(from)) {
+      if (relation.downstream.has(to)) return 'down'
+    }
+    return 'dim'
+  }
+
+  const nodeState = (name: string): string | undefined => {
+    if (!selected || !relation) return undefined
+    if (name === selected) return 'selected'
+    if (relation.upstream.has(name)) return 'up'
+    if (relation.downstream.has(name)) return 'down'
+    return 'dim'
+  }
+
+  return (
+    <div className="cu-topo-scroll">
+      <div className="cu-topo" style={{ width: layout.width, height: layout.height }}>
+        <svg aria-hidden="true" className="cu-topo-svg" width={layout.width} height={layout.height}>
+          <defs>
+            <marker
+              id="cu-topo-arrow"
+              viewBox="0 0 8 8"
+              refX="7"
+              refY="4"
+              markerWidth="8"
+              markerHeight="8"
+              orient="auto"
+            >
+              <path d="M0 0 L8 4 L0 8 Z" />
+            </marker>
+          </defs>
+          {layout.edges.map((edge) => (
+            <path
+              key={edge.key}
+              className="cu-topo-edge"
+              data-rel={edgeState(edge.from, edge.to)}
+              data-running={input.containers.find((c) => c.name === edge.to)?.state === 'ready' ? '' : undefined}
+              d={`M ${edge.start.x} ${edge.start.y} H ${edge.midX} V ${edge.end.y} H ${edge.end.x - 1}`}
+              markerEnd="url(#cu-topo-arrow)"
+            />
+          ))}
+        </svg>
+
+        <div
+          className="cu-topo-group"
+          style={{ left: layout.group.x, top: layout.group.y, width: layout.group.w, height: layout.group.h }}
+        >
+          <span className="cu-topo-group-label">
+            <span className="cu-topo-group-kind">namespace</span>
+            <span className="cu-mono">{input.namespace ?? '–'}</span>
+            {input.file ? <span className="cu-topo-group-file cu-mono">{input.file.split('/').pop()}</span> : null}
+          </span>
+        </div>
+
+        <div
+          className="cu-topo-engine"
+          style={{ left: layout.engine.x, top: layout.engine.y, width: layout.engine.w, height: layout.engine.h }}
+        >
+          <span className="cu-topo-title">
+            <Layers />
+            engine
+          </span>
+          <span className="cu-mono cu-topo-sub">
+            {input.engine.host ?? '127.0.0.1'}
+            {input.engine.port ? `:${input.engine.port}` : ''}
+          </span>
+          <span className="cu-topo-sub">{input.engine.pid ? `daemon pid ${input.engine.pid}` : 'compose daemon'}</span>
+        </div>
+
+        {layout.nodes.map((node) => {
+          const c = node.container
+          return (
+            <button
+              key={c.name}
+              type="button"
+              data-node={c.name}
+              data-state={c.state}
+              data-rel={nodeState(c.name)}
+              aria-pressed={selected === c.name}
+              className="cu-topo-node"
+              style={{ left: node.x, top: node.y, width: node.w, height: node.h }}
+              onClick={() => onSelect(selected === c.name ? null : c.name)}
+              onKeyDown={(event) => moveFocus(event, c.name)}
+              title={c.lastError ?? undefined}
+            >
+              <span className="cu-topo-title">
+                <StatusDot tone={dotTone(c.state)} pulse={c.state === 'starting'} aria-hidden />
+                <span className="cu-mono cu-topo-name">{c.name}</span>
+                {c.ports.length ? <span className="cu-mono cu-topo-ports">:{c.ports.join(' :')}</span> : null}
+              </span>
+              <span className="cu-mono cu-topo-sub" title={c.ref ?? undefined}>
+                {sourceLabel(c) || c.state}
+              </span>
+              <span className="cu-topo-sub">
+                {c.state}
+                {c.pid ? ` · pid ${c.pid}` : ''}
+              </span>
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/compose-ui/ui/src/page/icons.tsx
+++ b/compose-ui/ui/src/page/icons.tsx
@@ -131,3 +131,10 @@ export const Search = (p: IconProps) => (
     <path d="m21 21-4.3-4.3" />
   </Svg>
 )
+
+export const X = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M18 6 6 18" />
+    <path d="m6 6 12 12" />
+  </Svg>
+)

--- a/compose-ui/ui/src/page/index.tsx
+++ b/compose-ui/ui/src/page/index.tsx
@@ -46,6 +46,7 @@ import {
   Server,
   ShieldCheck,
   Square,
+  X,
 } from './icons'
 import { Topology } from './Topology'
 import type { TopologyInput } from './topology-layout'
@@ -1018,151 +1019,152 @@ export function ComposePage({ host, onRequestClose, panelSide, commands, panelCo
             <>
               <StatusDot tone={styleFor(selectedContainer.state).dot} pulse={selectedContainer.state === 'starting'} />
               <span className="cu-mono">{selectedContainer.container}</span>
+              <Badge variant={styleFor(selectedContainer.state).badge}>{selectedContainer.state}</Badge>
             </>
           }
-          actions={<Badge variant={styleFor(selectedContainer.state).badge}>{selectedContainer.state}</Badge>}
+          actions={
+            <div className="cu-actions cu-detail-actions">
+              {running(selectedContainer.state) ? (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  disabled={!!busy}
+                  onClick={() => confirmLifecycle('down', selectedContainer.container)}
+                >
+                  <Square />
+                  Stop
+                </Button>
+              ) : (
+                <Button
+                  variant="primary"
+                  size="sm"
+                  disabled={!!busy}
+                  onClick={() => void lifecycle('up', selectedContainer.container)}
+                >
+                  <Play />
+                  Start
+                </Button>
+              )}
+              <Button
+                variant="ghost"
+                size="sm"
+                disabled={!!busy}
+                onClick={() => confirmLifecycle('restart', selectedContainer.container)}
+              >
+                <RotateCw />
+                Restart
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setSection('containers')
+                  setQuery('')
+                  setExpanded(selectedContainer.container)
+                  void loadLogs(selectedContainer.container)
+                }}
+              >
+                <FileText />
+                Log
+              </Button>
+              <IconButton label="Close details" variant="ghost" onClick={() => setSelectedNode(null)}>
+                <X />
+              </IconButton>
+            </div>
+          }
         >
-          <Facts
-            items={[
-              {
-                term: 'PID',
-                children: (
-                  <span className="cu-mono">
-                    {running(selectedContainer.state) ? (selectedContainer.pid ?? '–') : '–'}
-                  </span>
-                ),
-              },
-              { term: 'Supervision', children: supervision(selectedContainer) },
-              {
-                term: 'Source',
-                children: selectedDeclared ? (
-                  <span className="cu-mono">
-                    {selectedDeclared.source === 'package'
-                      ? `package://${selectedDeclared.ref}${selectedDeclared.version ? `@${selectedDeclared.version}` : ''}`
-                      : `${selectedDeclared.source}://${selectedDeclared.ref}`}
-                  </span>
-                ) : (
-                  '–'
-                ),
-                wide: true,
-              },
-              {
-                term: 'Ports',
-                children: selectedDeclared?.ports.length ? (
-                  <span className="cu-mono">
-                    {selectedDeclared.ports
+          <div className="cu-detail-grid">
+            <div className="cu-detail-fact">
+              <span className="cu-detail-term">PID</span>
+              <span className="cu-mono cu-detail-value">
+                {running(selectedContainer.state) ? (selectedContainer.pid ?? '–') : '–'}
+              </span>
+            </div>
+            <div className="cu-detail-fact">
+              <span className="cu-detail-term">Supervision</span>
+              <span className="cu-detail-value">{supervision(selectedContainer)}</span>
+            </div>
+            <div className="cu-detail-fact">
+              <span className="cu-detail-term">Listening</span>
+              <span className="cu-mono cu-detail-value">
+                {selectedDeclared?.ports.length
+                  ? selectedDeclared.ports
                       .map((port) => `${port.address === '*' ? '' : `${port.address}:`}${port.port}`)
-                      .join(', ')}
-                  </span>
-                ) : (
-                  <span className="cu-faint">none</span>
-                ),
-              },
-              {
-                term: 'Starts after',
-                children: selectedDeclared?.start_after.length ? (
+                      .join(', ')
+                  : '–'}
+              </span>
+            </div>
+            <div className="cu-detail-fact">
+              <span className="cu-detail-term">Source</span>
+              <span className="cu-mono cu-detail-value" title={selectedDeclared?.ref}>
+                {selectedDeclared
+                  ? selectedDeclared.source === 'package'
+                    ? `${selectedDeclared.ref.split('/').pop()}${selectedDeclared.version ? `@${selectedDeclared.version}` : ''}`
+                    : `${selectedDeclared.source}://${selectedDeclared.ref}`
+                  : '–'}
+              </span>
+            </div>
+          </div>
+          <div className="cu-detail-relations">
+            <div className="cu-detail-fact">
+              <span className="cu-detail-term">Starts after</span>
+              {selectedDeclared?.start_after.length ? (
+                <span className="cu-chips">
+                  {selectedDeclared.start_after.map((dep) => (
+                    <Chip key={dep} tone="neutral" onClick={() => setSelectedNode(dep)} role="button" tabIndex={0}>
+                      <span className="cu-mono">{dep}</span>
+                    </Chip>
+                  ))}
+                </span>
+              ) : (
+                <span className="cu-detail-value cu-faint">the engine only</span>
+              )}
+            </div>
+            <div className="cu-detail-fact">
+              <span className="cu-detail-term">Depended on by</span>
+              {(() => {
+                const dependents = (project?.containers ?? []).filter((d) =>
+                  d.start_after.includes(selectedContainer.container),
+                )
+                return dependents.length ? (
                   <span className="cu-chips">
-                    {selectedDeclared.start_after.map((dep) => (
-                      <Chip key={dep} tone="neutral" onClick={() => setSelectedNode(dep)} role="button" tabIndex={0}>
-                        <span className="cu-mono">{dep}</span>
+                    {dependents.map((d) => (
+                      <Chip
+                        key={d.name}
+                        tone="neutral"
+                        onClick={() => setSelectedNode(d.name)}
+                        role="button"
+                        tabIndex={0}
+                      >
+                        <span className="cu-mono">{d.name}</span>
                       </Chip>
                     ))}
                   </span>
                 ) : (
-                  <span className="cu-faint">engine only</span>
-                ),
-                wide: true,
-              },
-              {
-                term: 'Depended on by',
-                children: (() => {
-                  const dependents = (project?.containers ?? []).filter((d) =>
-                    d.start_after.includes(selectedContainer.container),
-                  )
-                  return dependents.length ? (
-                    <span className="cu-chips">
-                      {dependents.map((d) => (
-                        <Chip
-                          key={d.name}
-                          tone="neutral"
-                          onClick={() => setSelectedNode(d.name)}
-                          role="button"
-                          tabIndex={0}
-                        >
-                          <span className="cu-mono">{d.name}</span>
-                        </Chip>
-                      ))}
-                    </span>
-                  ) : (
-                    <span className="cu-faint">nothing</span>
-                  )
-                })(),
-                wide: true,
-              },
-              ...(selectedDeclared?.environment.length
-                ? [
-                    {
-                      term: 'Environment',
-                      children: <span className="cu-mono">{selectedDeclared.environment.join(', ')}</span>,
-                      wide: true,
-                    },
-                  ]
-                : []),
-              ...(selectedDeclared?.run
-                ? [{ term: 'Run', children: <span className="cu-mono">{selectedDeclared.run}</span>, wide: true }]
-                : []),
-              ...(selectedContainer.last_error
-                ? [
-                    {
-                      term: 'Last error',
-                      children: <span className="cu-last-error">{selectedContainer.last_error}</span>,
-                      wide: true,
-                    },
-                  ]
-                : []),
-            ]}
-          />
-          <div className="cu-actions">
-            {running(selectedContainer.state) ? (
-              <Button
-                variant="ghost"
-                disabled={!!busy}
-                onClick={() => confirmLifecycle('down', selectedContainer.container)}
-              >
-                <Square />
-                Stop
-              </Button>
-            ) : (
-              <Button
-                variant="primary"
-                disabled={!!busy}
-                onClick={() => void lifecycle('up', selectedContainer.container)}
-              >
-                <Play />
-                Start
-              </Button>
-            )}
-            <Button
-              variant="ghost"
-              disabled={!!busy}
-              onClick={() => confirmLifecycle('restart', selectedContainer.container)}
-            >
-              <RotateCw />
-              Restart
-            </Button>
-            <Button
-              variant="pill"
-              onClick={() => {
-                setSection('containers')
-                setQuery('')
-                setExpanded(selectedContainer.container)
-                void loadLogs(selectedContainer.container)
-              }}
-            >
-              <FileText />
-              Show log
-            </Button>
+                  <span className="cu-detail-value cu-faint">nothing</span>
+                )
+              })()}
+            </div>
           </div>
+          {selectedDeclared?.run || selectedDeclared?.environment.length ? (
+            <dl className="cu-detail-lines">
+              {selectedDeclared.run ? (
+                <div>
+                  <dt>run</dt>
+                  <dd className="cu-mono">{selectedDeclared.run}</dd>
+                </div>
+              ) : null}
+              {selectedDeclared.environment.length ? (
+                <div>
+                  <dt>environment</dt>
+                  <dd className="cu-mono">{selectedDeclared.environment.join('  ')}</dd>
+                </div>
+              ) : null}
+            </dl>
+          ) : null}
+          {selectedContainer.last_error ? (
+            <StatusPanel variant="alert" headline="Last error" detail={selectedContainer.last_error} />
+          ) : null}
         </SectionCard>
       ) : null}
     </>

--- a/compose-ui/ui/src/page/index.tsx
+++ b/compose-ui/ui/src/page/index.tsx
@@ -1006,8 +1006,8 @@ export function ComposePage({ host, onRequestClose, panelSide, commands, panelCo
         ) : (
           <>
             <p className="cu-note">
-              Left to right in start order. Arrows follow <span className="cu-mono">start_after</span>; pick a container
-              to trace what it needs and what depends on it.
+              Ordered by <span className="cu-mono">start_after</span>. Pick a container to trace what it needs and what
+              depends on it.
             </p>
             <Topology input={topology} selected={selectedNode} onSelect={setSelectedNode} />
           </>

--- a/compose-ui/ui/src/page/index.tsx
+++ b/compose-ui/ui/src/page/index.tsx
@@ -263,6 +263,25 @@ function portSummary(project: Project | null): ReactNode {
   )
 }
 
+function NodeChip({ name, onPick }: { name: string; onPick: (name: string) => void }) {
+  return (
+    <Chip
+      tone="neutral"
+      role="button"
+      tabIndex={0}
+      onClick={() => onPick(name)}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault()
+          onPick(name)
+        }
+      }}
+    >
+      <span className="cu-mono">{name}</span>
+    </Chip>
+  )
+}
+
 function Field({ id, label, hint, children }: { id: string; label: string; hint?: string; children: ReactNode }) {
   return (
     <div className={uiClasses.field}>
@@ -621,6 +640,9 @@ export function ComposePage({ host, onRequestClose, panelSide, commands, panelCo
   )
   const selectedContainer = selectedNode ? (all.find((c) => c.container === selectedNode) ?? null) : null
   const selectedDeclared = selectedNode ? declared.get(selectedNode) : undefined
+  useEffect(() => {
+    if (loaded && selectedNode && !all.some((c) => c.container === selectedNode)) setSelectedNode(null)
+  }, [loaded, selectedNode, all])
   const counts = useMemo(() => {
     const next = { ready: 0, starting: 0, failed: 0, stopped: 0 }
     for (const c of all) if (c.state in next) next[c.state as ContainerState] += 1
@@ -1111,9 +1133,7 @@ export function ComposePage({ host, onRequestClose, panelSide, commands, panelCo
               {selectedDeclared?.start_after.length ? (
                 <span className="cu-chips">
                   {selectedDeclared.start_after.map((dep) => (
-                    <Chip key={dep} tone="neutral" onClick={() => setSelectedNode(dep)} role="button" tabIndex={0}>
-                      <span className="cu-mono">{dep}</span>
-                    </Chip>
+                    <NodeChip key={dep} name={dep} onPick={setSelectedNode} />
                   ))}
                 </span>
               ) : (
@@ -1129,15 +1149,7 @@ export function ComposePage({ host, onRequestClose, panelSide, commands, panelCo
                 return dependents.length ? (
                   <span className="cu-chips">
                     {dependents.map((d) => (
-                      <Chip
-                        key={d.name}
-                        tone="neutral"
-                        onClick={() => setSelectedNode(d.name)}
-                        role="button"
-                        tabIndex={0}
-                      >
-                        <span className="cu-mono">{d.name}</span>
-                      </Chip>
+                      <NodeChip key={d.name} name={d.name} onPick={setSelectedNode} />
                     ))}
                   </span>
                 ) : (

--- a/compose-ui/ui/src/page/index.tsx
+++ b/compose-ui/ui/src/page/index.tsx
@@ -47,6 +47,8 @@ import {
   ShieldCheck,
   Square,
 } from './icons'
+import { Topology } from './Topology'
+import type { TopologyInput } from './topology-layout'
 
 type Props = PageRenderProps & { host: Host }
 
@@ -115,7 +117,7 @@ type Validation = { namespace?: string; start_order?: string[]; deferred_package
 type LogTail = { container: string; path: string; lines: string[]; size: number; truncated: boolean; missing: boolean }
 type ChangedEvent = { kind?: string; file?: string; namespace?: string; state_dir?: string; path?: string }
 
-type Section = 'overview' | 'containers' | 'workers' | 'daemon'
+type Section = 'topology' | 'overview' | 'containers' | 'workers' | 'daemon'
 
 type Confirm = { title: string; description: string; confirmLabel: string; run: () => void }
 
@@ -128,6 +130,7 @@ const sections: {
   description: string
   icon: (props: { className?: string }) => ReactNode
 }[] = [
+  { id: 'topology', label: 'Topology', description: 'Engine, namespace, dependencies', icon: Layers },
   { id: 'overview', label: 'Overview', description: 'Project health, lifecycle', icon: Activity },
   { id: 'containers', label: 'Containers', description: 'State, PIDs, logs', icon: Boxes },
   { id: 'workers', label: 'Workers', description: 'Add, update, remove packages', icon: Package },
@@ -316,7 +319,8 @@ function Stat({ value, label, tone }: { value: ReactNode; label: string; tone?: 
 }
 
 export function ComposePage({ host, onRequestClose, panelSide, commands, panelContext }: Props) {
-  const [section, setSection] = useState<Section>('overview')
+  const [section, setSection] = useState<Section>('topology')
+  const [selectedNode, setSelectedNode] = useState<string | null>(null)
   const [status, setStatus] = useState<Status | null>(null)
   const [projects, setProjects] = useState<ProjectList | null>(null)
   const [project, setProject] = useState<Project | null>(null)
@@ -421,11 +425,9 @@ export function ComposePage({ host, onRequestClose, panelSide, commands, panelCo
         ? (context as { container?: unknown }).container
         : null
     if (typeof container !== 'string' || !container) return
-    setSection('containers')
-    setQuery('')
-    setExpanded(container)
-    void loadLogs(container)
-  }, [panelContext?.id, panelContext?.context, loadLogs])
+    setSection('topology')
+    setSelectedNode(container)
+  }, [panelContext?.id, panelContext?.context])
 
   const act = useCallback(
     async <T,>(key: string, run: () => Promise<T>, summarize: (result: T) => string) => {
@@ -589,6 +591,35 @@ export function ComposePage({ host, onRequestClose, panelSide, commands, panelCo
 
   const all = status?.containers ?? []
   const declared = useMemo(() => new Map((project?.containers ?? []).map((c) => [c.name, c])), [project])
+  const topology = useMemo<TopologyInput>(
+    () => ({
+      namespace: status?.namespace ?? project?.namespace ?? null,
+      file: status?.file ?? project?.file ?? null,
+      engine: {
+        url: project?.engine_url ?? null,
+        host: project?.engine_host ?? null,
+        port: project?.engine_port ?? null,
+        pid: status?.daemon_pid ?? null,
+      },
+      containers: all.map((c) => {
+        const d = declared.get(c.container)
+        return {
+          name: c.container,
+          state: c.state,
+          pid: running(c.state) ? (c.pid ?? null) : null,
+          source: d?.source ?? null,
+          ref: d?.ref ?? null,
+          version: d?.version ?? null,
+          ports: d?.ports.map((port) => port.port) ?? [],
+          startAfter: d?.start_after ?? [],
+          lastError: c.last_error ?? null,
+        }
+      }),
+    }),
+    [all, declared, project, status],
+  )
+  const selectedContainer = selectedNode ? (all.find((c) => c.container === selectedNode) ?? null) : null
+  const selectedDeclared = selectedNode ? declared.get(selectedNode) : undefined
   const counts = useMemo(() => {
     const next = { ready: 0, starting: 0, failed: 0, stopped: 0 }
     for (const c of all) if (c.state in next) next[c.state as ContainerState] += 1
@@ -603,6 +634,7 @@ export function ComposePage({ host, onRequestClose, panelSide, commands, panelCo
 
   const sectionMeta = (id: Section): ReactNode => {
     if (!loaded) return null
+    if (id === 'topology' && counts.failed) return <Chip tone="danger">{counts.failed} failing</Chip>
     if (id === 'overview' && health) return <Chip tone={health.tone}>{health.label}</Chip>
     if (id === 'containers') return <Chip tone={counts.failed ? 'danger' : 'neutral'}>{all.length}</Chip>
     if (id === 'daemon' && projects?.projects?.length) return <Chip tone="neutral">{projects.projects.length}</Chip>
@@ -950,6 +982,192 @@ export function ComposePage({ host, onRequestClose, panelSide, commands, panelCo
     </SectionCard>
   )
 
+  const topologySection = (
+    <>
+      <SectionCard
+        title={
+          <>
+            Topology
+            {loaded ? <span className="cu-count">{all.length}</span> : null}
+          </>
+        }
+        actions={health ? <Chip tone={health.tone}>{health.label}</Chip> : null}
+      >
+        {!loaded ? (
+          <LoadingRows rows={5} />
+        ) : all.length === 0 ? (
+          <EmptyState
+            icon={Boxes}
+            title="Nothing to draw"
+            description="This compose file declares no containers yet. Add a worker to start one."
+            action={{ label: 'Add worker', onClick: focusWorker }}
+          />
+        ) : (
+          <>
+            <p className="cu-note">
+              Left to right in start order. Arrows follow <span className="cu-mono">start_after</span>; pick a container
+              to trace what it needs and what depends on it.
+            </p>
+            <Topology input={topology} selected={selectedNode} onSelect={setSelectedNode} />
+          </>
+        )}
+      </SectionCard>
+      {selectedContainer ? (
+        <SectionCard
+          title={
+            <>
+              <StatusDot tone={styleFor(selectedContainer.state).dot} pulse={selectedContainer.state === 'starting'} />
+              <span className="cu-mono">{selectedContainer.container}</span>
+            </>
+          }
+          actions={<Badge variant={styleFor(selectedContainer.state).badge}>{selectedContainer.state}</Badge>}
+        >
+          <Facts
+            items={[
+              {
+                term: 'PID',
+                children: (
+                  <span className="cu-mono">
+                    {running(selectedContainer.state) ? (selectedContainer.pid ?? '–') : '–'}
+                  </span>
+                ),
+              },
+              { term: 'Supervision', children: supervision(selectedContainer) },
+              {
+                term: 'Source',
+                children: selectedDeclared ? (
+                  <span className="cu-mono">
+                    {selectedDeclared.source === 'package'
+                      ? `package://${selectedDeclared.ref}${selectedDeclared.version ? `@${selectedDeclared.version}` : ''}`
+                      : `${selectedDeclared.source}://${selectedDeclared.ref}`}
+                  </span>
+                ) : (
+                  '–'
+                ),
+                wide: true,
+              },
+              {
+                term: 'Ports',
+                children: selectedDeclared?.ports.length ? (
+                  <span className="cu-mono">
+                    {selectedDeclared.ports
+                      .map((port) => `${port.address === '*' ? '' : `${port.address}:`}${port.port}`)
+                      .join(', ')}
+                  </span>
+                ) : (
+                  <span className="cu-faint">none</span>
+                ),
+              },
+              {
+                term: 'Starts after',
+                children: selectedDeclared?.start_after.length ? (
+                  <span className="cu-chips">
+                    {selectedDeclared.start_after.map((dep) => (
+                      <Chip key={dep} tone="neutral" onClick={() => setSelectedNode(dep)} role="button" tabIndex={0}>
+                        <span className="cu-mono">{dep}</span>
+                      </Chip>
+                    ))}
+                  </span>
+                ) : (
+                  <span className="cu-faint">engine only</span>
+                ),
+                wide: true,
+              },
+              {
+                term: 'Depended on by',
+                children: (() => {
+                  const dependents = (project?.containers ?? []).filter((d) =>
+                    d.start_after.includes(selectedContainer.container),
+                  )
+                  return dependents.length ? (
+                    <span className="cu-chips">
+                      {dependents.map((d) => (
+                        <Chip
+                          key={d.name}
+                          tone="neutral"
+                          onClick={() => setSelectedNode(d.name)}
+                          role="button"
+                          tabIndex={0}
+                        >
+                          <span className="cu-mono">{d.name}</span>
+                        </Chip>
+                      ))}
+                    </span>
+                  ) : (
+                    <span className="cu-faint">nothing</span>
+                  )
+                })(),
+                wide: true,
+              },
+              ...(selectedDeclared?.environment.length
+                ? [
+                    {
+                      term: 'Environment',
+                      children: <span className="cu-mono">{selectedDeclared.environment.join(', ')}</span>,
+                      wide: true,
+                    },
+                  ]
+                : []),
+              ...(selectedDeclared?.run
+                ? [{ term: 'Run', children: <span className="cu-mono">{selectedDeclared.run}</span>, wide: true }]
+                : []),
+              ...(selectedContainer.last_error
+                ? [
+                    {
+                      term: 'Last error',
+                      children: <span className="cu-last-error">{selectedContainer.last_error}</span>,
+                      wide: true,
+                    },
+                  ]
+                : []),
+            ]}
+          />
+          <div className="cu-actions">
+            {running(selectedContainer.state) ? (
+              <Button
+                variant="ghost"
+                disabled={!!busy}
+                onClick={() => confirmLifecycle('down', selectedContainer.container)}
+              >
+                <Square />
+                Stop
+              </Button>
+            ) : (
+              <Button
+                variant="primary"
+                disabled={!!busy}
+                onClick={() => void lifecycle('up', selectedContainer.container)}
+              >
+                <Play />
+                Start
+              </Button>
+            )}
+            <Button
+              variant="ghost"
+              disabled={!!busy}
+              onClick={() => confirmLifecycle('restart', selectedContainer.container)}
+            >
+              <RotateCw />
+              Restart
+            </Button>
+            <Button
+              variant="pill"
+              onClick={() => {
+                setSection('containers')
+                setQuery('')
+                setExpanded(selectedContainer.container)
+                void loadLogs(selectedContainer.container)
+              }}
+            >
+              <FileText />
+              Show log
+            </Button>
+          </div>
+        </SectionCard>
+      ) : null}
+    </>
+  )
+
   const daemon = (
     <SectionCard title="Daemon">
       {!loaded ? (
@@ -1017,7 +1235,7 @@ export function ComposePage({ host, onRequestClose, panelSide, commands, panelCo
     </SectionCard>
   )
 
-  const content = { overview, containers, workers, daemon }[section]
+  const content = { topology: topologySection, overview, containers, workers, daemon }[section]
 
   return (
     <PageShell className="cu-shell">

--- a/compose-ui/ui/src/page/topology-layout.ts
+++ b/compose-ui/ui/src/page/topology-layout.ts
@@ -59,9 +59,9 @@ export const TOPO = {
   engineW: 176,
   engineH: 64,
   nodeW: 208,
-  nodeH: 64,
-  hGap: 64,
-  vGap: 12,
+  nodeH: 56,
+  hGap: 88,
+  vGap: 14,
   groupPad: 16,
   groupLabelH: 30,
 } as const

--- a/compose-ui/ui/src/page/topology-layout.ts
+++ b/compose-ui/ui/src/page/topology-layout.ts
@@ -1,0 +1,198 @@
+export interface TopologyContainer {
+  name: string
+  state: string
+  pid: number | null
+  source: 'path' | 'package' | 'unknown' | null
+  ref: string | null
+  version: string | null
+  ports: number[]
+  startAfter: string[]
+  lastError: string | null
+}
+
+export interface TopologyEngine {
+  url: string | null
+  host: string | null
+  port: number | null
+  pid: number | null
+}
+
+export interface TopologyInput {
+  namespace: string | null
+  file: string | null
+  engine: TopologyEngine
+  containers: TopologyContainer[]
+}
+
+export interface Box {
+  x: number
+  y: number
+  w: number
+  h: number
+}
+
+export interface TopologyNode extends Box {
+  container: TopologyContainer
+  level: number
+}
+
+export interface TopologyEdge {
+  key: string
+  from: string
+  to: string
+  start: { x: number; y: number }
+  end: { x: number; y: number }
+  midX: number
+}
+
+export interface TopologyLayout {
+  width: number
+  height: number
+  engine: Box
+  group: Box & { labelH: number }
+  nodes: TopologyNode[]
+  edges: TopologyEdge[]
+}
+
+export const TOPO = {
+  pad: 20,
+  engineW: 176,
+  engineH: 64,
+  nodeW: 208,
+  nodeH: 64,
+  hGap: 64,
+  vGap: 12,
+  groupPad: 16,
+  groupLabelH: 30,
+} as const
+
+export function assignLevels(containers: TopologyContainer[]): Map<string, number> {
+  const byName = new Map(containers.map((c) => [c.name, c]))
+  const levels = new Map<string, number>()
+  const visiting = new Set<string>()
+  const level = (name: string): number => {
+    const known = levels.get(name)
+    if (known !== undefined) return known
+    if (visiting.has(name)) return 0
+    visiting.add(name)
+    const container = byName.get(name)
+    let depth = 0
+    for (const dep of container?.startAfter ?? []) {
+      if (dep === name || !byName.has(dep)) continue
+      depth = Math.max(depth, level(dep) + 1)
+    }
+    visiting.delete(name)
+    levels.set(name, depth)
+    return depth
+  }
+  for (const c of containers) level(c.name)
+  return levels
+}
+
+function byName(a: TopologyContainer, b: TopologyContainer): number {
+  return a.name.localeCompare(b.name)
+}
+
+export function layoutTopology(input: TopologyInput): TopologyLayout {
+  const { pad, engineW, engineH, nodeW, nodeH, hGap, vGap, groupPad, groupLabelH } = TOPO
+  const containers = [...input.containers].sort(byName)
+  const levels = assignLevels(containers)
+  const columns = new Map<number, TopologyContainer[]>()
+  for (const c of containers) {
+    const lvl = levels.get(c.name) ?? 0
+    const column = columns.get(lvl)
+    if (column) column.push(c)
+    else columns.set(lvl, [c])
+  }
+  const levelCount = columns.size === 0 ? 0 : Math.max(...columns.keys()) + 1
+  const tallest = Math.max(0, ...[...columns.values()].map((col) => col.length))
+  const columnsH = tallest === 0 ? 0 : tallest * nodeH + (tallest - 1) * vGap
+  const groupInnerH = Math.max(columnsH, engineH)
+  const groupX = pad + engineW + hGap
+  const groupY = pad
+  const groupW = levelCount === 0 ? nodeW + groupPad * 2 : groupPad * 2 + levelCount * nodeW + (levelCount - 1) * hGap
+  const groupH = groupLabelH + groupPad * 2 + groupInnerH
+  const contentTop = groupY + groupLabelH + groupPad
+
+  const nodes: TopologyNode[] = []
+  const positions = new Map<string, TopologyNode>()
+  for (const [lvl, column] of [...columns.entries()].sort((a, b) => a[0] - b[0])) {
+    const colH = column.length * nodeH + (column.length - 1) * vGap
+    let y = contentTop + (groupInnerH - colH) / 2
+    const x = groupX + groupPad + lvl * (nodeW + hGap)
+    for (const c of column) {
+      const node: TopologyNode = { container: c, level: lvl, x, y, w: nodeW, h: nodeH }
+      nodes.push(node)
+      positions.set(c.name, node)
+      y += nodeH + vGap
+    }
+  }
+
+  const engine: Box = { x: pad, y: contentTop + (groupInnerH - engineH) / 2, w: engineW, h: engineH }
+
+  const edges: TopologyEdge[] = []
+  for (const node of nodes) {
+    const deps = node.container.startAfter.filter((dep) => positions.has(dep) && dep !== node.container.name)
+    if (deps.length === 0) {
+      edges.push({
+        key: `engine→${node.container.name}`,
+        from: 'engine',
+        to: node.container.name,
+        start: { x: engine.x + engine.w, y: engine.y + engine.h / 2 },
+        end: { x: node.x, y: node.y + node.h / 2 },
+        midX: engine.x + engine.w + (node.x - engine.x - engine.w) / 2,
+      })
+      continue
+    }
+    for (const dep of deps) {
+      const from = positions.get(dep)
+      if (!from) continue
+      const startX = from.x + from.w
+      edges.push({
+        key: `${dep}→${node.container.name}`,
+        from: dep,
+        to: node.container.name,
+        start: { x: startX, y: from.y + from.h / 2 },
+        end: { x: node.x, y: node.y + node.h / 2 },
+        midX: startX + Math.max(hGap / 2, (node.x - startX) / 2),
+      })
+    }
+  }
+
+  return {
+    width: groupX + groupW + pad,
+    height: groupY + groupH + pad,
+    engine,
+    group: { x: groupX, y: groupY, w: groupW, h: groupH, labelH: groupLabelH },
+    nodes,
+    edges,
+  }
+}
+
+export function related(
+  containers: TopologyContainer[],
+  name: string,
+): { upstream: Set<string>; downstream: Set<string> } {
+  const byNameMap = new Map(containers.map((c) => [c.name, c]))
+  const upstream = new Set<string>()
+  const walkUp = (n: string) => {
+    for (const dep of byNameMap.get(n)?.startAfter ?? []) {
+      if (upstream.has(dep) || !byNameMap.has(dep)) continue
+      upstream.add(dep)
+      walkUp(dep)
+    }
+  }
+  walkUp(name)
+  const downstream = new Set<string>()
+  const walkDown = (n: string) => {
+    for (const c of containers) {
+      if (!c.startAfter.includes(n) || downstream.has(c.name)) continue
+      downstream.add(c.name)
+      walkDown(c.name)
+    }
+  }
+  walkDown(name)
+  upstream.delete(name)
+  downstream.delete(name)
+  return { upstream, downstream }
+}

--- a/compose-ui/ui/styles.css
+++ b/compose-ui/ui/styles.css
@@ -349,7 +349,7 @@
   stroke: var(--color-ink-faint);
   stroke-width: 1;
   stroke-dasharray: 4 3;
-  opacity: 0.75;
+  opacity: 0.55;
 }
 
 [data-iii-ui='compose-ui'] .cu-topo-edge[data-running] {
@@ -478,12 +478,30 @@
 }
 
 [data-iii-ui='compose-ui'] .cu-topo-sub {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  min-width: 0;
   font-size: 0.75rem;
   color: var(--color-ink-faint);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   overflow-wrap: normal;
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-sub[data-state='failed'] {
+  color: var(--color-alert);
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-sub[data-state='starting'] {
+  color: var(--color-warn);
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-source {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--color-ink-faint);
 }
 
 @media (hover: hover) and (pointer: fine) {

--- a/compose-ui/ui/styles.css
+++ b/compose-ui/ui/styles.css
@@ -321,6 +321,177 @@
   width: 86%;
 }
 
+[data-iii-ui='compose-ui'] .cu-topo-scroll {
+  overflow: auto;
+  max-width: 100%;
+  border: 1px solid var(--color-edge);
+  border-radius: var(--radius-md, 6px);
+  background: var(--color-panel);
+}
+
+[data-iii-ui='compose-ui'] .cu-topo {
+  position: relative;
+  min-width: max-content;
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-svg {
+  position: absolute;
+  inset: 0;
+  overflow: visible;
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-svg marker path {
+  fill: var(--color-ink-faint);
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-edge {
+  fill: none;
+  stroke: var(--color-ink-faint);
+  stroke-width: 1;
+  stroke-dasharray: 4 3;
+  opacity: 0.75;
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-edge[data-running] {
+  stroke-dasharray: none;
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-edge[data-rel='up'],
+[data-iii-ui='compose-ui'] .cu-topo-edge[data-rel='down'] {
+  stroke: var(--color-accent);
+  stroke-width: 1.5;
+  opacity: 1;
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-edge[data-rel='dim'] {
+  opacity: 0.25;
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-group {
+  position: absolute;
+  border: 1px dashed var(--color-edge);
+  border-radius: var(--radius-md, 6px);
+  background: var(--color-surface);
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-group-label {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  padding: 0.375rem 0.75rem;
+  font-family: var(--font-sans);
+  font-size: 0.8125rem;
+  color: var(--color-ink);
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-group-kind {
+  font-size: 0.75rem;
+  color: var(--color-ink-faint);
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-group-file {
+  font-size: 0.75rem;
+  color: var(--color-ink-faint);
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-engine,
+[data-iii-ui='compose-ui'] .cu-topo-node {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.125rem;
+  padding: 0 0.75rem;
+  border: 1px solid var(--color-edge);
+  border-radius: var(--radius-md, 6px);
+  background: var(--color-panel-raised);
+  color: var(--color-ink);
+  text-align: left;
+  font-family: var(--font-sans);
+  overflow: hidden;
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-node {
+  cursor: pointer;
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-node:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 1px;
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-node[data-state='failed'] {
+  border-color: var(--color-alert);
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-node[data-state='starting'] {
+  border-color: var(--color-warn);
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-node[data-state='stopped'] {
+  border-style: dashed;
+  color: var(--color-ink-faint);
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-node[aria-pressed='true'] {
+  background: var(--color-surface-selected);
+  border-color: var(--color-ink);
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-node[data-rel='up'],
+[data-iii-ui='compose-ui'] .cu-topo-node[data-rel='down'] {
+  border-color: var(--color-accent);
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-node[data-rel='dim'] {
+  opacity: 0.45;
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  min-width: 0;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-title svg {
+  color: var(--color-ink-faint);
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  overflow-wrap: normal;
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-ports {
+  color: var(--color-ink-faint);
+  font-weight: 400;
+  font-size: 0.75rem;
+  overflow-wrap: normal;
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-sub {
+  font-size: 0.75rem;
+  color: var(--color-ink-faint);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  overflow-wrap: normal;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  [data-iii-ui='compose-ui'] .cu-topo-node:hover {
+    background: var(--color-surface-hover);
+  }
+}
+
 @keyframes compose-ui-spin {
   to {
     transform: rotate(360deg);

--- a/compose-ui/ui/styles.css
+++ b/compose-ui/ui/styles.css
@@ -15,6 +15,7 @@
   min-width: 0;
   min-height: 0;
   padding: 1rem;
+  overflow-x: hidden;
   overflow-y: auto;
 }
 
@@ -321,12 +322,112 @@
   width: 86%;
 }
 
+[data-iii-ui='compose-ui'] .cu-topo-frame {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-width: 0;
+  max-width: 100%;
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  min-height: 1.75rem;
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-hint {
+  font-family: var(--font-sans);
+  font-size: 0.75rem;
+  color: var(--color-ink-faint);
+}
+
 [data-iii-ui='compose-ui'] .cu-topo-scroll {
   overflow: auto;
+  min-width: 0;
   max-width: 100%;
   border: 1px solid var(--color-edge);
   border-radius: var(--radius-md, 6px);
   background: var(--color-panel);
+}
+
+[data-iii-ui='compose-ui'] .cu-topo[data-dragging] {
+  cursor: grabbing;
+  user-select: none;
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-node[data-dragging],
+[data-iii-ui='compose-ui'] .cu-topo-engine[data-dragging] {
+  z-index: 3;
+  cursor: grabbing;
+  box-shadow: 0 6px 18px color-mix(in srgb, var(--color-ink) 18%, transparent);
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-engine[data-node] {
+  cursor: grab;
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-engine:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 1px;
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-engine-static {
+  position: static;
+  height: auto;
+  padding: 0.5rem 0.75rem;
+  cursor: default;
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-group-label-static {
+  position: static;
+  padding: 0;
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-level {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  min-width: 0;
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-level-head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin: 0;
+  font-family: var(--font-sans);
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--color-ink-faint);
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-level-count {
+  font-family: var(--font-mono);
+  font-weight: 400;
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-level-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(9.5rem, 1fr));
+  gap: 0.5rem;
+}
+
+[data-iii-ui='compose-ui'] .cu-topo-level-grid .cu-topo-node {
+  position: static;
+  height: auto;
+  min-height: 3.25rem;
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
 }
 
 [data-iii-ui='compose-ui'] .cu-topo {
@@ -415,7 +516,7 @@
 }
 
 [data-iii-ui='compose-ui'] .cu-topo-node {
-  cursor: pointer;
+  cursor: grab;
 }
 
 [data-iii-ui='compose-ui'] .cu-topo-node:focus-visible {
@@ -507,6 +608,83 @@
 @media (hover: hover) and (pointer: fine) {
   [data-iii-ui='compose-ui'] .cu-topo-node:hover {
     background: var(--color-surface-hover);
+  }
+}
+
+[data-iii-ui='compose-ui'] .cu-detail-actions {
+  flex-wrap: nowrap;
+}
+
+[data-iii-ui='compose-ui'] .cu-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+  gap: 0.75rem 1.5rem;
+}
+
+[data-iii-ui='compose-ui'] .cu-detail-relations {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+  gap: 0.75rem 1.5rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--color-edge);
+}
+
+[data-iii-ui='compose-ui'] .cu-detail-fact {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+[data-iii-ui='compose-ui'] .cu-detail-term {
+  font-family: var(--font-sans);
+  font-size: 0.75rem;
+  color: var(--color-ink-faint);
+}
+
+[data-iii-ui='compose-ui'] .cu-detail-value {
+  font-size: 0.8125rem;
+  color: var(--color-ink);
+  overflow-wrap: anywhere;
+}
+
+[data-iii-ui='compose-ui'] .cu-detail-lines {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  margin: 0;
+  padding: 0.75rem 0.875rem;
+  border-radius: var(--radius-md, 6px);
+  background: var(--color-surface);
+}
+
+[data-iii-ui='compose-ui'] .cu-detail-lines > div {
+  display: grid;
+  grid-template-columns: 6.5rem minmax(0, 1fr);
+  gap: 0.75rem;
+  align-items: baseline;
+}
+
+[data-iii-ui='compose-ui'] .cu-detail-lines dt {
+  font-family: var(--font-sans);
+  font-size: 0.75rem;
+  color: var(--color-ink-faint);
+}
+
+[data-iii-ui='compose-ui'] .cu-detail-lines dd {
+  margin: 0;
+  font-size: 0.8125rem;
+  overflow-wrap: anywhere;
+}
+
+@container (max-width: 44rem) {
+  [data-iii-ui='compose-ui'] .cu-detail-actions {
+    flex-wrap: wrap;
+  }
+
+  [data-iii-ui='compose-ui'] .cu-detail-lines > div {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.125rem;
   }
 }
 

--- a/compose-ui/ui/styles.css
+++ b/compose-ui/ui/styles.css
@@ -381,14 +381,14 @@
   min-width: 0;
 }
 
-[data-iii-ui='compose-ui'] .cu-topo-engine-static {
+[data-iii-ui='compose-ui'] .cu-topo-stack .cu-topo-engine-static {
   position: static;
   height: auto;
   padding: 0.5rem 0.75rem;
   cursor: default;
 }
 
-[data-iii-ui='compose-ui'] .cu-topo-group-label-static {
+[data-iii-ui='compose-ui'] .cu-topo-stack .cu-topo-group-label-static {
   position: static;
   padding: 0;
 }

--- a/docs/sops/console-ui-conformance.md
+++ b/docs/sops/console-ui-conformance.md
@@ -70,7 +70,7 @@ selection, tooltip, or selector behavior.
 | `state` | Neutral hierarchy navigation; shared motion tokens | Progressive scope/key/value browser |
 | `storage` | Neutral object/config navigation; shared motion tokens | Bucket/object browser |
 | `tailscale` | Shared page chrome with `PageSidebar` section navigation, `ListItem` rows, `IconButton` header and row actions, shared `Input`/`Select`/`SegmentedControl`, `Table` family, `Badge`/`Chip`/`StatusDot`, `EmptyState`/`Skeleton`, `ConfirmDialog` for public publishing; neutral selection; shared motion tokens | Tailnet device table with ping paths, QR link card, netcheck and DNS facts, preference rows |
-| `compose-ui` | Shared page chrome with `PageSidebar` section navigation, `ListItem` rows, `IconButton` row actions, ghost `Button` refresh with a live `StatusDot` in the header, `Input`, `Table` family, `Badge`/`Chip`/`StatusDot`, `EmptyState`/`Skeleton`, `TerminalStream` log tails, `ConfirmDialog` for stop/restart/remove/update/daemon stop; neutral selection; shared motion tokens; no section-switch animation | Compose project health stats, container table with log tail rows, worker package declaration with selectable declared-worker chips, daemon projects table |
+| `compose-ui` | Shared page chrome with `PageSidebar` section navigation, `ListItem` rows, `IconButton` row actions, ghost `Button` refresh with a live `StatusDot` in the header, `Input`, `Table` family, `Badge`/`Chip`/`StatusDot`, `EmptyState`/`Skeleton`, `TerminalStream` log tails, `ConfirmDialog` for stop/restart/remove/update/daemon stop; neutral selection; shared motion tokens; no section-switch animation | Topology graph (engine, namespace group, containers layered by `start_after`, upstream/downstream tracing on select, arrow-key node navigation), project health stats, container table with log tail rows, worker package declaration with selectable declared-worker chips, daemon projects table |
 | `web` | Minimal shared renderer audited; no selectable navigation | HTTP response payload |
 | `worktree` | Neutral graph node/edge selection; shared motion tokens | Worktree ownership and graph semantics |
 
@@ -115,7 +115,7 @@ owns; the registry refuses those at registration. See the injectable-UI SOP,
 | computer | start, stop; setup: open | `N`, `X` | sessions (`computer::sessions::list`) |
 | worktree | refresh, close detail; setup: open | `R`, `Escape` | worktrees (`worktree::list`) |
 | tailscale | refresh, create link, copy link, open link, stop route, sections 1-7; setup: open | `R`, `N`, `C`, `O`, `X`, `1`-`7` | |
-| compose-ui (page `compose`) | refresh, filter containers, add worker…, validate compose file, sections 1-4; setup: open | `R`, `/`, `N`, `V`, `1`-`4` | containers (`compose::status`) |
+| compose-ui (page `compose`) | refresh, filter containers, add worker…, validate compose file, sections 1-5 (Topology first); setup: open | `R`, `/`, `N`, `V`, `1`-`5` | containers (`compose::status`) |
 | console catalog (functions, triggers) | search, toggle internal, refresh, run function; setup: open | `/`, `I`, `R`, `Mod+Enter` | functions (built in) |
 | eval | new evaluation, refresh history; setup: open, new evaluation… | `N`, `R` | evaluations (`api.list`) |
 | github | toggle live, refresh, close detail; setup: open | `L`, `R`, `Escape` | (PR / issue data not wired in the UI yet) |


### PR DESCRIPTION
## What

The Compose page now opens on a **Topology** section: a map of the project the way compose and Kubernetes visualizers draw one.

- The engine is the root node on the left (host:port from the compose file's `engine.url`, daemon PID).
- The project namespace is a labelled group (namespace + compose file name), the way Headlamp draws a namespace around its resources.
- Containers are cards laid out left to right by `start_after` depth (a container sits one column after its deepest dependency); each card shows the state dot, name, listening ports, source (`path ../x` or `web@1.2.10`), state and PID. Failed cards get an alert border, starting cards a warn border, stopped cards a dashed one.
- Edges follow `start_after` as curved arrows (engine → every root container); dotted while the dependent is not running, solid once it is.
- Picking a card highlights everything it needs (upstream) and everything that depends on it (downstream) and dims the rest, so a cascade like "stopping provider-anthropic took harness down" reads off the map. A detail card under the map lists PID, supervision, source, ports, `start_after` and dependents as clickable chips, environment variable names, run script, last error, and the same start / stop / restart / show-log actions as the table.
- Cards drag: pointer drag moves a card (and the engine) with the edges following live; the arrangement persists per project in the browser (`localStorage`, a per-viewer convenience like a panel width) and a "Reset layout" action returns to the computed layout. Shift+arrows nudge the focused card 8 px for keyboard users.
- Narrow panes (below 560 px, phones and tight splits) get a stacked view instead of a canvas: the engine, the namespace label, then one group per start level with the same cards in a wrapping grid. Selection and tracing still work; nothing scrolls sideways.
- The detail panel under the map: name + state in the title, Stop / Start, Restart, Log and close in the header, a fluid fact grid (PID, supervision, listening ports, source), "starts after" and "depended on by" as clickable chips side by side, run script and environment variable names as lines, last error as a status panel.
- Keyboard: cards are buttons; arrows move between neighbours (up/down within a column, left/right to the nearest card in the adjacent column), Escape clears the selection. `host.panels.open({ pageId: 'compose', context: { container } })` and the containers palette source now land on the map with that card selected.

## How

No graph library. `ui/src/page/topology-layout.ts` is a pure px layout (level assignment with a cycle guard, column packing, edge geometry, transitive `related()`), the same approach as the worktree page's graph; `Topology.tsx` renders SVG edges under absolutely positioned HTML cards. Data is what the page already fetched: `compose::status` for state and PID, `compose-ui::project` for `start_after`, sources and ports. Live updates re-render without motion; the map scrolls inside its own frame on narrow panes.

## Verified

- 7 layout tests (levels, cycle survival, column order, edge set and geometry, empty project, transitive relations); biome, tsc (worker + ui), 28 tests, bundle green.
- Against the local rig (17 containers): 17 cards, 32 edges; selecting `llm-router` highlights `state` upstream and the five providers, `context-manager`, and `harness` downstream; a stopped container renders dashed; at 390 px the map scrolls within the section with no page overflow.

Docs: conformance inventory and commands rows (`1`-`5`, Topology first), README, SKILL.
