### PR TITLE
(MOT-4598) fix(queue): keep the engine-provider connection out of the III_WORKER_NAME override

### DIFF
--- a/queue/src/main.rs
+++ b/queue/src/main.rs
@@ -108,6 +108,15 @@ async fn main() -> Result<()> {
     // Connect the project-scoped worker first. Compose observes that
     // registration to verify III_NAMESPACE before this process opens the
     // additional default-scoped connection for reserved engine::* providers.
+    //
+    // Compose injects III_WORKER_NAME, and the SDK lets that env override
+    // `metadata.name` on EVERY register_worker in this process — so this
+    // second connection would also register as 'queue' and, when the project
+    // namespace IS `default`, be rejected by the engine's per-namespace
+    // worker-name uniqueness (0.23+), killing the engine::* enqueue
+    // provider. Drop the env so `engine_worker_metadata()` actually names
+    // it 'queue-engine'.
+    std::env::remove_var("III_WORKER_NAME");
     let default_iii = Arc::new(register_worker(
         &cli.url,
         InitOptions {


### PR DESCRIPTION
Ref: [MOT-4598](https://linear.app/motia/issue/MOT-4598/queue-reserved-engine-provider-connection-self-conflicts-when-the)

## The bug

The queue opens two connections by design: the project-scoped worker (`queue`) and a default-scoped one (`queue-engine`) that registers the reserved `engine::queue::enqueue` provider. Compose injects `III_WORKER_NAME` for the container, and the SDK lets that env override `metadata.name` on **every** `register_worker` in the process — so both connections registered as `queue`. Engine 0.23 enforces worker-name uniqueness per namespace and rejects the second registration (`WORKER_NAMESPACE_CONFLICT`), killing the enqueue provider: `harness::send` fails with `NO QUEUE PROVIDER IS INSTALLED`, and turns that do start hang at "dispatching" (`function_queue_job` rides the same provider).

It only manifests when the Compose project namespace **is** `default` — both registrations land in the same namespace. CI and quickstart mint unique namespaces per execution, so they never hit it; a local stack on the default namespace hits it on every cold boot.

Engine-side evidence (0.23.0-rc.4 built from iii@main, includes iii-hq/iii#2088):

```
[WARN] iii::engine Worker name already held by a live worker in this namespace — registration rejected
    ├ rejected_worker: 78887629-…
    ├ owner: 7516674d-…
    ├ namespace: default
    └ worker_name: queue
```

## The fix

Drop `III_WORKER_NAME` from the process environment before opening the second connection, so `engine_worker_metadata()`'s `queue-engine` name actually applies. The project-scoped connection is registered (and observed by Compose) before the removal, and its own metadata already carries `name: "queue"`, so reconnects stay correctly named.

## Validation (live, engine 0.23.0-rc.4 + workers@main)

- Before: second registration rejected on every cold boot; `harness::send` → `NO QUEUE PROVIDER IS INSTALLED`; started turns hang at "dispatching".
- After: both `queue` (6 fns) and `queue-engine` (5 fns) registered; real chat turn end-to-end — reply in 7s, turn trace in the scoped traces list in 9s.

Follow-up worth considering SDK-side (tracked in MOT-4598): an `InitOptions` name override that beats the env, so multi-connection workers don't need env surgery.

https://claude.ai/code/session_01AG4J9zkEQPppaB8hmrq5XF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Engine workers now retain the correct `queue-engine` name instead of inheriting an injected worker name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->