### PR TITLE
ci: run harness integration on self-hosted pool

### DIFF
--- a/.github/scripts/tests/test_rust_ci_workflows.py
+++ b/.github/scripts/tests/test_rust_ci_workflows.py
@@ -51,12 +51,9 @@ def test_prs_restore_rust_caches_and_main_pushes_publish_them() -> None:
     assert ci["jobs"]["harness-integration"]["with"]["save-cache"] == expected
 
 
-def test_only_trusted_main_pushes_use_the_rust_self_hosted_runner() -> None:
+def test_harness_integration_uses_the_rust_self_hosted_runner() -> None:
     integration = workflow("_harness-integration.yml")["jobs"]["integration"]
-    assert integration["runs-on"] == (
-        "${{ github.event_name == 'push' && github.ref == 'refs/heads/main' "
-        "&& 'rust' || 'ubuntu-latest' }}"
-    )
+    assert integration["runs-on"] == ["self-hosted", "Linux", "X64", "rust"]
 
 
 def test_actionlint_knows_the_repository_runner_pool_labels() -> None:

--- a/.github/workflows/_harness-integration.yml
+++ b/.github/workflows/_harness-integration.yml
@@ -22,9 +22,7 @@ on:
 jobs:
   integration:
     name: harness integration
-    # `rust` is the repository-scoped self-hosted pool. Keep public PR code on
-    # fresh GitHub-hosted runners and use the persistent pool only after merge.
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'rust' || 'ubuntu-latest' }}
+    runs-on: [self-hosted, Linux, X64, rust]
     steps:
       - uses: actions/checkout@v5
         with:

--- a/harness/src/deferred.rs
+++ b/harness/src/deferred.rs
@@ -478,6 +478,30 @@ pub async fn resolve_parent(
     result: Option<&Value>,
     reason: Option<&str>,
 ) -> bool {
+    // Lock-free pre-check. Every caller is a child-finalize tail that still
+    // holds the CHILD session lock; `resolve` below takes the PARENT lock. A
+    // parent turn holding its own lock while spawning into this child (the
+    // in-turn re-task) waits on the child lock — taking the parent lock here
+    // unconditionally is an AB-BA deadlock. Fire-and-forget children have no
+    // parked parent call, so skip the lock when there is nothing to resolve;
+    // a genuinely parked parent is between steps and its lock is free.
+    // `resolve` re-validates under the lock, so this stale read only skips.
+    let cfg = deps.cfg().await;
+    // On a state read error, fall through and let `resolve` report it.
+    if let Ok(record) =
+        crate::state::get_turn(&deps.iii, &parent.session_id, cfg.session_timeout_ms).await
+    {
+        let pending = record.is_some_and(|r| {
+            r.turn_id == parent.turn_id
+                && !r.status.is_terminal()
+                && r.calls
+                    .get(&parent.function_call_id)
+                    .is_some_and(|c| c.state == CallState::Pending)
+        });
+        if !pending {
+            return false;
+        }
+    }
     let (content, details, is_error) = if status == "completed" {
         let text = result.map(render_text).unwrap_or_default();
         (


### PR DESCRIPTION
## Summary

- make the self-hosted Rust pool the default for Harness integration
- run the reusable integration job on the pool for both main pushes and pull requests
- keep regression coverage for the complete runner label set

## Security note

The repository is public. Once a fork PR is approved to run, its Harness integration job will execute on the persistent self-hosted runner.

## Validation

- `pytest -q .github/scripts/tests/test_rust_ci_workflows.py .github/scripts/tests/test_release_workflows.py` (20 passed)
- `/tmp/actionlint -color`
- `pytest -q .github/scripts/tests/` (258 passed, 3 subtests passed)
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deferred operation handling to prevent potential deadlocks when resolving parent and child tasks.
  * Added safer handling for completed, missing, or non-pending parent operations.

* **Chores**
  * Standardized integration checks to run on the designated self-hosted Linux x64 Rust environment.

* **Tests**
  * Updated workflow validation to verify the consistent integration runner configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->