### PR TITLE
(MOT-4595) feat: add agent profile management

### DIFF
--- a/console/web/public/vendor/console-ui.js
+++ b/console/web/public/vendor/console-ui.js
@@ -50,6 +50,7 @@ export const {
   ListItem,
   Markdown,
   MarkdownPreview,
+  ModelPicker,
   PageBody,
   PageHeader,
   PageMain,

--- a/console/web/src/components/chat/AgentPicker.tsx
+++ b/console/web/src/components/chat/AgentPicker.tsx
@@ -4,12 +4,14 @@ import { useCallback, useState } from 'react'
 import { type AgentEntry, listAgents } from '@/lib/backend/directory-prompts'
 import { getIiiClient } from '@/lib/iii-client'
 import { cn } from '@/lib/utils'
+import type { SubagentIcon } from '@/types/chat'
 import { SUBAGENT_ICON_COMPONENTS } from './ActiveSubagentChips'
 import {
   AGENT_CHOICE_PREFIX,
+  agentIdFromSystemPrompt,
   type SystemPromptState,
+  withAgentChoice,
 } from './system-prompt-selection'
-import type { SubagentIcon } from '@/types/chat'
 
 /**
  * The new-session agent picker: "Default" (the provider's built-in prompt)
@@ -28,10 +30,7 @@ function agentIcon(icon: string | null): React.ComponentType<{
   className?: string
   'aria-hidden'?: boolean
 }> {
-  return (
-    (icon && SUBAGENT_ICON_COMPONENTS[icon as SubagentIcon]) ||
-    Bot
-  )
+  return (icon && SUBAGENT_ICON_COMPONENTS[icon as SubagentIcon]) || Bot
 }
 
 function AgentItem({
@@ -91,21 +90,13 @@ export function AgentPicker({
   const handleOpenChange = useCallback(async (open: boolean) => {
     if (!open) return
     try {
-      /* Leaf agents are spawn targets for orchestrators, not session
-         identities — the picker offers only agents that may delegate. */
-      setEntries(
-        (await listAgents(await getIiiClient())).filter((e) => !e.leaf),
-      )
+      setEntries(await listAgents(await getIiiClient()))
     } catch {
       setEntries((prev) => prev ?? [])
     }
   }, [])
 
-  const selectedId =
-    typeof value.choice === 'object' &&
-    value.choice.named.startsWith(AGENT_CHOICE_PREFIX)
-      ? value.choice.named.slice(AGENT_CHOICE_PREFIX.length)
-      : null
+  const selectedId = agentIdFromSystemPrompt(value)
 
   const handleValueChange = useCallback(
     (v: string) => {
@@ -116,18 +107,14 @@ export function AgentPicker({
       /* Store only the id; the harness resolves the profile on the first
          send (`options.agent`) and freezes it server-side. */
       const id = v.slice(`named:${AGENT_CHOICE_PREFIX}`.length)
-      onChange({
-        ...value,
-        choice: { named: `${AGENT_CHOICE_PREFIX}${id}` },
-        namedBody: '',
-        strategy: 'enrich',
-      })
+      onChange(withAgentChoice(value, id))
     },
     [onChange, value],
   )
 
   const selectedEntry = entries?.find((e) => e.id === selectedId)
-  const label = selectedId === null ? 'Default' : (selectedEntry?.name ?? selectedId)
+  const label =
+    selectedId === null ? 'Default' : (selectedEntry?.name ?? selectedId)
   const TriggerIconComp = agentIcon(selectedEntry?.icon ?? null)
 
   return (
@@ -142,7 +129,7 @@ export function AgentPicker({
       disabled={disabled}
     >
       <SelectPrimitive.Trigger
-        aria-label="agent"
+        aria-label="agent profile"
         className={cn(
           'inline-flex w-full items-center justify-between gap-x-2 rounded-sm border border-transparent bg-bg px-3 h-9 text-ink font-sans text-[13px] hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rule-focus data-[state=open]:bg-surface-active transition-colors',
           disabled && 'opacity-40 pointer-events-none',
@@ -174,7 +161,7 @@ export function AgentPicker({
             <AgentItem
               value="default"
               label="Default"
-              description="No agent — the provider's built-in prompt"
+              description="No agent profile — the provider's built-in prompt"
             />
             {(entries ?? []).map((e) => (
               <AgentItem

--- a/console/web/src/components/chat/ChatSettingsSheet.tsx
+++ b/console/web/src/components/chat/ChatSettingsSheet.tsx
@@ -53,6 +53,8 @@ interface ChatSettingsSheetProps {
   defaultWorkingDir?: string | null
   worktreePicker?: WorktreePickerOptions
   disabled?: boolean
+  /** Disable only model/reasoning while leaving other chat settings usable. */
+  modelDisabled?: boolean
   onModeChange: (next: Mode) => void
   onModelChange: (next: ModelId) => void
   onMemoryBankChange?: (next: string | null) => void
@@ -117,6 +119,7 @@ export function ChatSettingsSheet({
   defaultWorkingDir,
   worktreePicker,
   disabled,
+  modelDisabled,
   onModeChange,
   onModelChange,
   onMemoryBankChange,
@@ -164,7 +167,7 @@ export function ChatSettingsSheet({
                   ) : undefined
                 }
                 icon={<Sparkles className="size-[18px]" aria-hidden />}
-                disabled={disabled || catalogLoading}
+                disabled={disabled || modelDisabled || catalogLoading}
                 onClick={() => navigation.push('model')}
               />
             </SettingsSection>
@@ -233,7 +236,7 @@ export function ChatSettingsSheet({
                 navigation.push('provider-config')
               }}
               onOpenReasoning={() => navigation.push('reasoning')}
-              disabled={disabled}
+              disabled={disabled || modelDisabled}
               loading={catalogLoading}
             />
           </SheetPage>
@@ -254,7 +257,7 @@ export function ChatSettingsSheet({
                 onThinkingLevelChange(next)
                 navigation.back()
               }}
-              disabled={disabled}
+              disabled={disabled || modelDisabled}
             />
           </SheetPage>
         ) : null}

--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -1179,10 +1179,14 @@ export function ChatView({
       // prompt + skills itself; suppressing the client-side selection also
       // covers pre-upgrade drafts whose persisted namedBody would otherwise
       // collide with the agent field.
-      const agentId = agentIdForSend(effectiveSystemPrompt, {
-        turnEstablished,
-        willQueue,
-      })
+      const agentId = conversation.agentProfile
+        ? turnEstablished || willQueue
+          ? undefined
+          : conversation.agentProfile.id
+        : agentIdForSend(effectiveSystemPrompt, {
+            turnEstablished,
+            willQueue,
+          })
       const systemPrompt = agentId
         ? null
         : selectionForSend(effectiveSystemPrompt, turnEstablished)
@@ -1729,6 +1733,7 @@ export function ChatView({
     },
     [
       conversation.id,
+      conversation.agentProfile,
       conversation.mode,
       conversation.model,
       conversation.skills,
@@ -2239,7 +2244,9 @@ export function ChatView({
             {panelTitle ?? 'Chat'}
           </span>
           <span className="shrink-0 text-ink-ghost">·</span>
-          <span className="min-w-0 truncate">{effectiveModel}</span>
+          <span className="min-w-0 truncate">
+            {conversation.agentProfile?.name ?? effectiveModel}
+          </span>
         </div>
       </PageHeader>
 
@@ -2251,6 +2258,7 @@ export function ChatView({
 
       <MessageList
         messages={conversation.messages}
+        agentName={conversation.agentProfile?.name}
         spawnContext={{
           title: conversation.title,
           model: effectiveModel,
@@ -2353,6 +2361,7 @@ export function ChatView({
             modelOptions={modelOptions}
             catalogLoading={catalogLoading}
             modelPickerOpenRequest={modelPickerOpenRequest}
+            modelLocked={Boolean(conversation.agentProfile?.model)}
             functionEntries={functionEntries}
             permissionMode={approvalSettings.settings.mode}
             permissionModeLoading={!approvalSettings.loaded}

--- a/console/web/src/components/chat/Composer.tsx
+++ b/console/web/src/components/chat/Composer.tsx
@@ -55,6 +55,8 @@ interface ComposerProps {
   catalogLoading?: boolean
   /** Increment to open the visible model picker from an external CTA. */
   modelPickerOpenRequest?: number
+  /** Agent profile owns model + effort for this session. */
+  modelLocked?: boolean
   /**
    * Per-conversation permission mode (manual / auto / full). Owned by
    * the backend `approval_settings` scope; ChatView passes the loaded
@@ -161,6 +163,7 @@ export function Composer({
   modelOptions,
   catalogLoading,
   modelPickerOpenRequest,
+  modelLocked,
   permissionMode,
   permissionModeLoading,
   showPermissionMode = true,
@@ -463,7 +466,7 @@ export function Composer({
           thinkingLevel={thinkingLevel}
           onChange={onModelChange}
           onThinkingLevelChange={onThinkingLevelChange}
-          disabled={optionsDisabled}
+          disabled={optionsDisabled || modelLocked}
           loading={catalogLoading}
           showRefresh={false}
           className="min-w-0 flex-1 bg-surface"
@@ -511,7 +514,7 @@ export function Composer({
             thinkingLevel={thinkingLevel}
             onChange={onModelChange}
             onThinkingLevelChange={onThinkingLevelChange}
-            disabled={optionsDisabled}
+            disabled={optionsDisabled || modelLocked}
             loading={catalogLoading}
             className="min-w-0 flex-1 max-lg:order-first max-lg:min-w-40"
           />
@@ -551,6 +554,7 @@ export function Composer({
         defaultWorkingDir={defaultWorkingDir}
         worktreePicker={worktreePicker}
         disabled={optionsDisabled}
+        modelDisabled={modelLocked}
         onModeChange={onModeChange}
         onModelChange={onModelChange}
         onMemoryBankChange={onMemoryBankChange}

--- a/console/web/src/components/chat/EmptyState.css
+++ b/console/web/src/components/chat/EmptyState.css
@@ -1,0 +1,138 @@
+:root {
+  --acc-expand: 250ms;
+  --acc-collapse: 250ms;
+  --acc-chevron: 250ms;
+  --acc-ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* grid-template-rows 0fr → 1fr gives a clean height animation
+   with no JS measurement; the inner element clips overflow. */
+.t-acc-panel {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows var(--acc-collapse) var(--acc-ease);
+}
+.t-acc[data-open="true"] .t-acc-panel {
+  grid-template-rows: 1fr;
+  transition: grid-template-rows var(--acc-expand) var(--acc-ease);
+}
+.t-acc-panel-inner {
+  overflow: hidden;
+  opacity: 0;
+  filter: blur(2px);
+  transition:
+    opacity var(--acc-collapse) var(--acc-ease),
+    filter var(--acc-collapse) var(--acc-ease);
+}
+.t-acc[data-open="true"] .t-acc-panel-inner {
+  opacity: 1;
+  filter: blur(0);
+  transition:
+    opacity var(--acc-expand) var(--acc-ease),
+    filter var(--acc-expand) var(--acc-ease);
+}
+/* Flip the chevron vertically to turn the "v" into a "^".
+   scaleY(-1) about the centre passes through a flat line at
+   the midpoint (same look as a `d:` path morph) but animates
+   in every browser, unlike CSS `d:` morphing (Chromium only).
+   The chevron path is symmetric about the 16x16 viewBox
+   centre, so the flip lands exactly on the "^"; non-scaling
+   -stroke keeps the stroke width constant through the flip. */
+.t-acc-chevron {
+  display: inline-flex;
+  transform: scaleY(1);
+  transform-origin: center;
+  transition: transform var(--acc-chevron) var(--acc-ease);
+}
+.t-acc-chevron path { vector-effect: non-scaling-stroke; }
+.t-acc[data-open="true"] .t-acc-chevron {
+  transform: scaleY(-1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .t-acc-panel, .t-acc-panel-inner, .t-acc-chevron {
+    transition: none !important;
+  }
+}
+
+/* The agent gallery is the inverse track: it leaves while manual setup opens. */
+.empty-state-agent-panel {
+  display: grid;
+  grid-template-rows: 1fr;
+  transition: grid-template-rows var(--acc-collapse) var(--acc-ease);
+}
+
+.t-acc[data-open="true"] .empty-state-agent-panel {
+  grid-template-rows: 0fr;
+  transition: grid-template-rows var(--acc-expand) var(--acc-ease);
+}
+
+.empty-state-agent-panel-inner {
+  min-height: 0;
+  overflow: hidden;
+  opacity: 1;
+  filter: blur(0);
+  transition:
+    opacity var(--acc-collapse) var(--acc-ease),
+    filter var(--acc-collapse) var(--acc-ease);
+}
+
+.t-acc[data-open="true"] .empty-state-agent-panel-inner {
+  opacity: 0;
+  filter: blur(2px);
+  transition:
+    opacity var(--acc-expand) var(--acc-ease),
+    filter var(--acc-expand) var(--acc-ease);
+}
+
+.empty-state-manual-trigger {
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  padding: 8px 10px;
+  color: var(--color-ink-faint);
+  font-family: var(--font-sans, ui-sans-serif, sans-serif);
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.empty-state-manual-trigger:hover {
+  color: var(--color-ink);
+}
+
+.empty-state-manual-trigger:focus-visible {
+  outline: 2px solid var(--color-rule-focus);
+  outline-offset: 2px;
+}
+
+/* Agent identities reuse the harness semantic palette with a richer tile
+   treatment for selection cards. */
+.agent-choice-avatar.active-subagent-chip {
+  background: linear-gradient(
+    145deg,
+    color-mix(in oklab, var(--subagent-chip-tone) 40%, var(--color-panel)),
+    color-mix(in oklab, var(--subagent-chip-tone) 18%, var(--color-panel))
+  );
+  box-shadow: inset 0 0 0 1px
+    color-mix(in oklab, var(--subagent-chip-tone) 24%, transparent);
+}
+
+.agent-choice-avatar.active-subagent-chip:hover {
+  background: linear-gradient(
+    145deg,
+    color-mix(in oklab, var(--subagent-chip-tone) 40%, var(--color-panel)),
+    color-mix(in oklab, var(--subagent-chip-tone) 18%, var(--color-panel))
+  );
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .empty-state-agent-panel,
+  .empty-state-agent-panel-inner {
+    transition: none !important;
+  }
+}

--- a/console/web/src/components/chat/EmptyState.stories.tsx
+++ b/console/web/src/components/chat/EmptyState.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { useState } from 'react'
 import { fn } from 'storybook/test'
 import type { InstallStage } from '@/hooks/use-harness-status'
+import type { AgentEntry } from '@/lib/backend/directory-prompts'
 import { EmptyState, type EmptyStateProps } from './EmptyState'
 import {
   DEFAULT_SYSTEM_PROMPT_STATE,
@@ -25,6 +26,42 @@ const failedStages: InstallStage[] = [
     worker: 'harness',
     error: { code: 'W900', message: 'registry unreachable' },
     at: 4,
+  },
+]
+
+const agents: AgentEntry[] = [
+  {
+    id: 'qa-assistant',
+    name: 'QA Assistant',
+    description: 'Focuses on testing, quality checks, and bug prevention.',
+    logo: null,
+    icon: 'review',
+    color: 'purple',
+    model: 'gpt-5.6-sol',
+    skill_count: 3,
+    modified_at: '2026-08-27T00:00:00.000Z',
+  },
+  {
+    id: 'engineer',
+    name: 'Engineer',
+    description: 'Builds, tests, and reviews production code.',
+    logo: null,
+    icon: 'code',
+    color: 'blue',
+    model: 'gpt-5.6-sol',
+    skill_count: 4,
+    modified_at: '2026-08-27T00:00:00.000Z',
+  },
+  {
+    id: 'researcher',
+    name: 'Researcher',
+    description: 'Finds reliable evidence and turns it into clear decisions.',
+    logo: null,
+    icon: 'search',
+    color: 'teal',
+    model: null,
+    skill_count: 2,
+    modified_at: '2026-08-27T00:00:00.000Z',
   },
 ]
 
@@ -71,6 +108,7 @@ function ConfiguredReadyStory(args: EmptyStateProps) {
 
 export const Ready: Story = {
   name: 'ready (harness + provider)',
+  render: (args) => <ConfiguredReadyStory {...args} />,
   args: {
     variant: 'ready',
     workingDir: '/Users/sergio/Documents/workspaces/iii/workers',
@@ -79,6 +117,7 @@ export const Ready: Story = {
     systemPrompt: DEFAULT_SYSTEM_PROMPT_STATE,
     onSystemPromptChange: fn(),
     onSkillsChange: fn(),
+    agentEntries: agents,
   },
 }
 
@@ -97,6 +136,7 @@ export const ReadyConfigured: Story = {
     onSystemPromptChange: fn(),
     skills: ['design', 'linear-workflow', 'canonicalize-tailwind'],
     onSkillsChange: fn(),
+    agentEntries: agents,
   },
 }
 
@@ -109,6 +149,7 @@ export const ReadyWithoutProject: Story = {
     systemPrompt: DEFAULT_SYSTEM_PROMPT_STATE,
     onSystemPromptChange: fn(),
     onSkillsChange: fn(),
+    agentEntries: agents,
   },
 }
 

--- a/console/web/src/components/chat/EmptyState.test.tsx
+++ b/console/web/src/components/chat/EmptyState.test.tsx
@@ -1,7 +1,35 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
 import { EmptyState } from './EmptyState'
-import { DEFAULT_SYSTEM_PROMPT_STATE } from './system-prompt-selection'
+import {
+  AGENT_CHOICE_PREFIX,
+  DEFAULT_SYSTEM_PROMPT_STATE,
+} from './system-prompt-selection'
+
+const agents = [
+  {
+    id: 'engineer',
+    name: 'Engineer',
+    description: 'Builds and reviews production code.',
+    logo: null,
+    icon: 'code',
+    color: 'blue',
+    model: null,
+    skill_count: 2,
+    modified_at: '2026-08-27T00:00:00.000Z',
+  },
+  {
+    id: 'researcher',
+    name: 'Researcher',
+    description: 'Finds evidence and summarizes it.',
+    logo: null,
+    icon: 'search',
+    color: 'teal',
+    model: null,
+    skill_count: 1,
+    modified_at: '2026-08-27T00:00:00.000Z',
+  },
+]
 
 describe('EmptyState', () => {
   it('shrinks and scrolls while keeping short content centered', () => {
@@ -29,10 +57,15 @@ describe('EmptyState', () => {
         onSystemPromptChange={() => {}}
         skills={['design', 'linear-workflow']}
         onSkillsChange={() => {}}
+        agentEntries={agents}
       />,
     )
 
     expect(html).toContain('aria-label="session setup"')
+    expect(html).toContain('Configure manually')
+    expect(html).toContain('aria-expanded="true"')
+    expect(html).toContain('data-open="true"')
+    expect(html).toContain('t-acc-panel')
     expect(html).toContain('System prompt')
     expect(html).toContain('reviewer')
     expect(html).toContain('items-baseline')
@@ -42,5 +75,32 @@ describe('EmptyState', () => {
     expect(html).toContain('Add skills')
     expect(html).toContain('remove design from this session')
     expect(html).toContain('remove linear-workflow from this session')
+  })
+
+  it('shows agent cards by default with only identity content', () => {
+    const html = renderToStaticMarkup(
+      <EmptyState
+        variant="ready"
+        workingDir="/workspace/console"
+        systemPrompt={{
+          ...DEFAULT_SYSTEM_PROMPT_STATE,
+          choice: { named: `${AGENT_CHOICE_PREFIX}engineer` },
+        }}
+        onSystemPromptChange={() => {}}
+        agentEntries={agents}
+      />,
+    )
+
+    expect(html).toContain('Choose an agent profile')
+    expect(html).toContain('aria-expanded="false"')
+    expect(html).toContain('data-open="false"')
+    expect(html).toContain('Use Engineer agent profile')
+    expect(html).toContain('aria-pressed="true"')
+    expect(html).toContain('Builds and reviews production code.')
+    expect(html).toContain('Use Researcher agent profile')
+    expect(html).toContain('active-subagent-chip')
+    expect(html).toContain('data-color="blue"')
+    expect(html).not.toContain('Sub-agent')
+    expect(html).not.toContain('ActivityMetadata')
   })
 })

--- a/console/web/src/components/chat/EmptyState.test.tsx
+++ b/console/web/src/components/chat/EmptyState.test.tsx
@@ -103,4 +103,26 @@ describe('EmptyState', () => {
     expect(html).not.toContain('Sub-agent')
     expect(html).not.toContain('ActivityMetadata')
   })
+
+  it('uses the frozen session profile to keep the selected card identified', () => {
+    const html = renderToStaticMarkup(
+      <EmptyState
+        variant="ready"
+        systemPrompt={DEFAULT_SYSTEM_PROMPT_STATE}
+        onSystemPromptChange={() => {}}
+        agentEntries={agents}
+        agentProfile={{
+          id: 'researcher',
+          name: 'Researcher',
+          model: 'openai-codex::codex/gpt-5.6-sol',
+          reasoningEffort: 'high',
+          icon: 'search',
+          color: 'teal',
+        }}
+      />,
+    )
+
+    expect(html).toContain('Use Researcher agent profile')
+    expect(html).toMatch(/Use Researcher agent profile[^>]*aria-pressed="true"/)
+  })
 })

--- a/console/web/src/components/chat/EmptyState.tsx
+++ b/console/web/src/components/chat/EmptyState.tsx
@@ -9,7 +9,11 @@ import { type AgentEntry, listAgents } from '@/lib/backend/directory-prompts'
 import { getIiiClient } from '@/lib/iii-client'
 import { normalizeErrorMessage } from '@/lib/providers'
 import { cn } from '@/lib/utils'
-import type { SubagentColor, SubagentIcon } from '@/types/chat'
+import type {
+  AgentProfileSnapshot,
+  SubagentColor,
+  SubagentIcon,
+} from '@/types/chat'
 import { SUBAGENT_ICON_COMPONENTS } from './ActiveSubagentChips'
 import { DirectoryPicker, type WorktreePickerOptions } from './DirectoryPicker'
 import { SessionAddonsPicker } from './SessionAddonsPicker'
@@ -73,6 +77,9 @@ export interface EmptyStateProps {
   onSkillsChange?: (next: SkillSelection) => void
   /** Optional deterministic catalog for stories/tests; omitted loads Directory. */
   agentEntries?: AgentEntry[] | null
+  /** Frozen identity/configuration for the selected Directory agent. */
+  agentProfile?: AgentProfileSnapshot
+  onAgentProfileChange?: (next: AgentProfileSnapshot | undefined) => void
 }
 
 const HARNESS_INSTALL_COMMAND = 'iii trigger compose::add worker=harness'
@@ -99,6 +106,8 @@ export function EmptyState({
   skills,
   onSkillsChange,
   agentEntries,
+  agentProfile,
+  onAgentProfileChange,
 }: EmptyStateProps) {
   const emptyPad = density === 'dock' ? 'px-3 sm:px-4' : 'px-3 sm:px-6 lg:px-9'
   const eyebrow = variant === 'no-provider' ? 'New session' : 'Setup'
@@ -130,6 +139,8 @@ export function EmptyState({
             skills={skills}
             onSkillsChange={onSkillsChange}
             agentEntries={agentEntries}
+            agentProfile={agentProfile}
+            onAgentProfileChange={onAgentProfileChange}
           />
         ) : (
           <div className="font-sans text-base font-medium text-ink-faint sm:text-sm">
@@ -168,6 +179,8 @@ function ReadyBody({
   skills,
   onSkillsChange,
   agentEntries,
+  agentProfile,
+  onAgentProfileChange,
 }: {
   workingDir?: string | null
   onWorkingDirChange?: (next: string) => void
@@ -179,6 +192,8 @@ function ReadyBody({
   skills?: SkillSelection
   onSkillsChange?: (next: SkillSelection) => void
   agentEntries?: AgentEntry[] | null
+  agentProfile?: AgentProfileSnapshot
+  onAgentProfileChange?: (next: AgentProfileSnapshot | undefined) => void
 }) {
   const projectName = workingDir
     ? (workingDir.split('/').filter(Boolean).at(-1) ?? workingDir)
@@ -213,6 +228,8 @@ function ReadyBody({
             skills={skills}
             onSkillsChange={onSkillsChange}
             agentEntries={agentEntries}
+            agentProfile={agentProfile}
+            onAgentProfileChange={onAgentProfileChange}
           />
         ) : null}
       </div>
@@ -226,14 +243,19 @@ function SessionSetupControls({
   skills,
   onSkillsChange,
   agentEntries,
+  agentProfile,
+  onAgentProfileChange,
 }: {
   systemPrompt: SystemPromptState
   onSystemPromptChange: (next: SystemPromptState) => void
   skills?: SkillSelection
   onSkillsChange?: (next: SkillSelection) => void
   agentEntries?: AgentEntry[] | null
+  agentProfile?: AgentProfileSnapshot
+  onAgentProfileChange?: (next: AgentProfileSnapshot | undefined) => void
 }) {
-  const selectedAgentId = agentIdFromSystemPrompt(systemPrompt)
+  const selectedAgentId =
+    agentProfile?.id ?? agentIdFromSystemPrompt(systemPrompt)
   const [manualOpen, setManualOpen] = useState(
     () =>
       selectedAgentId === null &&
@@ -247,7 +269,10 @@ function SessionSetupControls({
     const next = !manualOpen
     setManualOpen(next)
     if (next && selectedAgentId !== null) {
-      onSystemPromptChange(withoutAgentChoice(systemPrompt))
+      if (agentIdFromSystemPrompt(systemPrompt) !== null) {
+        onSystemPromptChange(withoutAgentChoice(systemPrompt))
+      }
+      onAgentProfileChange?.(undefined)
     }
   }
 
@@ -268,9 +293,22 @@ function SessionSetupControls({
             loading={catalog.entries === null}
             error={catalog.error}
             selectedId={selectedAgentId}
-            onSelect={(agentId) =>
-              onSystemPromptChange(withAgentChoice(systemPrompt, agentId))
-            }
+            onSelect={(entry) => {
+              const profile: AgentProfileSnapshot = {
+                id: entry.id,
+                name: entry.name.trim() || entry.id,
+                ...(entry.model ? { model: entry.model } : {}),
+                ...(entry.reasoning_effort
+                  ? { reasoningEffort: entry.reasoning_effort }
+                  : {}),
+                ...(entry.icon ? { icon: entry.icon as SubagentIcon } : {}),
+                ...(entry.color ? { color: entry.color as SubagentColor } : {}),
+              }
+              if (onAgentProfileChange) onAgentProfileChange(profile)
+              else {
+                onSystemPromptChange(withAgentChoice(systemPrompt, entry.id))
+              }
+            }}
           />
         </div>
       </div>
@@ -361,7 +399,7 @@ function AgentGallery({
   loading: boolean
   error: boolean
   selectedId: string | null
-  onSelect: (agentId: string) => void
+  onSelect: (entry: AgentEntry) => void
 }) {
   return (
     <div className="pb-3 text-left">
@@ -400,7 +438,7 @@ function AgentGallery({
               <AgentChoiceCard
                 entry={entry}
                 selected={selectedId === entry.id}
-                onSelect={() => onSelect(entry.id)}
+                onSelect={() => onSelect(entry)}
               />
             </li>
           ))}

--- a/console/web/src/components/chat/EmptyState.tsx
+++ b/console/web/src/components/chat/EmptyState.tsx
@@ -1,19 +1,28 @@
-import { X } from 'lucide-react'
+import { Bot, Check, X } from 'lucide-react'
+import { useEffect, useId, useState } from 'react'
 import { CopyCommandButton } from '@/components/chat/sandbox/terminal/CopyCommandButton'
 import { Terminal } from '@/components/chat/sandbox/terminal/Terminal'
 import { Button } from '@/components/ui/Button'
 import { Wordmark } from '@/components/ui/Wordmark'
 import type { InstallStage } from '@/hooks/use-harness-status'
+import { type AgentEntry, listAgents } from '@/lib/backend/directory-prompts'
+import { getIiiClient } from '@/lib/iii-client'
 import { normalizeErrorMessage } from '@/lib/providers'
 import { cn } from '@/lib/utils'
+import type { SubagentColor, SubagentIcon } from '@/types/chat'
+import { SUBAGENT_ICON_COMPONENTS } from './ActiveSubagentChips'
 import { DirectoryPicker, type WorktreePickerOptions } from './DirectoryPicker'
 import { SessionAddonsPicker } from './SessionAddonsPicker'
 import { SystemPromptPicker } from './SystemPromptPicker'
 import {
+  agentIdFromSystemPrompt,
   type SkillSelection,
   type SystemPromptState,
   toggleSkillSelection,
+  withAgentChoice,
+  withoutAgentChoice,
 } from './system-prompt-selection'
+import './EmptyState.css'
 
 /**
  * The chat empty state, as a small set of presentational variants:
@@ -24,10 +33,10 @@ import {
  *   - `installing`     — `worker::add` in flight -> live console
  *   - `install-failed` — add failed -> console + retry
  *
- * The component is intentionally dumb: `MessageList` derives the variant from
- * `ConversationsContext` (harness presence + model catalog) and passes the
- * callbacks. Keeping it props-only is what lets every state render in
- * Storybook without a provider.
+ * `MessageList` derives the variant from `ConversationsContext` (harness
+ * presence + model catalog) and passes the callbacks. The ready state loads
+ * agent profiles from Directory unless a deterministic catalog is supplied by a
+ * story or test.
  */
 
 export type EmptyStateVariant =
@@ -62,6 +71,8 @@ export interface EmptyStateProps {
   /** Exact model-invocable skill IDs curated for this session. */
   skills?: SkillSelection
   onSkillsChange?: (next: SkillSelection) => void
+  /** Optional deterministic catalog for stories/tests; omitted loads Directory. */
+  agentEntries?: AgentEntry[] | null
 }
 
 const HARNESS_INSTALL_COMMAND = 'iii trigger compose::add worker=harness'
@@ -87,6 +98,7 @@ export function EmptyState({
   onSystemPromptChange,
   skills,
   onSkillsChange,
+  agentEntries,
 }: EmptyStateProps) {
   const emptyPad = density === 'dock' ? 'px-3 sm:px-4' : 'px-3 sm:px-6 lg:px-9'
   const eyebrow = variant === 'no-provider' ? 'New session' : 'Setup'
@@ -100,8 +112,10 @@ export function EmptyState({
     >
       <div
         className={cn(
-          'my-auto flex w-full max-w-[520px] flex-col py-6',
-          variant === 'ready' ? 'items-center gap-5 text-center' : 'gap-6',
+          'my-auto flex w-full flex-col py-6',
+          variant === 'ready'
+            ? 'max-w-[680px] items-center gap-5 text-center'
+            : 'max-w-[520px] gap-6',
         )}
       >
         {variant === 'ready' ? (
@@ -115,6 +129,7 @@ export function EmptyState({
             onSystemPromptChange={onSystemPromptChange}
             skills={skills}
             onSkillsChange={onSkillsChange}
+            agentEntries={agentEntries}
           />
         ) : (
           <div className="font-sans text-base font-medium text-ink-faint sm:text-sm">
@@ -152,6 +167,7 @@ function ReadyBody({
   onSystemPromptChange,
   skills,
   onSkillsChange,
+  agentEntries,
 }: {
   workingDir?: string | null
   onWorkingDirChange?: (next: string) => void
@@ -162,6 +178,7 @@ function ReadyBody({
   onSystemPromptChange?: (next: SystemPromptState) => void
   skills?: SkillSelection
   onSkillsChange?: (next: SkillSelection) => void
+  agentEntries?: AgentEntry[] | null
 }) {
   const projectName = workingDir
     ? (workingDir.split('/').filter(Boolean).at(-1) ?? workingDir)
@@ -170,7 +187,7 @@ function ReadyBody({
   return (
     <>
       <Wordmark appearance="inset" />
-      <div className="flex max-w-full flex-col items-center gap-2.5">
+      <div className="flex w-full max-w-full flex-col items-center gap-2.5">
         <div className="max-w-full font-sans text-xl font-medium text-ink-faint sm:text-lg">
           What should we build in{' '}
           {onWorkingDirChange ? (
@@ -195,6 +212,7 @@ function ReadyBody({
             onSystemPromptChange={onSystemPromptChange}
             skills={skills}
             onSkillsChange={onSkillsChange}
+            agentEntries={agentEntries}
           />
         ) : null}
       </div>
@@ -207,6 +225,246 @@ function SessionSetupControls({
   onSystemPromptChange,
   skills,
   onSkillsChange,
+  agentEntries,
+}: {
+  systemPrompt: SystemPromptState
+  onSystemPromptChange: (next: SystemPromptState) => void
+  skills?: SkillSelection
+  onSkillsChange?: (next: SkillSelection) => void
+  agentEntries?: AgentEntry[] | null
+}) {
+  const selectedAgentId = agentIdFromSystemPrompt(systemPrompt)
+  const [manualOpen, setManualOpen] = useState(
+    () =>
+      selectedAgentId === null &&
+      (systemPrompt.choice !== 'default' || Boolean(skills?.length)),
+  )
+  const panelId = useId()
+  const catalog = useAgentCatalog(agentEntries)
+  const agents = catalog.entries ?? []
+
+  const toggleManual = () => {
+    const next = !manualOpen
+    setManualOpen(next)
+    if (next && selectedAgentId !== null) {
+      onSystemPromptChange(withoutAgentChoice(systemPrompt))
+    }
+  }
+
+  return (
+    <section
+      aria-label="session setup"
+      className="t-acc w-full max-w-[40rem]"
+      data-open={manualOpen}
+    >
+      <div className="empty-state-agent-panel">
+        <div
+          className="empty-state-agent-panel-inner"
+          aria-hidden={manualOpen}
+          inert={manualOpen}
+        >
+          <AgentGallery
+            entries={agents}
+            loading={catalog.entries === null}
+            error={catalog.error}
+            selectedId={selectedAgentId}
+            onSelect={(agentId) =>
+              onSystemPromptChange(withAgentChoice(systemPrompt, agentId))
+            }
+          />
+        </div>
+      </div>
+
+      <button
+        type="button"
+        className="t-acc-head empty-state-manual-trigger"
+        aria-expanded={manualOpen}
+        aria-controls={panelId}
+        onClick={toggleManual}
+      >
+        <span>Configure manually</span>
+        <span className="t-acc-chevron" aria-hidden>
+          <svg
+            className="size-4 fill-none stroke-current"
+            viewBox="0 0 16 16"
+            aria-hidden
+          >
+            <title>Toggle manual configuration</title>
+            <path
+              d="M4 6.5L8 10.5L12 6.5"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </span>
+      </button>
+
+      <div id={panelId} className="t-acc-panel">
+        <div
+          className="t-acc-panel-inner"
+          aria-hidden={!manualOpen}
+          inert={!manualOpen}
+        >
+          <ManualSessionSetupControls
+            systemPrompt={systemPrompt}
+            onSystemPromptChange={onSystemPromptChange}
+            skills={skills}
+            onSkillsChange={onSkillsChange}
+          />
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function useAgentCatalog(provided: AgentEntry[] | null | undefined): {
+  entries: AgentEntry[] | null
+  error: boolean
+} {
+  const [entries, setEntries] = useState<AgentEntry[] | null>(null)
+  const [error, setError] = useState(false)
+
+  useEffect(() => {
+    if (provided !== undefined) return
+    let cancelled = false
+    setError(false)
+    void getIiiClient()
+      .then((client) => listAgents(client))
+      .then((next) => {
+        if (!cancelled) setEntries(next)
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setEntries([])
+          setError(true)
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [provided])
+
+  return provided === undefined
+    ? { entries, error }
+    : { entries: provided, error: false }
+}
+
+function AgentGallery({
+  entries,
+  loading,
+  error,
+  selectedId,
+  onSelect,
+}: {
+  entries: AgentEntry[]
+  loading: boolean
+  error: boolean
+  selectedId: string | null
+  onSelect: (agentId: string) => void
+}) {
+  return (
+    <div className="pb-3 text-left">
+      <div className="mb-2 font-sans text-base font-medium text-ink-faint sm:text-sm">
+        Choose an agent profile
+      </div>
+      {loading ? (
+        <div
+          className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 p-1"
+          aria-hidden
+        >
+          <div className="h-40 rounded-lg bg-panel-raised shadow-raised" />
+          <div className="h-40 rounded-lg bg-panel-raised shadow-raised" />
+          <div className="h-40 rounded-lg bg-panel-raised shadow-raised" />
+        </div>
+      ) : error ? (
+        <p className="rounded-md bg-panel-raised px-3 py-4 font-sans text-base text-ink-faint shadow-raised sm:text-sm">
+          Agent profiles are unavailable. Configure the session manually
+          instead.
+        </p>
+      ) : entries.length === 0 ? (
+        <p className="rounded-md bg-panel-raised px-3 py-4 font-sans text-base text-ink-faint shadow-raised sm:text-sm">
+          No agent profiles are available yet.
+        </p>
+      ) : (
+        <ul
+          // biome-ignore lint/a11y/noRedundantRoles: keep list semantics when CSS resets remove markers.
+          role="list"
+          className={cn(
+            'grid grid-cols-1 gap-3 sm:grid-cols-2 p-1',
+            entries.length >= 3 && 'md:grid-cols-3',
+          )}
+        >
+          {entries.map((entry) => (
+            <li key={entry.id} className="min-w-0">
+              <AgentChoiceCard
+                entry={entry}
+                selected={selectedId === entry.id}
+                onSelect={() => onSelect(entry.id)}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+function AgentChoiceCard({
+  entry,
+  selected,
+  onSelect,
+}: {
+  entry: AgentEntry
+  selected: boolean
+  onSelect: () => void
+}) {
+  const Icon =
+    (entry.icon && SUBAGENT_ICON_COMPONENTS[entry.icon as SubagentIcon]) || Bot
+  const title = entry.name.trim() || entry.id
+  const color = (entry.color ?? 'neutral') as SubagentColor
+
+  return (
+    <button
+      type="button"
+      aria-label={`Use ${title} agent profile`}
+      aria-pressed={selected}
+      onClick={onSelect}
+      className={cn(
+        'group/agent relative h-full min-h-40 w-full cursor-pointer rounded-lg bg-panel-raised p-4 text-left shadow-raised ring-1 ring-rule-2 transition-[transform,box-shadow] duration-150 hover:-translate-y-px hover:shadow-floating focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent',
+        selected && 'ring-2 ring-accent',
+      )}
+    >
+      {selected ? (
+        <span className="absolute right-3 top-3 flex size-5 items-center justify-center rounded-full bg-accent text-white shadow-xs">
+          <Check aria-hidden className="size-4" strokeWidth={3} />
+        </span>
+      ) : null}
+      <div className="flex min-w-0 flex-col gap-3">
+        <div
+          className="agent-choice-avatar active-subagent-chip flex size-12 shrink-0 items-center justify-center rounded-lg sm:size-11"
+          data-color={color}
+        >
+          <Icon aria-hidden className="size-5" strokeWidth={2.25} />
+        </div>
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <div className="font-sans text-base font-semibold text-ink sm:text-sm">
+            {title}
+          </div>
+          <p className="line-clamp-3 text-pretty font-sans text-base leading-6 text-ink-faint sm:text-sm sm:leading-5">
+            {entry.description.trim() || 'No description provided.'}
+          </p>
+        </div>
+      </div>
+    </button>
+  )
+}
+
+function ManualSessionSetupControls({
+  systemPrompt,
+  onSystemPromptChange,
+  skills,
+  onSkillsChange,
 }: {
   systemPrompt: SystemPromptState
   onSystemPromptChange: (next: SystemPromptState) => void
@@ -214,10 +472,7 @@ function SessionSetupControls({
   onSkillsChange?: (next: SkillSelection) => void
 }) {
   return (
-    <section
-      aria-label="session setup"
-      className="flex max-w-full flex-col items-center gap-2"
-    >
+    <div className="flex max-w-full flex-col items-center gap-2 pt-3">
       <div className="flex max-w-full min-w-0 items-baseline justify-center gap-1.5 font-sans text-base text-ink-faint sm:text-sm">
         <span>System prompt</span>
         <SystemPromptPicker
@@ -268,7 +523,7 @@ function SessionSetupControls({
           ))}
         </ul>
       ) : null}
-    </section>
+    </div>
   )
 }
 

--- a/console/web/src/components/chat/Message.test.tsx
+++ b/console/web/src/components/chat/Message.test.tsx
@@ -1,6 +1,6 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
-import type { UserMessage } from '@/types/chat'
+import type { AssistantMessage, UserMessage } from '@/types/chat'
 import { Message } from './Message'
 
 const spawnMessage: UserMessage = {
@@ -10,6 +10,25 @@ const spawnMessage: UserMessage = {
   spawn: true,
   createdAt: 0,
 }
+
+const assistantMessage: AssistantMessage = {
+  id: 'assistant-message',
+  role: 'assistant',
+  content: 'Done.',
+  model: 'codex/gpt-5.6-sol',
+  createdAt: 0,
+}
+
+describe('AssistantMessage', () => {
+  it('shows the session agent profile name in the message header', () => {
+    const html = renderToStaticMarkup(
+      <Message message={assistantMessage} agentName="Researcher" />,
+    )
+
+    expect(html).toContain('>Researcher</span>')
+    expect(html).toContain('· codex/gpt-5.6-sol')
+  })
+})
 
 describe('SpawnTaskMessage', () => {
   it('uses the shared card recipe and current sub-agent identity', () => {

--- a/console/web/src/components/chat/Message.tsx
+++ b/console/web/src/components/chat/Message.tsx
@@ -55,6 +55,8 @@ interface MessageProps {
   triggerNotification?: UserMessageType
   /** Current child-session identity for a direct spawn seed message. */
   spawnContext?: SpawnTaskContext
+  /** Session agent profile name shown on assistant message headers. */
+  agentName?: string
 }
 
 export interface SpawnTaskContext {
@@ -75,6 +77,7 @@ export function Message({
   registration,
   triggerNotification,
   spawnContext,
+  agentName,
 }: MessageProps) {
   switch (message.role) {
     case 'user':
@@ -94,7 +97,13 @@ export function Message({
         <UserMessage message={message} />
       )
     case 'assistant':
-      return <AssistantMessage message={message} copyText={copyText} />
+      return (
+        <AssistantMessage
+          message={message}
+          copyText={copyText}
+          agentName={agentName}
+        />
+      )
     case 'thought':
       return <ThoughtMessage message={message} />
     case 'function-trigger': {
@@ -396,7 +405,10 @@ function SpawnTaskMessage({
           </div>
         </div>
 
-        <div className="h-px bg-edge/40" style={{ width: 'calc(100% + 24px)', marginLeft: '-12px' }}></div>
+        <div
+          className="h-px bg-edge/40"
+          style={{ width: 'calc(100% + 24px)', marginLeft: '-12px' }}
+        ></div>
 
         <CardBody className="p-0">
           <div className="break-words p-4 text-ink-faint sm:p-3">
@@ -500,9 +512,11 @@ function UserMessage({ message }: { message: UserMessageType }) {
 function AssistantMessage({
   message,
   copyText,
+  agentName,
 }: {
   message: AssistantMessageType
   copyText?: string | (() => string)
+  agentName?: string
 }) {
   const showCaret = !!message.streaming
   // A tool-only turn has no prose but still carries a copy payload (its
@@ -515,7 +529,9 @@ function AssistantMessage({
       data-message-role="assistant"
     >
       <header className="flex flex-wrap items-center gap-2 font-sans text-base text-ink-ghost sm:text-sm">
-        <span className="font-medium text-ink-faint">Agent</span>
+        <span className="font-medium text-ink-faint">
+          {agentName ?? 'Agent'}
+        </span>
         {copySource !== undefined && !message.streaming ? (
           <CopyMessageButton
             text={copySource}

--- a/console/web/src/components/chat/MessageList.tsx
+++ b/console/web/src/components/chat/MessageList.tsx
@@ -105,6 +105,8 @@ interface MessageListProps {
   onConfigureProvider?: () => void
   /** Current child-session identity shown by direct spawn seed messages. */
   spawnContext?: SpawnTaskContext
+  /** Session agent profile name shown on assistant message headers. */
+  agentName?: string
   workingDir?: string | null
   onWorkingDirChange?: (next: string) => void
   workingDirError?: string | null
@@ -300,6 +302,7 @@ export function MessageList({
   onManageFilesystemAccess,
   onConfigureProvider,
   spawnContext,
+  agentName,
   workingDir,
   onWorkingDirChange,
   workingDirError,
@@ -741,6 +744,7 @@ export function MessageList({
                     onResolveFilesystemAccess={onResolveFilesystemAccess}
                     onManageFilesystemAccess={onManageFilesystemAccess}
                     workingDir={workingDir}
+                    agentName={agentName}
                     summaryCopyText={
                       row.summary
                         ? (() => {
@@ -777,6 +781,7 @@ export function MessageList({
                 <Message
                   message={m}
                   spawnContext={spawnContext}
+                  agentName={agentName}
                   copyText={copyText}
                   defaultOpenCalls={defaultOpenCalls}
                   onResolveApproval={onResolveApproval}
@@ -831,6 +836,7 @@ interface FunctionTriggerGroupProps {
   onResolveFilesystemAccess?: MessageListProps['onResolveFilesystemAccess']
   onManageFilesystemAccess?: MessageListProps['onManageFilesystemAccess']
   workingDir?: string | null
+  agentName?: string
   /** External landing target — a hidden matching item expands the group. */
   focusMessageId?: string | null
 }
@@ -852,6 +858,7 @@ function FunctionTriggerGroup({
   onResolveFilesystemAccess,
   onManageFilesystemAccess,
   workingDir,
+  agentName,
   focusMessageId,
 }: FunctionTriggerGroupProps) {
   const [expanded, setExpanded] = useState(!!defaultOpenCalls)
@@ -938,6 +945,7 @@ function FunctionTriggerGroup({
               >
                 <Message
                   message={message}
+                  agentName={agentName}
                   triggerNotification={notification}
                   registration={
                     registrations.get(message.id) ??
@@ -959,7 +967,11 @@ function FunctionTriggerGroup({
       </div>
       {row.summary ? (
         <div data-message-row={row.summary.id}>
-          <Message message={row.summary} copyText={summaryCopyText} />
+          <Message
+            message={row.summary}
+            copyText={summaryCopyText}
+            agentName={agentName}
+          />
         </div>
       ) : null}
     </section>
@@ -1000,6 +1012,10 @@ function resolveEmptyState(
     systemPrompt: active?.systemPrompt ?? DEFAULT_SYSTEM_PROMPT_STATE,
     onSystemPromptChange: active
       ? (next: SystemPromptState) => ctx.setSystemPrompt(active.id, next)
+      : undefined,
+    agentProfile: active?.agentProfile,
+    onAgentProfileChange: active
+      ? (next) => ctx.setAgentProfile(active.id, next)
       : undefined,
     skills: active?.skills,
     onSkillsChange: active

--- a/console/web/src/components/chat/ModelPicker.tsx
+++ b/console/web/src/components/chat/ModelPicker.tsx
@@ -35,7 +35,7 @@ const DEFAULT_EFFORT: ReasoningEffortOption = {
 const FILTER_KEYS = ['ArrowDown', 'ArrowUp', 'Home', 'End', 'Enter', 'Escape']
 const MODEL_PICKER_PAGE_TRANSITION_MS = 250
 
-interface ModelPickerProps {
+export interface ModelPickerProps {
   value: ModelId | null
   options: ModelOption[]
   /** Incremented by a parent CTA to open this picker when its trigger is visible. */
@@ -46,6 +46,12 @@ interface ModelPickerProps {
   disabled?: boolean
   loading?: boolean
   showRefresh?: boolean
+  /** Copy shown when models exist but this optional field has no selection. */
+  placeholder?: string
+  /** Worker/profile pickers can hide provider setup owned by chat settings. */
+  showProviderConfiguration?: boolean
+  /** Worker/profile pickers can choose a model without configuring effort. */
+  showReasoningEffort?: boolean
   className?: string
 }
 
@@ -135,6 +141,9 @@ export function ModelPicker({
   disabled,
   loading,
   showRefresh = true,
+  placeholder = 'Choose model',
+  showProviderConfiguration = true,
+  showReasoningEffort = true,
   className,
 }: ModelPickerProps) {
   const ctx = useConversationsCtxOptional()
@@ -250,7 +259,12 @@ export function ModelPicker({
             !selected && 'text-ink-faint',
           )}
         >
-          {selected?.label ?? (loading ? 'Loading…' : 'No models')}
+          {selected?.label ??
+            (loading
+              ? 'Loading…'
+              : options.length > 0
+                ? placeholder
+                : 'No models')}
         </span>
         {selectedEfforts.length > 1 && thinkingLevel !== 'default' ? (
           <span className="shrink-0 text-[11px] text-ink-faint">
@@ -283,12 +297,18 @@ export function ModelPicker({
           thinkingLevel={thinkingLevel}
           onChange={onChange}
           onThinkingLevelChange={onThinkingLevelChange}
-          onConfigureProvider={(providerId) => {
-            setReasoningOpen(false)
-            setRenderedConfigurationProvider(providerId)
-            setConfigurationProvider(providerId)
-          }}
-          onOpenReasoning={() => setReasoningOpen(true)}
+          onConfigureProvider={
+            showProviderConfiguration
+              ? (providerId) => {
+                  setReasoningOpen(false)
+                  setRenderedConfigurationProvider(providerId)
+                  setConfigurationProvider(providerId)
+                }
+              : undefined
+          }
+          onOpenReasoning={
+            showReasoningEffort ? () => setReasoningOpen(true) : undefined
+          }
           disabled={disabled}
           loading={loading}
           contentClassName="space-y-4 px-3 pb-3"
@@ -697,23 +717,25 @@ export function ModelPickerPanel({
         )}
       </div>
 
-      <button
-        type="button"
-        disabled={disabled || loading || !selected || !onOpenReasoning}
-        onClick={onOpenReasoning}
-        className="sticky bottom-0 flex min-h-16 w-full shrink-0 items-center justify-between gap-3 border-t border-edge bg-panel-raised px-4 py-2 text-left font-sans text-base text-ink shadow-[0_-8px_20px_rgba(0,0,0,0.08)] hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-rule-focus disabled:pointer-events-none disabled:opacity-40 sm:min-h-14 sm:text-sm"
-      >
-        <span className="min-w-0 flex-1">
-          <span className="block font-medium">Reasoning effort</span>
-          <span className="block capitalize text-ink-faint">
-            {thinkingLevel}
+      {onOpenReasoning ? (
+        <button
+          type="button"
+          disabled={disabled || loading || !selected}
+          onClick={onOpenReasoning}
+          className="sticky bottom-0 flex min-h-16 w-full shrink-0 items-center justify-between gap-3 border-t border-edge bg-panel-raised px-4 py-2 text-left font-sans text-base text-ink shadow-[0_-8px_20px_rgba(0,0,0,0.08)] hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-rule-focus disabled:pointer-events-none disabled:opacity-40 sm:min-h-14 sm:text-sm"
+        >
+          <span className="min-w-0 flex-1">
+            <span className="block font-medium">Reasoning effort</span>
+            <span className="block capitalize text-ink-faint">
+              {thinkingLevel}
+            </span>
           </span>
-        </span>
-        <ChevronRight
-          className="size-5 shrink-0 text-ink-faint sm:size-4"
-          aria-hidden
-        />
-      </button>
+          <ChevronRight
+            className="size-5 shrink-0 text-ink-faint sm:size-4"
+            aria-hidden
+          />
+        </button>
+      ) : null}
     </div>
   )
 }

--- a/console/web/src/components/chat/system-prompt-selection.test.ts
+++ b/console/web/src/components/chat/system-prompt-selection.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   AGENT_CHOICE_PREFIX,
   agentIdForSend,
+  agentIdFromSystemPrompt,
   choiceToValue,
   DEFAULT_SYSTEM_PROMPT_STATE,
   type SystemPromptState,
@@ -10,6 +11,8 @@ import {
   toggleSkillSelection,
   toSelection,
   valueToChoice,
+  withAgentChoice,
+  withoutAgentChoice,
 } from './system-prompt-selection'
 
 describe('toSelection', () => {
@@ -218,5 +221,31 @@ describe('agentIdForSend', () => {
 
   it('an agent choice with an empty namedBody yields no prompt selection', () => {
     expect(toSelection(agentState)).toBeNull()
+  })
+})
+
+describe('agent choice state', () => {
+  it('selects an agent and returns to a clean manual default', () => {
+    const agent = withAgentChoice(DEFAULT_SYSTEM_PROMPT_STATE, 'engineer')
+
+    expect(agentIdFromSystemPrompt(agent)).toBe('engineer')
+    expect(agent.choice).toEqual({
+      named: `${AGENT_CHOICE_PREFIX}engineer`,
+    })
+    expect(agent.strategy).toBe('enrich')
+
+    const manual = withoutAgentChoice(agent)
+    expect(agentIdFromSystemPrompt(manual)).toBeNull()
+    expect(manual.choice).toBe('default')
+  })
+
+  it('leaves an existing manual prompt unchanged', () => {
+    const manual: SystemPromptState = {
+      ...DEFAULT_SYSTEM_PROMPT_STATE,
+      choice: { named: 'reviewer' },
+      namedBody: 'Review carefully.',
+    }
+
+    expect(withoutAgentChoice(manual)).toBe(manual)
   })
 })

--- a/console/web/src/components/chat/system-prompt-selection.ts
+++ b/console/web/src/components/chat/system-prompt-selection.ts
@@ -57,6 +57,41 @@ export const DEFAULT_SYSTEM_PROMPT_STATE: SystemPromptState = {
   addons: [],
 }
 
+/** Agent id encoded in a new-session selection, or null for manual setup. */
+export function agentIdFromSystemPrompt(
+  state: SystemPromptState,
+): string | null {
+  if (
+    typeof state.choice !== 'object' ||
+    !state.choice.named.startsWith(AGENT_CHOICE_PREFIX)
+  ) {
+    return null
+  }
+  return state.choice.named.slice(AGENT_CHOICE_PREFIX.length) || null
+}
+
+/** Select an agent profile while preserving the dormant manual fields. */
+export function withAgentChoice(
+  state: SystemPromptState,
+  agentId: string,
+): SystemPromptState {
+  return {
+    ...state,
+    choice: { named: `${AGENT_CHOICE_PREFIX}${agentId}` },
+    namedBody: '',
+    strategy: 'enrich',
+  }
+}
+
+/** Enter manual setup without carrying an agent profile into the first send. */
+export function withoutAgentChoice(
+  state: SystemPromptState,
+): SystemPromptState {
+  return agentIdFromSystemPrompt(state) === null
+    ? state
+    : { ...state, choice: 'default', namedBody: '' }
+}
+
 /** Map picker state to the per-send selection; null = send no prompt fields. */
 export function toSelection(
   s: SystemPromptState,
@@ -104,16 +139,7 @@ export function agentIdForSend(
   state: { turnEstablished: boolean; willQueue: boolean },
 ): string | undefined {
   if (state.turnEstablished || state.willQueue) return undefined
-  if (
-    typeof s.choice === 'object' &&
-    s.choice !== null &&
-    'named' in s.choice &&
-    s.choice.named.startsWith(AGENT_CHOICE_PREFIX)
-  ) {
-    const id = s.choice.named.slice(AGENT_CHOICE_PREFIX.length)
-    return id || undefined
-  }
-  return undefined
+  return agentIdFromSystemPrompt(s) ?? undefined
 }
 
 export function toggleSkillSelection(

--- a/console/web/src/components/sidebar/ConversationRow.tsx
+++ b/console/web/src/components/sidebar/ConversationRow.tsx
@@ -140,36 +140,41 @@ export function ConversationRow({
           />
         )
       ) : null}
-      {/* Sub-agent origin: ⚡ a trigger reaction spawned it, otherwise the
-          spawn's declared display identity (subagent_display icon + color)
-          when present, falling back to the generic 🤖. Absent on roots and
-          pre-stamp sessions. */}
-      {depth > 0 && conversation.spawnedBy ? (
+      {/* A selected agent profile owns the session glyph at every depth.
+          Sessions without one retain the child-origin presentation. */}
+      {conversation.agentProfile || (depth > 0 && conversation.spawnedBy) ? (
         <span
           className="subagent-tree-icon flex items-center shrink-0 text-ink-ghost"
           data-color={
-            conversation.spawnedBy === 'agent'
+            conversation.agentProfile?.color ??
+            (conversation.spawnedBy === 'agent'
               ? conversation.subagentAppearance?.color
-              : undefined
+              : undefined)
           }
           title={
-            conversation.spawnedBy === 'trigger'
+            conversation.agentProfile?.name ??
+            (conversation.spawnedBy === 'trigger'
               ? 'spawned by a trigger'
-              : (conversation.subagentAppearance?.name ?? 'spawned by an agent')
+              : (conversation.subagentAppearance?.name ??
+                'spawned by an agent'))
           }
         >
-          {conversation.spawnedBy === 'trigger' ? (
+          {!conversation.agentProfile &&
+          conversation.spawnedBy === 'trigger' ? (
             <TriggerIcon
               aria-label="spawned by a trigger"
               className="size-4 shrink-0 fill-ink-ghost"
             />
           ) : (
             (() => {
-              const icon = conversation.subagentAppearance?.icon
+              const icon =
+                conversation.agentProfile?.icon ??
+                conversation.subagentAppearance?.icon
               const Icon = (icon && SUBAGENT_ICON_COMPONENTS[icon]) || Bot
               return (
                 <Icon
                   aria-label={
+                    conversation.agentProfile?.name ??
                     conversation.subagentAppearance?.name ??
                     'spawned by an agent'
                   }

--- a/console/web/src/components/ui/ModeToggle.test.tsx
+++ b/console/web/src/components/ui/ModeToggle.test.tsx
@@ -1,6 +1,7 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
 import { SegmentedControl } from './ModeToggle'
+import { TooltipProvider } from './Tooltip'
 
 describe('SegmentedControl', () => {
   it('uses shared line tabs and semantic icons by default', () => {
@@ -40,5 +41,28 @@ describe('SegmentedControl', () => {
     expect(html).toContain('role="radiogroup"')
     expect(html).toContain('iii-ui-segmented')
     expect(html).not.toContain('iii-ui-tab__icon')
+  })
+
+  it('renders icon-only tabs with accessible labels and tooltip triggers', () => {
+    const html = renderToStaticMarkup(
+      <TooltipProvider delayDuration={0}>
+        <SegmentedControl
+          value="skills"
+          onChange={() => undefined}
+          iconOnly
+          options={[
+            { value: 'skills', label: 'Skills' },
+            { value: 'agents', label: 'Agent Profiles' },
+          ]}
+          aria-label="Directory collection"
+        />
+      </TooltipProvider>,
+    )
+
+    expect(html).toContain('data-icon-only="true"')
+    expect(html).toContain('aria-label="Skills"')
+    expect(html).toContain('aria-label="Agent Profiles"')
+    expect(html).toContain('data-state="closed"')
+    expect(html).not.toContain('<span>Skills</span>')
   })
 })

--- a/console/web/src/components/ui/ModeToggle.tsx
+++ b/console/web/src/components/ui/ModeToggle.tsx
@@ -3,6 +3,7 @@ import type * as React from 'react'
 import { useRef } from 'react'
 import { cn } from '@/lib/utils'
 import { TabIconSlot } from './TabIcon'
+import { Tooltip, TooltipContent, TooltipTrigger } from './Tooltip'
 
 export interface SegmentedControlOption<T extends string> {
   value: T
@@ -29,6 +30,8 @@ export interface SegmentedControlProps<T extends string> {
   itemClassName?: string
   activeItemClassName?: string
   variant?: SegmentedControlVariant
+  /** Show only the semantic icon and expose each label through Tooltip. */
+  iconOnly?: boolean
   /** Accessible name for the group. Required for `variant="radio"`. */
   'aria-label'?: string
 }
@@ -41,10 +44,12 @@ export function SegmentedControl<T extends string>({
   itemClassName,
   activeItemClassName,
   variant = 'tabs',
+  iconOnly = false,
   'aria-label': ariaLabel,
 }: SegmentedControlProps<T>) {
   const groupRole = variant === 'radio' ? 'radiogroup' : 'tablist'
   const itemRole = variant === 'radio' ? 'radio' : 'tab'
+  const renderIconOnly = iconOnly && variant === 'tabs'
   const buttonRefs = useRef<(HTMLButtonElement | null)[]>([])
 
   // Both tabs and radios are one keyboard stop. Arrow keys move and commit;
@@ -82,6 +87,7 @@ export function SegmentedControl<T extends string>({
       role={groupRole}
       aria-label={ariaLabel}
       data-variant={variant}
+      data-icon-only={renderIconOnly || undefined}
       className={cn(
         variant === 'tabs' ? uiClasses.tabsList : uiClasses.segmentedControl,
         className,
@@ -93,19 +99,22 @@ export function SegmentedControl<T extends string>({
           variant === 'radio'
             ? { 'aria-checked': active }
             : { 'aria-selected': active }
-        return (
+        const accessibleLabel =
+          opt.title ?? (typeof opt.label === 'string' ? opt.label : opt.value)
+        const button = (
           <button
             key={opt.value}
             type="button"
             role={itemRole}
             {...ariaState}
+            aria-label={renderIconOnly ? accessibleLabel : undefined}
             ref={(el) => {
               buttonRefs.current[idx] = el
             }}
             tabIndex={active ? 0 : -1}
             onClick={() => onChange(opt.value)}
             onKeyDown={(e) => handleKeyDown(e, idx)}
-            title={opt.title}
+            title={renderIconOnly ? undefined : opt.title}
             data-selected={active || undefined}
             className={cn(
               variant === 'tabs' ? uiClasses.tab : uiClasses.segmentedItem,
@@ -116,8 +125,15 @@ export function SegmentedControl<T extends string>({
             {variant === 'tabs' ? (
               <TabIconSlot icon={opt.icon} value={opt.value} />
             ) : null}
-            <span>{opt.label}</span>
+            {renderIconOnly ? null : <span>{opt.label}</span>}
           </button>
+        )
+        if (!renderIconOnly) return button
+        return (
+          <Tooltip key={opt.value}>
+            <TooltipTrigger asChild>{button}</TooltipTrigger>
+            <TooltipContent>{opt.label}</TooltipContent>
+          </Tooltip>
         )
       })}
     </div>

--- a/console/web/src/components/ui/TabIcon.tsx
+++ b/console/web/src/components/ui/TabIcon.tsx
@@ -1,6 +1,7 @@
 import uiClasses from '@iii-dev/console-ui/ui-classes'
 import {
   Activity,
+  Bot,
   Braces,
   ChartNoAxesColumnIncreasing,
   CircleAlert,
@@ -36,6 +37,8 @@ import { TriggerIcon } from './TriggerIcon'
 
 const TAB_ICONS: Readonly<Record<string, LucideIcon>> = {
   activity: Activity,
+  agent: Bot,
+  agents: Bot,
   baggage: Braces,
   cell: Braces,
   changes: History,

--- a/console/web/src/hooks/use-conversations.test.ts
+++ b/console/web/src/hooks/use-conversations.test.ts
@@ -116,6 +116,29 @@ describe('applyCatalogModelFallback', () => {
     expect(next[0].model).toBeNull()
     expect(next).toBe(sessions)
   })
+
+  it('never replaces an agent profile model that left the live catalog', () => {
+    const profileModel = 'openai-codex::codex/gpt-retired'
+    const sessions = [
+      conversation({
+        model: profileModel,
+        agentProfile: {
+          id: 'reviewer',
+          name: 'Reviewer',
+          model: profileModel,
+        },
+      }),
+    ]
+
+    const next = applyCatalogModelFallback(
+      sessions,
+      new Set(['provider::current-model']),
+      'provider::current-model',
+    )
+
+    expect(next).toBe(sessions)
+    expect(next[0].model).toBe(profileModel)
+  })
 })
 
 describe('mergeConversationMeta', () => {
@@ -545,6 +568,41 @@ describe('reconnect hydration', () => {
 })
 
 describe('metadataFor', () => {
+  it('round-trips the frozen agent profile identity and configuration', () => {
+    const agentProfile = {
+      id: 'reviewer',
+      name: 'Code Reviewer',
+      model: 'openai-codex::codex/gpt-5.6-sol',
+      reasoningEffort: 'ultra',
+      icon: 'review' as const,
+      color: 'purple' as const,
+    }
+    const metadata = metadataFor(
+      conversation({
+        model: agentProfile.model,
+        thinkingLevel: agentProfile.reasoningEffort,
+        agentProfile,
+      }),
+    )
+
+    expect(metadata.agent_profile).toEqual({
+      id: 'reviewer',
+      name: 'Code Reviewer',
+      model: 'openai-codex::codex/gpt-5.6-sol',
+      reasoning_effort: 'ultra',
+      icon: 'review',
+      color: 'purple',
+    })
+
+    const restored = mergeConversationMeta(
+      undefined,
+      sessionMeta({ metadata, message_count: 2 }),
+    )
+    expect(restored.agentProfile).toEqual(agentProfile)
+    expect(restored.model).toBe(agentProfile.model)
+    expect(restored.thinkingLevel).toBe('ultra')
+  })
+
   it('preserves harness linkage and appearance across whole-object writes', () => {
     const next = metadataFor(
       conversation({

--- a/console/web/src/hooks/use-conversations.ts
+++ b/console/web/src/hooks/use-conversations.ts
@@ -27,6 +27,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
+  agentIdFromSystemPrompt,
   DEFAULT_SYSTEM_PROMPT_STATE,
   type SystemPromptAddon,
   type SystemPromptState,
@@ -69,6 +70,7 @@ import {
 } from '@/lib/storage'
 import { releaseConsoleClaimIfAny } from '@/lib/worktree-claims'
 import {
+  type AgentProfileSnapshot,
   type Conversation,
   type ConversationMetadataEdits,
   DEFAULT_MODE,
@@ -264,15 +266,56 @@ function decodeSkills(v: unknown): string[] | undefined {
   return skills.length > 0 ? skills : undefined
 }
 
+function decodeAgentProfile(value: unknown): AgentProfileSnapshot | undefined {
+  if (typeof value !== 'object' || value === null) return undefined
+  const raw = value as Record<string, unknown>
+  const id = typeof raw.id === 'string' ? raw.id.trim() : ''
+  if (!id) return undefined
+  const name = typeof raw.name === 'string' ? raw.name.trim() : ''
+  const icon =
+    typeof raw.icon === 'string' &&
+    SUBAGENT_ICON_VALUES.has(raw.icon as SubagentIcon)
+      ? (raw.icon as SubagentIcon)
+      : undefined
+  const color =
+    typeof raw.color === 'string' &&
+    SUBAGENT_COLOR_VALUES.has(raw.color as SubagentColor)
+      ? (raw.color as SubagentColor)
+      : undefined
+  const model = typeof raw.model === 'string' ? raw.model.trim() : ''
+  const reasoningEffort =
+    typeof raw.reasoning_effort === 'string'
+      ? raw.reasoning_effort.trim()
+      : typeof raw.reasoningEffort === 'string'
+        ? raw.reasoningEffort.trim()
+        : ''
+  return {
+    id,
+    name: name || id,
+    ...(model ? { model } : {}),
+    ...(reasoningEffort ? { reasoningEffort } : {}),
+    ...(icon ? { icon } : {}),
+    ...(color ? { color } : {}),
+  }
+}
+
 function decodeSessionSelections(
   md: Record<string, unknown>,
   started: boolean,
-): Pick<Conversation, 'systemPrompt' | 'skills' | 'legacySkillMigration'> {
+): Pick<
+  Conversation,
+  'systemPrompt' | 'agentProfile' | 'skills' | 'legacySkillMigration'
+> {
   const systemPrompt = decodeSystemPrompt(md.system_prompt)
+  const legacyAgentId = agentIdFromSystemPrompt(systemPrompt)
+  const agentProfile =
+    decodeAgentProfile(md.agent_profile) ??
+    (legacyAgentId ? { id: legacyAgentId, name: legacyAgentId } : undefined)
   const skills = decodeSkills(md.skills)
   const hasLegacySkills = systemPrompt.addons.length > 0
   return {
     systemPrompt,
+    agentProfile,
     skills,
     legacySkillMigration:
       !started && hasLegacySkills
@@ -391,11 +434,24 @@ export function metadataFor(
     | 'workingDir'
     | 'memoryBank'
     | 'systemPrompt'
+    | 'agentProfile'
     | 'skills'
     | 'sessionMetadata'
   >,
 ): Record<string, unknown> {
   const systemPrompt = encodeSystemPrompt(c.systemPrompt)
+  const agentProfile = c.agentProfile
+    ? {
+        id: c.agentProfile.id,
+        name: c.agentProfile.name,
+        ...(c.agentProfile.model ? { model: c.agentProfile.model } : {}),
+        ...(c.agentProfile.reasoningEffort
+          ? { reasoning_effort: c.agentProfile.reasoningEffort }
+          : {}),
+        ...(c.agentProfile.icon ? { icon: c.agentProfile.icon } : {}),
+        ...(c.agentProfile.color ? { color: c.agentProfile.color } : {}),
+      }
+    : undefined
   // session::set-meta replaces metadata wholesale. Keep keys owned by the
   // harness (parent linkage and sub-agent presentation) and other surfaces,
   // while rebuilding the console-owned keys below so clearing one really
@@ -409,6 +465,7 @@ export function metadataFor(
     fs_scope: _fsScope,
     memory_bank: _memoryBank,
     system_prompt: _systemPrompt,
+    agent_profile: _agentProfile,
     skills: _skills,
     ...preserved
   } = c.sessionMetadata ?? {}
@@ -424,6 +481,7 @@ export function metadataFor(
     ...(c.workingDir ? { fs_scope: { root: c.workingDir } } : {}),
     ...(c.memoryBank ? { memory_bank: c.memoryBank } : {}),
     ...(systemPrompt ? { system_prompt: systemPrompt } : {}),
+    ...(agentProfile ? { agent_profile: agentProfile } : {}),
     ...(c.skills?.length ? { skills: c.skills } : {}),
   }
 }
@@ -437,6 +495,7 @@ const CONSOLE_METADATA_KEYS = [
   'fs_scope',
   'memory_bank',
   'system_prompt',
+  'agent_profile',
   'skills',
 ] as const
 
@@ -513,18 +572,20 @@ function conversationFromMeta(
   migrationPending = false,
 ): Conversation {
   const md = meta.metadata ?? {}
-  const { systemPrompt, skills, legacySkillMigration } =
+  const { systemPrompt, agentProfile, skills, legacySkillMigration } =
     decodeSessionSelections(md, started && !migrationPending)
   return {
     id: meta.session_id,
     title: meta.title || meta.session_id,
     titleManual: md.title_manual === true,
     model:
-      typeof md.model === 'string' && md.model.length > 0 ? md.model : null,
+      typeof md.model === 'string' && md.model.length > 0
+        ? md.model
+        : (agentProfile?.model ?? null),
     thinkingLevel:
       typeof md.thinking_level === 'string' && md.thinking_level.length > 0
         ? md.thinking_level
-        : DEFAULT_THINKING_LEVEL,
+        : (agentProfile?.reasoningEffort ?? DEFAULT_THINKING_LEVEL),
     mode: isMode(md.mode) ? md.mode : DEFAULT_MODE,
     workingDir:
       typeof md.fs_scope === 'object' &&
@@ -538,6 +599,7 @@ function conversationFromMeta(
         ? md.memory_bank
         : null,
     systemPrompt,
+    agentProfile,
     skills,
     legacySkillMigration,
     started,
@@ -583,7 +645,7 @@ export function applyConversationMetadataEvent(
     return conversation
   }
   const md = event.metadata ?? {}
-  const { systemPrompt, skills, legacySkillMigration } =
+  const { systemPrompt, agentProfile, skills, legacySkillMigration } =
     decodeSessionSelections(
       md,
       conversation.started === true && !conversation.legacySkillMigration,
@@ -595,17 +657,18 @@ export function applyConversationMetadataEvent(
     model:
       typeof md.model === 'string' && md.model.length > 0
         ? md.model
-        : conversation.model,
+        : (agentProfile?.model ?? conversation.model),
     thinkingLevel:
       typeof md.thinking_level === 'string' && md.thinking_level.length > 0
         ? md.thinking_level
-        : DEFAULT_THINKING_LEVEL,
+        : (agentProfile?.reasoningEffort ?? DEFAULT_THINKING_LEVEL),
     mode: isMode(md.mode) ? md.mode : conversation.mode,
     memoryBank:
       typeof md.memory_bank === 'string' && md.memory_bank.length > 0
         ? md.memory_bank
         : null,
     systemPrompt,
+    agentProfile,
     skills,
     legacySkillMigration,
     sessionMetadata: md,
@@ -671,6 +734,11 @@ export function applyCatalogModelFallback(
   let changed = false
   const next = conversations.map((c) => {
     if (c.model && validModels.has(c.model)) return c
+    // A profile model is authoritative even when the live catalog no longer
+    // advertises it. Directory deliberately keeps retired ids loadable so
+    // the send path can surface the real resolution error; silently swapping
+    // in the first catalog model would run the profile on the wrong model.
+    if (c.agentProfile?.model) return c
     // A discovered session (sub-agent, other-surface) with no model choice
     // must stay null — inventing one here would misreport the model the
     // session actually runs; the chat view derives it from the transcript.
@@ -780,6 +848,7 @@ export function mergeConversationMeta(
       workingDir: existing.workingDir,
       memoryBank: existing.memoryBank,
       systemPrompt: existing.systemPrompt,
+      agentProfile: existing.agentProfile,
       skills: existing.skills,
       legacySkillMigration: existing.legacySkillMigration,
       sessionMetadata: existing.sessionMetadata,
@@ -915,6 +984,11 @@ export interface ConversationsApi {
   setMemoryBank: (id: string, memoryBank: string | null) => void
   /** This chat's system prompt, chosen on the new-session screen. */
   setSystemPrompt: (id: string, systemPrompt: SystemPromptState) => void
+  /** Select or clear the Directory agent profile frozen onto this session. */
+  setAgentProfile: (
+    id: string,
+    agentProfile: AgentProfileSnapshot | undefined,
+  ) => void
   setSkills: (id: string, skills: string[] | undefined) => void
   setMode: (id: string, mode: Mode) => void
   /** Per-session working directory; null clears a scope that is no longer usable. */
@@ -2103,6 +2177,36 @@ export function useConversations(
     [patchConversation, conversations, writeMeta],
   )
 
+  const setAgentProfile = useCallback(
+    (id: string, agentProfile: AgentProfileSnapshot | undefined) => {
+      const patch: ConversationMetadataEdits = {
+        agentProfile,
+        ...(agentProfile?.model ? { model: agentProfile.model } : {}),
+        ...(agentProfile
+          ? {
+              thinkingLevel:
+                agentProfile.reasoningEffort ?? DEFAULT_THINKING_LEVEL,
+            }
+          : {}),
+      }
+      patchConversation(id, (conversation) =>
+        applyConversationMetadataPatch(conversation, patch),
+      )
+      const conversation = conversations.find((item) => item.id === id)
+      if (conversation) {
+        const updated = applyConversationMetadataPatch(conversation, patch)
+        writeMeta(updated)
+        if (agentProfile?.model) saveLastModel(agentProfile.model)
+        if (agentProfile) {
+          saveLastThinkingLevel(
+            agentProfile.reasoningEffort ?? DEFAULT_THINKING_LEVEL,
+          )
+        }
+      }
+    },
+    [patchConversation, conversations, writeMeta],
+  )
+
   const setSkills = useCallback(
     (id: string, skills: string[] | undefined) => {
       const normalized = skills?.length ? skills : undefined
@@ -2310,6 +2414,7 @@ export function useConversations(
     setThinkingLevel,
     setMemoryBank,
     setSystemPrompt,
+    setAgentProfile,
     setSkills,
     setMode,
     setWorkingDir,

--- a/console/web/src/lib/backend/directory-prompts.ts
+++ b/console/web/src/lib/backend/directory-prompts.ts
@@ -116,11 +116,10 @@ export interface AgentEntry {
   description: string
   logo: string | null
   icon: string | null
+  /** Semantic display color; absent on older Directory workers. */
+  color?: string | null
   model: string | null
   skill_count: number | null
-  /** true = a specialist meant to be spawned, not to front a session.
-   * Absent on directory workers that predate the field. */
-  leaf?: boolean
   modified_at: string
 }
 

--- a/console/web/src/lib/backend/directory-prompts.ts
+++ b/console/web/src/lib/backend/directory-prompts.ts
@@ -119,6 +119,7 @@ export interface AgentEntry {
   /** Semantic display color; absent on older Directory workers. */
   color?: string | null
   model: string | null
+  reasoning_effort?: string | null
   skill_count: number | null
   modified_at: string
 }

--- a/console/web/src/lib/console-api.ts
+++ b/console/web/src/lib/console-api.ts
@@ -12,6 +12,7 @@
 
 import tokenNames from '@iii-dev/console-ui/token-names'
 import sharedUiClasses from '@iii-dev/console-ui/ui-classes'
+import { ModelPicker } from '@/components/chat/ModelPicker'
 import { AnnotationLayer, AnnotationList } from '@/components/ui/Annotations'
 import { AnsiText } from '@/components/ui/AnsiText'
 import { Badge } from '@/components/ui/Badge'
@@ -179,6 +180,7 @@ export const components: ConsoleApi['components'] = {
   JsonHighlight,
   Markdown,
   MarkdownPreview,
+  ModelPicker,
   // The one page-level composite in the kit: worker pages offer "configure"
   // in place instead of navigating to the workers tab and stranding the
   // operator there when the editor closes.

--- a/console/web/src/lib/console-ui-conformance.test.ts
+++ b/console/web/src/lib/console-ui-conformance.test.ts
@@ -22,6 +22,7 @@ import componentNames from '@iii-dev/console-ui/component-names'
 import tokenNames from '@iii-dev/console-ui/token-names'
 import uiClasses, { uiClassNames } from '@iii-dev/console-ui/ui-classes'
 import { describe, expect, it } from 'vitest'
+import { ModelPicker } from '@/components/chat/ModelPicker'
 import { AnnotationLayer, AnnotationList } from '@/components/ui/Annotations'
 import { AnsiText } from '@/components/ui/AnsiText'
 import { Badge } from '@/components/ui/Badge'
@@ -153,6 +154,7 @@ const conformance: {
   ListItem: typeof ConsoleUi.ListItem
   Markdown: typeof ConsoleUi.Markdown
   MarkdownPreview: typeof ConsoleUi.MarkdownPreview
+  ModelPicker: typeof ConsoleUi.ModelPicker
   PageBody: typeof ConsoleUi.PageBody
   PageHeader: typeof ConsoleUi.PageHeader
   PageMain: typeof ConsoleUi.PageMain
@@ -230,6 +232,7 @@ const conformance: {
   ListItem,
   Markdown,
   MarkdownPreview,
+  ModelPicker,
   PageBody,
   PageHeader,
   PageMain,

--- a/console/web/src/types/chat.ts
+++ b/console/web/src/types/chat.ts
@@ -321,6 +321,8 @@ export interface ConversationMetadataEdits {
   workingDir?: string | null
   memoryBank?: string | null
   systemPrompt?: SystemPromptState
+  /** An own `undefined` value clears the selected agent profile. */
+  agentProfile?: AgentProfileSnapshot | undefined
   /** An own `undefined` value records an explicit All-skills selection. */
   skills?: string[] | undefined
 }
@@ -352,6 +354,16 @@ export type SubagentColor =
  */
 export interface SubagentAppearance {
   name: string
+  icon?: SubagentIcon
+  color?: SubagentColor
+}
+
+/** Directory agent profile frozen onto session metadata at selection/send. */
+export interface AgentProfileSnapshot {
+  id: string
+  name: string
+  model?: ModelId
+  reasoningEffort?: ThinkingLevel
   icon?: SubagentIcon
   color?: SubagentColor
 }
@@ -395,6 +407,8 @@ export interface Conversation {
    * Omitted = `DEFAULT_SYSTEM_PROMPT_STATE`.
    */
   systemPrompt?: SystemPromptState
+  /** Selected Directory agent profile, frozen for session identity/rendering. */
+  agentProfile?: AgentProfileSnapshot
   /** Undefined/empty means all model-invocable skills; otherwise exact IDs. */
   skills?: string[]
   /**

--- a/docs/architecture/agent-profile-storage.md
+++ b/docs/architecture/agent-profile-storage.md
@@ -2,7 +2,7 @@
 
 ## Decision
 
-Agent profiles live in a dedicated root as one Markdown file per agent:
+Agent profiles live in a dedicated root as one Markdown file per profile:
 
 ```text
 agents/
@@ -46,14 +46,14 @@ Automatic vendor-directory discovery stays out of scope.
 ## Discovery and identity
 
 The scanner reads only direct `<agents_folder>/<id>.md` files. Nested files
-are ignored. Agent ids keep the current lowercase ASCII, digit, hyphen, and
+are ignored. Agent profile ids keep the current lowercase ASCII, digit, hyphen, and
 underscore validation.
 
 The current required frontmatter and non-empty body validation stays in
 place. Unknown frontmatter keys remain harmless, so fields that iii does not
 consume do not prevent a profile from loading.
 
-Agent list/get/update/delete resolve against the merged project +
+Agent-profile list/get/update/delete operations resolve against the merged project +
 user-global scan; only create is anchored to the project root:
 
 - create writes `<agents_folder>/<id>.md`, and refuses an id already served
@@ -73,7 +73,7 @@ classification. A request to create a skill whose id contains that segment
 returns a normal validation error and directs the caller to
 `directory::agents::create`; it must never panic.
 
-Skill and system-prompt scans do not inspect `agents_folder`. Agent scans do
+Skill and system-prompt scans do not inspect `agents_folder`. Agent-profile scans do
 not inspect `skills_folder`, `local_skills_folder`, or
 `agents_skills_folder`.
 
@@ -87,10 +87,10 @@ that exact shape are not treated as agent profiles.
 The registry's existing skills snapshot transport may carry those entries;
 that wire name does not determine their destination. Repository skill
 downloads continue to copy only the requested skill and do not install an
-unrelated top-level agent catalog.
+unrelated top-level agent-profile catalog.
 
 Installing a bundle may atomically replace a profile with the same id, just
-as reinstalling a bundle may replace its skills. Agent ids are therefore a
+as reinstalling a bundle may replace its skills. Agent profile ids are therefore a
 shared catalog namespace.
 
 The download response and console renderer show all three result families:
@@ -113,8 +113,8 @@ events and suppress the corresponding external-write event.
 ## Compatibility with harness
 
 Harness remains storage-agnostic. `harness::send` and `harness::spawn` keep
-passing a flat agent id to `directory::agents::get`, so session resolution,
-delegation, model selection, and frozen identity behavior do not change.
+passing a flat agent profile id to `directory::agents::get`, so session resolution,
+spawn behavior, model selection, and frozen identity behavior do not change.
 
 Tests must cover the default/configured root, exact scanner shape, CRUD
 destinations, lack of legacy fallback, bundle routing, root-aware watch

--- a/docs/architecture/agent-profile-storage.md
+++ b/docs/architecture/agent-profile-storage.md
@@ -53,6 +53,13 @@ The current required frontmatter and non-empty body validation stays in
 place. Unknown frontmatter keys remain harmless, so fields that iii does not
 consume do not prevent a profile from loading.
 
+`model` and `reasoning_effort` are optional, verbatim catalog selections. A
+catalog key may include its provider (`provider::model`); the harness splits
+that key when routing. Directory deliberately does not reject a retired model
+or effort: resolution against the live catalog happens when the profile is
+used, so the profile remains editable and the send returns the authoritative
+resolution error instead of silently choosing another model.
+
 Agent-profile list/get/update/delete operations resolve against the merged project +
 user-global scan; only create is anchored to the project root:
 
@@ -112,9 +119,14 @@ events and suppress the corresponding external-write event.
 
 ## Compatibility with harness
 
-Harness remains storage-agnostic. `harness::send` and `harness::spawn` keep
-passing a flat agent profile id to `directory::agents::get`, so session resolution,
-spawn behavior, model selection, and frozen identity behavior do not change.
+Harness remains storage-agnostic. `harness::send` and `harness::spawn` pass a
+flat agent profile id to `directory::agents::get` and freeze its prompt,
+skills, model, reasoning effort, display name, icon, and color. When a profile
+declares a model, that model and its effort are authoritative for the session.
+The harness also writes the frozen display/configuration snapshot to
+`SessionMeta.metadata.agent_profile`, allowing the Console sidebar and panel
+header to identify the session without re-reading the mutable Directory
+catalog. Existing sessions are therefore unaffected by later profile edits.
 
 Tests must cover the default/configured root, exact scanner shape, CRUD
 destinations, lack of legacy fallback, bundle routing, root-aware watch

--- a/harness/README.md
+++ b/harness/README.md
@@ -199,19 +199,22 @@ profile (`directory::agents::*`, one markdown file per profile). The harness
 resolves it ONCE via `directory::agents::get` and freezes the result onto the
 turn: `"You are <name>."` plus the file body becomes the enrich system prompt
 over the top-level identity, the profile's skill filter becomes the session's
-skill selection (an explicit `options.skills` wins), its `model` is the
-fallback when the send names none, and — when the send also omits
+skill selection (an explicit `options.skills` wins), its `model` and optional
+provider-native `reasoning_effort` are authoritative for the session, and —
+when the send also omits
 `options.functions` — the dispatch policy defaults to the configured
 `default_functions` baseline instead of deny-all (an identity picked to DO
 something must be able to dispatch; the ask-mode cap still applies). The
-frozen identity travels with the prompt-stickiness rule: bare later sends
+The frozen name/icon/color/model/effort snapshot is also written to session
+metadata for clients that render established sessions. The frozen identity
+travels with the prompt-stickiness rule: bare later sends
 inherit it, an explicit prompt field sheds it. Refused on an existing
 session or combined with either prompt field. Directory edits after
 resolution never reach a live session — start a new one to pick them up.
 
 `harness::spawn` takes the same id as a top-level `agent` field: the profile
-body enriches the sub-agent identity, its skills/model slot in the same way
-(model precedence `model` → profile → parent, without dragging the parent's
+body enriches the sub-agent identity, its skills/model/effort slot in the same way
+(model precedence profile → explicit `model` → parent, without dragging the parent's
 provider onto a foreign model), and its name and icon become the display
 defaults. Which agent profile a spawn names is the prompt's decision — the profile
 body steers it, nothing gates it. Spawning

--- a/harness/README.md
+++ b/harness/README.md
@@ -195,7 +195,7 @@ operating-mode paragraph — resend the prompt fields to re-resolve.
 ### Agent profiles
 
 `options.agent` on a session-creating `harness::send` names a directory agent
-profile (`directory::agents::*`, one markdown file per agent). The harness
+profile (`directory::agents::*`, one markdown file per profile). The harness
 resolves it ONCE via `directory::agents::get` and freezes the result onto the
 turn: `"You are <name>."` plus the file body becomes the enrich system prompt
 over the top-level identity, the profile's skill filter becomes the session's
@@ -206,18 +206,15 @@ fallback when the send names none, and — when the send also omits
 something must be able to dispatch; the ask-mode cap still applies). The
 frozen identity travels with the prompt-stickiness rule: bare later sends
 inherit it, an explicit prompt field sheds it. Refused on an existing
-session, combined with either prompt field, or naming a `leaf: true` profile
-(leaves are spawn targets). Directory edits after resolution never reach a
-live session — start a new one to pick them up.
+session or combined with either prompt field. Directory edits after
+resolution never reach a live session — start a new one to pick them up.
 
-`harness::spawn` takes the same id as a top-level `agent` field, typically a
-`leaf` specialist: the profile body enriches the sub-agent identity, its
-skills/model slot in the same way (model precedence `model` → profile →
-parent, without dragging the parent's provider onto a foreign model), its
-name and icon become the display defaults, and an unset
-`options.orchestrator` defaults to `true` for a non-leaf profile. Which
-agent a spawn names is the prompt's decision — the profile body steers it,
-nothing gates it. Spawning
+`harness::spawn` takes the same id as a top-level `agent` field: the profile
+body enriches the sub-agent identity, its skills/model slot in the same way
+(model precedence `model` → profile → parent, without dragging the parent's
+provider onto a foreign model), and its name and icon become the display
+defaults. Which agent profile a spawn names is the prompt's decision — the profile
+body steers it, nothing gates it. Spawning
 with `agent` into an already RUNNING session of the caller's own tree merges
 the task like any reuse and does not re-apply the profile.
 

--- a/harness/src/agents.rs
+++ b/harness/src/agents.rs
@@ -13,7 +13,7 @@ use iii_sdk::protocol::TriggerRequest;
 use crate::config::WorkerConfig;
 use crate::deps::Deps;
 use crate::error::HarnessError;
-use crate::functions::spawn::SubagentIcon;
+use crate::functions::spawn::{SubagentColor, SubagentIcon};
 use crate::types::turn::AgentIdentity;
 
 const AGENTS_GET_ID: &str = "directory::agents::get";
@@ -27,11 +27,11 @@ struct AgentGetWire {
     #[serde(default)]
     skills: Vec<String>,
     #[serde(default)]
-    leaf: bool,
-    #[serde(default)]
     model: Option<String>,
     #[serde(default)]
     icon: Option<String>,
+    #[serde(default)]
+    color: Option<String>,
 }
 
 /// A profile resolved and normalized for turn seeding.
@@ -50,8 +50,9 @@ pub struct ResolvedAgent {
     /// Harness display icon; `None` when the profile has none (the token set
     /// is shared, so a directory-validated icon always parses).
     pub icon: Option<SubagentIcon>,
-    /// `true` = spawn target only, refused as a session identity.
-    pub leaf: bool,
+    /// Harness display color; `None` when the profile uses the neutral
+    /// default.
+    pub color: Option<SubagentColor>,
 }
 
 /// Fetch and normalize one agent profile. An unknown id maps to
@@ -78,11 +79,11 @@ pub async fn resolve(
     Ok(normalize(id, wire))
 }
 
-/// D410 is the directory's not-found code for agents — the caller named a
+/// D410 is the directory's not-found code for agent profiles — the caller named a
 /// bad id, not a broken dependency.
 fn classify_fetch_error(message: &str) -> HarnessError {
     if message.contains("D410") {
-        HarnessError::InvalidRequest(format!("agent resolution failed: {message}"))
+        HarnessError::InvalidRequest(format!("agent profile resolution failed: {message}"))
     } else {
         HarnessError::Dependency(format!("{AGENTS_GET_ID}: {message}"))
     }
@@ -103,7 +104,9 @@ fn normalize(id: &str, wire: AgentGetWire) -> ResolvedAgent {
         icon: wire.icon.and_then(|t| {
             serde_json::from_value::<SubagentIcon>(serde_json::Value::String(t)).ok()
         }),
-        leaf: wire.leaf,
+        color: wire.color.and_then(|t| {
+            serde_json::from_value::<SubagentColor>(serde_json::Value::String(t)).ok()
+        }),
     }
 }
 
@@ -118,8 +121,8 @@ mod tests {
     #[test]
     fn not_found_maps_to_invalid_request_and_keeps_the_directory_hint() {
         let err = classify_fetch_error(
-            "handler error: D410 not_found: agent \"nope\" does not exist. Did you mean: coder. \
-             Next: call directory::agents::list to browse agent ids.",
+            "handler error: D410 not_found: agent profile \"nope\" does not exist. Did you mean: coder. \
+             Next: call directory::agents::list to browse agent profile ids.",
         );
         assert_eq!(err.code(), "harness/invalid_request");
         assert!(err.to_string().contains("directory::agents::list"));
@@ -137,15 +140,16 @@ mod tests {
                 "name": "Tech Leader",
                 "system_prompt": "Delegate everything.",
                 "skills": [],
-                "leaf": false,
                 "model": "codex/gpt-5.4",
                 "icon": "agent",
+                "color": "purple",
             })),
         );
         assert_eq!(agent.prompt, "You are Tech Leader.\n\nDelegate everything.");
         assert_eq!(agent.skills, None, "empty filter means every skill");
         assert_eq!(agent.identity.id, "tech-leader");
         assert_eq!(agent.icon, Some(SubagentIcon::Agent));
+        assert_eq!(agent.color, Some(SubagentColor::Purple));
         assert_eq!(agent.model.as_deref(), Some("codex/gpt-5.4"));
     }
 
@@ -157,8 +161,8 @@ mod tests {
                 "name": "  ",
                 "system_prompt": "Write code.",
                 "skills": ["review"],
-                "leaf": true,
                 "icon": "magnifier",
+                "color": "ultraviolet",
             })),
         );
         assert_eq!(
@@ -168,6 +172,6 @@ mod tests {
         assert_eq!(agent.prompt, "You are coder.\n\nWrite code.");
         assert_eq!(agent.skills.as_deref(), Some(&["review".to_string()][..]));
         assert_eq!(agent.icon, None, "unknown token degrades, never errors");
-        assert!(agent.leaf);
+        assert_eq!(agent.color, None, "unknown color degrades, never errors");
     }
 }

--- a/harness/src/agents.rs
+++ b/harness/src/agents.rs
@@ -5,8 +5,10 @@
 //! later directory edits never reach a live session, matching the skills
 //! baseline freeze.
 
+use std::collections::BTreeMap;
+
 use serde::Deserialize;
-use serde_json::json;
+use serde_json::{json, Value};
 
 use iii_sdk::protocol::TriggerRequest;
 
@@ -14,6 +16,7 @@ use crate::config::WorkerConfig;
 use crate::deps::Deps;
 use crate::error::HarnessError;
 use crate::functions::spawn::{SubagentColor, SubagentIcon};
+use crate::types::model::ThinkingLevel;
 use crate::types::turn::AgentIdentity;
 
 const AGENTS_GET_ID: &str = "directory::agents::get";
@@ -29,6 +32,8 @@ struct AgentGetWire {
     #[serde(default)]
     model: Option<String>,
     #[serde(default)]
+    reasoning_effort: Option<String>,
+    #[serde(default)]
     icon: Option<String>,
     #[serde(default)]
     color: Option<String>,
@@ -43,8 +48,10 @@ pub struct ResolvedAgent {
     pub prompt: String,
     /// `None` when the profile filters nothing (every skill).
     pub skills: Option<Vec<String>>,
-    /// Default model for sessions running as this agent.
+    /// Authoritative model for sessions running as this agent when present.
     pub model: Option<String>,
+    /// Provider-native reasoning effort paired with the profile model.
+    pub reasoning_effort: Option<String>,
     /// Display name for spawn identity defaults.
     pub name: String,
     /// Harness display icon; `None` when the profile has none (the token set
@@ -95,18 +102,105 @@ fn normalize(id: &str, wire: AgentGetWire) -> ResolvedAgent {
     } else {
         wire.name.trim().to_string()
     };
+    let icon = wire
+        .icon
+        .and_then(|token| serde_json::from_value::<SubagentIcon>(Value::String(token)).ok());
+    let color = wire
+        .color
+        .and_then(|token| serde_json::from_value::<SubagentColor>(Value::String(token)).ok());
     ResolvedAgent {
-        identity: AgentIdentity { id: id.to_string() },
+        identity: AgentIdentity {
+            id: id.to_string(),
+            name: Some(name.clone()),
+            icon: icon.and_then(|value| {
+                serde_json::to_value(value)
+                    .ok()?
+                    .as_str()
+                    .map(str::to_string)
+            }),
+            color: color.and_then(|value| {
+                serde_json::to_value(value)
+                    .ok()?
+                    .as_str()
+                    .map(str::to_string)
+            }),
+        },
         prompt: format!("You are {name}.\n\n{}", wire.system_prompt),
         skills: (!wire.skills.is_empty()).then_some(wire.skills),
         model: wire.model,
+        reasoning_effort: wire.reasoning_effort,
         name,
-        icon: wire.icon.and_then(|t| {
-            serde_json::from_value::<SubagentIcon>(serde_json::Value::String(t)).ok()
-        }),
-        color: wire.color.and_then(|t| {
-            serde_json::from_value::<SubagentColor>(serde_json::Value::String(t)).ok()
-        }),
+        icon,
+        color,
+    }
+}
+
+impl ResolvedAgent {
+    /// Split the Console catalog key (`provider::model`) when present. Plain
+    /// router model ids remain valid and leave provider routing automatic.
+    pub fn model_and_provider(&self) -> Option<(String, Option<String>)> {
+        let model = self.model.as_deref()?.trim();
+        let split = model
+            .split_once("::")
+            .filter(|(provider, id)| !provider.is_empty() && !id.is_empty());
+        Some(match split {
+            Some((provider, id)) => (id.to_string(), Some(provider.to_string())),
+            None => (model.to_string(), None),
+        })
+    }
+
+    /// Apply the profile's effort as both the compatibility enum (when it is
+    /// one of the Harness levels) and the exact provider-native option. The
+    /// latter preserves catalog additions such as `ultra` without a Harness
+    /// enum release.
+    pub fn apply_reasoning(
+        &self,
+        provider: Option<&str>,
+        thinking_level: &mut Option<ThinkingLevel>,
+        provider_options: &mut Option<BTreeMap<String, Value>>,
+    ) {
+        let Some(effort) = self
+            .reasoning_effort
+            .as_deref()
+            .map(str::trim)
+            .filter(|effort| !effort.is_empty() && *effort != "default")
+        else {
+            return;
+        };
+        *thinking_level = serde_json::from_value(Value::String(effort.to_lowercase())).ok();
+        let Some(provider) = provider else {
+            return;
+        };
+        let options = provider_options.get_or_insert_with(BTreeMap::new);
+        let provider_value = options
+            .entry(provider.to_string())
+            .or_insert_with(|| json!({}));
+        if !provider_value.is_object() {
+            *provider_value = json!({});
+        }
+        provider_value
+            .as_object_mut()
+            .expect("provider options normalized to an object")
+            .insert("reasoning_effort".into(), Value::String(effort.to_string()));
+    }
+
+    /// Frozen session-manager metadata consumed by Console and other clients.
+    pub fn session_metadata(&self) -> Value {
+        let mut value =
+            serde_json::to_value(&self.identity).expect("agent identity always serializes");
+        let object = value
+            .as_object_mut()
+            .expect("agent identity serializes as an object");
+        if let Some(model) = &self.model {
+            object.insert("model".into(), Value::String(model.clone()));
+        }
+        if let Some(reasoning_effort) = &self.reasoning_effort {
+            object.insert(
+                "reasoning_effort".into(),
+                Value::String(reasoning_effort.clone()),
+            );
+        }
+        value
     }
 }
 
@@ -140,7 +234,8 @@ mod tests {
                 "name": "Tech Leader",
                 "system_prompt": "Delegate everything.",
                 "skills": [],
-                "model": "codex/gpt-5.4",
+                "model": "openai-codex::codex/gpt-5.4",
+                "reasoning_effort": "ultra",
                 "icon": "agent",
                 "color": "purple",
             })),
@@ -148,9 +243,36 @@ mod tests {
         assert_eq!(agent.prompt, "You are Tech Leader.\n\nDelegate everything.");
         assert_eq!(agent.skills, None, "empty filter means every skill");
         assert_eq!(agent.identity.id, "tech-leader");
+        assert_eq!(agent.identity.name.as_deref(), Some("Tech Leader"));
+        assert_eq!(agent.identity.icon.as_deref(), Some("agent"));
+        assert_eq!(agent.identity.color.as_deref(), Some("purple"));
         assert_eq!(agent.icon, Some(SubagentIcon::Agent));
         assert_eq!(agent.color, Some(SubagentColor::Purple));
-        assert_eq!(agent.model.as_deref(), Some("codex/gpt-5.4"));
+        assert_eq!(
+            agent.model_and_provider(),
+            Some(("codex/gpt-5.4".into(), Some("openai-codex".into())))
+        );
+        assert_eq!(agent.reasoning_effort.as_deref(), Some("ultra"));
+        assert_eq!(
+            agent.session_metadata(),
+            serde_json::json!({
+                "id": "tech-leader",
+                "name": "Tech Leader",
+                "icon": "agent",
+                "color": "purple",
+                "model": "openai-codex::codex/gpt-5.4",
+                "reasoning_effort": "ultra",
+            })
+        );
+
+        let mut thinking = Some(ThinkingLevel::Low);
+        let mut provider_options = None;
+        agent.apply_reasoning(Some("openai-codex"), &mut thinking, &mut provider_options);
+        assert_eq!(thinking, None, "native-only effort has no enum fallback");
+        assert_eq!(
+            provider_options.unwrap()["openai-codex"],
+            serde_json::json!({ "reasoning_effort": "ultra" })
+        );
     }
 
     #[test]

--- a/harness/src/clients/session.rs
+++ b/harness/src/clients/session.rs
@@ -256,6 +256,22 @@ impl SessionClient {
             .ok_or_else(|| HarnessError::Dependency("session::create: no session_id".into()))
     }
 
+    /// Replace one session's metadata after the caller has merged against an
+    /// authoritative read. `session::set-meta` is whole-object replacement,
+    /// so accepting the complete map here makes that hazard explicit.
+    pub async fn set_metadata(
+        &self,
+        session_id: &str,
+        metadata: serde_json::Map<String, Value>,
+    ) -> Result<(), HarnessError> {
+        self.call(
+            "session::set-meta",
+            json!({ "session_id": session_id, "metadata": metadata }),
+        )
+        .await?;
+        Ok(())
+    }
+
     /// Set the coarse session status (idle/working/done/error).
     pub async fn set_status(
         &self,

--- a/harness/src/functions/send.rs
+++ b/harness/src/functions/send.rs
@@ -122,10 +122,11 @@ pub struct SendRequest {
     /// The incoming message; a string is sugar for a user text message. The
     /// role must be `user` or `custom`.
     pub message: MessageInput,
-    /// Required to start a NEW session. Steering or waking an EXISTING
-    /// session may omit it — the session's last turn's model (and provider,
-    /// unless overridden) is inherited, the same rule the notification
-    /// inject path uses.
+    /// Required to start a NEW session unless `options.agent` supplies a
+    /// model. Steering or waking an EXISTING session may omit it — the
+    /// session's last turn's model (and provider, unless overridden) is
+    /// inherited, the same rule the notification inject path uses. A model
+    /// declared by the selected agent profile is authoritative.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -243,27 +244,33 @@ async fn start_with_delivery_lock(
     // and a failed resolve must leave no session or budget ledger behind.
     let agent = resolve_send_agent(deps, &cfg, &req, prev.as_ref()).await?;
 
-    let (model, provider) = match (
-        req.model
-            .clone()
-            .or_else(|| agent.as_ref().and_then(|a| a.model.clone())),
-        &prev,
-    ) {
-        (Some(m), _) => (m, req.provider.clone()),
-        (None, Some(prev)) => (
+    // A profile-associated model is authoritative for that profile. Console
+    // locks its picker to the same value, while this server-side precedence
+    // keeps non-Console callers from accidentally running the identity on a
+    // different model. Catalog keys may carry `provider::model`; split them
+    // before routing.
+    let agent_route = agent
+        .as_ref()
+        .and_then(|profile| profile.model_and_provider());
+    let (model, provider) = match (agent_route, req.model.clone(), &prev) {
+        (Some((model, profile_provider)), _, _) => {
+            (model, profile_provider.or_else(|| req.provider.clone()))
+        }
+        (None, Some(model), _) => (model, req.provider.clone()),
+        (None, None, Some(prev)) => (
             prev.options.model.clone(),
             req.provider
                 .clone()
                 .or_else(|| prev.options.provider.clone()),
         ),
-        (None, None) if req.session_id.is_some() => {
+        (None, None, None) if req.session_id.is_some() => {
             return Err(HarnessError::InvalidRequest(
                 "harness::send without `model` inherits from the session's prior \
                  turn, but this session has none — name a `model`"
                     .into(),
             ))
         }
-        (None, None) => {
+        (None, None, None) => {
             return Err(HarnessError::InvalidRequest(
                 "harness::send creating a NEW session requires `model` (steering an \
                  existing session may omit it)"
@@ -310,11 +317,23 @@ async fn start_with_delivery_lock(
         .as_ref()
         .map(|s| (s.title.clone(), s.metadata.clone()))
         .unwrap_or((None, None));
+    let metadata = session_metadata_with_agent(metadata, agent.as_ref());
     let session_id = match &req.session_id {
         Some(id) => {
-            session
+            let ensured = session
                 .ensure(id, title.as_deref(), metadata.as_ref())
                 .await?;
+            // Console materialises its draft before calling harness::send, so
+            // ensure cannot apply the authoritative Directory snapshot on
+            // creation. Merge it into the stored whole-object metadata once.
+            if let Some(agent) = agent.as_ref() {
+                let snapshot = agent.session_metadata();
+                if ensured.metadata.get("agent_profile") != Some(&snapshot) {
+                    let mut stored = ensured.metadata;
+                    stored.insert("agent_profile".into(), snapshot);
+                    session.set_metadata(id, stored).await?;
+                }
+            }
             id.clone()
         }
         None => session.create(title.as_deref(), metadata.as_ref()).await?,
@@ -753,6 +772,15 @@ fn build_options(
 ) -> TurnOptions {
     let opts = req.options.clone().unwrap_or_default();
     let functions = clamp_for_mode(cfg, opts.mode, opts.functions);
+    let mut thinking_level = opts.thinking_level;
+    let mut provider_options = opts.provider_options;
+    if let Some(agent) = agent {
+        agent.apply_reasoning(
+            provider.as_deref(),
+            &mut thinking_level,
+            &mut provider_options,
+        );
+    }
     TurnOptions {
         model,
         provider,
@@ -781,8 +809,8 @@ fn build_options(
         max_total_tokens: opts.max_total_tokens,
         max_cost_usd: opts.max_cost_usd,
         budget_root_session_id: None,
-        thinking_level: opts.thinking_level,
-        provider_options: opts.provider_options,
+        thinking_level,
+        provider_options,
         output: opts.output.unwrap_or_default(),
         functions,
         metadata: opts.metadata,
@@ -792,6 +820,22 @@ fn build_options(
             .unwrap_or(cfg.max_validation_retries),
         max_transient_resumes: cfg.max_transient_resumes,
     }
+}
+
+/// Merge the frozen agent display/configuration snapshot into session
+/// metadata without disturbing console-owned or tenancy keys.
+pub(crate) fn session_metadata_with_agent(
+    metadata: Option<Value>,
+    agent: Option<&crate::agents::ResolvedAgent>,
+) -> Option<Value> {
+    let Some(agent) = agent else {
+        return metadata;
+    };
+    let mut object = metadata
+        .and_then(|value| value.as_object().cloned())
+        .unwrap_or_default();
+    object.insert("agent_profile".into(), agent.session_metadata());
+    Some(Value::Object(object))
 }
 
 /// The single chokepoint for the ask-mode policy cap:
@@ -2125,10 +2169,14 @@ mod tests {
         crate::agents::ResolvedAgent {
             identity: crate::types::turn::AgentIdentity {
                 id: "tech-leader".into(),
+                name: Some("Tech Leader".into()),
+                icon: None,
+                color: None,
             },
             prompt: "You are Tech Leader.\n\nDelegate everything.".into(),
             skills: Some(vec!["review".into()]),
             model: model.map(str::to_string),
+            reasoning_effort: None,
             name: "Tech Leader".into(),
             icon: None,
             color: None,
@@ -2208,6 +2256,53 @@ mod tests {
         );
         assert!(prompt.ends_with("You are Tech Leader.\n\nDelegate everything."));
         assert_eq!(opts.agent, Some(agent.identity));
+    }
+
+    #[test]
+    fn build_options_applies_the_profile_reasoning_effort_exactly() {
+        let cfg = WorkerConfig::default();
+        let req = agent_send_request(SendOptions {
+            agent: Some("tech-leader".into()),
+            thinking_level: Some(ThinkingLevel::Low),
+            ..Default::default()
+        });
+        let mut agent = resolved_agent(Some("openai-codex::codex/gpt-5.6-sol"));
+        agent.reasoning_effort = Some("high".into());
+        let opts = build_options(
+            &cfg,
+            &req,
+            "codex/gpt-5.6-sol".into(),
+            Some("openai-codex".into()),
+            Some(&agent),
+        );
+        assert_eq!(opts.thinking_level, Some(ThinkingLevel::High));
+        assert_eq!(
+            opts.provider_options.unwrap()["openai-codex"],
+            serde_json::json!({ "reasoning_effort": "high" })
+        );
+    }
+
+    #[test]
+    fn agent_session_metadata_preserves_existing_keys() {
+        let mut agent = resolved_agent(Some("openai-codex::codex/gpt-5.6-sol"));
+        agent.reasoning_effort = Some("high".into());
+        let metadata = session_metadata_with_agent(
+            Some(serde_json::json!({
+                "surface": "console",
+                "fs_scope": { "root": "/workspace" },
+            })),
+            Some(&agent),
+        )
+        .unwrap();
+
+        assert_eq!(metadata["surface"], "console");
+        assert_eq!(metadata["fs_scope"]["root"], "/workspace");
+        assert_eq!(metadata["agent_profile"]["id"], "tech-leader");
+        assert_eq!(
+            metadata["agent_profile"]["model"],
+            "openai-codex::codex/gpt-5.6-sol"
+        );
+        assert_eq!(metadata["agent_profile"]["reasoning_effort"], "high");
     }
 
     #[test]

--- a/harness/src/functions/send.rs
+++ b/harness/src/functions/send.rs
@@ -45,8 +45,8 @@ pub struct SendOptions {
     /// enrich system prompt, its skill filter the session's skill selection,
     /// its `model` the fallback when this send names none, and its identity
     /// sticks like the system prompt (later sends inherit; naming an explicit
-    /// prompt field sheds it). Refused on an existing session, combined with
-    /// either prompt field, or naming a `leaf` profile (a spawn target).
+    /// prompt field sheds it). Refused on an existing session or combined
+    /// with either prompt field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -941,8 +941,7 @@ fn inherit_prior_system_prompt(options: &mut TurnOptions, prev: &TurnOptions) {
 }
 
 /// Resolve `options.agent` for this send, or `None` when absent. Validation
-/// happens before any session/budget side effects; the fetched profile is
-/// checked by [`validate_resolved_agent`].
+/// happens before any session/budget side effects.
 async fn resolve_send_agent(
     deps: &Deps,
     cfg: &WorkerConfig,
@@ -952,9 +951,7 @@ async fn resolve_send_agent(
     let Some(id) = agent_send_id(req.options.as_ref(), prev.is_some())? else {
         return Ok(None);
     };
-    let agent = crate::agents::resolve(deps, cfg, id).await?;
-    validate_resolved_agent(&agent)?;
-    Ok(Some(agent))
+    crate::agents::resolve(deps, cfg, id).await.map(Some)
 }
 
 /// The pre-fetch half of agent-send validation: which id (if any) this send
@@ -969,30 +966,18 @@ fn agent_send_id(
     if has_prev {
         return Err(HarnessError::InvalidRequest(
             "`options.agent` applies only when starting a session; later sends inherit the \
-             frozen identity — start a new session to run as a different agent"
+             frozen identity — start a new session to use a different agent profile"
                 .into(),
         ));
     }
     if !prompt_fields_omitted(options) {
         return Err(HarnessError::InvalidRequest(
-            "`options.agent` supplies the system prompt; drop `system_prompt` / \
+            "`options.agent` selects an agent profile that supplies the system prompt; drop `system_prompt` / \
              `system_prompt_strategy` or drop `agent`"
                 .into(),
         ));
     }
     Ok(Some(id))
-}
-
-/// The IO-free half of send-side agent validation.
-fn validate_resolved_agent(agent: &crate::agents::ResolvedAgent) -> Result<(), HarnessError> {
-    if agent.leaf {
-        return Err(HarnessError::InvalidRequest(format!(
-            "agent `{}` is `leaf: true` — a spawn target, not a session identity; pass it to \
-             `harness::spawn` as `agent` instead",
-            agent.identity.id
-        )));
-    }
-    Ok(())
 }
 
 /// A send whose metadata does not name the `fs_scope` key inherits the prior
@@ -2136,7 +2121,7 @@ mod tests {
         );
     }
 
-    fn resolved_agent(leaf: bool, model: Option<&str>) -> crate::agents::ResolvedAgent {
+    fn resolved_agent(model: Option<&str>) -> crate::agents::ResolvedAgent {
         crate::agents::ResolvedAgent {
             identity: crate::types::turn::AgentIdentity {
                 id: "tech-leader".into(),
@@ -2146,7 +2131,7 @@ mod tests {
             model: model.map(str::to_string),
             name: "Tech Leader".into(),
             icon: None,
-            leaf,
+            color: None,
         }
     }
 
@@ -2208,20 +2193,13 @@ mod tests {
     }
 
     #[test]
-    fn leaf_agents_are_refused_as_session_identities() {
-        let err = validate_resolved_agent(&resolved_agent(true, None)).unwrap_err();
-        assert!(err.to_string().contains("harness::spawn"), "{err}");
-        assert!(validate_resolved_agent(&resolved_agent(false, None)).is_ok());
-    }
-
-    #[test]
     fn build_options_applies_agent_prompt_and_identity() {
         let cfg = WorkerConfig::default();
         let req = agent_send_request(SendOptions {
             agent: Some("tech-leader".into()),
             ..Default::default()
         });
-        let agent = resolved_agent(false, None);
+        let agent = resolved_agent(None);
         let opts = build_options(&cfg, &req, "m".into(), None, Some(&agent));
         let prompt = opts.system_prompt.expect("agent prompt");
         assert!(
@@ -2235,7 +2213,7 @@ mod tests {
     #[test]
     fn agent_send_defaults_functions_to_the_configured_baseline() {
         let cfg = WorkerConfig::default();
-        let agent = resolved_agent(false, None);
+        let agent = resolved_agent(None);
         let req = agent_send_request(SendOptions {
             agent: Some("tech-leader".into()),
             ..Default::default()
@@ -2299,7 +2277,7 @@ mod tests {
     #[test]
     fn agent_identity_inherits_with_the_prompt_and_sheds_with_it() {
         let cfg = WorkerConfig::default();
-        let agent = resolved_agent(false, None);
+        let agent = resolved_agent(None);
         let req = agent_send_request(SendOptions {
             agent: Some("tech-leader".into()),
             ..Default::default()

--- a/harness/src/functions/spawn.rs
+++ b/harness/src/functions/spawn.rs
@@ -98,8 +98,7 @@ pub struct SpawnOptions {
     /// and `engine::registered-triggers::*`, so it performs its assignment and
     /// updates shared state without spawning, messaging sessions, or touching
     /// trigger registrations. `true` skips those denies; the child still never
-    /// exceeds its parent's policy. When the spawn names an `agent` profile
-    /// and this field is omitted, a non-leaf profile defaults it to `true`.
+    /// exceeds its parent's policy.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub orchestrator: Option<bool>,
     /// Fan-out guard for the child's own spawns.
@@ -121,11 +120,11 @@ pub struct SpawnRequest {
     /// db: "primary"`); the child cannot infer resources from the parent.
     pub task: MessageInput,
     /// Run the child as a directory agent profile (`directory::agents::*`
-    /// id) — typically a `leaf` specialist. The profile's body becomes the
-    /// child's enrich system prompt (over the sub-agent identity), its skill
+    /// id). The profile's body becomes the child's enrich system prompt
+    /// (over the sub-agent identity), its skill
     /// filter applies when `options.skills` is omitted, its `model` slots
     /// between an explicit `model` and the parent's, and its name/icon become
-    /// the display defaults. Which agent to name is the prompt's decision.
+    /// the display defaults. Which agent profile to name is the prompt's decision.
     /// Refused combined with `options.system_prompt`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent: Option<String>,

--- a/harness/src/subagent.rs
+++ b/harness/src/subagent.rs
@@ -259,10 +259,13 @@ async fn seed_child(
     };
     let display = normalize_display(merged_display(req.display.as_ref(), agent.as_ref()).as_ref())?;
 
-    let model = req
-        .model
-        .clone()
-        .or_else(|| agent.as_ref().and_then(|a| a.model.clone()))
+    let agent_route = agent
+        .as_ref()
+        .and_then(|profile| profile.model_and_provider());
+    let model = agent_route
+        .as_ref()
+        .map(|(model, _)| model.clone())
+        .or_else(|| req.model.clone())
         .or_else(|| parent_record.map(|p| p.options.model.clone()))
         .ok_or_else(|| {
             HarnessError::InvalidRequest(
@@ -272,9 +275,10 @@ async fn seed_child(
                     .into(),
             )
         })?;
-    let inherits_parent_model =
-        req.model.is_none() && agent.as_ref().is_none_or(|a| a.model.is_none());
-    let provider = child_provider(req, parent_record, inherits_parent_model);
+    let inherits_parent_model = req.model.is_none() && agent_route.is_none();
+    let provider = agent_route
+        .and_then(|(_, provider)| provider)
+        .or_else(|| child_provider(req, parent_record, inherits_parent_model));
     // Children get the embedded minimal sub-agent identity, never the
     // top-level orchestrator prompt: a child
     // knows its one task, its state destination, and nothing else — by
@@ -316,6 +320,15 @@ async fn seed_child(
     // session that a later call can reuse around the fan-out budget.
     let task = normalize_message(req.task.clone())?;
     let (entry_id, origin) = (Some(ids::spawn_entry_id()), Some(json!({ "spawn": true })));
+    let mut thinking_level = req.options.as_ref().and_then(|o| o.thinking_level);
+    let mut provider_options = None;
+    if let Some(agent) = agent.as_ref() {
+        agent.apply_reasoning(
+            provider.as_deref(),
+            &mut thinking_level,
+            &mut provider_options,
+        );
+    }
     let mut options = TurnOptions {
         model,
         provider,
@@ -351,8 +364,8 @@ async fn seed_child(
         max_cost_usd: parent_record.and_then(|p| p.options.max_cost_usd),
         budget_root_session_id: parent_record
             .and_then(|p| p.options.budget_root_session_id.clone()),
-        thinking_level: req.options.as_ref().and_then(|o| o.thinking_level),
-        provider_options: None,
+        thinking_level,
+        provider_options,
         output: req
             .options
             .as_ref()
@@ -384,11 +397,14 @@ async fn seed_child(
     // nests the child (no policy inheritance, no parent-call resolution).
     // `spawned_by` is always "agent": every spawn is a direct call now —
     // trigger delivery never creates an agent.
-    let linkage = child_session_metadata(
-        parent,
-        req.parent_session_id.as_deref(),
-        depth,
-        display.as_ref(),
+    let linkage = send::session_metadata_with_agent(
+        child_session_metadata(
+            parent,
+            req.parent_session_id.as_deref(),
+            depth,
+            display.as_ref(),
+        ),
+        agent.as_ref(),
     );
     let title = display.as_ref().map(|value| value.name.as_str());
     let mut reused = false;
@@ -1286,10 +1302,14 @@ mod tests {
         crate::agents::ResolvedAgent {
             identity: crate::types::turn::AgentIdentity {
                 id: name.to_lowercase(),
+                name: Some(name.to_string()),
+                icon: None,
+                color: None,
             },
             prompt: format!("You are {name}.\n\nWork."),
             skills: None,
             model: None,
+            reasoning_effort: None,
             name: name.to_string(),
             icon,
             color: None,

--- a/harness/src/subagent.rs
+++ b/harness/src/subagent.rs
@@ -238,9 +238,7 @@ async fn seed_child(
     let session = deps.session().await;
 
     // Resolve the agent profile (if named) before anything else fallible —
-    // an unknown id must not leave a session behind. Leaf profiles are the
-    // POINT here (specialists meant to be spawned), so unlike send there is
-    // no leaf refusal.
+    // an unknown id must not leave a session behind.
     let agent = match req.agent.as_deref() {
         Some(id) => {
             if req
@@ -285,10 +283,11 @@ async fn seed_child(
     // an `agent` profile enriches this same identity with its body.
     let identity = prompt::SUBAGENT;
 
-    let orchestrator = child_orchestrator(
-        req.options.as_ref().and_then(|o| o.orchestrator),
-        agent.as_ref(),
-    );
+    let orchestrator = req
+        .options
+        .as_ref()
+        .and_then(|o| o.orchestrator)
+        .unwrap_or(false);
 
     let functions = child_functions(
         cfg,
@@ -530,20 +529,10 @@ fn caller_holds_child_session_lock(
     parent_record.is_some_and(|parent| parent.session_id == child_session_id)
 }
 
-/// An unset `orchestrator` follows the profile: a non-leaf agent exists to
-/// delegate, so it gets the orchestration surface; a leaf (or no profile)
-/// stays a leaf. An explicit value always wins.
-fn child_orchestrator(
-    explicit: Option<bool>,
-    agent: Option<&crate::agents::ResolvedAgent>,
-) -> bool {
-    explicit.unwrap_or_else(|| agent.is_some_and(|a| !a.leaf))
-}
-
 /// Display defaults from the agent profile: no explicit display → the
-/// profile's name (truncated to the 48-char cap) and icon; an explicit
-/// display keeps its fields and only borrows the profile icon when it names
-/// none. Without a profile the request passes through untouched.
+/// profile's name (truncated to the 48-char cap), icon, and color; an explicit
+/// display keeps its fields and borrows profile appearance where fields are
+/// absent. Without a profile the request passes through untouched.
 fn merged_display(
     display: Option<&SubagentDisplay>,
     agent: Option<&crate::agents::ResolvedAgent>,
@@ -554,12 +543,13 @@ fn merged_display(
     match display {
         Some(d) => Some(SubagentDisplay {
             icon: d.icon.or(agent.icon),
+            color: d.color.or(agent.color),
             ..d.clone()
         }),
         None => Some(SubagentDisplay {
             name: agent.name.chars().take(48).collect(),
             icon: agent.icon,
-            color: None,
+            color: agent.color,
         }),
     }
 }
@@ -1292,11 +1282,7 @@ mod tests {
             .is_some_and(|message| message.contains("8 child sessions created this turn")));
     }
 
-    fn resolved_agent(
-        name: &str,
-        leaf: bool,
-        icon: Option<SubagentIcon>,
-    ) -> crate::agents::ResolvedAgent {
+    fn resolved_agent(name: &str, icon: Option<SubagentIcon>) -> crate::agents::ResolvedAgent {
         crate::agents::ResolvedAgent {
             identity: crate::types::turn::AgentIdentity {
                 id: name.to_lowercase(),
@@ -1306,31 +1292,20 @@ mod tests {
             model: None,
             name: name.to_string(),
             icon,
-            leaf,
+            color: None,
         }
     }
 
     #[test]
-    fn orchestrator_defaults_follow_the_profile() {
-        let lead = resolved_agent("Lead", false, None);
-        let coder = resolved_agent("Coder", true, None);
-        assert!(child_orchestrator(None, Some(&lead)));
-        assert!(!child_orchestrator(None, Some(&coder)));
-        assert!(!child_orchestrator(None, None));
-        // Explicit always wins, both directions.
-        assert!(!child_orchestrator(Some(false), Some(&lead)));
-        assert!(child_orchestrator(Some(true), Some(&coder)));
-    }
-
-    #[test]
     fn display_merges_profile_defaults_under_explicit_fields() {
-        let coder = resolved_agent("Coder", true, Some(SubagentIcon::Code));
+        let mut coder = resolved_agent("Coder", Some(SubagentIcon::Code));
+        coder.color = Some(SubagentColor::Purple);
         // No explicit display → full profile identity.
         let display = merged_display(None, Some(&coder)).unwrap();
         assert_eq!(display.name, "Coder");
         assert_eq!(display.icon, Some(SubagentIcon::Code));
-        assert_eq!(display.color, None);
-        // Explicit display keeps its fields, borrowing only a missing icon.
+        assert_eq!(display.color, Some(SubagentColor::Purple));
+        // Explicit display keeps its fields, borrowing missing profile fields.
         let explicit = SubagentDisplay {
             name: "Fixer".into(),
             icon: None,
@@ -1340,6 +1315,16 @@ mod tests {
         assert_eq!(display.name, "Fixer");
         assert_eq!(display.icon, Some(SubagentIcon::Code));
         assert_eq!(display.color, Some(SubagentColor::Blue));
+        let colorless = SubagentDisplay {
+            color: None,
+            ..explicit.clone()
+        };
+        assert_eq!(
+            merged_display(Some(&colorless), Some(&coder))
+                .unwrap()
+                .color,
+            Some(SubagentColor::Purple)
+        );
         let iconed = SubagentDisplay {
             icon: Some(SubagentIcon::Search),
             ..explicit.clone()
@@ -1352,7 +1337,7 @@ mod tests {
         assert_eq!(merged_display(None, None), None);
         assert_eq!(merged_display(Some(&explicit), None), Some(explicit));
         // Long profile names are truncated to the display cap, not rejected.
-        let long = resolved_agent(&"x".repeat(60), false, None);
+        let long = resolved_agent(&"x".repeat(60), None);
         let display = merged_display(None, Some(&long)).unwrap();
         assert_eq!(display.name.chars().count(), 48);
         assert!(normalize_display(Some(&display)).is_ok());

--- a/harness/src/types/turn.rs
+++ b/harness/src/types/turn.rs
@@ -88,10 +88,9 @@ pub struct SkillAck {
 /// The agent profile a turn runs as, frozen at resolution time
 /// (`options.agent` on `harness::send`, `agent` on `harness::spawn`). Only
 /// what later turn machinery needs survives here: the id for display and
-/// inheritance. Which agent a spawn may name is the prompt's decision — the
+/// inheritance. Which agent profile a spawn may name is the prompt's decision — the
 /// profile body steers it; nothing gates it. Directory edits after
-/// resolution never reach a live session. (Old records carrying the retired
-/// `delegates_to` key still deserialize; the key is ignored.)
+/// resolution never reach a live session.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct AgentIdentity {
     pub id: String,

--- a/harness/src/types/turn.rs
+++ b/harness/src/types/turn.rs
@@ -94,6 +94,14 @@ pub struct SkillAck {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct AgentIdentity {
     pub id: String,
+    /// Display name frozen with the profile so clients never need to resolve
+    /// the mutable Directory catalog to label an established session.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub icon: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub color: Option<String>,
 }
 
 /// Per-send options frozen onto the turn record when it is created; they
@@ -610,6 +618,9 @@ mod tests {
             .contains_key("agent"));
         r.options.agent = Some(AgentIdentity {
             id: "tech-leader".into(),
+            name: Some("Tech Leader".into()),
+            icon: Some("agent".into()),
+            color: Some("purple".into()),
         });
         let back: TurnRecord = serde_json::from_value(serde_json::to_value(&r).unwrap()).unwrap();
         assert_eq!(back, r);

--- a/harness/tests/golden/schemas/harness.send.json
+++ b/harness/tests/golden/schemas/harness.send.json
@@ -720,7 +720,7 @@
         "description": "The incoming message; a string is sugar for a user text message. The role must be `user` or `custom`."
       },
       "model": {
-        "description": "Required to start a NEW session. Steering or waking an EXISTING session may omit it — the session's last turn's model (and provider, unless overridden) is inherited, the same rule the notification inject path uses.",
+        "description": "Required to start a NEW session unless `options.agent` supplies a model. Steering or waking an EXISTING session may omit it — the session's last turn's model (and provider, unless overridden) is inherited, the same rule the notification inject path uses. A model declared by the selected agent profile is authoritative.",
         "type": [
           "string",
           "null"

--- a/harness/tests/golden/schemas/harness.send.json
+++ b/harness/tests/golden/schemas/harness.send.json
@@ -430,7 +430,7 @@
         "description": "Per-send options frozen onto the turn record (harness.md § `harness::send`).",
         "properties": {
           "agent": {
-            "description": "Run the session as a directory agent profile (`directory::agents::*` id). Session-creating sends only — the profile's body becomes the enrich system prompt, its skill filter the session's skill selection, its `model` the fallback when this send names none, and its identity sticks like the system prompt (later sends inherit; naming an explicit prompt field sheds it). Refused on an existing session, combined with either prompt field, or naming a `leaf` profile (a spawn target).",
+            "description": "Run the session as a directory agent profile (`directory::agents::*` id). Session-creating sends only — the profile's body becomes the enrich system prompt, its skill filter the session's skill selection, its `model` the fallback when this send names none, and its identity sticks like the system prompt (later sends inherit; naming an explicit prompt field sheds it). Refused on an existing session or combined with either prompt field.",
             "type": [
               "string",
               "null"

--- a/harness/tests/golden/schemas/harness.spawn.json
+++ b/harness/tests/golden/schemas/harness.spawn.json
@@ -493,7 +493,7 @@
             ]
           },
           "orchestrator": {
-            "description": "Grant this child the orchestration surface. Default false: a spawned child is a LEAF — its policy gains deny globs for `harness::spawn`, `harness::send`, `engine::register_trigger`, `engine::unregister_trigger` and `engine::registered-triggers::*`, so it performs its assignment and updates shared state without spawning, messaging sessions, or touching trigger registrations. `true` skips those denies; the child still never exceeds its parent's policy. When the spawn names an `agent` profile and this field is omitted, a non-leaf profile defaults it to `true`.",
+            "description": "Grant this child the orchestration surface. Default false: a spawned child is a LEAF — its policy gains deny globs for `harness::spawn`, `harness::send`, `engine::register_trigger`, `engine::unregister_trigger` and `engine::registered-triggers::*`, so it performs its assignment and updates shared state without spawning, messaging sessions, or touching trigger registrations. `true` skips those denies; the child still never exceeds its parent's policy.",
             "type": [
               "boolean",
               "null"
@@ -739,7 +739,7 @@
     },
     "properties": {
       "agent": {
-        "description": "Run the child as a directory agent profile (`directory::agents::*` id) — typically a `leaf` specialist. The profile's body becomes the child's enrich system prompt (over the sub-agent identity), its skill filter applies when `options.skills` is omitted, its `model` slots between an explicit `model` and the parent's, and its name/icon become the display defaults. Which agent to name is the prompt's decision. Refused combined with `options.system_prompt`.",
+        "description": "Run the child as a directory agent profile (`directory::agents::*` id). The profile's body becomes the child's enrich system prompt (over the sub-agent identity), its skill filter applies when `options.skills` is omitted, its `model` slots between an explicit `model` and the parent's, and its name/icon become the display defaults. Which agent profile to name is the prompt's decision. Refused combined with `options.system_prompt`.",
         "type": [
           "string",
           "null"

--- a/harness/tests/integration/src/scenarios/agent_identity.rs
+++ b/harness/tests/integration/src/scenarios/agent_identity.rs
@@ -1,13 +1,13 @@
 //! INT-026 — agent-profile identity, end to end (MOT-4485): a send naming
 //! `options.agent` (and OMITTING `options.functions`) runs as the directory
-//! profile, and delegation resolves spawn-side:
+//! profile, and the same profile resolution works spawn-side:
 //!   * the parent's prompt is the top-level identity ENRICHED with
 //!     `You are Lead.` + the profile body, resolved server-side from the
 //!     run's `agents/lead.md` — no prompt fields on the send;
 //!   * the omitted policy defaults to the configured baseline (`allow: *`),
 //!     which is what lets the spawn dispatch at all;
 //!   * the spawn (`agent: coder`) seeds a child whose prompt is the
-//!     sub-agent identity enriched with `You are Coder.` — the leaf profile
+//!     sub-agent identity enriched with `You are Coder.` — the coder profile
 //!     applied spawn-side, no `options.system_prompt` anywhere.
 //!
 //! The child runs in its own session (untracked by the floor); its generation
@@ -31,9 +31,8 @@ You are the integration lead. Delegate the task to your coder and report.
 
 const CODER_PROFILE: &str = "---
 name: Coder
-description: Implementation leaf test profile.
+description: Implementation test profile.
 icon: code
-leaf: true
 ---
 Do the one task you are given, then stop.
 ";
@@ -54,7 +53,7 @@ pub(super) fn scenario() -> ScenarioFixture {
         ID,
         "agent-identity",
         "A send running as a directory agent profile (no functions policy on the wire) \
-         delegates through harness::spawn: the leaf profile seeds the child with its own \
+         spawns through harness::spawn: the coder profile seeds the child with its own \
          enriched identity.",
         ScenarioDriver::Direct,
         model.clone(),

--- a/harness/tests/integration/src/scenarios/streamed_text.rs
+++ b/harness/tests/integration/src/scenarios/streamed_text.rs
@@ -37,6 +37,11 @@ pub(super) fn scenario() -> ScenarioFixture {
                 2,
             )),
     )
+    // Console E2E reuses this fixture for longer UI journeys (workspace
+    // persistence, reloads, multiple browsers, and responsive navigation).
+    // Keep the playground alive for those interactions after the turn itself
+    // has completed instead of applying the short direct-scenario default.
+    .scenario_timeout_ms(60_000)
     .verify(|run| {
         run.expect_assistant_texts([TEXT])?;
         run.expect_message_counts(1, 1, 0)?;
@@ -53,6 +58,7 @@ mod tests {
     #[test]
     fn stream_has_one_terminal_frame_and_matching_response() {
         let fixture = scenario();
+        assert_eq!(fixture.scenario.deadlines.scenario_ms, 60_000);
         let generation = &fixture.script.generations[0];
         assert_eq!(
             generation

--- a/iii-directory/README.md
+++ b/iii-directory/README.md
@@ -9,7 +9,7 @@ into five surfaces (all MCP-agnostic):
 |---|---|---|
 | **Skills** (`directory::skills::*`) | Enriched listing via `directory::skills::list` (`{ id, title, type, function_id, disable_model_invocation, description, bytes, modified_at }` per row), a single-skill reader `directory::skills::get { id }` returning `{ id, title, type, function_id, disable_model_invocation, path, body, modified_at }` (the full body instead of the list teaser), and `directory::skills::index` which renders a short per-worker overview document (one `## <title>` + first paragraph + `read more` link per `type: index` skill). Authored by `create`, edited by `update`, removed by `delete`. `title` prefers the YAML frontmatter `title:` (then `name:`) over the body H1; `type` is lifted from frontmatter `type:` (e.g. `index`, `how-to`, `reference`) and serialised as `null` when absent. System-installed agent skills under the read-only `agents_skills_folder` are served too (see [On-disk layout](#on-disk-layout)). | Orientation: "when and why to use my worker's tools" |
 | **System prompts** (`directory::system-prompts::*`) | Identity prompts listed by `list`, read by `get`, authored by `create`, edited by `update`, and removed by `delete`. The list response keeps its `prompts` field name. Stored under any `system-prompts/` path segment; `create` writes `<skills_folder>/system-prompts/<name>.md`. | What the chat's system-prompt picker offers as an identity prompt (enrich or replace) |
-| **Agents** (`directory::agents::*`) | Reusable agent profiles — a session identity whose file body is the system prompt, with display `name`, emoji `logo`, a `skills` filter and a `leaf` delegation flag in required frontmatter. `list` rows carry `{ id, name, description, logo, skill_count, modified_at }` and `get` adds `system_prompt` and `unknown_skills`. Stored as direct `<agents_folder>/<id>.md` files. See [Agent profile storage](../docs/architecture/agent-profile-storage.md). | A named identity a session runs as (`harness::send { options: { agent } }`) |
+| **Agent Profiles** (`directory::agents::*`) | Reusable session identities whose file body is the system prompt, with display `name`, emoji `logo`, a `skills` filter and an optional default `model` in required frontmatter. `list` rows carry `{ id, name, description, logo, skill_count, modified_at }` and `get` adds `system_prompt` and `unknown_skills`. Stored as direct `<agents_folder>/<id>.md` files. See [Agent profile storage](../docs/architecture/agent-profile-storage.md). | A named identity selected with `harness::send { options: { agent } }` |
 | **Search** (`directory::search_functions`) | One to six external capabilities → compact function-id candidates (installed, plus registry workers under `installable`), with a conditional pre-generate hint pointing agents at it. | "Which functions do I call for this task?" |
 | **Registry** (`directory::registry::*`) | HTTP proxy over `api.workers.iii.dev` with `workers::{list,info}`. Rows share the core `name` / `description` / `version` fields with the engine's `engine::workers::list` and add publication metadata (`type`, `config`, `supported_targets`, `total_downloads`, `dependencies`, optional `image`). `workers::list` is cursor-paginated with a server-authored page size. | "What's published in the public registry?" |
 
@@ -263,9 +263,9 @@ A few rules:
   and must declare a non-empty `name`
   (the display name — the id is always the file stem); `description` may
   be empty, `logo` is emoji-only (≤16 bytes, no path characters),
-  `skills:` filters the skill index (absent/empty = every skill),
-  `leaf:` marks an agent that may not delegate, and `model:` names a
-  default model id for sessions running as this agent (absent = the
+  `skills:` filters the skill index (absent/empty = every skill), and
+  `model:` names a
+  default model id for sessions using this profile (absent = the
   send decides; stored verbatim, resolved against the live model
   catalog where it is used). The body is the
   system prompt, verbatim. Unknown `skills` ids are
@@ -333,15 +333,15 @@ other adapter.
 | `directory::system-prompts::create` | Create a NEW system prompt file at `<skills_folder>/system-prompts/<name>.md` from full-file content: `{ name, content }`, where `content` is the FULL file including frontmatter. The frontmatter must carry a non-empty `description` (and a `name` matching the request, when declared) — the same rules `update` enforces. Refuses a `name` that already exists anywhere in the merged system-prompt scan, and a target path that already exists on disk even if the scanner would skip it. Atomic write; fans out `directory::system-prompts::on-change` with `op: "create"`. Returns `{ name, description, bytes, modified_at }`. |
 | `directory::system-prompts::delete` | Permanently remove one EXISTING system prompt file by `{ name }`. Resolves against the same merged scan as `list`/`get`, fans out `directory::system-prompts::on-change` with `op: "delete"`, and returns `{ name }`. |
 
-### `directory::agents::*` (filesystem reader + editor)
+### Agent Profiles — `directory::agents::*` (filesystem reader + editor)
 
 | Function ID | Description |
 |---|---|
 | `directory::agents::list` | Metadata-only listing of every fs-backed agent profile: `{ id, name, description, logo, skill_count, model, modified_at }` per row (`skill_count: null` = every skill; `model: null` = the send decides). |
-| `directory::agents::get` | Fetch one agent by `{ id }`: `system_prompt` (the file body), `skills` + `unknown_skills` (filter entries matching no visible skill — warnings), `leaf`, `model` (default model id, `null` = the send decides), and `modified_at`. Pass `raw: true` to additionally get the FULL on-disk file as `raw`. |
-| `directory::agents::update` | Overwrite one EXISTING agent file with new full-file content: `{ id, content }`. Same rules the scanner enforces (required frontmatter with non-empty `name`, emoji-only `logo`, non-empty body); the id stays the file stem. Atomic write; fans out `directory::agents::on-change` with `op: "update"`. |
-| `directory::agents::create` | Create a NEW agent at `<agents_folder>/<id>.md` from full-file content: `{ id, content }`. Refuses an `id` that already exists in the configured agent root, and a target path that already exists on disk even if the scanner would skip it. Atomic write; fans out `directory::agents::on-change` with `op: "create"`. Returns `{ id, name, description, logo, bytes, modified_at }`. |
-| `directory::agents::delete` | Permanently remove one EXISTING agent file by `{ id }`. Resolves against the same configured root as `list`/`get`, fans out `directory::agents::on-change` with `op: "delete"`, and returns `{ id }`. Sessions already running as the agent are unaffected. |
+| `directory::agents::get` | Fetch one agent profile by `{ id }`: `system_prompt` (the file body), `skills` + `unknown_skills` (filter entries matching no visible skill — warnings), `model` (default model id, `null` = the send decides), and `modified_at`. Pass `raw: true` to additionally get the FULL on-disk file as `raw`. |
+| `directory::agents::update` | Overwrite one EXISTING agent profile file with new full-file content: `{ id, content }`. Same rules the scanner enforces (required frontmatter with non-empty `name`, emoji-only `logo`, non-empty body); the id stays the file stem. Atomic write; fans out `directory::agents::on-change` with `op: "update"`. |
+| `directory::agents::create` | Create a NEW agent profile at `<agents_folder>/<id>.md` from full-file content: `{ id, content }`. Refuses an `id` that already exists in the configured agent-profile root, and a target path that already exists on disk even if the scanner would skip it. Atomic write; fans out `directory::agents::on-change` with `op: "create"`. Returns `{ id, name, description, logo, bytes, modified_at }`. |
+| `directory::agents::delete` | Permanently remove one EXISTING agent profile file by `{ id }`. Resolves against the same configured root as `list`/`get`, fans out `directory::agents::on-change` with `op: "delete"`, and returns `{ id }`. Sessions already using the profile are unaffected. |
 
 ### Engine introspection (native, plus one wrapper)
 

--- a/iii-directory/README.md
+++ b/iii-directory/README.md
@@ -9,7 +9,7 @@ into five surfaces (all MCP-agnostic):
 |---|---|---|
 | **Skills** (`directory::skills::*`) | Enriched listing via `directory::skills::list` (`{ id, title, type, function_id, disable_model_invocation, description, bytes, modified_at }` per row), a single-skill reader `directory::skills::get { id }` returning `{ id, title, type, function_id, disable_model_invocation, path, body, modified_at }` (the full body instead of the list teaser), and `directory::skills::index` which renders a short per-worker overview document (one `## <title>` + first paragraph + `read more` link per `type: index` skill). Authored by `create`, edited by `update`, removed by `delete`. `title` prefers the YAML frontmatter `title:` (then `name:`) over the body H1; `type` is lifted from frontmatter `type:` (e.g. `index`, `how-to`, `reference`) and serialised as `null` when absent. System-installed agent skills under the read-only `agents_skills_folder` are served too (see [On-disk layout](#on-disk-layout)). | Orientation: "when and why to use my worker's tools" |
 | **System prompts** (`directory::system-prompts::*`) | Identity prompts listed by `list`, read by `get`, authored by `create`, edited by `update`, and removed by `delete`. The list response keeps its `prompts` field name. Stored under any `system-prompts/` path segment; `create` writes `<skills_folder>/system-prompts/<name>.md`. | What the chat's system-prompt picker offers as an identity prompt (enrich or replace) |
-| **Agent Profiles** (`directory::agents::*`) | Reusable session identities whose file body is the system prompt, with display `name`, emoji `logo`, a `skills` filter and an optional default `model` in required frontmatter. `list` rows carry `{ id, name, description, logo, skill_count, modified_at }` and `get` adds `system_prompt` and `unknown_skills`. Stored as direct `<agents_folder>/<id>.md` files. See [Agent profile storage](../docs/architecture/agent-profile-storage.md). | A named identity selected with `harness::send { options: { agent } }` |
+| **Agent Profiles** (`directory::agents::*`) | Reusable session identities whose file body is the system prompt, with display `name`, emoji `logo`, a `skills` filter, and optional `model` + `reasoning_effort` in required frontmatter. `list` rows carry the display/configuration metadata and `get` adds `system_prompt` and `unknown_skills`. Stored as direct `<agents_folder>/<id>.md` files. See [Agent profile storage](../docs/architecture/agent-profile-storage.md). | A named identity selected with `harness::send { options: { agent } }` |
 | **Search** (`directory::search_functions`) | One to six external capabilities → compact function-id candidates (installed, plus registry workers under `installable`), with a conditional pre-generate hint pointing agents at it. | "Which functions do I call for this task?" |
 | **Registry** (`directory::registry::*`) | HTTP proxy over `api.workers.iii.dev` with `workers::{list,info}`. Rows share the core `name` / `description` / `version` fields with the engine's `engine::workers::list` and add publication metadata (`type`, `config`, `supported_targets`, `total_downloads`, `dependencies`, optional `image`). `workers::list` is cursor-paginated with a server-authored page size. | "What's published in the public registry?" |
 
@@ -264,10 +264,10 @@ A few rules:
   (the display name — the id is always the file stem); `description` may
   be empty, `logo` is emoji-only (≤16 bytes, no path characters),
   `skills:` filters the skill index (absent/empty = every skill), and
-  `model:` names a
-  default model id for sessions using this profile (absent = the
-  send decides; stored verbatim, resolved against the live model
-  catalog where it is used). The body is the
+  `model:` names a model id for sessions using this profile (absent = the
+  send decides), and optional `reasoning_effort:` names its provider-native
+  effort. Both are stored verbatim and resolved against the live model
+  catalog where they are used. The body is the
   system prompt, verbatim. Unknown `skills` ids are
   warnings surfaced by `get`, never load failures.
 - Under a skills root, files outside `prompts/`, `system-prompts/`, and
@@ -337,8 +337,8 @@ other adapter.
 
 | Function ID | Description |
 |---|---|
-| `directory::agents::list` | Metadata-only listing of every fs-backed agent profile: `{ id, name, description, logo, skill_count, model, modified_at }` per row (`skill_count: null` = every skill; `model: null` = the send decides). |
-| `directory::agents::get` | Fetch one agent profile by `{ id }`: `system_prompt` (the file body), `skills` + `unknown_skills` (filter entries matching no visible skill — warnings), `model` (default model id, `null` = the send decides), and `modified_at`. Pass `raw: true` to additionally get the FULL on-disk file as `raw`. |
+| `directory::agents::list` | Metadata-only listing of every fs-backed agent profile: `{ id, name, description, logo, skill_count, model, reasoning_effort, icon, color, modified_at }` per row (`skill_count: null` = every skill; `model: null` = the send decides). |
+| `directory::agents::get` | Fetch one agent profile by `{ id }`: `system_prompt` (the file body), `skills` + `unknown_skills` (filter entries matching no visible skill — warnings), `model` (`null` = the send decides), provider-native `reasoning_effort`, display `icon`/`color`, and `modified_at`. Pass `raw: true` to additionally get the FULL on-disk file as `raw`. |
 | `directory::agents::update` | Overwrite one EXISTING agent profile file with new full-file content: `{ id, content }`. Same rules the scanner enforces (required frontmatter with non-empty `name`, emoji-only `logo`, non-empty body); the id stays the file stem. Atomic write; fans out `directory::agents::on-change` with `op: "update"`. |
 | `directory::agents::create` | Create a NEW agent profile at `<agents_folder>/<id>.md` from full-file content: `{ id, content }`. Refuses an `id` that already exists in the configured agent-profile root, and a target path that already exists on disk even if the scanner would skip it. Atomic write; fans out `directory::agents::on-change` with `op: "create"`. Returns `{ id, name, description, logo, bytes, modified_at }`. |
 | `directory::agents::delete` | Permanently remove one EXISTING agent profile file by `{ id }`. Resolves against the same configured root as `list`/`get`, fans out `directory::agents::on-change` with `op: "delete"`, and returns `{ id }`. Sessions already using the profile are unaffected. |

--- a/iii-directory/skills/SKILL.md
+++ b/iii-directory/skills/SKILL.md
@@ -62,7 +62,7 @@ never appear in `index` and `update`/`delete` refuse them.
 - Do not put a skill id (`/`) in `agent_trigger`'s `function:` field, and do not pass a function id (`::`) to `directory::skills::get`.
 - System prompt files without a `description:` in frontmatter are silently skipped by `directory::system-prompts::list`.
 - Skills and system prompts share `skills_folder`; a `system-prompts/` path component selects the prompt family, other `prompts/` paths are ignored, and `agents/` is reserved. Agent profiles are direct `<agents_folder>/<id>.md` files.
-- An agent's `skills:` list is curation, not enforcement: it narrows what a skill index shows, grants no access, and unknown ids are reported by `get` as `unknown_skills` warnings rather than errors. `agents_folder` profiles are unrelated to the read-only `agents_skills_folder` (`~/.agents/skills`), which holds external tools' skills.
+- An agent profile's `skills:` list is curation, not enforcement: it narrows what a skill index shows, grants no access, and unknown ids are reported by `get` as `unknown_skills` warnings rather than errors. `agents_folder` profiles are unrelated to the read-only `agents_skills_folder` (`~/.agents/skills`), which holds external tools' skills.
 - Registry answers (`registry::workers::list` / `info`) are cached ~60 s per unique input by default (`registry_cache_ttl_ms`) — change a parameter to refresh.
 
 ## Functions
@@ -83,15 +83,15 @@ never appear in `index` and `update`/`delete` refuse them.
 - `directory::system-prompts::update` — overwrite one EXISTING system prompt; the frontmatter must keep a non-empty `description` (a declared `name` renames it).
 - `directory::system-prompts::delete` — permanently remove one EXISTING system prompt by name.
 - `directory::agents::list` — list agent profiles (id, display name, description, emoji logo, `skill_count` where null means every skill).
-- `directory::agents::get` — read one agent by id: its system prompt (the file body), skill filter + `unknown_skills`, `leaf`, and `model` (the agent's default model id — use it when spawning/sending as this agent; `null` = caller decides); `raw: true` as above.
-- `directory::agents::create` — create a NEW agent at `<agents_folder>/<id>.md` from full-file content; frontmatter needs a non-empty `name`, `logo` is emoji-only.
-- `directory::agents::update` — overwrite one EXISTING agent (same scanner rules; the id stays the file stem, frontmatter `name` is display-only).
-- `directory::agents::delete` — permanently remove one EXISTING agent by id; running sessions are unaffected.
+- `directory::agents::get` — read one agent profile by id: its system prompt (the file body), skill filter + `unknown_skills`, and `model` (the profile's default model id — use it when spawning/sending with this profile; `null` = caller decides); `raw: true` as above.
+- `directory::agents::create` — create a NEW agent profile at `<agents_folder>/<id>.md` from full-file content; frontmatter needs a non-empty `name`, `logo` is emoji-only.
+- `directory::agents::update` — overwrite one EXISTING agent profile (same scanner rules; the id stays the file stem, frontmatter `name` is display-only).
+- `directory::agents::delete` — permanently remove one EXISTING agent profile by id; running sessions are unaffected.
 - `directory::registry::workers::list` — page through published workers in the public registry (`pagination.next_cursor` feeds the next page's `cursor`).
 - `directory::registry::workers::info` — full registry detail for one worker, including ones not installed: `api_reference` (functions + triggers with schemas) and `skills_tree`.
 - `directory::engine::functions::info` — thin proxy to the engine's `engine::functions::info`; returns request/response schema, metadata, and registered triggers for one function id.
 
-A failed call returns one plain sentence carrying a `Did you mean:` suggestion and a `Next:` function to call (codes `D110`/`D112`/`D210`/`D310`/`D311`, `D410` for a missing agent, `D320` when the registry is unreachable, and on the write paths `D213` for content the next scan would skip, `D214`/`D114`/`D414` for a create whose name/id or target path is already taken, `D115` for a skill id the visibility filter or an agents namespace reserves, and `D116` for a write to a read-only system-installed skill) — follow it instead of retrying the same input. Downloads overwrite file-by-file, so hand-edited extra files survive a re-pull.
+A failed call returns one plain sentence carrying a `Did you mean:` suggestion and a `Next:` function to call (codes `D110`/`D112`/`D210`/`D310`/`D311`, `D410` for a missing agent profile, `D320` when the registry is unreachable, and on the write paths `D213` for content the next scan would skip, `D214`/`D114`/`D414` for a create whose name/id or target path is already taken, `D115` for a skill id the visibility filter or an agents namespace reserves, and `D116` for a write to a read-only system-installed skill) — follow it instead of retrying the same input. Downloads overwrite file-by-file, so hand-edited extra files survive a re-pull.
 
 ## Reactive triggers
 
@@ -110,7 +110,7 @@ Direct `<id>.md` profile edits under `agents_folder` fire
 
 Reach for it when:
 
-- A worker caches the skill, system-prompt, or agent list and must invalidate it on change.
+- A worker caches the skill, system-prompt, or agent-profile list and must invalidate it on change.
 - You want a push the moment new bundles install, instead of polling `directory::skills::list`.
 
 Do not bind when:

--- a/iii-directory/src/fs_source.rs
+++ b/iii-directory/src/fs_source.rs
@@ -449,12 +449,16 @@ pub struct FsAgent {
     pub logo: Option<String>,
     /// Skill-id filter. Empty = every skill.
     pub skills: Vec<String>,
-    /// Default model id for sessions running as this agent (a router
+    /// Model id for sessions running as this agent (a router
     /// model id, e.g. `codex/gpt-5.4-mini`). `None` = the send decides.
     /// Stored verbatim — whether the id resolves is checked where it is
     /// used (the harness / the UI's model catalog), not at scan time,
     /// so an agent never fails to load over a retired model.
     pub model: Option<String>,
+    /// Provider-native reasoning effort paired with `model` (for example
+    /// `high` or `ultra`). Stored verbatim for the same reason as the model:
+    /// the live model catalog is authoritative at use time.
+    pub reasoning_effort: Option<String>,
     /// Harness subagent icon token (one of [`AGENT_ICON_TOKENS`]) for
     /// spawn display identities. `None` = caller picks.
     pub icon: Option<String>,
@@ -476,6 +480,8 @@ pub struct AgentFrontmatter {
     pub skills: Vec<String>,
     #[serde(default)]
     pub model: Option<String>,
+    #[serde(default)]
+    pub reasoning_effort: Option<String>,
     #[serde(default)]
     pub icon: Option<String>,
     #[serde(default)]
@@ -635,6 +641,12 @@ pub fn scan_agents(root: &Path) -> (Vec<FsAgent>, Vec<SkipReason>) {
                 .as_deref()
                 .map(str::trim)
                 .filter(|m| !m.is_empty())
+                .map(str::to_string),
+            reasoning_effort: fm
+                .reasoning_effort
+                .as_deref()
+                .map(str::trim)
+                .filter(|effort| !effort.is_empty())
                 .map(str::to_string),
             icon: fm
                 .icon

--- a/iii-directory/src/fs_source.rs
+++ b/iii-directory/src/fs_source.rs
@@ -436,8 +436,8 @@ pub fn scan_system_prompts(skills_folder: &Path) -> (Vec<FsPrompt>, Vec<SkipReas
 // ───────────────────────── agents family ─────────────────────────────
 
 /// One filesystem-backed agent profile entry. Everything a `list` row
-/// or a delegation catalog needs is parsed at scan time; only the body
-/// (the system prompt) is re-read on `get`.
+/// needs is parsed at scan time; only the body (the system prompt) is
+/// re-read on `get`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FsAgent {
     /// Flat id: the file stem, validated like a prompt name.
@@ -449,8 +449,6 @@ pub struct FsAgent {
     pub logo: Option<String>,
     /// Skill-id filter. Empty = every skill.
     pub skills: Vec<String>,
-    /// `true` = this agent may not delegate at all.
-    pub leaf: bool,
     /// Default model id for sessions running as this agent (a router
     /// model id, e.g. `codex/gpt-5.4-mini`). `None` = the send decides.
     /// Stored verbatim — whether the id resolves is checked where it is
@@ -460,6 +458,9 @@ pub struct FsAgent {
     /// Harness subagent icon token (one of [`AGENT_ICON_TOKENS`]) for
     /// spawn display identities. `None` = caller picks.
     pub icon: Option<String>,
+    /// Harness subagent color token (one of [`AGENT_COLOR_TOKENS`]) for
+    /// display identities. `None` = neutral.
+    pub color: Option<String>,
     pub abs_path: PathBuf,
 }
 
@@ -474,11 +475,11 @@ pub struct AgentFrontmatter {
     #[serde(default)]
     pub skills: Vec<String>,
     #[serde(default)]
-    pub leaf: bool,
-    #[serde(default)]
     pub model: Option<String>,
     #[serde(default)]
     pub icon: Option<String>,
+    #[serde(default)]
+    pub color: Option<String>,
 }
 
 /// The harness `SubagentIcon` closed token set — `harness::spawn`
@@ -486,6 +487,12 @@ pub struct AgentFrontmatter {
 /// than letting a typo fail every future spawn.
 pub const AGENT_ICON_TOKENS: &[&str] = &[
     "agent", "code", "search", "terminal", "database", "test", "review", "docs", "design",
+];
+
+/// The harness `SubagentColor` closed token set. Keeping the directory
+/// validator in lock-step means saved profiles always render in the console.
+pub const AGENT_COLOR_TOKENS: &[&str] = &[
+    "neutral", "blue", "purple", "teal", "green", "amber", "rose",
 ];
 
 /// Max byte length for an emoji logo (a couple of emoji with modifiers).
@@ -519,6 +526,19 @@ pub fn parse_agent_frontmatter(content: &str) -> Result<AgentFrontmatter, String
             return Err(format!(
                 "`icon` must be one of {} (got {icon:?})",
                 AGENT_ICON_TOKENS.join(", ")
+            ));
+        }
+    }
+    if let Some(color) = fm
+        .color
+        .as_deref()
+        .map(str::trim)
+        .filter(|color| !color.is_empty())
+    {
+        if !AGENT_COLOR_TOKENS.contains(&color) {
+            return Err(format!(
+                "`color` must be one of {} (got {color:?})",
+                AGENT_COLOR_TOKENS.join(", ")
             ));
         }
     }
@@ -596,7 +616,7 @@ pub fn scan_agents(root: &Path) -> (Vec<FsAgent>, Vec<SkipReason>) {
             .unwrap_or("")
             .to_string();
         if let Err(e) = validate_name(&name) {
-            skip(format!("invalid agent id {name:?}: {e}"));
+            skip(format!("invalid agent profile id {name:?}: {e}"));
             continue;
         }
         agents.push(FsAgent {
@@ -610,7 +630,6 @@ pub fn scan_agents(root: &Path) -> (Vec<FsAgent>, Vec<SkipReason>) {
                 .to_string(),
             logo: fm.logo.map(|l| l.trim().to_string()),
             skills: fm.skills,
-            leaf: fm.leaf,
             model: fm
                 .model
                 .as_deref()
@@ -622,6 +641,12 @@ pub fn scan_agents(root: &Path) -> (Vec<FsAgent>, Vec<SkipReason>) {
                 .as_deref()
                 .map(str::trim)
                 .filter(|i| !i.is_empty())
+                .map(str::to_string),
+            color: fm
+                .color
+                .as_deref()
+                .map(str::trim)
+                .filter(|color| !color.is_empty())
                 .map(str::to_string),
             abs_path: abs,
         });
@@ -1773,7 +1798,7 @@ mod tests {
         write_fixture(
             tmp.path(),
             "captain.md",
-            "---\nname: Release Captain\ndescription: Cuts releases.\nlogo: \"🚢\"\nskills:\n  - iii-sandbox\nleaf: true\nmodel: codex/gpt-5.4-mini\n---\nYou are the captain.\n",
+            "---\nname: Release Captain\ndescription: Cuts releases.\nlogo: \"🚢\"\nskills:\n  - iii-sandbox\nmodel: codex/gpt-5.4-mini\n---\nYou are the captain.\n",
         );
         let (agents, skipped) = scan_agents(tmp.path());
         assert!(skipped.is_empty(), "unexpected skips: {skipped:?}");
@@ -1784,7 +1809,6 @@ mod tests {
         assert_eq!(a.description, "Cuts releases.");
         assert_eq!(a.logo.as_deref(), Some("🚢"));
         assert_eq!(a.skills, vec!["iii-sandbox".to_string()]);
-        assert!(a.leaf);
         assert_eq!(a.model.as_deref(), Some("codex/gpt-5.4-mini"));
     }
 
@@ -1798,7 +1822,6 @@ mod tests {
         assert_eq!(a.description, "");
         assert!(a.logo.is_none());
         assert!(a.skills.is_empty());
-        assert!(!a.leaf);
         assert!(a.model.is_none());
     }
 
@@ -1830,7 +1853,9 @@ mod tests {
             .any(|r| r.contains("missing YAML frontmatter")));
         assert!(reasons.iter().any(|r| r.contains("non-empty `name`")));
         assert!(reasons.iter().any(|r| r.contains("emoji only")));
-        assert!(reasons.iter().any(|r| r.contains("invalid agent id")));
+        assert!(reasons
+            .iter()
+            .any(|r| r.contains("invalid agent profile id")));
     }
 
     #[test]

--- a/iii-directory/src/functions/agents.rs
+++ b/iii-directory/src/functions/agents.rs
@@ -67,9 +67,12 @@ pub struct AgentEntry {
     /// Length of the agent profile's skill filter; `null` = no filter (every
     /// skill).
     pub skill_count: Option<usize>,
-    /// Default model id for sessions using this profile; `null` =
+    /// Model id for sessions using this profile; `null` =
     /// the send decides.
     pub model: Option<String>,
+    /// Provider-native reasoning effort paired with `model`; `null` = the
+    /// model/provider default.
+    pub reasoning_effort: Option<String>,
     /// Harness subagent icon token for spawn display identities;
     /// `null` = caller picks.
     pub icon: Option<String>,
@@ -108,10 +111,13 @@ pub struct AgentGetOutput {
     /// Filter entries that resolve to no currently visible skill.
     /// Warnings — the agent profile still loads.
     pub unknown_skills: Vec<String>,
-    /// Default model id for sessions using this profile; `null` =
+    /// Model id for sessions using this profile; `null` =
     /// the send decides. Served verbatim — resolution against the live
     /// model catalog happens where it is used.
     pub model: Option<String>,
+    /// Provider-native reasoning effort paired with `model`; `null` = the
+    /// model/provider default. Served verbatim and validated at use time.
+    pub reasoning_effort: Option<String>,
     /// Harness subagent icon token (closed set, validated at write
     /// time); `null` = caller picks.
     pub icon: Option<String>,
@@ -197,7 +203,7 @@ fn register_list(iii: &Arc<IIIClient>, cfg: &SharedConfig) {
         })
         .description(
             "List filesystem-backed agent profiles (id, display name, description, emoji \
-             logo, icon, color, model, skill_count, modified_at) from the configured \
+             logo, icon, color, model, reasoning_effort, skill_count, modified_at) from the configured \
              agents folder. An agent profile is a reusable session identity: its file body \
              is the system prompt. skill_count null = sessions using the profile can use \
              every skill.",
@@ -224,7 +230,7 @@ fn register_get(iii: &Arc<IIIClient>, cfg: &SharedConfig, cache: &Arc<Registered
             "Fetch one agent profile by id. Returns the system prompt (the file body, \
              frontmatter stripped), display name, description, emoji logo, the skill \
              filter plus unknown_skills (filter entries matching no visible skill — \
-             warnings, the profile still loads), \
+             warnings, the profile still loads), model, reasoning_effort, icon, color, \
              and modified_at. Pass raw: true to also get the exact on-disk file for \
              editing with directory::agents::update.",
         ),
@@ -336,6 +342,7 @@ pub fn list_agents(cfg: &SkillsConfig) -> ListAgentsOutput {
             modified_at: fs_modified_at(&a.abs_path),
             skill_count: (!a.skills.is_empty()).then_some(a.skills.len()),
             model: a.model,
+            reasoning_effort: a.reasoning_effort,
             icon: a.icon,
             color: a.color,
             id: a.name,
@@ -384,6 +391,7 @@ pub fn get_agent(
         skills: agent.skills,
         unknown_skills,
         model: agent.model,
+        reasoning_effort: agent.reasoning_effort,
         icon: agent.icon,
         color: agent.color,
         raw,
@@ -543,7 +551,7 @@ mod tests {
     use super::*;
     use std::path::{Path, PathBuf};
 
-    const CAPTAIN: &str = "---\nname: Release Captain\ndescription: Cuts releases.\nlogo: \"🚢\"\nskills:\n  - iii-sandbox\n  - agent-memory/observe\nmodel: codex/gpt-5.4-mini\nicon: search\ncolor: purple\n---\nYou are the release captain.\n";
+    const CAPTAIN: &str = "---\nname: Release Captain\ndescription: Cuts releases.\nlogo: \"🚢\"\nskills:\n  - iii-sandbox\n  - agent-memory/observe\nmodel: codex/gpt-5.4-mini\nreasoning_effort: high\nicon: search\ncolor: purple\n---\nYou are the release captain.\n";
 
     fn write_fixture(dir: &Path, rel: &str, contents: &str) {
         let path = dir.join(rel);
@@ -590,6 +598,7 @@ mod tests {
         assert_eq!(row.logo.as_deref(), Some("🚢"));
         assert_eq!(row.skill_count, Some(2));
         assert_eq!(row.model.as_deref(), Some("codex/gpt-5.4-mini"));
+        assert_eq!(row.reasoning_effort.as_deref(), Some("high"));
         assert_eq!(row.icon.as_deref(), Some("search"));
         assert_eq!(row.color.as_deref(), Some("purple"));
 
@@ -608,6 +617,7 @@ mod tests {
         assert_eq!(got.system_prompt.trim(), "You are the release captain.");
         assert_eq!(got.unknown_skills, vec!["agent-memory/observe".to_string()]);
         assert_eq!(got.model.as_deref(), Some("codex/gpt-5.4-mini"));
+        assert_eq!(got.reasoning_effort.as_deref(), Some("high"));
         assert_eq!(got.icon.as_deref(), Some("search"));
         assert_eq!(got.color.as_deref(), Some("purple"));
         assert_eq!(got.raw.as_deref(), Some(CAPTAIN));

--- a/iii-directory/src/functions/agents.rs
+++ b/iii-directory/src/functions/agents.rs
@@ -1,13 +1,13 @@
 //! Filesystem-backed agent profiles (`directory::agents::*`).
 //!
-//! An agent is a reusable identity a session runs as: a system prompt
+//! An agent profile is a reusable identity selected for a session: a system prompt
 //! (the file body), a display name, a description, an emoji logo, and a
 //! skill filter — one direct `<agents_folder>/<id>.md` file with required
 //! YAML frontmatter (see `docs/architecture/agent-profile-storage.md`).
 //! Five filesystem-backed verbs:
 //!
 //!   * `directory::agents::list`   — metadata-only listing.
-//!   * `directory::agents::get`    — one agent's system prompt + metadata,
+//!   * `directory::agents::get`    — one agent profile's system prompt + metadata,
 //!     plus `unknown_skills` (ids that resolve to nothing — warnings,
 //!     never load failures).
 //!   * `directory::agents::create` / `update` / `delete` — full-file
@@ -38,12 +38,15 @@ use crate::trigger_types;
 /// Recovery pointer attached to a `directory::agents::get` / write miss.
 const AGENT_NOT_FOUND_NEXT: &[NextAction] = &[NextAction::new(
     "directory::agents::list",
-    "browse agent ids",
+    "browse agent profile ids",
 )];
 
 const AGENT_CREATE_CONFLICT_NEXT: &[NextAction] = &[
-    NextAction::new("directory::agents::update", "edit the existing agent"),
-    NextAction::new("directory::agents::list", "browse agent ids"),
+    NextAction::new(
+        "directory::agents::update",
+        "edit the existing agent profile",
+    ),
+    NextAction::new("directory::agents::list", "browse agent profile ids"),
 ];
 
 // ---------- wire shapes ----------
@@ -53,26 +56,26 @@ struct ListAgentsInput {}
 
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct AgentEntry {
-    /// Flat agent id (the file stem) — what `harness::send { options:
+    /// Flat agent profile id (the file stem) — what `harness::send { options:
     /// { agent } }` will take.
     pub id: String,
     /// Display name from frontmatter (`name:`).
     pub name: String,
     pub description: String,
-    /// Emoji logo, `null` when the agent has none.
+    /// Emoji logo, `null` when the agent profile has none.
     pub logo: Option<String>,
-    /// Length of the agent's skill filter; `null` = no filter (every
+    /// Length of the agent profile's skill filter; `null` = no filter (every
     /// skill).
     pub skill_count: Option<usize>,
-    /// Default model id for sessions running as this agent; `null` =
+    /// Default model id for sessions using this profile; `null` =
     /// the send decides.
     pub model: Option<String>,
     /// Harness subagent icon token for spawn display identities;
     /// `null` = caller picks.
     pub icon: Option<String>,
-    /// `true` = this agent may not delegate — a specialist meant to be
-    /// spawned by an orchestrator, not to front a session.
-    pub leaf: bool,
+    /// Harness subagent color token for display identities; `null` =
+    /// neutral.
+    pub color: Option<String>,
     /// File mtime as RFC 3339.
     pub modified_at: String,
 }
@@ -103,17 +106,18 @@ pub struct AgentGetOutput {
     /// The frontmatter skill filter. Empty = every skill.
     pub skills: Vec<String>,
     /// Filter entries that resolve to no currently visible skill.
-    /// Warnings — the agent still loads and runs.
+    /// Warnings — the agent profile still loads.
     pub unknown_skills: Vec<String>,
-    /// `true` = this agent may not delegate at all.
-    pub leaf: bool,
-    /// Default model id for sessions running as this agent; `null` =
+    /// Default model id for sessions using this profile; `null` =
     /// the send decides. Served verbatim — resolution against the live
     /// model catalog happens where it is used.
     pub model: Option<String>,
     /// Harness subagent icon token (closed set, validated at write
     /// time); `null` = caller picks.
     pub icon: Option<String>,
+    /// Harness subagent color token (closed set, validated at write
+    /// time); `null` = neutral.
+    pub color: Option<String>,
     /// FULL on-disk file content. Present only when the request set
     /// `raw: true`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -124,9 +128,9 @@ pub struct AgentGetOutput {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct AgentCreateInput {
-    /// New agent id — becomes the file stem
+    /// New agent profile id — becomes the file stem
     /// (`<agents_folder>/<id>.md`). Lowercase ASCII, digits,
-    /// `-` and `_` only. Must not collide with an existing agent or an
+    /// `-` and `_` only. Must not collide with an existing agent profile or an
     /// on-disk file at the target path.
     pub id: String,
     /// FULL file content, frontmatter block included. Frontmatter must
@@ -137,7 +141,7 @@ pub struct AgentCreateInput {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct AgentUpdateInput {
-    /// Existing agent id, as returned by `directory::agents::list`.
+    /// Existing agent profile id, as returned by `directory::agents::list`.
     pub id: String,
     /// FULL new file content, frontmatter block included — the string
     /// `directory::agents::get { raw: true }` returns, edited.
@@ -159,7 +163,7 @@ pub struct AgentWriteOutput {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct AgentDeleteInput {
-    /// Existing agent id, as returned by `directory::agents::list`.
+    /// Existing agent profile id, as returned by `directory::agents::list`.
     pub id: String,
 }
 
@@ -193,9 +197,10 @@ fn register_list(iii: &Arc<IIIClient>, cfg: &SharedConfig) {
         })
         .description(
             "List filesystem-backed agent profiles (id, display name, description, emoji \
-             logo, skill_count, modified_at) from the configured agents folder. An agent \
-             is a reusable session identity: its file body is the \
-             system prompt. skill_count null = the agent uses every skill.",
+             logo, icon, color, model, skill_count, modified_at) from the configured \
+             agents folder. An agent profile is a reusable session identity: its file body \
+             is the system prompt. skill_count null = sessions using the profile can use \
+             every skill.",
         ),
     );
 }
@@ -219,7 +224,7 @@ fn register_get(iii: &Arc<IIIClient>, cfg: &SharedConfig, cache: &Arc<Registered
             "Fetch one agent profile by id. Returns the system prompt (the file body, \
              frontmatter stripped), display name, description, emoji logo, the skill \
              filter plus unknown_skills (filter entries matching no visible skill — \
-             warnings, the agent still runs), leaf, \
+             warnings, the profile still loads), \
              and modified_at. Pass raw: true to also get the exact on-disk file for \
              editing with directory::agents::update.",
         ),
@@ -251,7 +256,7 @@ fn register_create(iii: &Arc<IIIClient>, cfg: &SharedConfig, subs: &trigger_type
              or a target path that already exists on disk. The write is atomic and \
              fans out directory::agents::on-change with { op: \"create\" }.",
         )
-        .metadata(json!({"tool": {"label": "Create agent"}})),
+        .metadata(json!({"tool": {"label": "Create agent profile"}})),
     );
 }
 
@@ -276,11 +281,11 @@ fn register_update(iii: &Arc<IIIClient>, cfg: &SharedConfig, subs: &trigger_type
             "Overwrite one EXISTING agent profile with new full-file markdown content — \
              the same rules the scanner enforces (required frontmatter with a non-empty \
              `name`, emoji-only `logo`, non-empty body), so an update can never produce \
-             a file the next directory::agents::list would skip. The agent id stays the \
+             a file the next directory::agents::list would skip. The agent profile id stays the \
              file stem; frontmatter `name` is only the display name. The write is atomic \
              and fans out directory::agents::on-change with { op: \"update\" }.",
         )
-        .metadata(json!({"tool": {"label": "Update agent"}})),
+        .metadata(json!({"tool": {"label": "Update agent profile"}})),
     );
 }
 
@@ -303,12 +308,12 @@ fn register_delete(iii: &Arc<IIIClient>, cfg: &SharedConfig, subs: &trigger_type
         })
         .description(
             "Permanently delete one EXISTING agent profile by id. Resolves against the \
-             same merged scan as directory::agents::list, removes only that agent's \
+             same merged scan as directory::agents::list, removes only that profile's \
              markdown file, and fans out directory::agents::on-change with \
-             { op: \"delete\" }. Sessions already running as this agent are not \
+             { op: \"delete\" }. Sessions already using this profile are not \
              affected; the id just stops resolving for new sends.",
         )
-        .metadata(json!({"tool": {"label": "Delete agent"}})),
+        .metadata(json!({"tool": {"label": "Delete agent profile"}})),
     );
 }
 
@@ -332,7 +337,7 @@ pub fn list_agents(cfg: &SkillsConfig) -> ListAgentsOutput {
             skill_count: (!a.skills.is_empty()).then_some(a.skills.len()),
             model: a.model,
             icon: a.icon,
-            leaf: a.leaf,
+            color: a.color,
             id: a.name,
             name: a.display_name,
             description: a.description,
@@ -378,9 +383,9 @@ pub fn get_agent(
         system_prompt: body,
         skills: agent.skills,
         unknown_skills,
-        leaf: agent.leaf,
         model: agent.model,
         icon: agent.icon,
+        color: agent.color,
         raw,
     })
 }
@@ -404,7 +409,7 @@ pub fn create_agent(
         };
         return Err(invalid_input_message(
             "D414",
-            &format!("agent {:?} already exists{origin}.", req.id),
+            &format!("agent profile {:?} already exists{origin}.", req.id),
             AGENT_CREATE_CONFLICT_NEXT,
         ));
     }
@@ -495,7 +500,13 @@ fn agent_not_found(agents: &[FsAgent], missed: &str) -> String {
         .collect();
     scored.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(b.1)));
     let candidates: Vec<String> = scored.into_iter().take(3).map(|(_, n)| n.clone()).collect();
-    not_found_message("D410", "agent", missed, &candidates, AGENT_NOT_FOUND_NEXT)
+    not_found_message(
+        "D410",
+        "agent profile",
+        missed,
+        &candidates,
+        AGENT_NOT_FOUND_NEXT,
+    )
 }
 
 fn write_output(
@@ -532,7 +543,7 @@ mod tests {
     use super::*;
     use std::path::{Path, PathBuf};
 
-    const CAPTAIN: &str = "---\nname: Release Captain\ndescription: Cuts releases.\nlogo: \"🚢\"\nskills:\n  - iii-sandbox\n  - agent-memory/observe\nmodel: codex/gpt-5.4-mini\nicon: search\n---\nYou are the release captain.\n";
+    const CAPTAIN: &str = "---\nname: Release Captain\ndescription: Cuts releases.\nlogo: \"🚢\"\nskills:\n  - iii-sandbox\n  - agent-memory/observe\nmodel: codex/gpt-5.4-mini\nicon: search\ncolor: purple\n---\nYou are the release captain.\n";
 
     fn write_fixture(dir: &Path, rel: &str, contents: &str) {
         let path = dir.join(rel);
@@ -580,7 +591,7 @@ mod tests {
         assert_eq!(row.skill_count, Some(2));
         assert_eq!(row.model.as_deref(), Some("codex/gpt-5.4-mini"));
         assert_eq!(row.icon.as_deref(), Some("search"));
-        assert!(!row.leaf);
+        assert_eq!(row.color.as_deref(), Some("purple"));
 
         // `iii-sandbox` is known via the `<ns>/index` alias; the other id
         // matches nothing.
@@ -596,9 +607,9 @@ mod tests {
         .unwrap();
         assert_eq!(got.system_prompt.trim(), "You are the release captain.");
         assert_eq!(got.unknown_skills, vec!["agent-memory/observe".to_string()]);
-        assert!(!got.leaf);
         assert_eq!(got.model.as_deref(), Some("codex/gpt-5.4-mini"));
         assert_eq!(got.icon.as_deref(), Some("search"));
+        assert_eq!(got.color.as_deref(), Some("purple"));
         assert_eq!(got.raw.as_deref(), Some(CAPTAIN));
     }
 
@@ -639,7 +650,10 @@ mod tests {
             &[],
         )
         .unwrap_err();
-        assert!(err.starts_with("D410 not_found: agent"), "got: {err}");
+        assert!(
+            err.starts_with("D410 not_found: agent profile"),
+            "got: {err}"
+        );
         assert!(err.contains("real"), "candidate missing: {err}");
         assert!(err.contains("directory::agents::list"), "got: {err}");
     }
@@ -718,7 +732,10 @@ mod tests {
             },
         )
         .unwrap_err();
-        assert!(err.starts_with("D410 not_found: agent"), "got: {err}");
+        assert!(
+            err.starts_with("D410 not_found: agent profile"),
+            "got: {err}"
+        );
     }
 
     #[test]
@@ -732,6 +749,10 @@ mod tests {
             (
                 "---\nname: X\nicon: rocket\n---\nbody\n",
                 "`icon` must be one of",
+            ),
+            (
+                "---\nname: X\ncolor: ultraviolet\n---\nbody\n",
+                "`color` must be one of",
             ),
             ("---\nname: X\ndescription: y\n---\n", "non-empty"),
         ] {

--- a/iii-directory/src/functions/mod.rs
+++ b/iii-directory/src/functions/mod.rs
@@ -149,7 +149,7 @@ pub fn log_fs_health(cfg: &SkillsConfig) {
         let kind = match s.kind {
             SourceKind::Skill => "skill",
             SourceKind::SystemPrompt => "system prompt",
-            SourceKind::Agent => "agent",
+            SourceKind::Agent => "agent profile",
         };
         tracing::warn!(
             kind,

--- a/iii-directory/src/lib.rs
+++ b/iii-directory/src/lib.rs
@@ -20,10 +20,10 @@
 //!     namespace under the global or local root.
 //!   * **System prompts** (`directory::system-prompts::*`): filesystem-backed
 //!     prompts loaded from `system-prompts/` path segments with YAML frontmatter.
-//!   * **Agents** (`directory::agents::*`): filesystem-backed agent
+//!   * **Agent Profiles** (`directory::agents::*`): filesystem-backed
 //!     profiles stored directly under `agents_folder` — reusable session
 //!     identities whose file body is the system prompt, with display
-//!     name / emoji logo / skill filter / delegation fields in required
+//!     name / emoji logo / skill filter in required
 //!     YAML frontmatter (see `docs/architecture/agent-profile-storage.md`).
 //!   * **Registry** (`directory::registry::*`): HTTP proxy over
 //!     `api.workers.iii.dev` with the same `workers::{list,info}` shape
@@ -39,17 +39,17 @@
 //! defaults to `tag=latest`) or from a GitHub repo (`repo=URL
 //! skill=NAME branch?=main`) and writes skills/system prompts into
 //! `<skills_folder>/<namespace>/...`; legacy `prompts/` paths are ignored,
-//! while registry agent entries are routed to `agents_folder`.
+//! while registry agent-profile entries are routed to `agents_folder`.
 //! `directory::skills::update` /
 //! `directory::system-prompts::update` /
 //! `directory::agents::update` overwrite one existing file with edited
 //! full-file content; `directory::skills::{create,delete}`,
 //! `directory::system-prompts::{create,delete}` and
-//! `directory::agents::{create,delete}` manage skill/system-prompt/agent
+//! `directory::agents::{create,delete}` manage skill/system-prompt/agent-profile
 //! files (never touching the read-only `agents_skills_folder`). After
 //! every successful write the worker fires the matching family's
 //! `directory::*::on-change` (skills / system-prompts /
-//! agents) so subscribers can forward change notifications to their
+//! agent profiles) so subscribers can forward change notifications to their
 //! clients.
 //!
 //! The worker also ships an injectable console UI (see [`ui`]): a

--- a/iii-directory/ui/page.tsx
+++ b/iii-directory/ui/page.tsx
@@ -11,7 +11,6 @@
  * - src/page/             — the skills, system prompts & agents browser/editor
  * - src/configuration/    — custom form for the `iii-directory` configuration entry
  * - src/function-trigger/ — how directory::* function triggers render in chat/traces
- * - src/session-chip/     — the chat header's system-prompt read-out + dialog
  *
  * Registrations go through `host` so the loader disposes them on hot
  * reload / worker disconnect.
@@ -23,7 +22,6 @@ import { createDirectoryTriggerRenderer } from './src/function-trigger'
 import { DirectoryPage } from './src/page'
 import { registerDirectoryPalette } from './src/page/palette'
 import { createSearchTriggerRenderer } from './src/search/search-card'
-import { createSystemPromptChip } from './src/session-chip'
 
 /**
  * The pre-generate hook's transcript annotations (`origin.directory`) stay
@@ -55,10 +53,4 @@ export default function setup(host: Host) {
     render: DirectoryPassLine,
   })
 
-  /* Optional chained: the slot postdates the published Host type, so a
-     console that predates session chips just skips this contribution. */
-  host.chat?.registerSessionChip({
-    id: 'system-prompt',
-    render: createSystemPromptChip(host),
-  })
 }

--- a/iii-directory/ui/src/configuration/index.tsx
+++ b/iii-directory/ui/src/configuration/index.tsx
@@ -114,7 +114,7 @@ export function DirectoryConfigForm(props: ConfigFormProps) {
 
       <TextField
         field="agents_skills_folder"
-        label="Agents skills folder"
+        label="External agent skills folder"
         placeholder=".agents/skills"
         hint="Read-only root relative to III_COMPOSE_DIR (process cwd when standalone), scanned shallowly as <skill>/SKILL.md"
         value={asString(value.agents_skills_folder)}

--- a/iii-directory/ui/src/function-trigger/AgentsViews.tsx
+++ b/iii-directory/ui/src/function-trigger/AgentsViews.tsx
@@ -1,14 +1,6 @@
 import { MarkdownPreview } from '@iii-dev/console-ui'
 import { formatBytes, formatRelativeTime } from '../lib/format'
-import {
-  ActionLine,
-  Card,
-  EmptyRow,
-  KvChip,
-  MetaRow,
-  PulseLine,
-  StatusPill,
-} from '../lib/widgets'
+import { ActionLine, Card, EmptyRow, KvChip, MetaRow, PulseLine, StatusPill } from '../lib/widgets'
 import {
   agentsGetRequestSchema,
   agentsGetResponseSchema,
@@ -34,7 +26,7 @@ export function AgentsListView({ output, running }: ViewProps) {
         <MetaRow>
           <StatusPill label="listing…" variant="default" />
         </MetaRow>
-        <PulseLine label="scanning agents…" />
+        <PulseLine label="scanning agent profiles…" />
       </Card>
     )
   }
@@ -44,33 +36,24 @@ export function AgentsListView({ output, running }: ViewProps) {
 
   const label =
     resp.agents.length === 0
-      ? 'no agents'
-      : `${resp.agents.length} ${resp.agents.length === 1 ? 'agent' : 'agents'}`
+      ? 'no agent profiles'
+      : `${resp.agents.length} ${resp.agents.length === 1 ? 'agent profile' : 'agent profiles'}`
 
   return (
     <Card>
       <MetaRow>
-        <StatusPill
-          label={label}
-          variant={resp.agents.length === 0 ? 'warn' : 'accent'}
-        />
+        <StatusPill label={label} variant={resp.agents.length === 0 ? 'warn' : 'accent'} />
       </MetaRow>
       {resp.agents.length === 0 ? (
-        <EmptyRow label="no agents found" />
+        <EmptyRow label="no agent profiles found" />
       ) : (
         <ul className="dir-ui-list">
           {resp.agents.map((a) => (
             <li key={a.id} className="dir-ui-row">
-              <span className="dir-ui-id">
-                {[a.logo, a.name || a.id].filter(Boolean).join(' ')}
-              </span>
-              {a.description ? (
-                <div className="dir-ui-desc">{a.description}</div>
-              ) : null}
+              <span className="dir-ui-id">{[a.logo, a.name || a.id].filter(Boolean).join(' ')}</span>
+              {a.description ? <div className="dir-ui-desc">{a.description}</div> : null}
               <span className="dir-ui-fine">
-                {a.skill_count != null
-                  ? `${a.skill_count} skills · `
-                  : 'all skills · '}
+                {a.skill_count != null ? `${a.skill_count} skills · ` : 'all skills · '}
                 {formatRelativeTime(a.modified_at)}
               </span>
             </li>
@@ -93,7 +76,7 @@ export function AgentsGetView({ input, output, running }: ViewProps) {
           <StatusPill label="loading…" variant="default" />
           {req ? <KvChip label="id">{req.id}</KvChip> : null}
         </MetaRow>
-        <PulseLine label="fetching agent…" />
+        <PulseLine label="fetching agent profile…" />
       </Card>
     )
   }
@@ -104,27 +87,18 @@ export function AgentsGetView({ input, output, running }: ViewProps) {
   return (
     <Card>
       <MetaRow>
-        <StatusPill label="agent" variant="accent" />
-        {resp.leaf ? <KvChip label="leaf">yes</KvChip> : null}
+        <StatusPill label="agent profile" variant="accent" />
         {resp.model ? <KvChip label="model">{resp.model}</KvChip> : null}
-        <KvChip label="skills">
-          {resp.skills.length === 0 ? 'all' : String(resp.skills.length)}
-        </KvChip>
+        <KvChip label="skills">{resp.skills.length === 0 ? 'all' : String(resp.skills.length)}</KvChip>
         {resp.unknown_skills.length > 0 ? (
-          <KvChip label="unknown skills">
-            {resp.unknown_skills.join(', ')}
-          </KvChip>
+          <KvChip label="unknown skills">{resp.unknown_skills.join(', ')}</KvChip>
         ) : null}
         <KvChip label="modified">{formatRelativeTime(resp.modified_at)}</KvChip>
       </MetaRow>
       <ActionLine symbol="ƒ" tone="accent">
         <div className="dir-ui-stack">
-          <span className="dir-ui-id lg">
-            {[resp.logo, resp.name || resp.id].filter(Boolean).join(' ')}
-          </span>
-          {resp.description ? (
-            <span className="dir-ui-desc">{resp.description}</span>
-          ) : null}
+          <span className="dir-ui-id lg">{[resp.logo, resp.name || resp.id].filter(Boolean).join(' ')}</span>
+          {resp.description ? <span className="dir-ui-desc">{resp.description}</span> : null}
         </div>
       </ActionLine>
       <MarkdownPreview markdown={resp.system_prompt} />
@@ -134,12 +108,7 @@ export function AgentsGetView({ input, output, running }: ViewProps) {
 
 /* ---------------- directory::agents::update / create ---------------- */
 
-export function AgentsUpdateView({
-  input,
-  output,
-  running,
-  verb = 'updated',
-}: ViewProps & { verb?: string }) {
+export function AgentsUpdateView({ input, output, running, verb = 'updated' }: ViewProps & { verb?: string }) {
   const req = safeParseRequest(agentsUpdateRequestSchema, input)
 
   if (running) {
@@ -149,7 +118,7 @@ export function AgentsUpdateView({
           <StatusPill label="saving…" variant="default" />
           {req ? <KvChip label="id">{req.id}</KvChip> : null}
         </MetaRow>
-        <PulseLine label="writing agent…" />
+        <PulseLine label="writing agent profile…" />
       </Card>
     )
   }
@@ -166,12 +135,8 @@ export function AgentsUpdateView({
       </MetaRow>
       <ActionLine symbol="✎" tone="accent">
         <div className="dir-ui-stack">
-          <span className="dir-ui-id lg">
-            {[resp.logo, resp.name || resp.id].filter(Boolean).join(' ')}
-          </span>
-          {resp.description ? (
-            <span className="dir-ui-desc">{resp.description}</span>
-          ) : null}
+          <span className="dir-ui-id lg">{[resp.logo, resp.name || resp.id].filter(Boolean).join(' ')}</span>
+          {resp.description ? <span className="dir-ui-desc">{resp.description}</span> : null}
         </div>
       </ActionLine>
     </Card>

--- a/iii-directory/ui/src/function-trigger/DownloadView.test.tsx
+++ b/iii-directory/ui/src/function-trigger/DownloadView.test.tsx
@@ -35,7 +35,7 @@ describe('SkillsDownloadView', () => {
     expect(writtenLists).toEqual([
       { label: 'skills written', names: ['index.md'] },
       { label: 'system prompts written', names: ['assistant'] },
-      { label: 'agents written', names: ['reviewer'] },
+      { label: 'agent profiles written', names: ['reviewer'] },
     ])
   })
 })

--- a/iii-directory/ui/src/function-trigger/DownloadView.tsx
+++ b/iii-directory/ui/src/function-trigger/DownloadView.tsx
@@ -92,7 +92,7 @@ export function SkillsDownloadView({ input, output, running }: ViewProps) {
         label="system prompts written"
         names={resp.system_prompts_written}
       />
-      <WrittenList label="agents written" names={resp.agents_written} />
+      <WrittenList label="agent profiles written" names={resp.agents_written} />
     </Card>
   )
 }

--- a/iii-directory/ui/src/function-trigger/parsers.ts
+++ b/iii-directory/ui/src/function-trigger/parsers.ts
@@ -41,9 +41,7 @@ export const DIRECTORY_FUNCTION_IDS = [
 
 export type DirectoryFunctionId = (typeof DIRECTORY_FUNCTION_IDS)[number]
 
-const DIRECTORY_FUNCTION_ID_SET: ReadonlySet<string> = new Set<string>(
-  DIRECTORY_FUNCTION_IDS,
-)
+const DIRECTORY_FUNCTION_ID_SET: ReadonlySet<string> = new Set<string>(DIRECTORY_FUNCTION_IDS)
 
 export function isDirectoryFunction(id: string): id is DirectoryFunctionId {
   return DIRECTORY_FUNCTION_ID_SET.has(id)
@@ -125,9 +123,7 @@ export const skillsDownloadResponseSchema = z.object({
   agents_written: z.array(z.string()),
   source: z.unknown(),
 })
-export type SkillsDownloadResponse = z.infer<
-  typeof skillsDownloadResponseSchema
->
+export type SkillsDownloadResponse = z.infer<typeof skillsDownloadResponseSchema>
 
 /* ---------------- skills::update ---------------- */
 
@@ -150,9 +146,7 @@ export type SkillsUpdateResponse = z.infer<typeof skillsUpdateResponseSchema>
 /* ---------------- system-prompts::list ---------------- */
 
 export const systemPromptsListRequestSchema = z.object({})
-export type SystemPromptsListRequest = z.infer<
-  typeof systemPromptsListRequestSchema
->
+export type SystemPromptsListRequest = z.infer<typeof systemPromptsListRequestSchema>
 
 export const systemPromptEntrySchema = z.object({
   name: z.string(),
@@ -164,9 +158,7 @@ export type SystemPromptEntry = z.infer<typeof systemPromptEntrySchema>
 export const systemPromptsListResponseSchema = z.object({
   prompts: z.array(systemPromptEntrySchema),
 })
-export type SystemPromptsListResponse = z.infer<
-  typeof systemPromptsListResponseSchema
->
+export type SystemPromptsListResponse = z.infer<typeof systemPromptsListResponseSchema>
 
 /* ---------------- system-prompts::get ---------------- */
 
@@ -183,9 +175,7 @@ export const systemPromptsGetResponseSchema = z.object({
   raw: z.string().nullable().optional(),
   modified_at: z.string(),
 })
-export type SystemPromptsGetResponse = z.infer<
-  typeof systemPromptsGetResponseSchema
->
+export type SystemPromptsGetResponse = z.infer<typeof systemPromptsGetResponseSchema>
 
 /* ---------------- system-prompts::update ---------------- */
 
@@ -193,9 +183,7 @@ export const systemPromptsUpdateRequestSchema = z.object({
   name: z.string(),
   content: z.string(),
 })
-export type SystemPromptsUpdateRequest = z.infer<
-  typeof systemPromptsUpdateRequestSchema
->
+export type SystemPromptsUpdateRequest = z.infer<typeof systemPromptsUpdateRequestSchema>
 
 export const systemPromptsUpdateResponseSchema = z.object({
   name: z.string(),
@@ -203,9 +191,7 @@ export const systemPromptsUpdateResponseSchema = z.object({
   bytes: z.number(),
   modified_at: z.string(),
 })
-export type SystemPromptsUpdateResponse = z.infer<
-  typeof systemPromptsUpdateResponseSchema
->
+export type SystemPromptsUpdateResponse = z.infer<typeof systemPromptsUpdateResponseSchema>
 
 /* ---------------- agents::list ---------------- */
 
@@ -217,7 +203,7 @@ export const agentEntrySchema = z.object({
   skill_count: z.number().nullable().optional(),
   model: z.string().nullable().optional(),
   icon: z.string().nullable().optional(),
-  leaf: z.boolean().optional(),
+  color: z.string().nullable().optional(),
   modified_at: z.string(),
 })
 export type AgentEntry = z.infer<typeof agentEntrySchema>
@@ -243,9 +229,9 @@ export const agentsGetResponseSchema = z.object({
   system_prompt: z.string(),
   skills: z.array(z.string()),
   unknown_skills: z.array(z.string()),
-  leaf: z.boolean().optional(),
   model: z.string().nullable().optional(),
   icon: z.string().nullable().optional(),
+  color: z.string().nullable().optional(),
   raw: z.string().nullable().optional(),
   modified_at: z.string(),
 })
@@ -275,9 +261,7 @@ export const registryWorkersListRequestSchema = z.object({
   search: z.string().optional(),
   cursor: z.string().nullable().optional(),
 })
-export type RegistryWorkersListRequest = z.infer<
-  typeof registryWorkersListRequestSchema
->
+export type RegistryWorkersListRequest = z.infer<typeof registryWorkersListRequestSchema>
 
 export const registryWorkerAuthorSchema = z.object({
   name: z.string().nullable().optional(),
@@ -318,9 +302,7 @@ export const registryWorkersListResponseSchema = z.object({
   workers: z.array(registryWorkerSchema),
   pagination: registryPaginationSchema,
 })
-export type RegistryWorkersListResponse = z.infer<
-  typeof registryWorkersListResponseSchema
->
+export type RegistryWorkersListResponse = z.infer<typeof registryWorkersListResponseSchema>
 
 /* ---------------- registry::workers::info ---------------- */
 
@@ -329,9 +311,7 @@ export const registryWorkerInfoRequestSchema = z.object({
   version: z.string().nullable().optional(),
   tag: z.string().nullable().optional(),
 })
-export type RegistryWorkerInfoRequest = z.infer<
-  typeof registryWorkerInfoRequestSchema
->
+export type RegistryWorkerInfoRequest = z.infer<typeof registryWorkerInfoRequestSchema>
 
 export const apiReferenceFunctionSchema = z.object({
   name: z.string(),
@@ -371,24 +351,16 @@ export const registryWorkerInfoResponseSchema = z.object({
   api_reference: apiReferenceSchema,
   skills_tree: skillsTreeSchema,
 })
-export type RegistryWorkerInfoResponse = z.infer<
-  typeof registryWorkerInfoResponseSchema
->
+export type RegistryWorkerInfoResponse = z.infer<typeof registryWorkerInfoResponseSchema>
 
 /* ---------------- generic helpers ---------------- */
 
-export function safeParseRequest<T>(
-  schema: z.ZodType<T>,
-  value: unknown,
-): T | null {
+export function safeParseRequest<T>(schema: z.ZodType<T>, value: unknown): T | null {
   const parsed = schema.safeParse(value ?? {})
   return parsed.success ? parsed.data : null
 }
 
-export function safeParseResponse<T>(
-  schema: z.ZodType<T>,
-  value: unknown,
-): T | null {
+export function safeParseResponse<T>(schema: z.ZodType<T>, value: unknown): T | null {
   const parsed = schema.safeParse(unwrapEnvelope(value))
   return parsed.success ? parsed.data : null
 }

--- a/iii-directory/ui/src/lib/widgets.tsx
+++ b/iii-directory/ui/src/lib/widgets.tsx
@@ -140,6 +140,15 @@ export function PlusIcon({ className }: { className?: string }) {
   )
 }
 
+export function PencilIcon({ className }: { className?: string }) {
+  return (
+    <svg {...iconProps(className)} aria-hidden="true">
+      <path d="M12 20h9" />
+      <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L8 18l-4 1 1-4Z" />
+    </svg>
+  )
+}
+
 export function ChevronLeftIcon({ className }: { className?: string }) {
   return (
     <svg {...iconProps(className)} aria-hidden="true">

--- a/iii-directory/ui/src/page/agent-fields.test.tsx
+++ b/iii-directory/ui/src/page/agent-fields.test.tsx
@@ -1,0 +1,54 @@
+import { isValidElement, type ReactElement, type ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { AgentFormSkeleton } from './agent-fields'
+// @ts-expect-error Vite exposes source files imported with the raw query.
+import agentFieldsSource from './agent-fields.tsx?raw'
+
+vi.mock('@iii-dev/console-ui', () => ({}))
+
+function classesIn(node: ReactNode): string[] {
+  if (Array.isArray(node)) return node.flatMap(classesIn)
+  if (!isValidElement(node)) return []
+  const element = node as ReactElement<Record<string, unknown>>
+  if (typeof element.type === 'function') {
+    const Component = element.type as (
+      props: Record<string, unknown>,
+    ) => ReactNode
+    return classesIn(Component(element.props))
+  }
+  const props = element.props as { className?: string; children?: ReactNode }
+  return [props.className ?? '', ...classesIn(props.children)]
+}
+
+describe('AgentFormSkeleton', () => {
+  it('matches the visible agent form structure', () => {
+    const tree = AgentFormSkeleton()
+    const props = tree.props as { 'aria-label'?: string }
+    const classes = classesIn(tree)
+
+    expect(props['aria-label']).toBe('Loading agent profile')
+    expect(classes).toContain('t-skel-skeleton is-pulsing')
+    expect(classes).toContain('dir-ui-af-profile')
+    expect(classes).toContain('dir-ui-af-model-row')
+    expect(classes).toContain('dir-ui-af-prompt dir-ui-af-skeleton-prompt')
+    expect(classes).toContain('dir-ui-af-skills')
+    expect(
+      classes.filter((name) => name === 'dir-ui-af-skill-list-wrap'),
+    ).toHaveLength(2)
+  })
+})
+
+describe('AgentForm loading', () => {
+  it('keeps the skeleton and form mounted for the reveal transition', () => {
+    const formSource = agentFieldsSource.slice(
+      agentFieldsSource.indexOf('export function AgentForm'),
+    )
+
+    expect(formSource).not.toContain(
+      'if (catalogsLoading) return <AgentFormSkeleton />',
+    )
+    expect(formSource).toContain("catalogsLoading ? '' : ' is-revealed'")
+    expect(formSource).toContain('className="t-skel-content"')
+    expect(formSource).toContain('inert={catalogsLoading}')
+  })
+})

--- a/iii-directory/ui/src/page/agent-fields.tsx
+++ b/iii-directory/ui/src/page/agent-fields.tsx
@@ -1,46 +1,37 @@
-/**
- * The agent profile form (see `agentsAdapter.customForm` in index.tsx):
- * a sectioned settings layout — Identity (avatar + name + description),
- * Behavior & capabilities (skill selection; the markdown editor below
- * the form is the system prompt), Execution (default model), and
- * Delegation. Everything edits the draft's frontmatter through the same
- * guarded `editDraft` the built-in fields use; empty selections remove
- * their key (absent `skills` = every skill), matching the worker's
- * semantics.
- */
-
-import { Input, type Host } from '@iii-dev/console-ui'
-import type { ReactNode } from 'react'
-import { useEffect, useMemo, useState } from 'react'
+import { Button, type Host, Input, type ModelOption, ModelPicker } from '@iii-dev/console-ui'
+import type { CSSProperties, KeyboardEvent, ReactNode } from 'react'
+import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { PencilIcon, SearchIcon, XIcon } from '../lib/widgets'
 import { type FormContext, slugify } from './browser'
-import { TokenIcon } from './token-icons'
 import {
+  frontmatterBody,
   readFrontmatterField,
   readFrontmatterStringList,
+  setFrontmatterBody,
   setFrontmatterField,
   setFrontmatterStringList,
   withoutFrontmatterFields,
 } from './frontmatter'
+import { TokenIcon } from './token-icons'
 
 interface PickItem {
   id: string
   label: string
-  sublabel?: string
   desc?: string
-  /** Tree-icon token rendered as the row glyph (agents). */
-  iconToken?: string | null
 }
 
-/** One list-fn fetch per mounted collection; a failure leaves the picker
- * in its "edit in Content" fallback while still marking draft entries. */
-function useCatalog(
-  host: Host,
-  fetch: (host: Host) => Promise<PickItem[]>,
-): { items: PickItem[] | null; error: boolean } {
-  const [items, setItems] = useState<PickItem[] | null>(null)
+interface CatalogState<T> {
+  items: T[] | null
+  error: boolean
+}
+
+function useCatalog<T>(host: Host, fetch: (host: Host) => Promise<T[]>): CatalogState<T> {
+  const [items, setItems] = useState<T[] | null>(null)
   const [error, setError] = useState(false)
+
   useEffect(() => {
     let cancelled = false
+    setError(false)
     fetch(host)
       .then((next) => {
         if (!cancelled) setItems(next)
@@ -51,8 +42,8 @@ function useCatalog(
     return () => {
       cancelled = true
     }
-    // biome-ignore lint/correctness/useExhaustiveDependencies: fetch is a module-level constant per picker
-  }, [host])
+  }, [host, fetch])
+
   return { items, error }
 }
 
@@ -62,22 +53,59 @@ const fetchSkills = (host: Host) =>
       skills: { id: string; title: string; description: string }[]
     }>('directory::skills::list', { include_description: true })
     .then((out) =>
-      (out.skills ?? []).map((s) => ({
-        id: s.id,
-        label: s.title && s.title !== s.id ? s.title : s.id,
-        sublabel: s.title && s.title !== s.id ? s.id : undefined,
-        desc: s.description || undefined,
+      (out.skills ?? []).map((skill) => ({
+        id: skill.id,
+        label: skill.title && skill.title !== skill.id ? skill.title : skill.id,
+        desc: skill.description || undefined,
       })),
     )
 
-const fetchModels = (host: Host) =>
-  host.iii
-    .trigger<{ models: { id: string }[] }>('router::models::list', {})
-    .then((out) => (out.models ?? []).map((m) => ({ id: m.id, label: m.id })))
+interface CatalogModelRow {
+  id?: unknown
+  provider?: unknown
+  display_name?: unknown
+  context_window?: unknown
+  supports_thinking?: unknown
+  supports_vision?: unknown
+  reasoning_efforts?: unknown
+}
 
-/** Curated avatar presets, one per harness `SubagentIcon` token — picking
- * one keeps the emoji↔icon mapping mechanical for spawn display
- * identities. */
+function parseReasoningEfforts(value: unknown) {
+  if (!Array.isArray(value)) return undefined
+  const efforts = value.flatMap((raw) => {
+    if (!raw || typeof raw !== 'object') return []
+    const row = raw as Record<string, unknown>
+    if (typeof row.effort !== 'string' || !row.effort.trim()) return []
+    return [
+      {
+        effort: row.effort.trim(),
+        description: typeof row.description === 'string' && row.description.trim() ? row.description.trim() : undefined,
+      },
+    ]
+  })
+  return efforts.length > 0 ? efforts : undefined
+}
+
+const fetchModels = (host: Host): Promise<ModelOption[]> =>
+  host.iii.trigger<{ models?: CatalogModelRow[] }>('router::models::list', {}).then((out) =>
+    (out.models ?? []).flatMap((row) => {
+      const id = typeof row.id === 'string' ? row.id.trim() : ''
+      const provider = typeof row.provider === 'string' ? row.provider.trim() : ''
+      if (!id) return []
+      const catalogId = provider && !id.includes('::') ? `${provider}::${id}` : id
+      return [
+        {
+          id: catalogId,
+          label: typeof row.display_name === 'string' && row.display_name.trim() ? row.display_name.trim() : id,
+          contextWindow: typeof row.context_window === 'number' ? row.context_window : undefined,
+          supportsThinking: typeof row.supports_thinking === 'boolean' ? row.supports_thinking : undefined,
+          supportsVision: typeof row.supports_vision === 'boolean' ? row.supports_vision : undefined,
+          reasoningEfforts: parseReasoningEfforts(row.reasoning_efforts),
+        },
+      ]
+    }),
+  )
+
 const LOGO_PRESETS: { emoji: string; token: string }[] = [
   { emoji: '🤖', token: 'agent' },
   { emoji: '💻', token: 'code' },
@@ -90,192 +118,636 @@ const LOGO_PRESETS: { emoji: string; token: string }[] = [
   { emoji: '🎨', token: 'design' },
 ]
 
-// ─────────────────────────── building blocks ─────────────────────────
+const AGENT_COLORS = [
+  { id: 'neutral', label: 'Neutral' },
+  { id: 'blue', label: 'Blue' },
+  { id: 'purple', label: 'Purple' },
+  { id: 'teal', label: 'Teal' },
+  { id: 'green', label: 'Green' },
+  { id: 'amber', label: 'Amber' },
+  { id: 'rose', label: 'Rose' },
+] as const
 
-function Section({
+type AgentColor = (typeof AGENT_COLORS)[number]['id']
+
+function agentColor(value: string): AgentColor {
+  return AGENT_COLORS.some((color) => color.id === value) ? (value as AgentColor) : 'neutral'
+}
+
+function cssDurationMs(element: HTMLElement, variable: string, fallback: number) {
+  const value = getComputedStyle(element).getPropertyValue(variable).trim()
+  const duration = Number.parseFloat(value)
+  if (!Number.isFinite(duration)) return fallback
+  return value.endsWith('s') && !value.endsWith('ms') ? duration * 1000 : duration
+}
+
+function AvatarPicker({
+  icon,
+  color,
+  readOnly,
+  onIconChange,
+  onColorChange,
+}: {
+  icon: string
+  color: string
+  readOnly: boolean
+  onIconChange: (preset: { emoji: string; token: string } | null) => void
+  onColorChange: (color: AgentColor) => void
+}) {
+  const [state, setState] = useState<'closed' | 'open' | 'closing'>('closed')
+  const wrapRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const closeTimerRef = useRef<number | null>(null)
+
+  const close = useCallback(() => {
+    if (state !== 'open') return
+    setState('closing')
+    if (closeTimerRef.current !== null) window.clearTimeout(closeTimerRef.current)
+    const closeMs = wrapRef.current ? cssDurationMs(wrapRef.current, '--dropdown-close-dur', 150) : 150
+    closeTimerRef.current = window.setTimeout(() => {
+      setState('closed')
+      closeTimerRef.current = null
+    }, closeMs)
+  }, [state])
+
+  useEffect(() => {
+    if (state !== 'open') return
+    const onPointerDown = (event: PointerEvent) => {
+      if (!wrapRef.current?.contains(event.target as Node)) close()
+    }
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key !== 'Escape') return
+      event.preventDefault()
+      close()
+      triggerRef.current?.focus()
+    }
+    document.addEventListener('pointerdown', onPointerDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [close, state])
+
+  useEffect(
+    () => () => {
+      if (closeTimerRef.current !== null) window.clearTimeout(closeTimerRef.current)
+    },
+    [],
+  )
+
+  const open = () => {
+    if (readOnly) return
+    if (closeTimerRef.current !== null) window.clearTimeout(closeTimerRef.current)
+    setState('open')
+  }
+
+  const selectedColor = agentColor(color)
+
+  return (
+    <div ref={wrapRef} className="dir-ui-af-avatar-wrap">
+      <button
+        ref={triggerRef}
+        type="button"
+        className="dir-ui-af-avatar-trigger"
+        data-color={selectedColor}
+        aria-label="Choose agent profile avatar"
+        aria-haspopup="dialog"
+        aria-expanded={state === 'open'}
+        disabled={readOnly}
+        onClick={() => (state === 'open' ? close() : open())}
+      >
+        <TokenIcon token={icon || 'agent'} size={24} />
+      </button>
+      <div
+        data-origin="top-left"
+        className={`dir-ui-af-avatar-pop t-dropdown${
+          state === 'open' ? ' is-open' : state === 'closing' ? ' is-closing' : ''
+        }`}
+        role="dialog"
+        aria-label="Agent profile avatars"
+        aria-hidden={state === 'closed'}
+        inert={state !== 'open'}
+      >
+        <p className="dir-ui-af-avatar-pop-title">Choose an avatar</p>
+        <div className="dir-ui-af-avatar-grid">
+          {LOGO_PRESETS.map((preset) => (
+            <button
+              key={preset.token}
+              type="button"
+              aria-pressed={icon === preset.token}
+              aria-label={preset.token}
+              title={preset.token}
+              className="dir-ui-af-avatar-option"
+              data-color={selectedColor}
+              onClick={() => onIconChange(preset)}
+            >
+              <TokenIcon token={preset.token} size={20} />
+            </button>
+          ))}
+          <button
+            type="button"
+            aria-pressed={icon === ''}
+            aria-label="No avatar"
+            title="No avatar"
+            className="dir-ui-af-avatar-option"
+            data-color={selectedColor}
+            onClick={() => onIconChange(null)}
+          >
+            <XIcon className="dir-ui-af-avatar-option-icon" />
+          </button>
+        </div>
+        <div className="dir-ui-af-avatar-colors" role="radiogroup" aria-label="Avatar color">
+          {AGENT_COLORS.map((option) => (
+            <label key={option.id} className="dir-ui-af-avatar-color" data-color={option.id} title={option.label}>
+              <input
+                type="radio"
+                name="agent-avatar-color"
+                value={option.id}
+                aria-label={option.label}
+                checked={selectedColor === option.id}
+                disabled={readOnly}
+                onChange={() => onColorChange(option.id)}
+              />
+            </label>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function useAutoResizeTextarea(value: string) {
+  const ref = useRef<HTMLTextAreaElement>(null)
+  // biome-ignore lint/correctness/useExhaustiveDependencies: resize after controlled value changes
+  useLayoutEffect(() => {
+    const textarea = ref.current
+    if (!textarea) return
+    textarea.style.height = '0px'
+    textarea.style.height = `${textarea.scrollHeight}px`
+  }, [value])
+  return ref
+}
+
+function InlineTextField({
+  id,
+  name,
+  value,
+  placeholder,
+  readOnly,
+  multiline = false,
+  onChange,
+}: {
+  id: string
+  name: string
+  value: string
+  placeholder: string
+  readOnly: boolean
+  multiline?: boolean
+  onChange: (next: string) => void
+}) {
+  const [editing, setEditing] = useState(false)
+  const initialRef = useRef(value)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const textareaRef = useAutoResizeTextarea(value)
+
+  useEffect(() => {
+    if (!editing) return
+    const field = multiline ? textareaRef.current : inputRef.current
+    field?.focus()
+    if (!multiline && field instanceof HTMLInputElement) field.select()
+  }, [editing, multiline, textareaRef])
+
+  const begin = () => {
+    if (readOnly) return
+    initialRef.current = value
+    setEditing(true)
+  }
+  const cancel = () => {
+    onChange(initialRef.current)
+    setEditing(false)
+  }
+  const onKeyDown = (event: KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      cancel()
+      return
+    }
+    if ((!multiline && event.key === 'Enter') || (event.metaKey && event.key === 'Enter')) {
+      event.preventDefault()
+      setEditing(false)
+    }
+  }
+
+  if (editing) {
+    return multiline ? (
+      <textarea
+        ref={textareaRef}
+        id={id}
+        name={name}
+        value={value}
+        rows={1}
+        aria-label="Agent profile description"
+        placeholder={placeholder}
+        className="dir-ui-af-inline-input dir-ui-af-inline-description-input"
+        onChange={(event) => onChange(event.currentTarget.value)}
+        onBlur={() => setEditing(false)}
+        onKeyDown={onKeyDown}
+      />
+    ) : (
+      <input
+        ref={inputRef}
+        id={id}
+        name={name}
+        value={value}
+        required
+        spellCheck={false}
+        aria-label="Agent profile name"
+        placeholder={placeholder}
+        className="dir-ui-af-inline-input dir-ui-af-inline-name-input"
+        onChange={(event) => onChange(event.currentTarget.value)}
+        onBlur={() => setEditing(false)}
+        onKeyDown={onKeyDown}
+      />
+    )
+  }
+
+  const display = value.trim() || placeholder
+  if (readOnly) {
+    return (
+      <div className={`dir-ui-af-inline-display${multiline ? ' description' : ' name'}`}>
+        <span className={value.trim() ? '' : 'placeholder'}>{display}</span>
+      </div>
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      className={`dir-ui-af-inline-display${multiline ? ' description' : ' name'}`}
+      aria-label={`Edit agent profile ${multiline ? 'description' : 'name'}`}
+      onClick={begin}
+    >
+      <span className={value.trim() ? '' : 'placeholder'}>{display}</span>
+      <PencilIcon className="dir-ui-af-pencil" />
+    </button>
+  )
+}
+
+function CollapsibleSection({
   title,
-  hint,
+  description,
+  summary,
+  defaultOpen = true,
   children,
 }: {
   title: string
-  hint: string
+  description: string
+  summary?: string
+  defaultOpen?: boolean
   children: ReactNode
 }) {
+  const [open, setOpen] = useState(defaultOpen)
+  const panelId = useId()
   return (
-    <section className="dir-ui-af-section">
-      <h3 className="dir-ui-af-title">{title}</h3>
-      <p className="dir-ui-af-hint">{hint}</p>
-      <div className="dir-ui-af-card">{children}</div>
+    <section className="dir-ui-af-disclosure t-acc" data-open={open}>
+      <button
+        type="button"
+        className="dir-ui-af-disclosure-head t-acc-head"
+        aria-expanded={open}
+        aria-controls={panelId}
+        onClick={() => setOpen((current) => !current)}
+      >
+        <span className="dir-ui-af-disclosure-copy">
+          <span className="dir-ui-af-disclosure-title">{title}</span>
+          <span className="dir-ui-af-disclosure-description">{description}</span>
+        </span>
+        {summary ? <span className="dir-ui-af-disclosure-summary">{summary}</span> : null}
+        <span className="dir-ui-af-disclosure-chevron t-acc-chevron">
+          <svg viewBox="0 0 16 16" aria-hidden="true">
+            <path d="M4 6.5L8 10.5L12 6.5" />
+          </svg>
+        </span>
+      </button>
+      <div id={panelId} className="t-acc-panel">
+        <div className="dir-ui-af-disclosure-inner t-acc-panel-inner">
+          <div className="dir-ui-af-disclosure-content">{children}</div>
+        </div>
+      </div>
     </section>
   )
 }
 
-function Row({
-  label,
-  hint,
-  children,
+function SystemPromptEditor({ draft, editDraft, readOnly }: Pick<FormContext, 'draft' | 'editDraft' | 'readOnly'>) {
+  const rawBody = frontmatterBody(draft)
+  const separator = rawBody.startsWith('\r\n') ? '\r\n' : rawBody.startsWith('\n') ? '\n' : ''
+  const value = rawBody.slice(separator.length)
+  const textareaRef = useAutoResizeTextarea(value)
+
+  return (
+    <textarea
+      ref={textareaRef}
+      name="system_prompt"
+      value={value}
+      rows={6}
+      readOnly={readOnly}
+      spellCheck
+      aria-label="System prompt"
+      placeholder="Describe the profile's role, constraints, and working style…"
+      className="dir-ui-af-prompt"
+      onChange={(event) => editDraft(setFrontmatterBody(draft, `${separator}${event.currentTarget.value}`))}
+    />
+  )
+}
+
+function SkillCheckbox({
+  item,
+  checked,
+  disabled,
+  missing = false,
+  onChange,
 }: {
-  label: string
-  hint?: string
-  children: ReactNode
+  item: PickItem
+  checked: boolean
+  disabled: boolean
+  missing?: boolean
+  onChange: () => void
 }) {
   return (
-    <div className="dir-ui-af-row">
-      <span className="dir-ui-af-label">
-        {label}
-        {hint ? <span className="dir-ui-af-label-hint">{hint}</span> : null}
+    <label className="dir-ui-af-skill-row">
+      <input
+        type="checkbox"
+        name="skills"
+        value={item.id}
+        checked={checked}
+        disabled={disabled}
+        className="dir-ui-af-skill-native"
+        onChange={onChange}
+      />
+      <span
+        className="dir-ui-af-skill-check t-check"
+        aria-hidden="true"
+        data-checked={checked}
+        style={{ '--check-len': 15 } as CSSProperties}
+      >
+        <svg viewBox="0 0 10.1668 10.1668" aria-hidden="true">
+          <path d="M1 5.52L3.92 9.17L9.17 1" />
+        </svg>
       </span>
-      <div className="dir-ui-af-control">{children}</div>
+      <span className="dir-ui-af-skill-copy">
+        <span className="dir-ui-af-skill-name" title={item.label}>
+          {item.label}
+          {missing ? <span className="dir-ui-af-missing">Missing</span> : null}
+        </span>
+        <span className="dir-ui-af-skill-description" title={item.desc ?? 'No description.'}>
+          {item.desc ?? 'No description.'}
+        </span>
+      </span>
+    </label>
+  )
+}
+
+function SkillList({
+  title,
+  items,
+  checked,
+  disabled,
+  empty,
+  onToggle,
+}: {
+  title: string
+  items: (PickItem & { missing?: boolean })[]
+  checked: boolean
+  disabled: boolean
+  empty: string
+  onToggle: (id: string) => void
+}) {
+  return (
+    <div className="dir-ui-af-skill-list-wrap">
+      <div className="dir-ui-af-skill-list-head">
+        <span>{title}</span>
+        <span className="dir-ui-af-skill-count">{items.length}</span>
+      </div>
+      {/* The explicit role keeps list semantics when host styles remove markers. */}
+      {/* biome-ignore lint/a11y/noRedundantRoles: preserve list semantics across embedded hosts */}
+      <ul className="dir-ui-af-skill-list" role="list">
+        {items.length === 0 ? (
+          <li className="dir-ui-af-skill-empty">{empty}</li>
+        ) : (
+          items.map((item) => (
+            <li key={item.id}>
+              <SkillCheckbox
+                item={item}
+                checked={checked}
+                disabled={disabled}
+                missing={item.missing}
+                onChange={() => onToggle(item.id)}
+              />
+            </li>
+          ))
+        )}
+      </ul>
     </div>
   )
 }
 
-/** Collapsed "N selected — click to edit" row expanding into a search +
- * checkbox list, the reference pattern for skills. */
-function CollapsiblePicker({
-  noun,
-  emptyLabel,
+function SkillsEditor({
   items,
   error,
   selected,
   missing,
-  isChecked,
-  toggle,
   readOnly,
+  isSelected,
+  onToggle,
 }: {
-  noun: string
-  emptyLabel: string
   items: PickItem[] | null
   error: boolean
   selected: string[]
   missing: string[]
-  isChecked: (id: string) => boolean
-  toggle: (id: string) => void
   readOnly: boolean
+  isSelected: (id: string) => boolean
+  onToggle: (id: string) => void
 }) {
-  const [open, setOpen] = useState(false)
   const [filter, setFilter] = useState('')
   const needle = filter.trim().toLowerCase()
-  const visible = (items ?? []).filter(
-    (s) =>
-      !needle ||
-      s.id.toLowerCase().includes(needle) ||
-      s.label.toLowerCase().includes(needle) ||
-      (s.desc ?? '').toLowerCase().includes(needle),
-  )
-  const summary =
-    selected.length === 0
-      ? emptyLabel
-      : `${selected.length} selected — click to edit${missing.length ? ` · ${missing.length} missing` : ''}`
+  const matches = (item: PickItem) =>
+    !needle ||
+    item.id.toLowerCase().includes(needle) ||
+    item.label.toLowerCase().includes(needle) ||
+    (item.desc ?? '').toLowerCase().includes(needle)
 
-  if (!open) {
+  if (error) {
     return (
-      <button
-        type="button"
-        className="dir-ui-af-collapsed"
-        onClick={() => setOpen(true)}
-      >
-        <span className="dir-ui-af-plus">＋</span>
-        <span>{summary}</span>
-        <span className="dir-ui-af-chev">⌄</span>
-      </button>
+      <div className="dir-ui-af-catalog-message" role="status">
+        The skill catalog could not be loaded. Existing selections will be preserved when you save.
+      </div>
     )
   }
+  if (items === null) {
+    return <div className="dir-ui-af-catalog-message">Loading skills…</div>
+  }
+
+  const available = items.filter((item) => !isSelected(item.id) && matches(item))
+  const selectedItems: (PickItem & { missing?: boolean })[] = [
+    ...items.filter((item) => isSelected(item.id) && matches(item)),
+    ...missing
+      .map((id) => ({
+        id,
+        label: id,
+        desc: 'This skill is not in the current catalog.',
+        missing: true,
+      }))
+      .filter(matches),
+  ]
+
   return (
-    <div className="dir-ui-af-picker">
-      <div className="dir-ui-af-picker-head">
-        <span className="dir-ui-af-picker-count">
-          {selected.length ? `${selected.length} selected` : summary}
-        </span>
-        <button
-          type="button"
-          className="dir-ui-linkish"
-          onClick={() => setOpen(false)}
-        >
-          ✕ Collapse
-        </button>
+    <div className="dir-ui-af-skills">
+      <div className="dir-ui-af-skill-search">
+        <SearchIcon className="dir-ui-af-skill-search-icon" />
+        <Input
+          type="search"
+          name="skill_filter"
+          value={filter}
+          onChange={setFilter}
+          placeholder="Filter skills…"
+          aria-label="Filter skills"
+          spellCheck={false}
+          className="dir-ui-af-skill-search-input"
+        />
+        {filter ? (
+          <button
+            type="button"
+            className="dir-ui-af-skill-search-clear"
+            aria-label="Clear skill filter"
+            onClick={() => setFilter('')}
+          >
+            <XIcon className="dir-ui-af-skill-search-clear-icon" />
+          </button>
+        ) : null}
       </div>
-      {missing.length > 0 ? (
-        <div className="dir-ui-agent-skill-missing" role="status">
-          {missing.map((id) => (
-            <span key={id} className="dir-ui-agent-missing-row">
-              <span className="dir-ui-agent-missing-badge">missing</span>
-              <span className="mono">{id}</span>
-              {!readOnly ? (
-                <button
-                  type="button"
-                  className="dir-ui-linkish quiet"
-                  onClick={() => toggle(id)}
-                >
-                  remove
-                </button>
-              ) : null}
-            </span>
-          ))}
-        </div>
-      ) : null}
-      {error ? (
-        <div className="dir-ui-agent-skill-empty">
-          The {noun} catalog could not be loaded; edit the list in the source
-          below instead.
-        </div>
-      ) : items === null ? (
-        <div className="dir-ui-agent-skill-empty">Loading {noun}s…</div>
-      ) : (
-        <>
-          <Input
-            value={filter}
-            onChange={setFilter}
-            placeholder={`Search ${noun}s…`}
-            aria-label={`search ${noun}s`}
-            spellCheck={false}
-            className="dir-ui-edit-input"
-          />
-          <ul className="dir-ui-agent-skill-list tall">
-            {visible.length === 0 ? (
-              <li className="dir-ui-agent-skill-empty">
-                {needle ? `No ${noun}s match.` : `No ${noun}s available.`}
-              </li>
-            ) : (
-              visible.map((s) => (
-                <li key={s.id}>
-                  <label className="dir-ui-checkrow dir-ui-af-pick-row">
-                    <input
-                      type="checkbox"
-                      checked={isChecked(s.id)}
-                      disabled={readOnly}
-                      onChange={() => toggle(s.id)}
-                    />
-                    <span className="dir-ui-af-pick-body">
-                      <span className="dir-ui-af-pick-name">
-                        {s.iconToken ? (
-                          <span className="dir-ui-nav-ico">
-                            <TokenIcon token={s.iconToken} size={14} />
-                          </span>
-                        ) : null}
-                        {s.label}
-                        {s.sublabel ? (
-                          <span className="dir-ui-agent-skill-id mono">
-                            {s.sublabel}
-                          </span>
-                        ) : null}
-                      </span>
-                      {s.desc ? (
-                        <span className="dir-ui-af-pick-desc">{s.desc}</span>
-                      ) : null}
-                    </span>
-                  </label>
-                </li>
-              ))
-            )}
-          </ul>
-        </>
-      )}
+      <SkillList
+        title="Selected"
+        items={selectedItems}
+        checked
+        disabled={readOnly}
+        empty={
+          needle
+            ? 'No selected skills match.'
+            : selected.length === 0
+              ? 'No filter — sessions using this profile can use every skill.'
+              : 'No skills selected.'
+        }
+        onToggle={onToggle}
+      />
+      <div className="dir-ui-af-skill-transfer" aria-hidden="true">
+        <span>↓</span>
+        <span>↑</span>
+      </div>
+      <SkillList
+        title="Available"
+        items={available}
+        checked={false}
+        disabled={readOnly}
+        empty={needle ? 'No available skills match.' : 'All skills selected.'}
+        onToggle={onToggle}
+      />
     </div>
   )
 }
 
-// ───────────────────────────── the form ──────────────────────────────
+function SkeletonSkillList() {
+  return (
+    <div className="dir-ui-af-skill-list-wrap">
+      <div className="dir-ui-af-skill-list-head">
+        <span className="dir-ui-af-skeleton-block is-list-title" />
+        <span className="dir-ui-af-skeleton-block is-count" />
+      </div>
+      {/* biome-ignore lint/a11y/noRedundantRoles: preserve list semantics across embedded hosts */}
+      <ul className="dir-ui-af-skill-list" role="list">
+        {[0, 1].map((row) => (
+          <li key={row}>
+            <div className="dir-ui-af-skeleton-skill-row">
+              <span className="dir-ui-af-skeleton-block is-checkbox" />
+              <span className="dir-ui-af-skill-copy">
+                <span className="dir-ui-af-skeleton-block is-skill-name" />
+                <span className="dir-ui-af-skeleton-block is-skill-description" />
+              </span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+function SkeletonDisclosure({ kind }: { kind: 'prompt' | 'skills' }) {
+  return (
+    <section className="dir-ui-af-disclosure dir-ui-af-skeleton-disclosure">
+      <div className="dir-ui-af-disclosure-head">
+        <span className="dir-ui-af-disclosure-copy">
+          <span className="dir-ui-af-skeleton-block is-section-title" />
+          <span className="dir-ui-af-skeleton-block is-section-description" />
+        </span>
+        <span className="dir-ui-af-disclosure-summary dir-ui-af-skeleton-block is-summary" />
+        <span className="dir-ui-af-disclosure-chevron dir-ui-af-skeleton-block is-chevron" />
+      </div>
+      <div className="dir-ui-af-disclosure-content">
+        {kind === 'prompt' ? (
+          <div className="dir-ui-af-prompt dir-ui-af-skeleton-prompt">
+            <span className="dir-ui-af-skeleton-block is-prompt-line" />
+            <span className="dir-ui-af-skeleton-block is-prompt-line is-medium" />
+            <span className="dir-ui-af-skeleton-block is-prompt-line is-short" />
+          </div>
+        ) : (
+          <div className="dir-ui-af-skills">
+            <span className="dir-ui-af-skeleton-block is-search" />
+            <SkeletonSkillList />
+            <span className="dir-ui-af-skeleton-block is-transfer" />
+            <SkeletonSkillList />
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}
+
+function AgentFormSkeletonLayout() {
+  return (
+    <div className="dir-ui-af dir-ui-af-skeleton">
+      <div className="dir-ui-af-profile">
+        <span className="dir-ui-af-skeleton-block is-avatar" />
+        <div className="dir-ui-af-profile-copy">
+          <span className="dir-ui-af-skeleton-block is-name" />
+          <span className="dir-ui-af-skeleton-block is-description" />
+          <span className="dir-ui-af-skeleton-block is-description-short" />
+        </div>
+      </div>
+
+      <div className="dir-ui-af-aligned">
+        <div className="dir-ui-af-model-row">
+          <div className="dir-ui-af-model-label">
+            <span className="dir-ui-af-skeleton-block is-model-label" />
+            <span className="dir-ui-af-skeleton-block is-model-hint" />
+          </div>
+          <span className="dir-ui-af-skeleton-block is-model-picker" />
+        </div>
+        <SkeletonDisclosure kind="prompt" />
+        <SkeletonDisclosure kind="skills" />
+      </div>
+    </div>
+  )
+}
+
+export function AgentFormSkeleton() {
+  return (
+    <div className="dir-ui-af-loading t-skel" data-state="loading" role="status" aria-label="Loading agent profile">
+      <div className="t-skel-skeleton is-pulsing" aria-hidden="true">
+        <AgentFormSkeletonLayout />
+      </div>
+      <div className="t-skel-content" aria-hidden="true" />
+    </div>
+  )
+}
 
 export function AgentForm(ctx: FormContext) {
   const {
@@ -289,47 +761,21 @@ export function AgentForm(ctx: FormContext) {
     setName,
     setDescription,
     creating,
+    saving,
+    deleting,
+    onRemove,
   } = ctx
-
   const skills = readFrontmatterStringList(draft, 'skills').values
-  const leaf = /^true$/i.test(readFrontmatterField(draft, ['leaf']).value)
   const model = readFrontmatterField(draft, ['model']).value.trim()
   const icon = readFrontmatterField(draft, ['icon']).value.trim()
-
+  const color = readFrontmatterField(draft, ['color']).value.trim()
   const skillCatalog = useCatalog(host, fetchSkills)
   const modelCatalog = useCatalog(host, fetchModels)
-  const modelKnown =
-    modelCatalog.items === null ||
-    model === '' ||
-    modelCatalog.items.some((m) => m.id === model)
+  const derived = useMemo(() => slugify(nameValue), [nameValue])
 
-  const toggleIn = (key: 'skills', current: string[]) => {
-    return (id: string) => {
-      const next = current.includes(id)
-        ? current.filter((s) => s !== id)
-        : [...current, id]
-      editDraft(setFrontmatterStringList(draft, key, next))
-    }
-  }
-  const setLeaf = (next: boolean) => {
-    editDraft(
-      next
-        ? setFrontmatterField(draft, 'leaf', 'true', true)
-        : withoutFrontmatterFields(draft, ['leaf']),
-    )
-  }
   const setModel = (next: string) => {
-    editDraft(
-      next
-        ? setFrontmatterField(draft, 'model', next)
-        : withoutFrontmatterFields(draft, ['model']),
-    )
+    editDraft(next ? setFrontmatterField(draft, 'model', next) : withoutFrontmatterFields(draft, ['model']))
   }
-  /** The avatar IS the tree icon: one pick writes `icon` (the harness
-   * token the session tree renders) and the matching emoji `logo` (what
-   * the agent list rows show) in lockstep; clearing removes both. One
-   * edit carrying both fields — two editDraft calls in a row would lose
-   * the first (both close over the same `draft`). */
   const setAvatar = (preset: { emoji: string; token: string } | null) => {
     if (preset === null) {
       editDraft(withoutFrontmatterFields(draft, ['logo', 'icon']))
@@ -338,157 +784,168 @@ export function AgentForm(ctx: FormContext) {
     const withLogo = setFrontmatterField(draft, 'logo', preset.emoji)
     editDraft(setFrontmatterField(withLogo, 'icon', preset.token, true))
   }
-
-  const knownIn = (items: PickItem[] | null) => {
-    const ids = new Set((items ?? []).map((s) => s.id))
-    return (id: string) => ids.has(id) || ids.has(`${id}/index`)
+  const setAvatarColor = (next: AgentColor) => {
+    editDraft(setFrontmatterField(draft, 'color', next, true))
   }
-  const missingSkills =
-    skillCatalog.items === null
-      ? []
-      : skills.filter((id) => !knownIn(skillCatalog.items)(id))
-
-  const derived = useMemo(() => slugify(nameValue), [nameValue])
+  const equivalentSkillIds = (catalogId: string) => {
+    const ids = [catalogId]
+    if (catalogId.endsWith('/index')) {
+      ids.push(catalogId.slice(0, -'/index'.length))
+    } else {
+      ids.push(`${catalogId}/index`)
+    }
+    return ids
+  }
+  const isSkillSelected = (id: string) => equivalentSkillIds(id).some((candidate) => skills.includes(candidate))
+  const toggleSkill = (id: string) => {
+    const equivalents = new Set(equivalentSkillIds(id))
+    const next = isSkillSelected(id) ? skills.filter((skill) => !equivalents.has(skill)) : [...skills, id]
+    editDraft(setFrontmatterStringList(draft, 'skills', next))
+  }
+  const knownSkillIds = new Set((skillCatalog.items ?? []).flatMap((item) => equivalentSkillIds(item.id)))
+  const missingSkills = skillCatalog.items === null ? [] : skills.filter((id) => !knownSkillIds.has(id))
+  const pickerOptions = useMemo(() => {
+    const options = modelCatalog.items ?? []
+    if (!model || options.some((option) => option.id === model)) return options
+    return [{ id: model, label: model }, ...options]
+  }, [model, modelCatalog.items])
+  const modelKnown = !model || modelCatalog.items === null || modelCatalog.items.some((option) => option.id === model)
+  const catalogsLoading =
+    (skillCatalog.items === null && !skillCatalog.error) || (modelCatalog.items === null && !modelCatalog.error)
 
   return (
-    <div className="dir-ui-af">
-      <Section
-        title="Identity"
-        hint="Give the agent a recognizable name and a concise purpose."
-      >
-        <Row
-          label="Avatar"
-          hint={
-            icon
-              ? `${icon} — shown on the session in the side panel`
-              : 'pick the icon this agent shows in the session tree'
-          }
-        >
-          <div
-            className="dir-ui-af-icon-grid"
-            role="radiogroup"
-            aria-label="agent avatar"
-          >
-            {LOGO_PRESETS.map((p) => (
-              <button
-                key={p.token}
-                type="button"
-                role="radio"
-                aria-checked={icon === p.token}
-                title={p.token}
-                aria-label={`avatar ${p.token}`}
-                disabled={readOnly}
-                className={`dir-ui-af-icon-tile${icon === p.token ? ' active' : ''}`}
-                onClick={() => setAvatar(icon === p.token ? null : p)}
-              >
-                <TokenIcon token={p.token} />
-              </button>
-            ))}
-          </div>
-        </Row>
-        <Row
-          label="Name"
-          hint={
-            creating
-              ? derived
-                ? `→ ${derived}.md`
-                : 'the file name derives from it'
-              : undefined
-          }
-        >
-          <Input
-            id={`${fieldId}-name`}
-            value={nameValue}
-            onChange={setName}
-            placeholder="e.g. Deep Research Agent"
-            aria-label="agent name"
-            preserveCase
-            required
-            spellCheck={false}
-            readOnly={readOnly}
-            className="dir-ui-edit-input"
-          />
-        </Row>
-        <Row label="Description">
-          <textarea
-            id={`${fieldId}-description`}
-            value={descriptionValue}
-            onChange={(event) => setDescription(event.currentTarget.value)}
-            placeholder="What does this agent do?"
-            readOnly={readOnly}
-            rows={2}
-            className="dir-ui-edit-textarea"
-          />
-        </Row>
-      </Section>
-
-      <Section
-        title="Behavior & capabilities"
-        hint="The markdown below this form is the system prompt; attach the skills it can rely on."
-      >
-        <Row label="Skills">
-          <CollapsiblePicker
-            noun="skill"
-            emptyLabel="Add skills — none selected means every skill"
-            items={skillCatalog.items}
-            error={skillCatalog.error}
-            selected={skills}
-            missing={missingSkills}
-            isChecked={(id) =>
-              skills.includes(id) ||
-              (id.endsWith('/index') &&
-                skills.includes(id.slice(0, -'/index'.length)))
-            }
-            toggle={toggleIn('skills', skills)}
-            readOnly={readOnly}
-          />
-        </Row>
-      </Section>
-
-      <Section
-        title="Execution"
-        hint="Optionally pin the default model sessions run as this agent."
-      >
-        <Row
-          label="Model"
-          hint={modelKnown ? undefined : 'not in the model catalog'}
-        >
-          <select
-            id={`${fieldId}-model`}
-            value={model}
-            disabled={readOnly}
-            onChange={(event) => setModel(event.currentTarget.value)}
-            className="dir-ui-edit-input dir-ui-agent-model"
-          >
-            <option value="">Default — the send decides</option>
-            {!modelKnown ? (
-              <option value={model}>{model} (unavailable)</option>
-            ) : null}
-            {(modelCatalog.items ?? []).map((m) => (
-              <option key={m.id} value={m.id}>
-                {m.id}
-              </option>
-            ))}
-          </select>
-        </Row>
-      </Section>
-
-      <Section
-        title="Delegation"
-        hint="Which agent to hand work to is the prompt's decision; a leaf agent may not delegate at all."
-      >
-        <Row label="Leaf">
-          <label className="dir-ui-checkrow dir-ui-agent-leaf">
-            <input
-              type="checkbox"
-              checked={leaf}
-              disabled={readOnly}
-              onChange={(event) => setLeaf(event.currentTarget.checked)}
+    <div
+      className={`dir-ui-af-loading t-skel${catalogsLoading ? '' : ' is-revealed'}`}
+      data-state={catalogsLoading ? 'loading' : 'loaded'}
+      aria-busy={catalogsLoading}
+    >
+      <div className="t-skel-skeleton is-pulsing" aria-hidden={!catalogsLoading}>
+        <AgentFormSkeletonLayout />
+      </div>
+      <div className="t-skel-content" aria-hidden={catalogsLoading} inert={catalogsLoading}>
+        <div className="dir-ui-af">
+          <div className="dir-ui-af-profile">
+            <AvatarPicker
+              icon={icon}
+              color={color}
+              readOnly={readOnly}
+              onIconChange={setAvatar}
+              onColorChange={setAvatarColor}
             />
-            <span>May not delegate (leaf agent)</span>
-          </label>
-        </Row>
-      </Section>
+            <div className="dir-ui-af-profile-copy">
+              <div className="dir-ui-af-title-row">
+                <InlineTextField
+                  id={`${fieldId}-name`}
+                  name="name"
+                  value={nameValue}
+                  placeholder="Untitled agent profile"
+                  readOnly={readOnly}
+                  onChange={setName}
+                />
+              </div>
+              <InlineTextField
+                id={`${fieldId}-description`}
+                name="description"
+                value={descriptionValue}
+                placeholder="Add a concise description…"
+                readOnly={readOnly}
+                multiline
+                onChange={setDescription}
+              />
+              {creating ? (
+                <p className="dir-ui-af-file-hint">
+                  {derived ? `${derived}.md` : 'The file name follows the agent profile name.'}
+                </p>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="dir-ui-af-aligned">
+            <div className="dir-ui-af-model-row">
+              <div className="dir-ui-af-model-label">
+                <span>Model</span>
+                <span>{modelKnown ? 'Optional default.' : 'Unavailable in the catalog.'}</span>
+              </div>
+              <div className="dir-ui-af-model-control">
+                <ModelPicker
+                  value={model || null}
+                  options={pickerOptions}
+                  thinkingLevel="default"
+                  onChange={setModel}
+                  onThinkingLevelChange={() => undefined}
+                  disabled={readOnly || modelCatalog.error}
+                  loading={modelCatalog.items === null && !modelCatalog.error}
+                  showRefresh={false}
+                  showProviderConfiguration={false}
+                  showReasoningEffort={false}
+                  placeholder="Session default"
+                  className="dir-ui-af-model-picker"
+                />
+                {model && !readOnly ? (
+                  <button
+                    type="button"
+                    className="dir-ui-af-model-clear"
+                    aria-label="Use the session default model"
+                    title="Use the session default"
+                    onClick={() => setModel('')}
+                  >
+                    <XIcon className="dir-ui-af-model-clear-icon" />
+                  </button>
+                ) : null}
+              </div>
+            </div>
+
+            <CollapsibleSection
+              title="System prompt"
+              description="Instructions sessions using this profile follow."
+              summary="Markdown"
+            >
+              <SystemPromptEditor draft={draft} editDraft={editDraft} readOnly={readOnly} />
+            </CollapsibleSection>
+
+            <CollapsibleSection
+              title="Skills"
+              description="Move skills between the available and selected lists."
+              summary={`${skills.length} selected`}
+            >
+              <SkillsEditor
+                items={skillCatalog.items}
+                error={skillCatalog.error}
+                selected={skills}
+                missing={missingSkills}
+                readOnly={readOnly}
+                isSelected={isSkillSelected}
+                onToggle={toggleSkill}
+              />
+            </CollapsibleSection>
+
+            {onRemove ? (
+              <CollapsibleSection
+                title="Danger area"
+                description="Destructive actions for this agent profile."
+                summary="Delete"
+                defaultOpen={false}
+              >
+                <div className="dir-ui-af-remove-panel">
+                  <div className="dir-ui-af-remove-copy">
+                    <strong>Delete this agent profile</strong>
+                    <span>This action cannot be undone.</span>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="dir-ui-af-remove"
+                    disabled={saving || deleting}
+                    onClick={onRemove}
+                  >
+                    {deleting ? 'Deleting…' : 'Delete agent profile'}
+                  </Button>
+                </div>
+              </CollapsibleSection>
+            ) : null}
+          </div>
+        </div>
+      </div>
     </div>
   )
 }

--- a/iii-directory/ui/src/page/agent-fields.tsx
+++ b/iii-directory/ui/src/page/agent-fields.tsx
@@ -767,14 +767,34 @@ export function AgentForm(ctx: FormContext) {
   } = ctx
   const skills = readFrontmatterStringList(draft, 'skills').values
   const model = readFrontmatterField(draft, ['model']).value.trim()
+  const reasoningEffort = readFrontmatterField(draft, ['reasoning_effort']).value.trim() || 'default'
   const icon = readFrontmatterField(draft, ['icon']).value.trim()
   const color = readFrontmatterField(draft, ['color']).value.trim()
   const skillCatalog = useCatalog(host, fetchSkills)
   const modelCatalog = useCatalog(host, fetchModels)
   const derived = useMemo(() => slugify(nameValue), [nameValue])
+  const draftRef = useRef(draft)
+  draftRef.current = draft
+  const commitDraft = (next: string) => {
+    draftRef.current = next
+    editDraft(next)
+  }
 
   const setModel = (next: string) => {
-    editDraft(next ? setFrontmatterField(draft, 'model', next) : withoutFrontmatterFields(draft, ['model']))
+    const current = draftRef.current
+    commitDraft(
+      next
+        ? setFrontmatterField(current, 'model', next)
+        : withoutFrontmatterFields(current, ['model', 'reasoning_effort']),
+    )
+  }
+  const setReasoningEffort = (next: string) => {
+    const current = draftRef.current
+    commitDraft(
+      next && next !== 'default'
+        ? setFrontmatterField(current, 'reasoning_effort', next)
+        : withoutFrontmatterFields(current, ['reasoning_effort']),
+    )
   }
   const setAvatar = (preset: { emoji: string; token: string } | null) => {
     if (preset === null) {
@@ -870,14 +890,14 @@ export function AgentForm(ctx: FormContext) {
                 <ModelPicker
                   value={model || null}
                   options={pickerOptions}
-                  thinkingLevel="default"
+                  thinkingLevel={reasoningEffort}
                   onChange={setModel}
-                  onThinkingLevelChange={() => undefined}
+                  onThinkingLevelChange={setReasoningEffort}
                   disabled={readOnly || modelCatalog.error}
                   loading={modelCatalog.items === null && !modelCatalog.error}
                   showRefresh={false}
                   showProviderConfiguration={false}
-                  showReasoningEffort={false}
+                  showReasoningEffort
                   placeholder="Session default"
                   className="dir-ui-af-model-picker"
                 />

--- a/iii-directory/ui/src/page/browser.tsx
+++ b/iii-directory/ui/src/page/browser.tsx
@@ -38,13 +38,7 @@ import {
 } from '@iii-dev/console-ui'
 import type { ReactNode } from 'react'
 import { useCallback, useEffect, useId, useRef, useState } from 'react'
-import {
-  BackButton,
-  MarkdownFileIcon,
-  PlusIcon,
-  SearchIcon,
-  XIcon,
-} from '../lib/widgets'
+import { BackButton, MarkdownFileIcon, PlusIcon, SearchIcon, XIcon } from '../lib/widgets'
 import { draftAction, parseStoredDraft } from './draft-storage'
 import {
   frontmatterBody,
@@ -94,6 +88,12 @@ export interface FormContext extends ExtraFieldsContext {
   setName: (next: string) => void
   setDescription: (next: string) => void
   creating: boolean
+  dirty: boolean
+  saving: boolean
+  saved: boolean
+  deleting: boolean
+  onSave: () => void
+  onRemove?: () => void
 }
 
 export interface BrowserAdapter {
@@ -125,6 +125,8 @@ export interface BrowserAdapter {
   nameRequired?: boolean
   /** Starter document for a new entry (defaults to name+description). */
   newTemplate?: string
+  /** Treat the starter document as the pristine create-form baseline. */
+  newTemplateStartsClean?: boolean
   /** Extra frontmatter keys managed by `extraFields` — hidden from the
       content editor and restored verbatim on save, like name/description. */
   extraManagedKeys?: readonly string[]
@@ -134,6 +136,15 @@ export interface BrowserAdapter {
       sectioned Identity / Behavior / Execution form). Wins over
       `extraFields`. */
   customForm?: (ctx: FormContext) => ReactNode
+  /** Shape-matched loading state for a custom form. */
+  customLoading?: () => ReactNode
+  /** The custom form edits the markdown body itself, so omit CodeEditor. */
+  customFormOwnsContent?: boolean
+  /** The custom form provides its own identity/actions, so omit the generic
+      title, mode tabs, and save toolbar. */
+  customFormOwnsWorkspaceHeader?: boolean
+  /** Render list entries as identity rows with a larger glyph and title. */
+  prominentListItems?: boolean
   /** Label for the source editor header (default "Content"). */
   sourceLabel?: string
   /** Show the skill's model-invocation control. */
@@ -233,9 +244,7 @@ function errorText(e: unknown): string {
  * gives it. Measures synchronously on mount to avoid a wide-mode flash;
  * zero widths (display:none — the inactive collection) are ignored so a
  * hidden browser keeps its last real layout. */
-function useContainerNarrow(
-  threshold: number,
-): [(node: HTMLDivElement | null) => void, boolean] {
+function useContainerNarrow(threshold: number): [(node: HTMLDivElement | null) => void, boolean] {
   const [narrow, setNarrow] = useState(false)
   const observerRef = useRef<ResizeObserver | null>(null)
   const refCb = useCallback(
@@ -318,16 +327,10 @@ export function CollectionBrowser({
   /* Restore unsaved work from the last unmount (tab switch). A creating
      draft is self-contained; a selected-entry draft still needs the disk
      baseline, loaded by the mount effect below. */
-  const [restored] = useState(() =>
-    parseStoredDraft(readStored(`${storageKey}:draft`)),
-  )
-  const [selected, setSelected] = useState<string | null>(
-    restored && !restored.creating ? restored.key : null,
-  )
+  const [restored] = useState(() => parseStoredDraft(readStored(`${storageKey}:draft`)))
+  const [selected, setSelected] = useState<string | null>(restored && !restored.creating ? restored.key : null)
   const [creating, setCreating] = useState(restored?.creating ?? false)
-  const [loaded, setLoaded] = useState<Loaded | null>(
-    restored?.creating ? { key: '', content: '' } : null,
-  )
+  const [loaded, setLoaded] = useState<Loaded | null>(restored?.creating ? { key: '', content: '' } : null)
   const [draft, setDraft] = useState(restored?.content ?? '')
   const [loadError, setLoadError] = useState<string | null>(null)
 
@@ -365,7 +368,11 @@ export function CollectionBrowser({
   const readOnly = !creating && row?.readOnly === true
   const dirty = !readOnly && loaded !== null && draft !== loaded.content
   // Split needs side-by-side room; narrow containers fall back to edit.
-  const effMode: EditorMode = narrow && mode === 'split' ? 'edit' : mode
+  const effMode: EditorMode = adapter.customFormOwnsWorkspaceHeader
+    ? 'edit'
+    : narrow && mode === 'split'
+      ? 'edit'
+      : mode
 
   const refreshList = useCallback(() => {
     adapter
@@ -413,6 +420,7 @@ export function CollectionBrowser({
   /* One-shot: fetch the disk baseline under a restored selected-entry draft
      so dirty tracking and save() have the real `loaded.content` to diff
      against. The restored draft itself is kept, never overwritten. */
+  // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only restore
   useEffect(() => {
     if (!restored || restored.creating || !restored.key) return
     const key = restored.key
@@ -425,7 +433,6 @@ export function CollectionBrowser({
       .catch((e) => {
         if (selectedRef.current === key) setLoadError(errorText(e))
       })
-    // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only restore
   }, [])
 
   /* Mirror unsaved work to storage on every change, so a tab switch (which
@@ -491,16 +498,19 @@ export function CollectionBrowser({
     open(pendingOpen.key)
   }, [pendingOpen, open])
 
-  /** Blank editor for a new entry. `loaded.content` is empty rather than the
-      template, so the scaffold already counts as unsaved work and ⌘S/save is
-      live immediately. */
+  /** Blank editor for a new entry. Most collections count their scaffold as
+      unsaved work; custom forms can treat it as a pristine visual baseline. */
   const startCreate = useCallback(() => {
     guardDirty(() => {
+      const template = adapter.newTemplate ?? NEW_TEMPLATE
       removeStored(`${storageKey}:draft`)
       setCreating(true)
       setSelected(null)
-      setLoaded({ key: '', content: '' })
-      setDraft(adapter.newTemplate ?? NEW_TEMPLATE)
+      setLoaded({
+        key: '',
+        content: adapter.newTemplateStartsClean ? template : '',
+      })
+      setDraft(template)
       setLoadError(null)
       setSaveError(null)
       setDeleteError(null)
@@ -521,9 +531,7 @@ export function CollectionBrowser({
     adapter
       .load(host, key)
       .then((content) => {
-        setLoaded((prev) =>
-          prev && prev.key === key ? { key, content } : prev,
-        )
+        setLoaded((prev) => (prev && prev.key === key ? { key, content } : prev))
         setDraft((prev) => {
           const current = selectedRef.current
           return current === key ? content : prev
@@ -536,11 +544,7 @@ export function CollectionBrowser({
 
   const save = useCallback(() => {
     if (readOnly || !loaded || saving || deleting || draft === loaded.content) return
-    const name = readFrontmatterField(
-      draft,
-      adapter.nameKeys ?? ['name'],
-      adapter.defaultNameKey,
-    ).value.trim()
+    const name = readFrontmatterField(draft, adapter.nameKeys ?? ['name'], adapter.defaultNameKey).value.trim()
     if (adapter.nameRequired && !name) {
       setSaveError(`enter a display name for this ${adapter.noun}`)
       return
@@ -566,10 +570,7 @@ export function CollectionBrowser({
           ? SLUG_NAME
           : null
       if (pattern && !pattern.test(effectiveName)) {
-        setSaveError(
-          adapter.nameHint ??
-            'enter a name using lowercase letters, numbers, hyphens or underscores',
-        )
+        setSaveError(adapter.nameHint ?? 'enter a name using lowercase letters, numbers, hyphens or underscores')
         return
       }
     }
@@ -594,10 +595,7 @@ export function CollectionBrowser({
           setStaleOnDisk(false)
           setSavedFlash(true)
           window.clearTimeout(flashTimer.current)
-          flashTimer.current = window.setTimeout(
-            () => setSavedFlash(false),
-            2400,
-          )
+          flashTimer.current = window.setTimeout(() => setSavedFlash(false), 2400)
         })
         .catch((e) => {
           if (creatingRef.current) setSaveError(errorText(e))
@@ -630,6 +628,37 @@ export function CollectionBrowser({
       .finally(() => setSaving(false))
   }, [host, adapter, loaded, draft, saving, deleting, creating, readOnly, refreshList])
 
+  const revert = useCallback(() => {
+    setDraft(loaded?.content ?? '')
+    setSaveError(null)
+  }, [loaded])
+
+  const removeNow = useCallback(
+    (key: string) => {
+      if (!adapter.remove) return
+      setDeleting(true)
+      setDeleteError(null)
+      setSaveError(null)
+      adapter
+        .remove(host, key)
+        .then(() => {
+          setRows((current) => current?.filter((row) => row.key !== key) ?? null)
+          refreshList()
+          if (selectedRef.current !== key) return
+          setSelected(null)
+          setLoaded(null)
+          setDraft('')
+          setLoadError(null)
+          setStaleOnDisk(false)
+        })
+        .catch((error) => {
+          if (selectedRef.current === key) setDeleteError(errorText(error))
+        })
+        .finally(() => setDeleting(false))
+    },
+    [host, adapter, refreshList],
+  )
+
   const remove = useCallback(() => {
     if (readOnly || !adapter.remove || !loaded || creating || saving || deleting) return
     const key = loaded.key
@@ -640,30 +669,7 @@ export function CollectionBrowser({
       confirmLabel: 'Delete',
       proceed: () => removeNow(key),
     })
-  }, [adapter, loaded, creating, saving, deleting, readOnly, dirty])
-
-  const removeNow = useCallback((key: string) => {
-    if (!adapter.remove) return
-    setDeleting(true)
-    setDeleteError(null)
-    setSaveError(null)
-    adapter
-      .remove(host, key)
-      .then(() => {
-        setRows((current) => current?.filter((row) => row.key !== key) ?? null)
-        refreshList()
-        if (selectedRef.current !== key) return
-        setSelected(null)
-        setLoaded(null)
-        setDraft('')
-        setLoadError(null)
-        setStaleOnDisk(false)
-      })
-      .catch((error) => {
-        if (selectedRef.current === key) setDeleteError(errorText(error))
-      })
-      .finally(() => setDeleting(false))
-  }, [host, adapter, loaded, creating, saving, deleting, dirty, readOnly, refreshList])
+  }, [adapter, loaded, creating, saving, deleting, readOnly, dirty, removeNow])
 
   const onWorkspaceKeyDown = (e: React.KeyboardEvent) => {
     if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 's') {
@@ -737,10 +743,7 @@ export function CollectionBrowser({
     if (rect.width <= 0) return
     setSplit(clampRatio((clientX - rect.left) / rect.width))
   }
-  const persistSplit = useCallback(
-    (value: number) => writeStored(`${storageKey}:split`, String(value)),
-    [storageKey],
-  )
+  const persistSplit = useCallback((value: number) => writeStored(`${storageKey}:split`, String(value)), [storageKey])
   const onDividerPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
     e.preventDefault()
     e.currentTarget.setPointerCapture(e.pointerId)
@@ -762,8 +765,7 @@ export function CollectionBrowser({
     })
   }
   const onDividerKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    const step =
-      e.key === 'ArrowLeft' ? -0.05 : e.key === 'ArrowRight' ? 0.05 : null
+    const step = e.key === 'ArrowLeft' ? -0.05 : e.key === 'ArrowRight' ? 0.05 : null
     if (step !== null) {
       e.preventDefault()
       setSplit((v) => {
@@ -795,51 +797,24 @@ export function CollectionBrowser({
 
   const docKey = loaded?.key ?? selected
   const docSegments = docKey ? docKey.split('/') : []
-  const docName = creating
-    ? `New ${adapter.noun}`
-    : (docSegments[docSegments.length - 1] ?? '')
+  const docName = creating ? `New ${adapter.noun}` : (docSegments[docSegments.length - 1] ?? '')
 
-  const modeOptions: EditorMode[] = narrow
-    ? ['edit', 'preview']
-    : ['edit', 'split', 'preview']
+  const modeOptions: EditorMode[] = narrow ? ['edit', 'preview'] : ['edit', 'split', 'preview']
 
-  const nameField = readFrontmatterField(
-    draft,
-    adapter.nameKeys ?? ['name'],
-    adapter.defaultNameKey,
-  )
+  const nameField = readFrontmatterField(draft, adapter.nameKeys ?? ['name'], adapter.defaultNameKey)
   const descriptionField = readFrontmatterField(draft, ['description'])
-  const nameValue = nameField.present
-    ? nameField.value
-    : creating
-      ? ''
-      : row?.title || row?.key || ''
-  const descriptionValue = descriptionField.present
-    ? descriptionField.value
-    : creating
-      ? ''
-      : row?.description || ''
-  const modelInvocationField = readFrontmatterField(draft, [
-    'disable-model-invocation',
-  ])
-  const modelInvocationSimple = frontmatterFieldIsSimpleBoolean(
-    draft,
-    'disable-model-invocation',
-  )
-  const modelInvocationDisabled = /:\s*(?:true|True|TRUE)\s*$/.test(
-    modelInvocationField.raw ?? '',
-  )
+  const nameValue = nameField.present ? nameField.value : creating ? '' : row?.title || row?.key || ''
+  const descriptionValue = descriptionField.present ? descriptionField.value : creating ? '' : row?.description || ''
+  const modelInvocationField = readFrontmatterField(draft, ['disable-model-invocation'])
+  const modelInvocationSimple = frontmatterFieldIsSimpleBoolean(draft, 'disable-model-invocation')
+  const modelInvocationDisabled = /:\s*(?:true|True|TRUE)\s*$/.test(modelInvocationField.raw ?? '')
   const managedFields = [
     { ...nameField, value: nameValue, bare: adapter.slugName },
     { ...descriptionField, value: descriptionValue },
-    ...(adapter.modelInvocationOption && modelInvocationSimple
-      ? [{ ...modelInvocationField, bare: true }]
-      : []),
+    ...(adapter.modelInvocationOption && modelInvocationSimple ? [{ ...modelInvocationField, bare: true }] : []),
     // Extra keys an adapter's custom controls own (agents: logo, skills):
     // hidden from the content editor, restored verbatim from `raw` on save.
-    ...(adapter.extraManagedKeys ?? []).map((key) =>
-      readFrontmatterField(draft, [key]),
-    ),
+    ...(adapter.extraManagedKeys ?? []).map((key) => readFrontmatterField(draft, [key])),
   ]
   const editorSource = withoutFrontmatterFields(
     draft,
@@ -855,18 +830,12 @@ export function CollectionBrowser({
   const draftLines = loaded === null ? 0 : draft.split('\n').length
   const draftBytes = loaded === null ? 0 : new Blob([draft]).size
 
-  const saveStatus = saving
-    ? 'Saving…'
-    : savedFlash
-      ? '✓ Saved'
-      : dirty
-        ? 'Unsaved'
-        : ''
+  const saveStatus = saving ? 'Saving…' : savedFlash ? '✓ Saved' : dirty ? 'Unsaved' : ''
 
   return (
     // biome-ignore lint/a11y/noStaticElementInteractions: shortcut relay ('/' jumps to the filter) around real controls
     <div
-      className={`dir-ui-browser${narrow ? ' narrow' : ''}${panelSide === 'right' ? ' right' : ''}`}
+      className={`dir-ui-browser${narrow ? ' narrow' : ''}${panelSide === 'right' ? ' right' : ''}${adapter.prominentListItems ? ' prominent-list' : ''}`}
       ref={rootRef}
       onKeyDown={onRootKeyDown}
     >
@@ -991,11 +960,7 @@ export function CollectionBrowser({
                     <p>
                       No {adapter.noun}s match “{search.trim()}”.
                     </p>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => setSearch('')}
-                    >
+                    <Button variant="ghost" size="sm" onClick={() => setSearch('')}>
                       Clear filter
                     </Button>
                   </>
@@ -1011,20 +976,18 @@ export function CollectionBrowser({
                     <li key={r.key}>
                       <button
                         type="button"
-                        className={`dir-ui-nav-row${r.key === selected ? ' active' : ''}`}
+                        className={`dir-ui-nav-row${r.icon ? ' with-icon' : ''}${r.key === selected ? ' active' : ''}`}
                         aria-current={r.key === selected ? 'true' : undefined}
                         onClick={() => open(r.key)}
                       >
-                        <span className={`name${isTitled ? '' : ' mono'}`}>
-                          {r.icon ? (
-                            <span className="dir-ui-nav-ico">{r.icon}</span>
-                          ) : null}
-                          {isTitled ? r.title : r.key}
-                        </span>
-                        {isTitled ? <span className="id">{r.key}</span> : null}
-                        {r.description ? (
-                          <span className="desc">{r.description}</span>
+                        {r.icon ? (
+                          <span className="dir-ui-nav-ico" aria-hidden>
+                            {r.icon}
+                          </span>
                         ) : null}
+                        <span className={`name${isTitled ? '' : ' mono'}`}>{isTitled ? r.title : r.key}</span>
+                        {isTitled || adapter.prominentListItems ? <span className="id">{r.key}</span> : null}
+                        {r.description ? <span className="desc">{r.description}</span> : null}
                         <span className="fine">{r.fine}</span>
                       </button>
                     </li>
@@ -1037,11 +1000,7 @@ export function CollectionBrowser({
       ) : null}
 
       {showDoc ? (
-        <section
-          className="dir-ui-doc"
-          onKeyDown={onWorkspaceKeyDown}
-          aria-label={`${adapter.noun} workspace`}
-        >
+        <section className="dir-ui-doc" onKeyDown={onWorkspaceKeyDown} aria-label={`${adapter.noun} workspace`}>
           {selected === null && !creating ? (
             <div className="dir-ui-hero">
               <MarkdownFileIcon className="dir-ui-hero-icon" />
@@ -1053,86 +1012,93 @@ export function CollectionBrowser({
             </div>
           ) : (
             <>
-              <header className="dir-ui-doc-head">
-                {narrow ? (
-                  <BackButton
-                    onClick={goBack}
-                    label={`back to ${adapter.noun} list`}
-                  />
-                ) : null}
-                <div className="dir-ui-doc-identity">
-                  <span className="dir-ui-doc-name" title={docKey ?? ''}>
-                    <span className="txt">{docName}</span>
-                    {dirty ? (
-                      <span
-                        className="dir-ui-dirty-dot"
-                        title="unsaved changes"
-                        aria-hidden
-                      />
-                    ) : null}
-                  </span>
-                  {!narrow ? (
-                    <span className="dir-ui-doc-crumb">
-                      {[adapter.crumbRoot, ...docSegments].join(' / ')}
+              {!adapter.customFormOwnsWorkspaceHeader ? (
+                <header className="dir-ui-doc-head">
+                  {narrow ? <BackButton onClick={goBack} label={`back to ${adapter.noun} list`} /> : null}
+                  <div className="dir-ui-doc-identity">
+                    <span className="dir-ui-doc-name" title={docKey ?? ''}>
+                      <span className="txt">{docName}</span>
+                      {dirty ? <span className="dir-ui-dirty-dot" title="unsaved changes" aria-hidden /> : null}
                     </span>
+                    {!narrow ? (
+                      <span className="dir-ui-doc-crumb">{[adapter.crumbRoot, ...docSegments].join(' / ')}</span>
+                    ) : null}
+                  </div>
+                  <SegmentedControl<EditorMode>
+                    value={effMode}
+                    onChange={setMode}
+                    options={modeOptions.map((mode) => ({
+                      value: mode,
+                      label: EDITOR_MODE_LABELS[mode],
+                    }))}
+                    className="dir-ui-editor-tabs"
+                    aria-label="Editor mode"
+                  />
+                  <div className="dir-ui-save-area">
+                    {adapter.remove && !creating && !readOnly ? (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="dir-ui-delete-btn"
+                        disabled={!loaded || saving || deleting}
+                        onClick={remove}
+                      >
+                        {deleting ? 'Deleting…' : 'Delete'}
+                      </Button>
+                    ) : null}
+                    <span className="dir-ui-save-note" aria-live="polite">
+                      {readOnly ? 'Read only' : saveStatus}
+                    </span>
+                    {dirty && !saving ? (
+                      <Button variant="ghost" size="sm" disabled={deleting} onClick={revert}>
+                        Revert
+                      </Button>
+                    ) : null}
+                    {!readOnly ? (
+                      <Button variant="primary" size="sm" disabled={!dirty || saving || deleting} onClick={save}>
+                        {saving ? 'Saving…' : 'Save'}
+                      </Button>
+                    ) : null}
+                  </div>
+                </header>
+              ) : null}
+
+              {adapter.customFormOwnsWorkspaceHeader && (narrow || (dirty && !readOnly)) ? (
+                <div className="dir-ui-af-save-panel">
+                  {narrow ? (
+                    <div className="dir-ui-doc-mobile-back">
+                      <BackButton onClick={goBack} label={`back to ${adapter.noun} list`} />
+                      <span>{adapter.noun}s</span>
+                    </div>
+                  ) : null}
+                  {dirty && !readOnly ? (
+                    <div className="dir-ui-af-save-actions">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="dir-ui-af-revert"
+                        disabled={saving || deleting}
+                        onClick={revert}
+                      >
+                        Revert
+                      </Button>
+                      <Button
+                        variant="primary"
+                        size="sm"
+                        className="dir-ui-af-save"
+                        disabled={saving || deleting}
+                        onClick={save}
+                      >
+                        {saving ? 'Saving…' : 'Save'}
+                      </Button>
+                    </div>
                   ) : null}
                 </div>
-                <SegmentedControl<EditorMode>
-                  value={effMode}
-                  onChange={setMode}
-                  options={modeOptions.map((mode) => ({
-                    value: mode,
-                    label: EDITOR_MODE_LABELS[mode],
-                  }))}
-                  className="dir-ui-editor-tabs"
-                  aria-label="Editor mode"
-                />
-                <div className="dir-ui-save-area">
-                  {adapter.remove && !creating && !readOnly ? (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="dir-ui-delete-btn"
-                      disabled={!loaded || saving || deleting}
-                      onClick={remove}
-                    >
-                      {deleting ? 'Deleting…' : 'Delete'}
-                    </Button>
-                  ) : null}
-                  <span className="dir-ui-save-note" aria-live="polite">
-                    {readOnly ? 'Read only' : saveStatus}
-                  </span>
-                  {dirty && !saving ? (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      disabled={deleting}
-                      onClick={() => {
-                        setDraft(loaded?.content ?? '')
-                        setSaveError(null)
-                      }}
-                    >
-                      Revert
-                    </Button>
-                  ) : null}
-                  {!readOnly ? (
-                    <Button
-                      variant="primary"
-                      size="sm"
-                      disabled={!dirty || saving || deleting}
-                      onClick={save}
-                    >
-                      {saving ? 'Saving…' : 'Save'}
-                    </Button>
-                  ) : null}
-                </div>
-              </header>
+              ) : null}
 
               {staleOnDisk ? (
                 <div className="dir-ui-banner warn" role="status">
-                  <span>
-                    This {adapter.noun} changed on disk while you were editing.
-                  </span>
+                  <span>This {adapter.noun} changed on disk while you were editing.</span>
                   <button
                     type="button"
                     className="dir-ui-linkish"
@@ -1149,18 +1115,10 @@ export function CollectionBrowser({
                     Save failed.
                     <span className="detail">{saveError}</span>
                   </span>
-                  <button
-                    type="button"
-                    className="dir-ui-linkish"
-                    onClick={save}
-                  >
+                  <button type="button" className="dir-ui-linkish" onClick={save}>
                     Retry
                   </button>
-                  <button
-                    type="button"
-                    className="dir-ui-linkish quiet"
-                    onClick={() => setSaveError(null)}
-                  >
+                  <button type="button" className="dir-ui-linkish quiet" onClick={() => setSaveError(null)}>
                     dismiss
                   </button>
                 </div>
@@ -1172,18 +1130,10 @@ export function CollectionBrowser({
                     Delete failed.
                     <span className="detail">{deleteError}</span>
                   </span>
-                  <button
-                    type="button"
-                    className="dir-ui-linkish"
-                    onClick={remove}
-                  >
+                  <button type="button" className="dir-ui-linkish" onClick={remove}>
                     Retry
                   </button>
-                  <button
-                    type="button"
-                    className="dir-ui-linkish quiet"
-                    onClick={() => setDeleteError(null)}
-                  >
+                  <button type="button" className="dir-ui-linkish quiet" onClick={() => setDeleteError(null)}>
                     dismiss
                   </button>
                 </div>
@@ -1195,34 +1145,26 @@ export function CollectionBrowser({
                     {docKey} could not be loaded.
                     <span className="detail">{loadError}</span>
                   </p>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => docKey && open(docKey, { reload: true })}
-                  >
+                  <Button variant="ghost" size="sm" onClick={() => docKey && open(docKey, { reload: true })}>
                     Retry
                   </Button>
                 </div>
               ) : loaded === null ? (
-                <div className="dir-ui-doc-loading" aria-hidden>
-                  <span className="bar w40" />
-                  <span className="bar w90" />
-                  <span className="bar w75" />
-                  <span className="bar w85" />
-                  <span className="bar w30" />
-                </div>
+                adapter.customLoading ? (
+                  adapter.customLoading()
+                ) : (
+                  <div className="dir-ui-doc-loading" aria-hidden>
+                    <span className="bar w40" />
+                    <span className="bar w90" />
+                    <span className="bar w75" />
+                    <span className="bar w85" />
+                    <span className="bar w30" />
+                  </div>
+                )
               ) : (
                 <>
-                  <div
-                    className={`dir-ui-doc-body mode-${effMode}${dragging ? ' dragging' : ''}`}
-                    ref={bodyRef}
-                  >
-                    <div
-                      className="dir-ui-pane editor"
-                      style={
-                        effMode === 'split' ? { flexGrow: split } : undefined
-                      }
-                    >
+                  <div className={`dir-ui-doc-body mode-${effMode}${dragging ? ' dragging' : ''}`} ref={bodyRef}>
+                    <div className="dir-ui-pane editor" style={effMode === 'split' ? { flexGrow: split } : undefined}>
                       {adapter.customForm ? (
                         adapter.customForm({
                           host,
@@ -1242,157 +1184,122 @@ export function CollectionBrowser({
                                 adapter.slugName,
                               ),
                             ),
-                          setDescription: (next) =>
-                            editDraft(
-                              setFrontmatterField(
-                                draft,
-                                descriptionField.key,
-                                next,
-                              ),
-                            ),
+                          setDescription: (next) => editDraft(setFrontmatterField(draft, descriptionField.key, next)),
                           creating,
+                          dirty,
+                          saving,
+                          saved: savedFlash,
+                          deleting,
+                          onSave: save,
+                          onRemove: adapter.remove && !creating && !readOnly ? remove : undefined,
                         })
                       ) : (
-                      <div className="dir-ui-edit-fields">
-                        <label
-                          className="dir-ui-edit-field"
-                          htmlFor={`${fieldId}-name`}
-                        >
-                          <span className="dir-ui-edit-label">
-                            name
-                            {adapter.slugName ? (
-                              <span className="dir-ui-edit-hint">
-                                a–z · 0–9 · - · _
-                              </span>
-                            ) : adapter.separateId && creating ? (
-                              <span className="dir-ui-edit-hint">
-                                {slugify(nameValue)
-                                  ? `→ ${slugify(nameValue)}.md`
-                                  : 'the id derives from the name'}
-                              </span>
-                            ) : null}
-                          </span>
-                          <Input
-                            id={`${fieldId}-name`}
-                            value={nameValue}
-                            onChange={(next) =>
-                              editDraft(
-                                setFrontmatterField(
-                                  draft,
-                                  nameField.key,
-                                  adapter.slugName ? next.toLowerCase() : next,
-                                  adapter.slugName,
-                                ),
-                              )
-                            }
-                            placeholder={`${adapter.noun} name`}
-                            preserveCase={!adapter.slugName}
-                            required={adapter.slugName || adapter.nameRequired}
-                            pattern={
-                              adapter.slugName ? '[a-z0-9_-]+' : undefined
-                            }
-                            spellCheck={false}
-                            readOnly={readOnly}
-                            className="dir-ui-edit-input"
-                          />
-                        </label>
-                        <label
-                          className="dir-ui-edit-field"
-                          htmlFor={`${fieldId}-description`}
-                        >
-                          <span className="dir-ui-edit-label">Description</span>
-                          <textarea
-                            id={`${fieldId}-description`}
-                            value={descriptionValue}
-                            onChange={(event) =>
-                              editDraft(
-                                setFrontmatterField(
-                                  draft,
-                                  descriptionField.key,
-                                  event.currentTarget.value,
-                                ),
-                              )
-                            }
-                            placeholder={`what this ${adapter.noun} is for…`}
-                            required={adapter.descriptionRequired}
-                            readOnly={readOnly}
-                            rows={2}
-                            className="dir-ui-edit-textarea"
-                          />
-                        </label>
-                        {adapter.modelInvocationOption ? (
-                          modelInvocationSimple ? (
-                            <label className="dir-ui-checkrow dir-ui-model-invocation">
-                              <input
-                                id={`${fieldId}-disable-model-invocation`}
-                                type="checkbox"
-                                checked={modelInvocationDisabled}
-                                disabled={readOnly}
-                                onChange={(event) =>
-                                  editDraft(
-                                    event.currentTarget.checked
-                                      ? setFrontmatterField(
-                                          draft,
-                                          'disable-model-invocation',
-                                          'true',
-                                          true,
-                                        )
-                                      : withoutFrontmatterFields(draft, [
-                                          'disable-model-invocation',
-                                        ]),
-                                  )
-                                }
-                              />
-                              <span className={uiClasses.field}>
-                                <span className={uiClasses.fieldLabel}>
-                                  Require explicit invocation
+                        <div className="dir-ui-edit-fields">
+                          <label className="dir-ui-edit-field" htmlFor={`${fieldId}-name`}>
+                            <span className="dir-ui-edit-label">
+                              name
+                              {adapter.slugName ? (
+                                <span className="dir-ui-edit-hint">a–z · 0–9 · - · _</span>
+                              ) : adapter.separateId && creating ? (
+                                <span className="dir-ui-edit-hint">
+                                  {slugify(nameValue) ? `→ ${slugify(nameValue)}.md` : 'the id derives from the name'}
                                 </span>
-                                <span className={uiClasses.fieldDescription}>
-                                  The model won’t select this skill
-                                  automatically.
+                              ) : null}
+                            </span>
+                            <Input
+                              id={`${fieldId}-name`}
+                              value={nameValue}
+                              onChange={(next) =>
+                                editDraft(
+                                  setFrontmatterField(
+                                    draft,
+                                    nameField.key,
+                                    adapter.slugName ? next.toLowerCase() : next,
+                                    adapter.slugName,
+                                  ),
+                                )
+                              }
+                              placeholder={`${adapter.noun} name`}
+                              preserveCase={!adapter.slugName}
+                              required={adapter.slugName || adapter.nameRequired}
+                              pattern={adapter.slugName ? '[a-z0-9_-]+' : undefined}
+                              spellCheck={false}
+                              readOnly={readOnly}
+                              className="dir-ui-edit-input"
+                            />
+                          </label>
+                          <label className="dir-ui-edit-field" htmlFor={`${fieldId}-description`}>
+                            <span className="dir-ui-edit-label">Description</span>
+                            <textarea
+                              id={`${fieldId}-description`}
+                              value={descriptionValue}
+                              onChange={(event) =>
+                                editDraft(setFrontmatterField(draft, descriptionField.key, event.currentTarget.value))
+                              }
+                              placeholder={`what this ${adapter.noun} is for…`}
+                              required={adapter.descriptionRequired}
+                              readOnly={readOnly}
+                              rows={2}
+                              className="dir-ui-edit-textarea"
+                            />
+                          </label>
+                          {adapter.modelInvocationOption ? (
+                            modelInvocationSimple ? (
+                              <label className="dir-ui-checkrow dir-ui-model-invocation">
+                                <input
+                                  id={`${fieldId}-disable-model-invocation`}
+                                  type="checkbox"
+                                  checked={modelInvocationDisabled}
+                                  disabled={readOnly}
+                                  onChange={(event) =>
+                                    editDraft(
+                                      event.currentTarget.checked
+                                        ? setFrontmatterField(draft, 'disable-model-invocation', 'true', true)
+                                        : withoutFrontmatterFields(draft, ['disable-model-invocation']),
+                                    )
+                                  }
+                                />
+                                <span className={uiClasses.field}>
+                                  <span className={uiClasses.fieldLabel}>Require explicit invocation</span>
+                                  <span className={uiClasses.fieldDescription}>
+                                    The model won’t select this skill automatically.
+                                  </span>
                                 </span>
-                              </span>
-                            </label>
-                          ) : (
-                            <div
-                              className={`${uiClasses.field} dir-ui-model-invocation`}
-                            >
-                              <span className={uiClasses.fieldLabel}>
-                                Model invocation
-                              </span>
-                              <span className={uiClasses.fieldDescription}>
-                                Advanced value — edit it in Content.
-                              </span>
-                            </div>
-                          )
-                        ) : null}
-                        {adapter.extraFields?.({
-                          host,
-                          draft,
-                          editDraft,
-                          readOnly,
-                          fieldId,
-                          entryKey: creating ? null : (loaded?.key ?? selected),
-                        })}
-                      </div>
+                              </label>
+                            ) : (
+                              <div className={`${uiClasses.field} dir-ui-model-invocation`}>
+                                <span className={uiClasses.fieldLabel}>Model invocation</span>
+                                <span className={uiClasses.fieldDescription}>Advanced value — edit it in Content.</span>
+                              </div>
+                            )
+                          ) : null}
+                          {adapter.extraFields?.({
+                            host,
+                            draft,
+                            editDraft,
+                            readOnly,
+                            fieldId,
+                            entryKey: creating ? null : (loaded?.key ?? selected),
+                          })}
+                        </div>
                       )}
-                      <div className="dir-ui-source-head" aria-hidden>
-                        <span>{adapter.sourceLabel ?? 'Content'}</span>
-                        <span>Markdown</span>
-                      </div>
-                      <CodeEditor
-                        value={editorSource}
-                        onChange={(next) =>
-                          editDraft(
-                            restoreFrontmatterFields(next, managedFields),
-                          )
-                        }
-                        language="markdown"
-                        readOnly={readOnly}
-                        className="dir-ui-code"
-                        aria-label={`${adapter.noun} markdown content`}
-                        placeholder="# markdown…"
-                      />
+                      {!adapter.customFormOwnsContent ? (
+                        <>
+                          <div className="dir-ui-source-head" aria-hidden>
+                            <span>{adapter.sourceLabel ?? 'Content'}</span>
+                            <span>Markdown</span>
+                          </div>
+                          <CodeEditor
+                            value={editorSource}
+                            onChange={(next) => editDraft(restoreFrontmatterFields(next, managedFields))}
+                            language="markdown"
+                            readOnly={readOnly}
+                            className="dir-ui-code"
+                            aria-label={`${adapter.noun} markdown content`}
+                            placeholder="# markdown…"
+                          />
+                        </>
+                      ) : null}
                     </div>
                     {effMode === 'split' ? (
                       // biome-ignore lint/a11y/useSemanticElements: drag handle is not an <hr>; semantic separator + tabIndex is enough
@@ -1419,17 +1326,10 @@ export function CollectionBrowser({
                     {effMode !== 'edit' ? (
                       <div
                         className="dir-ui-pane preview"
-                        style={
-                          effMode === 'split'
-                            ? { flexGrow: 1 - split }
-                            : undefined
-                        }
+                        style={effMode === 'split' ? { flexGrow: 1 - split } : undefined}
                       >
                         <div className="dir-ui-reading">
-                          <MarkdownPreview
-                            markdown={frontmatterBody(draft)}
-                            className="dir-ui-preview"
-                          />
+                          <MarkdownPreview markdown={frontmatterBody(draft)} className="dir-ui-preview" />
                         </div>
                       </div>
                     ) : null}
@@ -1441,13 +1341,7 @@ export function CollectionBrowser({
                     </span>
                     <span className="fact">{formatKb(draftBytes)}</span>
                     <span className="spacer" />
-                    <span className="fact">
-                      {readOnly
-                        ? 'read only'
-                        : dirty
-                          ? '⌘S saves'
-                          : 'all changes saved'}
-                    </span>
+                    <span className="fact">{readOnly ? 'read only' : dirty ? '⌘S saves' : 'all changes saved'}</span>
                   </footer>
                 </>
               )}

--- a/iii-directory/ui/src/page/frontmatter.ts
+++ b/iii-directory/ui/src/page/frontmatter.ts
@@ -175,6 +175,11 @@ export function frontmatterBody(content: string): string {
   return splitFrontmatter(content).body
 }
 
+/** Replace only the markdown body, preserving frontmatter bytes and EOLs. */
+export function setFrontmatterBody(content: string, body: string): string {
+  return joinFrontmatter({ ...splitFrontmatter(content), body })
+}
+
 /** Decode one list item scalar (bare, quoted, or ~/null). */
 function decodeItem(raw: string): string {
   return decodeScalar(raw, [])

--- a/iii-directory/ui/src/page/index.tsx
+++ b/iii-directory/ui/src/page/index.tsx
@@ -9,19 +9,13 @@
  * unsaved draft survives switching between them.
  */
 
-import {
-  type Host,
-  PageHeader,
-  type PageRenderProps,
-  PageShell,
-  SegmentedControl,
-} from '@iii-dev/console-ui'
+import { type Host, PageHeader, type PageRenderProps, PageShell, SegmentedControl } from '@iii-dev/console-ui'
 import { useEffect, useRef, useState } from 'react'
 import { formatBytes, formatRelativeTime } from '../lib/format'
 import { MarkdownFileIcon } from '../lib/widgets'
-import { AgentForm } from './agent-fields'
-import { TokenIcon } from './token-icons'
+import { AgentForm, AgentFormSkeleton } from './agent-fields'
 import { type BrowserAdapter, CollectionBrowser } from './browser'
+import { TokenIcon } from './token-icons'
 
 interface SkillRow {
   id: string
@@ -43,6 +37,7 @@ interface AgentRow {
   description: string
   logo: string | null
   icon: string | null
+  color: string | null
   modified_at: string
 }
 
@@ -58,17 +53,13 @@ const skillsAdapter: BrowserAdapter = {
   modelInvocationOption: true,
   // Skill ids are slash-separated lowercase segments (ns/skill/…).
   namePattern: /^[a-z0-9_-]+(\/[a-z0-9_-]+)*$/,
-  nameHint:
-    'enter an id of lowercase slash-separated segments (a–z, 0–9, hyphens or underscores)',
+  nameHint: 'enter an id of lowercase slash-separated segments (a–z, 0–9, hyphens or underscores)',
   onChangeType: 'directory::skills::on-change',
   emptyTitle: 'Select a skill',
   emptyBody:
     'Choose a skill from the sidebar to view and edit its markdown. New skills arrive through the new-skill button, downloads (directory::skills::download), or direct edits to the skills folder.',
   async list(host) {
-    const out = await host.iii.trigger<{ skills: SkillRow[] }>(
-      'directory::skills::list',
-      { include_description: true },
-    )
+    const out = await host.iii.trigger<{ skills: SkillRow[] }>('directory::skills::list', { include_description: true })
     return (out.skills ?? []).map((s) => ({
       key: s.id,
       title: s.title,
@@ -77,29 +68,20 @@ const skillsAdapter: BrowserAdapter = {
     }))
   },
   async load(host, id) {
-    const out = await host.iii.trigger<{ body: string; raw?: string | null }>(
-      'directory::skills::get',
-      {
-        id,
-        raw: true,
-      },
-    )
+    const out = await host.iii.trigger<{ body: string; raw?: string | null }>('directory::skills::get', {
+      id,
+      raw: true,
+    })
     // `raw` is the exact on-disk file; body (frontmatter-stripped) is the
     // fallback against a not-yet-updated worker.
     return out.raw ?? out.body
   },
   async save(host, id, content) {
-    const out = await host.iii.trigger<{ id: string }>(
-      'directory::skills::update',
-      { id, content },
-    )
+    const out = await host.iii.trigger<{ id: string }>('directory::skills::update', { id, content })
     return out.id ?? id
   },
   async create(host, id, content) {
-    const out = await host.iii.trigger<{ id: string }>(
-      'directory::skills::create',
-      { id, content },
-    )
+    const out = await host.iii.trigger<{ id: string }>('directory::skills::create', { id, content })
     return out.id ?? id
   },
   async remove(host, id) {
@@ -119,9 +101,7 @@ export const systemPromptsAdapter: BrowserAdapter = {
   emptyBody:
     'Choose a system prompt from the sidebar to view and edit its markdown. These are what the chat picker offers as an identity prompt — filesystem-backed, so files added to the system-prompts folders appear here automatically.',
   async list(host) {
-    const out = await host.iii.trigger<{ prompts: SystemPromptRow[] }>(
-      'directory::system-prompts::list',
-    )
+    const out = await host.iii.trigger<{ prompts: SystemPromptRow[] }>('directory::system-prompts::list')
     return [
       {
         key: HARNESS_DEFAULT_SYSTEM_PROMPT_KEY,
@@ -140,36 +120,27 @@ export const systemPromptsAdapter: BrowserAdapter = {
   },
   async load(host, name) {
     if (name === HARNESS_DEFAULT_SYSTEM_PROMPT_KEY) {
-      const out = await host.iii.trigger<SystemPromptPreview>(
-        'harness::system-prompt::get',
-        {
-          session_id: `iii-directory:${host.iii.browserId}`,
-          default_only: true,
-        },
-      )
+      const out = await host.iii.trigger<SystemPromptPreview>('harness::system-prompt::get', {
+        session_id: `iii-directory:${host.iii.browserId}`,
+        default_only: true,
+      })
       const builtIn = out.parts.find((part) => part.kind === 'built_in')
       if (!builtIn) throw new Error('Harness default system prompt is unavailable')
       return builtIn.body
     }
-    const out = await host.iii.trigger<{ body: string; raw?: string | null }>(
-      'directory::system-prompts::get',
-      { name, raw: true },
-    )
+    const out = await host.iii.trigger<{ body: string; raw?: string | null }>('directory::system-prompts::get', {
+      name,
+      raw: true,
+    })
     return out.raw ?? out.body
   },
   async save(host, name, content) {
     // The effective name after the write follows a frontmatter rename.
-    const out = await host.iii.trigger<{ name: string }>(
-      'directory::system-prompts::update',
-      { name, content },
-    )
+    const out = await host.iii.trigger<{ name: string }>('directory::system-prompts::update', { name, content })
     return out.name ?? name
   },
   async create(host, name, content) {
-    const out = await host.iii.trigger<{ name: string }>(
-      'directory::system-prompts::create',
-      { name, content },
-    )
+    const out = await host.iii.trigger<{ name: string }>('directory::system-prompts::create', { name, content })
     return out.name ?? name
   },
   async remove(host, name) {
@@ -178,7 +149,7 @@ export const systemPromptsAdapter: BrowserAdapter = {
 }
 
 export const agentsAdapter: BrowserAdapter = {
-  noun: 'agent',
+  noun: 'agent profile',
   crumbRoot: 'agents',
   // The id (file stem) and the display name are different things for an
   // agent: "Release Captain" lives in frontmatter `name`, the file is
@@ -189,22 +160,23 @@ export const agentsAdapter: BrowserAdapter = {
   },
   nameRequired: true,
   newTemplate: '---\nname: \ndescription: ""\n---\n\n',
-  extraManagedKeys: ['logo', 'skills', 'leaf', 'model', 'icon'],
+  newTemplateStartsClean: true,
+  extraManagedKeys: ['logo', 'skills', 'model', 'icon', 'color'],
   customForm: (ctx) => <AgentForm {...ctx} />,
-  sourceLabel: 'Instructions · system prompt',
+  customLoading: () => <AgentFormSkeleton />,
+  customFormOwnsContent: true,
+  customFormOwnsWorkspaceHeader: true,
+  prominentListItems: true,
   onChangeType: 'directory::agents::on-change',
-  emptyTitle: 'Select an agent',
-  emptyBody:
-    'Choose an agent from the sidebar to view and edit its profile. The content below the fields is the system prompt the session runs as; name, logo and skill selection live in the fields above it.',
+  emptyTitle: 'Select an agent profile',
+  emptyBody: 'Choose an agent profile from the sidebar to edit its identity, default model, system prompt, and skills.',
   async list(host) {
-    const out = await host.iii.trigger<{ agents: AgentRow[] }>(
-      'directory::agents::list',
-    )
+    const out = await host.iii.trigger<{ agents: AgentRow[] }>('directory::agents::list')
     return (out.agents ?? []).map((a) => ({
       key: a.id,
       // The row glyph is the SAME token glyph the avatar picker and the
       // console session tree render — one identity, one pictogram.
-      icon: a.icon ? <TokenIcon token={a.icon} size={14} /> : undefined,
+      icon: <TokenIcon token={a.icon || 'agent'} size={20} />,
       title: a.name,
       description: a.description,
       fine: formatRelativeTime(a.modified_at),
@@ -218,17 +190,11 @@ export const agentsAdapter: BrowserAdapter = {
     return out.raw ?? out.system_prompt
   },
   async save(host, id, content) {
-    const out = await host.iii.trigger<{ id: string }>(
-      'directory::agents::update',
-      { id, content },
-    )
+    const out = await host.iii.trigger<{ id: string }>('directory::agents::update', { id, content })
     return out.id ?? id
   },
   async create(host, id, content) {
-    const out = await host.iii.trigger<{ id: string }>(
-      'directory::agents::create',
-      { id, content },
-    )
+    const out = await host.iii.trigger<{ id: string }>('directory::agents::create', { id, content })
     return out.id ?? id
   },
   async remove(host, id) {
@@ -241,7 +207,7 @@ type Collection = 'skills' | 'system-prompts' | 'agents'
 const COLLECTIONS: { value: Collection; label: string }[] = [
   { value: 'skills', label: 'Skills' },
   { value: 'system-prompts', label: 'System Prompts' },
-  { value: 'agents', label: 'Agents' },
+  { value: 'agents', label: 'Agent Profiles' },
 ]
 
 const ADAPTERS: Record<Collection, BrowserAdapter> = {
@@ -299,8 +265,9 @@ export function DirectoryPage({
       value={collection}
       onChange={setCollection}
       options={COLLECTIONS}
+      iconOnly
       className="dir-ui-collection-tabs"
-      aria-label="Browse skills, system prompts or agents"
+      aria-label="Browse skills, system prompts or agent profiles"
     />
   )
 
@@ -309,15 +276,11 @@ export function DirectoryPage({
       <PageHeader
         icon={<MarkdownFileIcon />}
         title="Directory"
-        description="Filesystem-backed skills, system prompts and agents"
+        description="Filesystem-backed skills, system prompts and agent profiles"
         onClose={onRequestClose}
       />
       {COLLECTIONS.map((c) => (
-        <div
-          key={c.value}
-          className="dir-ui-shell-body"
-          hidden={collection !== c.value}
-        >
+        <div key={c.value} className="dir-ui-shell-body" hidden={collection !== c.value}>
           <CollectionBrowser
             host={host}
             adapter={ADAPTERS[c.value]}
@@ -326,11 +289,7 @@ export function DirectoryPage({
             storageKey={`iii-directory-ui:${tabId || 'page'}:${c.value}`}
             commands={commands}
             active={collection === c.value}
-            pendingOpen={
-              pendingOpen && pendingOpen.collection === c.value
-                ? pendingOpen
-                : null
-            }
+            pendingOpen={pendingOpen && pendingOpen.collection === c.value ? pendingOpen : null}
           />
         </div>
       ))}

--- a/iii-directory/ui/src/page/index.tsx
+++ b/iii-directory/ui/src/page/index.tsx
@@ -161,7 +161,7 @@ export const agentsAdapter: BrowserAdapter = {
   nameRequired: true,
   newTemplate: '---\nname: \ndescription: ""\n---\n\n',
   newTemplateStartsClean: true,
-  extraManagedKeys: ['logo', 'skills', 'model', 'icon', 'color'],
+  extraManagedKeys: ['logo', 'skills', 'model', 'reasoning_effort', 'icon', 'color'],
   customForm: (ctx) => <AgentForm {...ctx} />,
   customLoading: () => <AgentFormSkeleton />,
   customFormOwnsContent: true,

--- a/iii-directory/ui/src/page/palette.ts
+++ b/iii-directory/ui/src/page/palette.ts
@@ -1,7 +1,7 @@
 /**
  * The directory worker in the command palette, before its page is even
  * open. One combined source answers a query across all three collections
- * (skills, system prompts, agents) — the worker has no unified search
+ * (skills, system prompts, agent profiles) — the worker has no unified search
  * function, so this fetches each collection's list and filters
  * client-side, the same as the in-page filter does. Rows open the page on
  * that collection with the entry selected (see the page's panelContext
@@ -30,7 +30,11 @@ const COLLECTIONS: {
     label: 'System prompts',
     listFn: 'directory::system-prompts::list',
   },
-  { id: 'agents', label: 'Agents', listFn: 'directory::agents::list' },
+  {
+    id: 'agents',
+    label: 'Agent Profiles',
+    listFn: 'directory::agents::list',
+  },
 ]
 
 interface Row {
@@ -50,7 +54,7 @@ async function listCollection(
     payload,
   )
   // Skills answer `{ skills }`, system prompts answer `{ prompts }`, and
-  // agents answer `{ agents }`.
+  // agent profiles answer `{ agents }`.
   const items = (out.skills ??
     out.prompts ??
     out.agents ??
@@ -105,8 +109,8 @@ export function registerDirectoryPalette(host: Host): void {
     {
       id: 'open',
       title: 'Open Directory',
-      detail: 'Filesystem-backed skills, system prompts and agents',
-      keywords: ['skills', 'system prompts', 'agents'],
+      detail: 'Filesystem-backed skills, system prompts and agent profiles',
+      keywords: ['skills', 'system prompts', 'agent profiles', 'agents'],
       run: () => host.panels?.open({ pageId: 'directory', context: {} }),
     },
   ])

--- a/iii-directory/ui/styles.css
+++ b/iii-directory/ui/styles.css
@@ -371,6 +371,11 @@
   width: 100%;
   flex-shrink: 0;
 }
+[data-iii-ui="iii-directory"]
+  .dir-ui-collection-tabs[data-icon-only="true"]
+  > button {
+  flex: 1 1 0;
+}
 
 /* search */
 [data-iii-ui="iii-directory"] .dir-ui-search {
@@ -497,11 +502,111 @@
   color: var(--color-ink-ghost);
   font-variant-numeric: tabular-nums;
 }
+[data-iii-ui="iii-directory"] .dir-ui-browser.prominent-list .dir-ui-nav-row {
+  display: grid;
+  min-height: 58px;
+  grid-template-columns: 32px minmax(0, 1fr);
+  grid-template-rows: auto auto;
+  column-gap: 10px;
+  row-gap: 2px;
+  align-content: center;
+  padding: 9px 10px;
+}
+[data-iii-ui="iii-directory"]
+  .dir-ui-browser.prominent-list
+  .dir-ui-nav-row
+  .name {
+  grid-column: 2;
+  grid-row: 1;
+  min-width: 0;
+  overflow: hidden;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-break: normal;
+}
+[data-iii-ui="iii-directory"]
+  .dir-ui-browser.prominent-list
+  .dir-ui-nav-row
+  .name.mono {
+  font-family: var(--font-sans, ui-sans-serif, sans-serif);
+  font-size: 14px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-browser.prominent-list .dir-ui-nav-ico {
+  grid-column: 1;
+  grid-row: 1 / 3;
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+  justify-content: center;
+  align-self: center;
+  margin-right: 0;
+  border-radius: 8px;
+  background: var(--color-surface);
+  color: var(--color-ink-faint);
+}
+[data-iii-ui="iii-directory"]
+  .dir-ui-browser.prominent-list
+  .dir-ui-nav-ico
+  svg {
+  width: 20px;
+  height: 20px;
+}
+[data-iii-ui="iii-directory"]
+  .dir-ui-browser.prominent-list
+  .dir-ui-nav-row
+  .id,
+[data-iii-ui="iii-directory"]
+  .dir-ui-browser.prominent-list
+  .dir-ui-nav-row
+  .desc {
+  grid-column: 2;
+  grid-row: 2;
+  min-width: 0;
+  overflow: hidden;
+  font-family: var(--font-sans, ui-sans-serif, sans-serif);
+  font-size: 12px;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-break: normal;
+}
+[data-iii-ui="iii-directory"]
+  .dir-ui-browser.prominent-list
+  .dir-ui-nav-row
+  .desc {
+  display: block;
+}
+[data-iii-ui="iii-directory"]
+  .dir-ui-browser.prominent-list
+  .dir-ui-nav-row:has(.desc)
+  .id,
+[data-iii-ui="iii-directory"]
+  .dir-ui-browser.prominent-list
+  .dir-ui-nav-row
+  .fine {
+  display: none;
+}
 /* Touch-sized targets in the drill-in flow. */
 [data-iii-ui="iii-directory"] .dir-ui-browser.narrow .dir-ui-nav-row {
   min-height: 44px;
   padding-top: 12px;
   padding-bottom: 12px;
+}
+[data-iii-ui="iii-directory"]
+  .dir-ui-browser.narrow.prominent-list
+  .dir-ui-nav-row {
+  min-height: 68px;
+  grid-template-columns: 36px minmax(0, 1fr);
+  column-gap: 12px;
+}
+[data-iii-ui="iii-directory"]
+  .dir-ui-browser.narrow.prominent-list
+  .dir-ui-nav-ico {
+  width: 36px;
+  height: 36px;
 }
 
 /* sidebar loading / empty / error */
@@ -836,8 +941,7 @@
   min-width: 0;
   padding-top: 2px;
 }
-[data-iii-ui="iii-directory"]
-  .dir-ui-checkrow.dir-ui-model-invocation {
+[data-iii-ui="iii-directory"] .dir-ui-checkrow.dir-ui-model-invocation {
   align-items: flex-start;
 }
 [data-iii-ui="iii-directory"] label.dir-ui-model-invocation {
@@ -1034,11 +1138,6 @@
 [data-iii-ui="iii-directory"] .dir-ui-preview ol {
   font-size: 14px;
   line-height: 1.65;
-}
-[data-iii-ui="iii-directory"] .dir-ui-browser.narrow .dir-ui-preview p,
-[data-iii-ui="iii-directory"] .dir-ui-browser.narrow .dir-ui-preview ul,
-[data-iii-ui="iii-directory"] .dir-ui-browser.narrow .dir-ui-preview ol {
-  font-size: 15px;
 }
 [data-iii-ui="iii-directory"] .dir-ui-preview h1,
 [data-iii-ui="iii-directory"] .dir-ui-preview h2,
@@ -1475,7 +1574,10 @@
   word-break: break-all;
 }
 
-[data-iii-ui="iii-directory"] .discovery-search-action .sym.tone-accent + .body {
+[data-iii-ui="iii-directory"]
+  .discovery-search-action
+  .sym.tone-accent
+  + .body {
   color: var(--color-accent);
 }
 
@@ -1511,7 +1613,9 @@
   list-style: none;
 }
 
-[data-iii-ui="iii-directory"] .discovery-search-fn > summary::-webkit-details-marker {
+[data-iii-ui="iii-directory"]
+  .discovery-search-fn
+  > summary::-webkit-details-marker {
   display: none;
 }
 
@@ -1661,7 +1765,9 @@
   list-style: none;
 }
 
-[data-iii-ui="iii-directory"] .discovery-search-guidance > summary::-webkit-details-marker {
+[data-iii-ui="iii-directory"]
+  .discovery-search-guidance
+  > summary::-webkit-details-marker {
   display: none;
 }
 
@@ -1669,7 +1775,10 @@
   color: var(--color-ink-faint);
 }
 
-[data-iii-ui="iii-directory"] .discovery-search-guidance[open] > summary .caret {
+[data-iii-ui="iii-directory"]
+  .discovery-search-guidance[open]
+  > summary
+  .caret {
   transform: rotate(90deg);
 }
 
@@ -1681,420 +1790,1275 @@
   overflow-wrap: anywhere;
 }
 
-/* ── agent profile fields: emoji logo + skill selection ─────────────────
-   Rendered by AgentExtraFields inside .dir-ui-edit-fields, so the grid,
-   label, and input styles above already apply; this only adds what the
-   picker needs — a full-width row, a bounded scrolling list, and the
-   missing-skill marker the ticket calls for. */
-[data-iii-ui="iii-directory"] .dir-ui-agent-logo {
-  max-width: 120px;
-  font-size: 16px;
-}
-[data-iii-ui="iii-directory"] .dir-ui-agent-skills {
-  grid-column: 1 / -1;
-}
-[data-iii-ui="iii-directory"] .dir-ui-agent-skill-list {
-  margin: 0;
-  padding: 4px;
-  list-style: none;
-  max-height: 168px;
-  overflow-y: auto;
-  border: 1px solid var(--color-edge);
-  border-radius: 6px;
-  background: var(--color-surface);
-  display: flex;
-  flex-direction: column;
-}
-[data-iii-ui="iii-directory"] .dir-ui-agent-skill-row {
-  padding: 5px 8px;
-  border-radius: 4px;
-  cursor: pointer;
-  min-width: 0;
-}
-[data-iii-ui="iii-directory"] .dir-ui-agent-skill-row:hover {
-  background: var(--color-surface-hover);
-}
-[data-iii-ui="iii-directory"] .dir-ui-agent-skill-row:has(input:disabled) {
-  cursor: default;
-}
-[data-iii-ui="iii-directory"] .dir-ui-agent-skill-name {
-  font-size: 12.5px;
-  color: var(--color-ink);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-[data-iii-ui="iii-directory"] .dir-ui-agent-skill-id {
-  font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 11px;
-  color: var(--color-ink-faint);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-[data-iii-ui="iii-directory"] .dir-ui-agent-skill-empty {
-  font-size: 12px;
-  color: var(--color-ink-faint);
-  padding: 6px 8px;
-}
-[data-iii-ui="iii-directory"] .dir-ui-agent-skill-missing {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-[data-iii-ui="iii-directory"] .dir-ui-agent-missing-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 12px;
-  color: var(--color-ink);
-}
-[data-iii-ui="iii-directory"] .dir-ui-agent-missing-row .mono {
-  font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 11.5px;
-}
-[data-iii-ui="iii-directory"] .dir-ui-agent-missing-badge {
-  font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 9.5px;
-  line-height: 1;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--color-warning, #b58900);
-  border: 1px solid currentColor;
-  border-radius: 999px;
-  padding: 3px 7px;
-}
-[data-iii-ui="iii-directory"] .dir-ui-agent-leaf {
-  padding: 2px 0 4px;
-  font-size: 12.5px;
-  color: var(--color-ink);
-  cursor: pointer;
-}
-[data-iii-ui="iii-directory"] .dir-ui-agent-leaf:has(input:disabled) {
-  cursor: default;
-}
-[data-iii-ui="iii-directory"] .dir-ui-agent-model {
-  appearance: none;
-  border: 1px solid transparent;
-  border-radius: 6px;
-  background: var(--color-surface);
-  color: var(--color-ink);
-  padding: 0 12px;
-  font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 12.5px;
-  cursor: pointer;
-}
-[data-iii-ui="iii-directory"] .dir-ui-agent-model:hover {
-  background: var(--color-surface-hover);
-}
-[data-iii-ui="iii-directory"] .dir-ui-agent-model:focus {
-  outline: none;
-  border-color: var(--color-rule-focus);
-  box-shadow: 0 0 0 3px var(--color-accent-muted);
-}
-[data-iii-ui="iii-directory"] .dir-ui-agent-model:disabled {
-  cursor: default;
-  opacity: 0.7;
-}
-[data-iii-ui="iii-directory"] .dir-ui-agent-logo-row {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  flex-wrap: wrap;
-}
-[data-iii-ui="iii-directory"] .dir-ui-agent-logo-preset {
-  appearance: none;
-  width: 36px;
-  height: 36px;
-  border: 1px solid var(--color-edge);
-  border-radius: 6px;
-  background: var(--color-surface);
-  font-size: 17px;
-  line-height: 1;
-  cursor: pointer;
-  transition:
-    border-color var(--motion-duration-control) var(--motion-ease-standard),
-    background-color var(--motion-duration-control) var(--motion-ease-standard);
-}
-[data-iii-ui="iii-directory"] .dir-ui-agent-logo-preset:hover {
-  background: var(--color-surface-hover);
-}
-[data-iii-ui="iii-directory"] .dir-ui-agent-logo-preset.active {
-  border-color: var(--color-rule-focus);
-  box-shadow: 0 0 0 3px var(--color-accent-muted);
-}
-[data-iii-ui="iii-directory"] .dir-ui-agent-logo-preset:disabled {
-  cursor: default;
-  opacity: 0.6;
-}
-
-/* ── agent form: sectioned settings layout (Identity / Behavior /
-   Execution / Delegation), the reference pattern. Sits where the flat
-   edit-fields grid sits for other collections, scrolling on its own so
-   the editor below keeps its room. */
-[data-iii-ui="iii-directory"] .dir-ui-af {
-  flex-shrink: 0;
-  max-height: 55%;
-  overflow-y: auto;
-  padding: 16px;
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
-  background: var(--color-panel-raised);
-  border-bottom: 1px solid var(--color-edge);
-}
-[data-iii-ui="iii-directory"] .dir-ui-af-section {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-[data-iii-ui="iii-directory"] .dir-ui-af-title {
-  margin: 0;
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--color-ink);
-}
-[data-iii-ui="iii-directory"] .dir-ui-af-hint {
-  margin: 0 0 6px;
-  font-size: 11.5px;
-  color: var(--color-ink-faint);
-}
-[data-iii-ui="iii-directory"] .dir-ui-af-card {
-  border: 1px solid var(--color-edge);
-  border-radius: 8px;
-  background: var(--color-surface);
-}
-[data-iii-ui="iii-directory"] .dir-ui-af-row {
-  display: grid;
-  grid-template-columns: minmax(110px, 150px) 1fr;
-  gap: 12px;
-  align-items: start;
-  padding: 12px 14px;
-}
-[data-iii-ui="iii-directory"] .dir-ui-af-row + .dir-ui-af-row {
-  border-top: 1px solid var(--color-edge);
-}
-[data-iii-ui="iii-directory"] .dir-ui-browser.narrow .dir-ui-af-row {
-  grid-template-columns: minmax(0, 1fr);
-}
-[data-iii-ui="iii-directory"] .dir-ui-af-label {
-  padding-top: 8px;
-  font-size: 12.5px;
-  color: var(--color-ink);
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-[data-iii-ui="iii-directory"] .dir-ui-af-label-hint {
-  font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 10.5px;
-  color: var(--color-ink-faint);
-}
-[data-iii-ui="iii-directory"] .dir-ui-af-control {
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-/* avatar + popover */
-[data-iii-ui="iii-directory"] .dir-ui-af-avatar-wrap {
-  position: relative;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-[data-iii-ui="iii-directory"] .dir-ui-af-avatar {
-  appearance: none;
-  width: 44px;
-  height: 44px;
-  border: 1px solid var(--color-edge);
-  border-radius: 10px;
-  background: var(--color-panel-raised);
-  font-size: 22px;
-  line-height: 1;
-  cursor: pointer;
-}
-[data-iii-ui="iii-directory"] .dir-ui-af-avatar:hover {
-  background: var(--color-surface-hover);
-}
-[data-iii-ui="iii-directory"] .dir-ui-af-avatar-empty {
-  opacity: 0.35;
-}
-[data-iii-ui="iii-directory"] .dir-ui-af-avatar-note {
-  font-size: 11.5px;
-  color: var(--color-ink-faint);
-}
-[data-iii-ui="iii-directory"] .dir-ui-af-pop-backdrop {
-  position: fixed;
-  inset: 0;
-  z-index: 40;
-}
-[data-iii-ui="iii-directory"] .dir-ui-af-pop {
-  position: absolute;
-  top: 50px;
-  left: 0;
-  z-index: 41;
-  width: max-content;
-  max-width: 320px;
-  padding: 10px;
-  border: 1px solid var(--color-edge);
-  border-radius: 10px;
-  background: var(--color-panel-raised);
-  box-shadow: 0 10px 32px rgba(0, 0, 0, 0.35);
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-[data-iii-ui="iii-directory"] .dir-ui-af-pop-head {
-  font-size: 11px;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--color-ink-faint);
-}
-[data-iii-ui="iii-directory"] .dir-ui-af-pop-grid {
-  display: grid;
-  grid-template-columns: repeat(8, 32px);
-  gap: 4px;
-  justify-content: start;
-}
-[data-iii-ui="iii-directory"] .dir-ui-af-pop-grid .dir-ui-agent-logo-preset {
-  width: 32px;
-  height: 32px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-  font-size: 16px;
-  line-height: 1;
-  font-family: 'Noto Color Emoji', 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif;
-}
-[data-iii-ui="iii-directory"] .dir-ui-af-pop-free {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-/* collapsed picker row + expanded panel */
-[data-iii-ui="iii-directory"] .dir-ui-af-collapsed {
-  appearance: none;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
-  padding: 9px 12px;
-  border: 1px solid var(--color-edge);
-  border-radius: 6px;
-  background: var(--color-panel-raised);
-  color: var(--color-ink-faint);
-  font-size: 12.5px;
-  cursor: pointer;
-  text-align: left;
-}
-[data-iii-ui="iii-directory"] .dir-ui-af-collapsed:hover {
-  background: var(--color-surface-hover);
-  color: var(--color-ink);
-}
-[data-iii-ui="iii-directory"] .dir-ui-af-plus {
-  font-size: 13px;
-}
-[data-iii-ui="iii-directory"] .dir-ui-af-chev {
-  margin-left: auto;
-  opacity: 0.6;
-}
-[data-iii-ui="iii-directory"] .dir-ui-af-picker {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-[data-iii-ui="iii-directory"] .dir-ui-af-picker-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-}
-[data-iii-ui="iii-directory"] .dir-ui-af-picker-count {
-  font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 10.5px;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--color-ink-faint);
-}
-[data-iii-ui="iii-directory"] .dir-ui-agent-skill-list.tall {
-  max-height: 240px;
-}
-[data-iii-ui="iii-directory"] .dir-ui-af-pick-row {
-  align-items: flex-start;
-  padding: 7px 8px;
-}
-[data-iii-ui="iii-directory"] .dir-ui-af-pick-row input {
-  margin-top: 2px;
-}
-[data-iii-ui="iii-directory"] .dir-ui-af-pick-body {
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-[data-iii-ui="iii-directory"] .dir-ui-af-pick-name {
-  display: flex;
-  align-items: baseline;
-  gap: 8px;
-  font-size: 12.5px;
-  color: var(--color-ink);
-}
-[data-iii-ui="iii-directory"] .dir-ui-af-pick-desc {
-  font-size: 11.5px;
-  color: var(--color-ink-faint);
-  overflow: hidden;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-}
-
-/* Tree-icon tiles: the exact lucide glyphs the console tree renders,
-   one per SubagentIcon token. Same tile chrome as the emoji presets. */
-[data-iii-ui="iii-directory"] .dir-ui-af-icon-grid {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
-[data-iii-ui="iii-directory"] .dir-ui-af-icon-tile {
-  appearance: none;
-  width: 34px;
-  height: 34px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-  border: 1px solid var(--color-edge);
-  border-radius: 6px;
-  background: var(--color-panel-raised);
-  color: var(--color-ink-faint);
-  cursor: pointer;
-  transition:
-    border-color var(--motion-duration-control) var(--motion-ease-standard),
-    color var(--motion-duration-control) var(--motion-ease-standard),
-    background-color var(--motion-duration-control) var(--motion-ease-standard);
-}
-[data-iii-ui="iii-directory"] .dir-ui-af-icon-tile:hover {
-  background: var(--color-surface-hover);
-  color: var(--color-ink);
-}
-[data-iii-ui="iii-directory"] .dir-ui-af-icon-tile.active {
-  border-color: var(--color-rule-focus);
-  color: var(--color-ink);
-  box-shadow: 0 0 0 3px var(--color-accent-muted);
-}
-[data-iii-ui="iii-directory"] .dir-ui-af-icon-tile:disabled {
-  cursor: default;
-  opacity: 0.6;
-}
-
 [data-iii-ui="iii-directory"] .dir-ui-nav-ico {
   display: inline-flex;
   align-items: center;
   vertical-align: -2px;
   margin-right: 6px;
   color: var(--color-ink-faint);
+}
+
+/* ── agent editor refresh ────────────────────────────────────────────
+   The editor is intentionally flatter than the generic settings form:
+   identity is inline, content stays aligned to the identity copy, and
+   system prompt / skills use disclosure rows instead of stacked cards. */
+
+:root {
+  --dropdown-open-dur: 250ms;
+  --dropdown-close-dur: 150ms;
+  --dropdown-pre-scale: 0.97;
+  --dropdown-closing-scale: 0.99;
+  --dropdown-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --acc-expand: 250ms;
+  --acc-collapse: 250ms;
+  --acc-chevron: 250ms;
+  --acc-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --check-box: 150ms;
+  --check-draw: 350ms;
+  --check-delay: 0ms;
+  --check-uncheck: 150ms;
+  --check-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --pulse-dur: 1000ms;
+  --pulse-count: 1;
+  --pulse-min: 0.5;
+  --reveal-dur: 400ms;
+  --reveal-blur: 2px;
+  --reveal-ease: ease-in-out;
+}
+
+.t-dropdown {
+  transform-origin: top left;
+  transform: scale(var(--dropdown-pre-scale));
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    transform var(--dropdown-open-dur) var(--dropdown-ease),
+    opacity var(--dropdown-open-dur) var(--dropdown-ease);
+  will-change: transform, opacity;
+}
+.t-dropdown[data-origin="top-right"] {
+  transform-origin: top right;
+}
+.t-dropdown[data-origin="top-center"] {
+  transform-origin: top center;
+}
+.t-dropdown[data-origin="bottom-left"] {
+  transform-origin: bottom left;
+}
+.t-dropdown[data-origin="bottom-center"] {
+  transform-origin: bottom center;
+}
+.t-dropdown[data-origin="bottom-right"] {
+  transform-origin: bottom right;
+}
+
+.t-dropdown.is-open {
+  transform: scale(1);
+  opacity: 1;
+  pointer-events: auto;
+}
+.t-dropdown.is-closing {
+  transform: scale(var(--dropdown-closing-scale));
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    transform var(--dropdown-close-dur) var(--dropdown-ease),
+    opacity var(--dropdown-close-dur) var(--dropdown-ease);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .t-dropdown {
+    transition: none !important;
+  }
+}
+
+/* The wrap stacks two layers on the same coordinates. The
+   skeleton owns the cold pulse + the fade-out side of the
+   reveal; the content owns the fade-in side. They share the
+   same duration / ease so the swap reads as one motion. */
+.t-skel { position: relative; }
+.t-skel-skeleton,
+.t-skel-content {
+  position: absolute;
+  inset: 0;
+}
+
+.t-skel-skeleton {
+  z-index: 1;
+  opacity: 1;
+  filter: blur(0);
+  transition:
+    opacity var(--reveal-dur) var(--reveal-ease),
+    filter  var(--reveal-dur) var(--reveal-ease);
+}
+.t-skel-content {
+  z-index: 2;
+  opacity: 0;
+  filter: blur(var(--reveal-blur));
+  transition:
+    opacity var(--reveal-dur) var(--reveal-ease),
+    filter  var(--reveal-dur) var(--reveal-ease);
+}
+.t-skel.is-revealed .t-skel-skeleton {
+  opacity: 0;
+  filter: blur(var(--reveal-blur));
+}
+.t-skel.is-revealed .t-skel-content {
+  opacity: 1;
+  filter: blur(0);
+}
+/* Snap-back when replaying: kill transitions so the reverse
+   (revealed → skeleton) is instant. Drop `.is-resetting`
+   after a forced reflow and the next reveal animates again. */
+.t-skel.is-resetting .t-skel-skeleton,
+.t-skel.is-resetting .t-skel-content {
+  transition: none !important;
+}
+
+/* Pulse: place the animation on the bar/avatar children, not
+   on the skeleton itself, so the skeleton's opacity / filter
+   stay free for the cross-fade transition above. */
+.t-skel-skeleton.is-pulsing > * {
+  animation: t-skel-pulse var(--pulse-dur) ease-in-out var(--pulse-count);
+}
+@keyframes t-skel-pulse {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: var(--pulse-min); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .t-skel-skeleton, .t-skel-content {
+    transition: none !important;
+  }
+  .t-skel-skeleton.is-pulsing > * { animation: none !important; }
+}
+
+/* grid-template-rows 0fr → 1fr gives a clean height animation
+   with no JS measurement; the inner element clips overflow. */
+.t-acc-panel {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows var(--acc-collapse) var(--acc-ease);
+}
+.t-acc[data-open="true"] .t-acc-panel {
+  grid-template-rows: 1fr;
+  transition: grid-template-rows var(--acc-expand) var(--acc-ease);
+}
+.t-acc-panel-inner {
+  overflow: hidden;
+  opacity: 0;
+  filter: blur(2px);
+  transition:
+    opacity var(--acc-collapse) var(--acc-ease),
+    filter var(--acc-collapse) var(--acc-ease);
+}
+.t-acc[data-open="true"] .t-acc-panel-inner {
+  opacity: 1;
+  filter: blur(0);
+  transition:
+    opacity var(--acc-expand) var(--acc-ease),
+    filter var(--acc-expand) var(--acc-ease);
+}
+/* Flip the chevron vertically to turn the "v" into a "^".
+   scaleY(-1) about the centre passes through a flat line at
+   the midpoint (same look as a `d:` path morph) but animates
+   in every browser, unlike CSS `d:` morphing (Chromium only).
+   The chevron path is symmetric about the 16x16 viewBox
+   centre, so the flip lands exactly on the "^"; non-scaling
+   -stroke keeps the stroke width constant through the flip. */
+.t-acc-chevron {
+  display: inline-flex;
+  transform: scaleY(1);
+  transform-origin: center;
+  transition: transform var(--acc-chevron) var(--acc-ease);
+}
+.t-acc-chevron path {
+  vector-effect: non-scaling-stroke;
+}
+.t-acc[data-open="true"] .t-acc-chevron {
+  transform: scaleY(-1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .t-acc-panel,
+  .t-acc-panel-inner,
+  .t-acc-chevron {
+    transition: none !important;
+  }
+}
+
+.t-check {
+  transition:
+    background var(--check-box) var(--check-ease),
+    box-shadow var(--check-box) var(--check-ease);
+}
+.t-check svg path {
+  stroke-dasharray: var(--check-len, 15);
+  stroke-dashoffset: var(--check-len, 15);
+  transition: stroke-dashoffset var(--check-uncheck) var(--check-ease);
+}
+.t-check[aria-checked="true"] svg path {
+  stroke-dashoffset: 0;
+  transition: stroke-dashoffset var(--check-draw) var(--check-ease)
+    var(--check-delay);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .t-check,
+  .t-check svg path {
+    transition: none !important;
+  }
+}
+
+[data-iii-ui="iii-directory"] .dir-ui-af {
+  display: flex;
+  flex: 0 0 auto;
+  flex-direction: column;
+  max-height: none;
+  overflow: visible;
+  gap: 22px;
+  padding: 32px clamp(20px, 4vw, 52px) 64px;
+  border-bottom: 0;
+  background: var(--color-panel);
+  font-family: var(--font-sans, ui-sans-serif, sans-serif);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-loading {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-loading .t-skel-skeleton {
+  min-height: 100%;
+}
+[data-iii-ui="iii-directory"]
+  .dir-ui-af-loading
+  .t-skel-skeleton.is-pulsing
+  > .dir-ui-af {
+  animation: none;
+}
+[data-iii-ui="iii-directory"]
+  .dir-ui-af-loading
+  .t-skel-skeleton.is-pulsing
+  .dir-ui-af-skeleton-block {
+  animation: t-skel-pulse var(--pulse-dur) ease-in-out var(--pulse-count);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skeleton {
+  min-height: 100%;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skeleton-block {
+  display: block;
+  flex-shrink: 0;
+  border-radius: 5px;
+  background: color-mix(
+    in oklab,
+    var(--color-ink) 8%,
+    var(--color-surface)
+  );
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skeleton-block.is-avatar {
+  width: 56px;
+  height: 56px;
+  border-radius: 12px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skeleton-block.is-name {
+  width: min(52%, 280px);
+  height: 24px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skeleton-block.is-description {
+  width: min(72%, 420px);
+  height: 12px;
+}
+[data-iii-ui="iii-directory"]
+  .dir-ui-af-skeleton-block.is-description-short {
+  width: min(48%, 280px);
+  height: 12px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skeleton-block.is-model-label {
+  width: 52px;
+  height: 12px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skeleton-block.is-model-hint {
+  width: 86px;
+  height: 8px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skeleton-block.is-model-picker {
+  width: min(100%, 280px);
+  height: 36px;
+  border-radius: 7px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skeleton-block.is-section-title {
+  width: 96px;
+  height: 16px;
+}
+[data-iii-ui="iii-directory"]
+  .dir-ui-af-skeleton-block.is-section-description {
+  width: min(70%, 300px);
+  height: 10px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skeleton-block.is-summary {
+  width: 52px;
+  height: 8px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skeleton-block.is-chevron {
+  width: 14px;
+  height: 14px;
+  border-radius: 4px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skeleton-prompt {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skeleton-block.is-prompt-line {
+  width: 88%;
+  height: 10px;
+}
+[data-iii-ui="iii-directory"]
+  .dir-ui-af-skeleton-block.is-prompt-line.is-medium {
+  width: 68%;
+}
+[data-iii-ui="iii-directory"]
+  .dir-ui-af-skeleton-block.is-prompt-line.is-short {
+  width: 42%;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skeleton-block.is-search {
+  width: 100%;
+  height: 36px;
+  border-radius: 7px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skeleton-block.is-list-title {
+  width: 72px;
+  height: 10px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skeleton-block.is-count {
+  width: 16px;
+  height: 10px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skeleton-skill-row {
+  display: flex;
+  min-height: 50px;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 7px 8px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skeleton-block.is-checkbox {
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skeleton-block.is-skill-name {
+  width: 42%;
+  height: 10px;
+}
+[data-iii-ui="iii-directory"]
+  .dir-ui-af-skeleton-block.is-skill-description {
+  width: 72%;
+  height: 9px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skeleton-block.is-transfer {
+  width: 36px;
+  height: 6px;
+  align-self: center;
+  border-radius: 999px;
+}
+@media (prefers-reduced-motion: reduce) {
+  [data-iii-ui="iii-directory"]
+    .dir-ui-af-loading
+    .t-skel-skeleton.is-pulsing
+    .dir-ui-af-skeleton-block {
+    animation: none !important;
+  }
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-profile,
+[data-iii-ui="iii-directory"] .dir-ui-af-aligned {
+  width: min(100%, 780px);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-profile {
+  display: grid;
+  grid-template-columns: 56px minmax(0, 1fr);
+  align-items: start;
+  gap: 16px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-profile-copy {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  padding-top: 1px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-title-row {
+  display: flex;
+  width: 100%;
+  min-width: 0;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-title-row .dir-ui-af-inline-display,
+[data-iii-ui="iii-directory"] .dir-ui-af-title-row .dir-ui-af-inline-input {
+  flex: 1;
+  min-width: 0;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-save-panel {
+  position: sticky;
+  top: 0;
+  z-index: 4;
+  display: flex;
+  min-height: 48px;
+  min-width: 0;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--color-edge);
+  background: var(--color-panel);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-save-actions {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-left: auto;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-save {
+  min-width: 72px;
+  flex-shrink: 0;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-revert {
+  flex-shrink: 0;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-aligned {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding-left: 72px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-avatar-wrap {
+  position: relative;
+  display: block;
+}
+[data-iii-ui="iii-directory"]
+  :is(
+    .dir-ui-af-avatar-trigger,
+    .dir-ui-af-avatar-option,
+    .dir-ui-af-avatar-color
+  ) {
+  --agent-avatar-tone: var(--color-ink-faint);
+}
+[data-iii-ui="iii-directory"]
+  :is(
+    .dir-ui-af-avatar-trigger,
+    .dir-ui-af-avatar-option,
+    .dir-ui-af-avatar-color
+  )[data-color="blue"] {
+  --agent-avatar-tone: #4b9dea;
+}
+[data-iii-ui="iii-directory"]
+  :is(
+    .dir-ui-af-avatar-trigger,
+    .dir-ui-af-avatar-option,
+    .dir-ui-af-avatar-color
+  )[data-color="purple"] {
+  --agent-avatar-tone: #8d68dc;
+}
+[data-iii-ui="iii-directory"]
+  :is(
+    .dir-ui-af-avatar-trigger,
+    .dir-ui-af-avatar-option,
+    .dir-ui-af-avatar-color
+  )[data-color="teal"] {
+  --agent-avatar-tone: #24b8aa;
+}
+[data-iii-ui="iii-directory"]
+  :is(
+    .dir-ui-af-avatar-trigger,
+    .dir-ui-af-avatar-option,
+    .dir-ui-af-avatar-color
+  )[data-color="green"] {
+  --agent-avatar-tone: #35a86b;
+}
+[data-iii-ui="iii-directory"]
+  :is(
+    .dir-ui-af-avatar-trigger,
+    .dir-ui-af-avatar-option,
+    .dir-ui-af-avatar-color
+  )[data-color="amber"] {
+  --agent-avatar-tone: #d99a24;
+}
+[data-iii-ui="iii-directory"]
+  :is(
+    .dir-ui-af-avatar-trigger,
+    .dir-ui-af-avatar-option,
+    .dir-ui-af-avatar-color
+  )[data-color="rose"] {
+  --agent-avatar-tone: #d65a80;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-avatar-trigger {
+  appearance: none;
+  display: inline-flex;
+  width: 56px;
+  height: 56px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 1px solid
+    color-mix(in oklab, var(--agent-avatar-tone) 28%, var(--color-edge));
+  border-radius: 12px;
+  background: linear-gradient(
+    145deg,
+    color-mix(in oklab, var(--agent-avatar-tone) 28%, var(--color-panel)),
+    color-mix(in oklab, var(--agent-avatar-tone) 12%, var(--color-panel))
+  );
+  color: var(--agent-avatar-tone);
+  cursor: pointer;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-avatar-trigger:hover {
+  background: linear-gradient(
+    145deg,
+    color-mix(in oklab, var(--agent-avatar-tone) 34%, var(--color-panel)),
+    color-mix(in oklab, var(--agent-avatar-tone) 17%, var(--color-panel))
+  );
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-avatar-trigger:focus-visible,
+[data-iii-ui="iii-directory"] .dir-ui-af-avatar-option:focus-visible,
+[data-iii-ui="iii-directory"] .dir-ui-af-model-clear:focus-visible,
+[data-iii-ui="iii-directory"] .dir-ui-af-skill-search-clear:focus-visible {
+  outline: 2px solid var(--color-rule-focus);
+  outline-offset: 2px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-avatar-trigger:disabled {
+  cursor: default;
+  opacity: 0.65;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-avatar-pop {
+  position: absolute;
+  top: 64px;
+  left: 0;
+  z-index: 50;
+  box-sizing: border-box;
+  width: 232px;
+  padding: 12px;
+  border: 1px solid var(--color-edge);
+  border-radius: 10px;
+  background: var(--color-panel-raised);
+  box-shadow: var(--shadow-floating);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-avatar-pop-title {
+  margin: 0 0 10px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-ink);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-avatar-grid {
+  display: grid;
+  grid-template-columns: repeat(5, 36px);
+  gap: 6px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-avatar-option {
+  appearance: none;
+  display: inline-flex;
+  width: 36px;
+  height: 36px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--agent-avatar-tone);
+  cursor: pointer;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-avatar-option:hover {
+  background: color-mix(
+    in oklab,
+    var(--agent-avatar-tone) 12%,
+    var(--color-panel)
+  );
+  color: var(--agent-avatar-tone);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-avatar-option[aria-pressed="true"] {
+  border-color: color-mix(
+    in oklab,
+    var(--agent-avatar-tone) 52%,
+    var(--color-edge)
+  );
+  background: color-mix(
+    in oklab,
+    var(--agent-avatar-tone) 18%,
+    var(--color-panel)
+  );
+  color: var(--agent-avatar-tone);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-avatar-option-icon {
+  width: 16px;
+  height: 16px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-avatar-colors {
+  display: grid;
+  grid-template-columns: repeat(7, 24px);
+  gap: 6px;
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--color-edge);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-avatar-color {
+  display: inline-grid;
+  width: 24px;
+  height: 24px;
+  place-items: center;
+  cursor: pointer;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-avatar-color input {
+  appearance: none;
+  box-sizing: border-box;
+  width: 20px;
+  height: 20px;
+  margin: 0;
+  border: 2px solid transparent;
+  border-radius: 999px;
+  background: var(--agent-avatar-tone);
+  cursor: pointer;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-avatar-color input:checked {
+  border-color: var(--color-panel-raised);
+  box-shadow:
+    0 0 0 2px var(--color-panel-raised),
+    0 0 0 3px var(--agent-avatar-tone);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-avatar-color input:focus-visible {
+  outline: 2px solid var(--color-rule-focus);
+  outline-offset: 2px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-inline-display {
+  appearance: none;
+  display: flex;
+  min-width: 0;
+  max-width: 100%;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--color-ink);
+  font-family: inherit;
+  text-align: left;
+}
+[data-iii-ui="iii-directory"] button.dir-ui-af-inline-display {
+  cursor: text;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-inline-display.name {
+  font-size: 24px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-inline-display.description {
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--color-ink-faint);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-inline-display .placeholder {
+  color: var(--color-ink-ghost);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-pencil {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  margin-top: 6px;
+  opacity: 0.65;
+  color: var(--color-ink-faint);
+}
+[data-iii-ui="iii-directory"]
+  .dir-ui-af-inline-display.description
+  .dir-ui-af-pencil {
+  margin-top: 3px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-inline-display:hover .dir-ui-af-pencil,
+[data-iii-ui="iii-directory"]
+  .dir-ui-af-inline-display:focus-visible
+  .dir-ui-af-pencil {
+  opacity: 1;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-inline-display:focus-visible {
+  outline: 2px solid var(--color-rule-focus);
+  outline-offset: 4px;
+  border-radius: 2px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-inline-input {
+  box-sizing: border-box;
+  width: 100%;
+  border: 0;
+  border-radius: 4px;
+  outline: 2px solid var(--color-rule-focus);
+  outline-offset: -1px;
+  background: var(--color-surface);
+  color: var(--color-ink);
+  font-family: inherit;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-inline-name-input {
+  height: 38px;
+  padding: 2px 8px;
+  font-size: 24px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-inline-description-input {
+  min-height: 32px;
+  overflow: hidden;
+  resize: none;
+  padding: 6px 8px;
+  font-size: 14px;
+  line-height: 1.55;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-file-hint {
+  margin: 0;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11px;
+  color: var(--color-ink-ghost);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-model-row {
+  display: grid;
+  grid-template-columns: 104px minmax(0, 320px);
+  align-items: center;
+  gap: 12px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-model-label {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-ink);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-model-label > span + span {
+  font-size: 11px;
+  font-weight: 400;
+  color: var(--color-ink-faint);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-model-control {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-model-picker {
+  width: min(100%, 280px);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-model-clear {
+  appearance: none;
+  display: inline-flex;
+  width: 36px;
+  height: 36px;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--color-ink-faint);
+  cursor: pointer;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-model-clear:hover {
+  background: var(--color-surface-hover);
+  color: var(--color-ink);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-model-clear-icon {
+  width: 16px;
+  height: 16px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-disclosure {
+  border-top: 1px solid var(--color-edge);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-disclosure-head {
+  appearance: none;
+  display: grid;
+  width: 100%;
+  min-height: 62px;
+  grid-template-columns: minmax(0, 1fr) auto 16px;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 0;
+  border: 0;
+  background: transparent;
+  color: var(--color-ink);
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-disclosure-head:focus-visible {
+  outline: 2px solid var(--color-rule-focus);
+  outline-offset: -2px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-disclosure-copy {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-disclosure-title {
+  font-size: 16px;
+  font-weight: 500;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-disclosure-description {
+  overflow: hidden;
+  font-size: 12px;
+  font-weight: 400;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--color-ink-faint);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-disclosure-summary {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 10px;
+  color: var(--color-ink-ghost);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-disclosure-chevron {
+  width: 16px;
+  height: 16px;
+  color: var(--color-ink-faint);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-disclosure-chevron svg {
+  width: 16px;
+  height: 16px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-disclosure-inner {
+  padding: 0;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-disclosure-content {
+  padding: 4px 0 22px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-prompt {
+  box-sizing: border-box;
+  display: block;
+  width: 100%;
+  min-height: 168px;
+  overflow: hidden;
+  resize: none;
+  border: 1px solid var(--color-edge);
+  border-radius: 8px;
+  outline: none;
+  background: var(--color-surface);
+  padding: 14px 16px;
+  color: var(--color-ink);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 13px;
+  line-height: 1.6;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-prompt::placeholder {
+  color: var(--color-ink-ghost);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-prompt:focus {
+  border-color: var(--color-rule-focus);
+  outline: 2px solid var(--color-rule-focus);
+  outline-offset: -1px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skills {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skill-search {
+  position: relative;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skill-search-icon {
+  position: absolute;
+  top: 50%;
+  left: 10px;
+  z-index: 1;
+  width: 16px;
+  height: 16px;
+  transform: translateY(-50%);
+  color: var(--color-ink-ghost);
+  pointer-events: none;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skill-search-input {
+  padding-right: 34px;
+  padding-left: 34px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skill-search-clear {
+  appearance: none;
+  position: absolute;
+  top: 50%;
+  right: 5px;
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  transform: translateY(-50%);
+  padding: 0;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--color-ink-faint);
+  cursor: pointer;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skill-search-clear:hover {
+  background: var(--color-surface-hover);
+  color: var(--color-ink);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skill-search-clear-icon {
+  width: 16px;
+  height: 16px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skill-list-wrap {
+  overflow: hidden;
+  border: 1px solid var(--color-edge);
+  border-radius: 8px;
+  background: var(--color-surface);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skill-list-head {
+  display: flex;
+  min-height: 34px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--color-edge);
+  background: var(--color-panel-raised);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-ink-faint);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skill-count {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-variant-numeric: tabular-nums;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skill-list {
+  max-height: 216px;
+  margin: 0;
+  overflow-y: auto;
+  padding: 4px;
+  list-style: none;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skill-list > li + li {
+  border-top: 1px solid var(--color-edge);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skill-row {
+  position: relative;
+  display: flex;
+  min-width: 0;
+  min-height: 50px;
+  align-items: start;
+  gap: 10px;
+  padding: 7px 8px;
+  border-radius: 5px;
+  cursor: pointer;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skill-row:hover {
+  background: var(--color-surface-hover);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skill-row:has(input:disabled) {
+  cursor: default;
+  opacity: 0.65;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skill-native {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  opacity: 0;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skill-check {
+  display: inline-flex;
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--color-edge);
+  border-radius: 4px;
+  background: var(--color-panel-raised);
+  box-shadow: 0 0 0 0 transparent;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skill-check[data-checked="true"] {
+  border-color: var(--color-ink);
+  background: var(--color-ink);
+}
+[data-iii-ui="iii-directory"]
+  .dir-ui-af-skill-check[data-checked="true"]
+  svg
+  path {
+  stroke-dashoffset: 0;
+  transition: stroke-dashoffset var(--check-draw) var(--check-ease)
+    var(--check-delay);
+}
+[data-iii-ui="iii-directory"]
+  .dir-ui-af-skill-row:has(.dir-ui-af-skill-native:focus-visible)
+  .dir-ui-af-skill-check {
+  box-shadow: 0 0 0 2px var(--color-rule-focus);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skill-check svg {
+  width: 12px;
+  height: 12px;
+  fill: none;
+  stroke: var(--color-panel-raised);
+  stroke-width: 1.7;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skill-copy {
+  min-width: 0;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 2px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skill-name,
+[data-iii-ui="iii-directory"] .dir-ui-af-skill-description {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skill-name {
+  font-size: 13px;
+  line-height: 1;
+  font-weight: 500;
+  color: var(--color-ink);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skill-description {
+  font-size: 12px;
+  color: var(--color-ink-faint);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-missing {
+  margin-left: 8px;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 9px;
+  font-weight: 400;
+  color: var(--color-warn);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skill-empty,
+[data-iii-ui="iii-directory"] .dir-ui-af-catalog-message {
+  padding: 14px 10px;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--color-ink-faint);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-skill-transfer {
+  display: flex;
+  height: 18px;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  font-size: 13px;
+  color: var(--color-ink-ghost);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-remove-panel {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding-top: 4px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-remove-copy {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  font-size: 13px;
+  color: var(--color-ink);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-remove-copy span {
+  color: var(--color-ink-faint);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-remove {
+  flex-shrink: 0;
+  color: var(--color-alert);
+}
+[data-iii-ui="iii-directory"] .dir-ui-af-remove:hover:not(:disabled) {
+  background: var(--color-alert-muted);
+  color: var(--color-alert);
+}
+
+[data-iii-ui="iii-directory"] .dir-ui-doc-body.mode-split .dir-ui-af {
+  padding-right: 20px;
+  padding-left: 20px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-doc-body.mode-split .dir-ui-af-aligned {
+  padding-left: 0;
+}
+
+[data-iii-ui="iii-directory"] .dir-ui-browser.narrow .dir-ui-af {
+  gap: 20px;
+  padding: 22px 16px 48px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-doc-mobile-back {
+  display: flex;
+  min-width: 0;
+  min-height: 32px;
+  flex: 1 1 auto;
+  align-items: center;
+  text-transform: capitalize;
+  gap: 4px;
+  padding: 0;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-ink-faint);
+}
+[data-iii-ui="iii-directory"] .dir-ui-doc-mobile-back > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+[data-iii-ui="iii-directory"] .dir-ui-doc-mobile-back .dir-ui-back {
+  margin-left: -8px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-browser.narrow .dir-ui-af-profile {
+  grid-template-columns: 52px minmax(0, 1fr);
+  gap: 12px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-browser.narrow .dir-ui-af-avatar-trigger {
+  width: 52px;
+  height: 52px;
+}
+[data-iii-ui="iii-directory"]
+  .dir-ui-browser.narrow
+  .dir-ui-af-skeleton-block.is-avatar {
+  width: 52px;
+  height: 52px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-browser.narrow .dir-ui-af-title-row {
+  gap: 10px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-browser.narrow .dir-ui-af-revert,
+[data-iii-ui="iii-directory"] .dir-ui-browser.narrow .dir-ui-af-save {
+  min-width: 64px;
+  min-height: 32px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-browser.narrow .dir-ui-af-aligned {
+  padding-left: 0;
+}
+[data-iii-ui="iii-directory"] .dir-ui-browser.narrow .dir-ui-af-model-row {
+  grid-template-columns: minmax(0, 1fr);
+  align-items: stretch;
+  gap: 8px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-browser.narrow .dir-ui-af-model-picker {
+  width: 100%;
+}
+[data-iii-ui="iii-directory"] .dir-ui-browser.narrow .dir-ui-af-model-clear {
+  width: 36px;
+  height: 36px;
+}
+[data-iii-ui="iii-directory"]
+  .dir-ui-browser.narrow
+  .dir-ui-af-disclosure-head {
+  min-height: 70px;
+  grid-template-columns: minmax(0, 1fr) 20px;
+  gap: 10px;
+}
+[data-iii-ui="iii-directory"]
+  .dir-ui-browser.narrow
+  .dir-ui-af-disclosure-summary {
+  display: none;
+}
+[data-iii-ui="iii-directory"] .dir-ui-browser.narrow .dir-ui-af-prompt {
+  min-height: 184px;
+  padding: 14px;
+}
+[data-iii-ui="iii-directory"]
+  .dir-ui-browser.narrow
+  .dir-ui-af-skill-search-input {
+  min-height: 48px;
+}
+[data-iii-ui="iii-directory"]
+  .dir-ui-browser.narrow
+  .dir-ui-af-skill-search-clear {
+  width: 48px;
+  height: 48px;
+  right: 0;
+}
+[data-iii-ui="iii-directory"]
+  .dir-ui-browser.narrow
+  .dir-ui-af-skill-list-head {
+  min-height: 44px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-browser.narrow .dir-ui-af-skill-row {
+  padding: 9px 8px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-browser.narrow .dir-ui-af-skill-check {
+  width: 20px;
+  height: 20px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-browser.narrow .dir-ui-af-remove-panel {
+  align-items: stretch;
+  flex-direction: row;
+  gap: 14px;
+}
+[data-iii-ui="iii-directory"] .dir-ui-browser.narrow .dir-ui-af-remove {
+  min-height: 48px;
+  align-self: flex-start;
+}
+
+/* Typography follows the browser viewport, not the width of a resized panel.
+   `.narrow` remains container-driven for layout and touch-target adaptation. */
+@media (max-width: 640px) {
+  [data-iii-ui="iii-directory"]
+    .dir-ui-browser.prominent-list
+    .dir-ui-nav-row
+    .name,
+  [data-iii-ui="iii-directory"]
+    .dir-ui-browser.prominent-list
+    .dir-ui-nav-row
+    .name.mono {
+    font-size: 16px;
+  }
+  [data-iii-ui="iii-directory"]
+    .dir-ui-browser.prominent-list
+    .dir-ui-nav-row
+    .id,
+  [data-iii-ui="iii-directory"]
+    .dir-ui-browser.prominent-list
+    .dir-ui-nav-row
+    .desc {
+    font-size: 14px;
+  }
+  [data-iii-ui="iii-directory"] .dir-ui-preview p,
+  [data-iii-ui="iii-directory"] .dir-ui-preview ul,
+  [data-iii-ui="iii-directory"] .dir-ui-preview ol {
+    font-size: 15px;
+  }
+  [data-iii-ui="iii-directory"] .dir-ui-af-inline-display.name,
+  [data-iii-ui="iii-directory"] .dir-ui-af-inline-name-input {
+    font-size: 22px;
+  }
+  [data-iii-ui="iii-directory"] .dir-ui-af-inline-display.description,
+  [data-iii-ui="iii-directory"] .dir-ui-af-inline-description-input,
+  [data-iii-ui="iii-directory"] .dir-ui-af-model-label,
+  [data-iii-ui="iii-directory"] .dir-ui-af-skill-name,
+  [data-iii-ui="iii-directory"] .dir-ui-af-skill-description,
+  [data-iii-ui="iii-directory"] .dir-ui-af-skill-empty,
+  [data-iii-ui="iii-directory"] .dir-ui-af-catalog-message,
+  [data-iii-ui="iii-directory"] .dir-ui-af-prompt,
+  [data-iii-ui="iii-directory"] .dir-ui-af-skill-search-input,
+  [data-iii-ui="iii-directory"] .dir-ui-af-remove-copy {
+    font-size: 16px;
+  }
+  [data-iii-ui="iii-directory"] .dir-ui-af-model-label > span + span,
+  [data-iii-ui="iii-directory"] .dir-ui-af-disclosure-description,
+  [data-iii-ui="iii-directory"] .dir-ui-af-skill-list-head {
+    font-size: 14px;
+  }
+  [data-iii-ui="iii-directory"] .dir-ui-af-disclosure-title {
+    font-size: 18px;
+  }
+}
+
+[data-theme="dark"] [data-iii-ui="iii-directory"] .dir-ui-af-avatar-pop {
+  box-shadow: none;
 }

--- a/iii-directory/ui/tests/frontmatter.test.mjs
+++ b/iii-directory/ui/tests/frontmatter.test.mjs
@@ -5,9 +5,21 @@ import {
   frontmatterFieldIsSimpleBoolean,
   readFrontmatterField,
   restoreFrontmatterFields,
+  setFrontmatterBody,
   setFrontmatterField,
   withoutFrontmatterFields,
 } from '../src/page/frontmatter.ts'
+
+test('replaces an agent body without changing its frontmatter or EOL style', () => {
+  const source = '---\r\nname: Agent\r\nskills: [review]\r\n---\r\n\r\nOld prompt.\r\n'
+  const next = setFrontmatterBody(source, '\r\nNew prompt.\r\nMore detail.\r\n')
+
+  assert.equal(
+    next,
+    '---\r\nname: Agent\r\nskills: [review]\r\n---\r\n\r\nNew prompt.\r\nMore detail.\r\n',
+  )
+  assert.equal(frontmatterBody(next), '\r\nNew prompt.\r\nMore detail.\r\n')
+})
 
 test('structured fields round-trip without dropping advanced metadata', () => {
   const content = `---

--- a/packages/console-ui/README.md
+++ b/packages/console-ui/README.md
@@ -67,6 +67,8 @@ Use the shared contracts for repeated Console interactions:
 - `Selector` is the searchable single-choice control, with grouped/disabled
   options, caller-owned async filtering, loading/empty/error/validation
   states, and optional free-form creation. `Select` is for small finite lists.
+  `ModelPicker` is the Console-owned responsive model catalog picker for chat
+  and injected profile editors; worker UIs provide the catalog and selection.
 - Shared `Tooltip`, `Dialog`, `ConfirmDialog`, `DropdownMenu`, `Select`, and
   `Selector` portals preserve an injected worker's `data-iii-ui` scope.
   `IconButton` combines an accessible label with the shared tooltip contract.

--- a/packages/console-ui/component-names.mjs
+++ b/packages/console-ui/component-names.mjs
@@ -53,6 +53,7 @@ export const componentNames = [
   'ListItem',
   'Markdown',
   'MarkdownPreview',
+  'ModelPicker',
   'PageBody',
   'PageHeader',
   'PageMain',

--- a/packages/console-ui/index.d.ts
+++ b/packages/console-ui/index.d.ts
@@ -1126,6 +1126,8 @@ export interface SegmentedControlProps<T extends string = string> {
   itemClassName?: string
   activeItemClassName?: string
   variant?: 'tabs' | 'radio'
+  /** Show only the semantic icon and expose each label through Tooltip. */
+  iconOnly?: boolean
   'aria-label'?: string
 }
 export declare const SegmentedControl: <T extends string = string>(
@@ -1358,6 +1360,38 @@ export interface MarkdownPreviewProps {
 /** `Markdown` inside the standard `bg-bg` pane chrome — the preview
     counterpart to `CodeEditor` for markdown-editing UIs. */
 export declare const MarkdownPreview: React.ComponentType<MarkdownPreviewProps>
+
+export type ModelId = string
+export type ThinkingLevel = string
+export interface ReasoningEffortOption {
+  effort: string
+  description?: string
+}
+export interface ModelOption {
+  id: ModelId
+  label: string
+  contextWindow?: number
+  supportsThinking?: boolean
+  supportsVision?: boolean
+  reasoningEfforts?: ReasoningEffortOption[]
+}
+export interface ModelPickerProps {
+  value: ModelId | null
+  options: ModelOption[]
+  openRequest?: number
+  thinkingLevel: ThinkingLevel
+  onChange: (next: ModelId) => void
+  onThinkingLevelChange: (next: ThinkingLevel) => void
+  disabled?: boolean
+  loading?: boolean
+  showRefresh?: boolean
+  placeholder?: string
+  showProviderConfiguration?: boolean
+  showReasoningEffort?: boolean
+  className?: string
+}
+/** The Console's responsive searchable model catalog picker. */
+export declare const ModelPicker: React.ComponentType<ModelPickerProps>
 
 export interface WorkerConfigurationDialogProps {
   /** Which worker's configuration to edit; `null` renders the dialog closed. */


### PR DESCRIPTION
## Summary

- Add the Agent Profiles gallery and editor across Console and Directory.
- Remove delegation and leaf metadata from profiles.
- Use Agent Profiles consistently in UI, errors, schemas, and docs.

## Testing

- Directory UI tests and build
- Console targeted tests and typecheck
- Directory and Harness Rust tests

Fixes MOT-4595

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an agent-profile gallery for chat setup, including selection, avatars, colors, loading states, and manual configuration.
  - Redesigned agent-profile editing with identity controls, color selection, collapsible prompts and skills, model selection, and deletion controls.
  - Added a responsive model picker with provider and reasoning options.
  - Added icon-only tab controls with accessible labels and tooltips.

- **Improvements**
  - Agent profiles now support model and reasoning preferences across sessions and spawned agents.
  - Chat headers and conversation lists display agent-profile identity details.
  - Updated directory labels and documentation to use “agent profile” terminology consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->