### PR TITLE
ci: route trusted jobs to self-hosted runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  labels:
+    - general
+    - rust

--- a/.github/scripts/tests/test_release_workflows.py
+++ b/.github/scripts/tests/test_release_workflows.py
@@ -209,6 +209,12 @@ def test_every_dispatch_is_actor_gated_and_emits_factual_evidence() -> None:
         assert ("--mutating" in body) == (name in MUTATING), name
 
 
+def test_harness_shadow_uses_the_general_self_hosted_pool() -> None:
+    observe = workflow(WORKFLOWS / "harness-e2e-shadow.yml")["jobs"]["observe"]
+    assert observe["runs-on"] == ["self-hosted", "Linux", "X64", "general"]
+    assert observe["environment"] == "harness-e2e-trusted"
+
+
 def test_candidate_smoke_prepares_kvm_only_for_scrapling() -> None:
     steps = workflow(WORKFLOWS / "candidate-smoke.yml")["jobs"]["smoke"]["steps"]
     prepare = next(step for step in steps if step.get("name") == "Prepare KVM for Scrapling sandbox")

--- a/.github/scripts/tests/test_rust_ci_workflows.py
+++ b/.github/scripts/tests/test_rust_ci_workflows.py
@@ -51,6 +51,21 @@ def test_prs_restore_rust_caches_and_main_pushes_publish_them() -> None:
     assert ci["jobs"]["harness-integration"]["with"]["save-cache"] == expected
 
 
+def test_only_trusted_main_pushes_use_the_rust_self_hosted_runner() -> None:
+    integration = workflow("_harness-integration.yml")["jobs"]["integration"]
+    assert integration["runs-on"] == (
+        "${{ github.event_name == 'push' && github.ref == 'refs/heads/main' "
+        "&& 'rust' || 'ubuntu-latest' }}"
+    )
+
+
+def test_actionlint_knows_the_repository_runner_pool_labels() -> None:
+    config = yaml.load(
+        (GITHUB / "actionlint.yaml").read_text(), Loader=yaml.BaseLoader
+    )
+    assert config["self-hosted-runner"]["labels"] == ["general", "rust"]
+
+
 def test_interface_smoke_bounds_each_engine_readiness_probe() -> None:
     steps = workflow("ci.yml")["jobs"]["interface-smoke"]["steps"]
     run = named_step(steps, "Start III engine")["run"]

--- a/.github/workflows/_harness-integration.yml
+++ b/.github/workflows/_harness-integration.yml
@@ -22,7 +22,9 @@ on:
 jobs:
   integration:
     name: harness integration
-    runs-on: ubuntu-latest
+    # `rust` is the repository-scoped self-hosted pool. Keep public PR code on
+    # fresh GitHub-hosted runners and use the persistent pool only after merge.
+    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'rust' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/harness-e2e-shadow.yml
+++ b/.github/workflows/harness-e2e-shadow.yml
@@ -33,7 +33,9 @@ concurrency:
 jobs:
   observe:
     name: Run observe-only plan
-    runs-on: ubuntu-latest
+    # This bot-gated default-branch workflow runs the trusted ephemeral stack
+    # on the repository-scoped general self-hosted pool.
+    runs-on: [self-hosted, Linux, X64, general]
     timeout-minutes: 210
     environment: harness-e2e-trusted
     env:


### PR DESCRIPTION
## Summary

- route Harness integration to the repository-scoped `rust` runner only for trusted pushes to `main`
- keep public pull-request integration jobs on fresh `ubuntu-latest` runners
- route the bot-gated `harness-e2e-shadow` workflow to the `general` runner pool
- register both custom labels in actionlint and enforce the routing contracts with tests

## Safety boundary

- no pull-request matrix job is moved to self-hosted infrastructure
- release, publish, promotion, and Registry mutation workflows are unchanged
- the shadow workflow retains `harness-e2e-trusted`, actor validation, OIDC admission, temporary HOME, and teardown

## Validation

- `actionlint` 1.7.12
- `python3 -m pytest -q .github/scripts/tests/test_rust_ci_workflows.py .github/scripts/tests/test_release_workflows.py` (20 passed)
- `python3 -m pytest -q .github/scripts/tests` (258 passed, 3 subtests passed)
- `git diff --check`

## Post-merge verification

- verify the `main` Harness integration job reports the `rust` self-hosted runner
- verify the next admitted shadow execution reports the `general` self-hosted runner
- compare queue, cold-cache, and warm-cache timings before expanding the migration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated continuous integration workflows to use dedicated runner pools for trusted main-branch integration checks.
  - Updated end-to-end shadow checks to run on the general self-hosted runner pool.

- **Tests**
  - Added coverage verifying runner selection and workflow environment settings.
  - Added validation for configured runner pool labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->