### PR TITLE
fix(ci): retry candidate publication CAS

### DIFF
--- a/.github/scripts/tests/test_release_workflows.py
+++ b/.github/scripts/tests/test_release_workflows.py
@@ -223,14 +223,11 @@ def test_candidate_smoke_prepares_kvm_only_for_scrapling() -> None:
     assert "sudo chmod 0666 /dev/kvm" in prepare["run"]
 
 
-def test_candidate_publish_serializes_and_safely_joins_prepared_commits() -> None:
+def test_candidate_publish_retries_and_safely_joins_prepared_commits() -> None:
     path = WORKFLOWS / "publish-candidate.yml"
     value = workflow(path)
     publish = value["jobs"]["publish"]
-    assert publish["concurrency"] == {
-        "group": "release-candidate-main",
-        "cancel-in-progress": "false",
-    }
+    assert "concurrency" not in publish
 
     steps = publish["steps"]
     verify = next(step for step in steps if step.get("name") == "Verify prepared artifact and release metadata")
@@ -241,7 +238,10 @@ def test_candidate_publish_serializes_and_safely_joins_prepared_commits() -> Non
     assert 'case "$changed" in' in verify["run"]
     assert '"$WORKER"/*)' in verify["run"]
     assert "prepare_main_target()" in push["run"]
+    assert "publish_git_refs()" in push["run"]
     assert 'git merge --no-ff --no-edit "$PREPARED_SHA"' in push["run"]
+    assert "for attempt in $(seq 1 60)" in push["run"]
+    assert "main advanced during candidate publication; retrying CAS" in push["run"]
     assert 'git push --atomic origin' in push["run"]
 
 

--- a/.github/workflows/publish-candidate.yml
+++ b/.github/workflows/publish-candidate.yml
@@ -63,12 +63,6 @@ concurrency:
 jobs:
   publish:
     name: Publish ${{ inputs.worker }} ${{ inputs.candidate_version }}
-    concurrency:
-      # Prepared commits from one multi-worker plan are siblings. Only the Git
-      # commit/tag section may advance main at a time; Registry jobs can still
-      # continue in parallel after this job releases the lock.
-      group: release-candidate-main
-      cancel-in-progress: false
     runs-on: ubuntu-latest
     timeout-minutes: 30
     outputs:
@@ -191,6 +185,31 @@ jobs:
             git merge --no-ff --no-edit "$PREPARED_SHA"
             main_target=$(git rev-parse HEAD)
           }
+          publish_git_refs() {
+            local include_tag=$1
+            local attempt
+            for attempt in $(seq 1 60); do
+              git fetch origin +refs/heads/main:refs/remotes/origin/main --quiet
+              prepare_main_target
+              if [[ -z "$main_target" ]]; then
+                if [[ "$include_tag" == true ]]; then
+                  git push origin "refs/tags/$TAG" && return 0
+                fi
+                return 0
+              fi
+              if [[ "$include_tag" == true ]]; then
+                git push --atomic origin \
+                  "$main_target:refs/heads/main" \
+                  "refs/tags/$TAG" && return 0
+              else
+                git push origin "$main_target:refs/heads/main" && return 0
+              fi
+              echo "main advanced during candidate publication; retrying CAS ($attempt/60)"
+              sleep $((RANDOM % 5 + 1))
+            done
+            echo "::error::main kept advancing during candidate publication"
+            return 1
+          }
           if git rev-parse --verify --quiet "refs/tags/$TAG" >/dev/null; then
             test "$(git rev-list -n 1 "$TAG^{}")" = "$PREPARED_SHA"
             annotation=$(git tag -l --format='%(contents)' "$TAG")
@@ -199,8 +218,7 @@ jobs:
               "plan-hash: $PLAN_HASH" "source-sha: $SOURCE_SHA" "prepared-sha: $PREPARED_SHA"; do
               grep -Fx "$field" <<<"$annotation" >/dev/null
             done
-            prepare_main_target
-            [[ -z "$main_target" ]] || git push origin "$main_target:refs/heads/main"
+            publish_git_refs false
             exit 0
           fi
           git tag -a "$TAG" -m "Release $TAG
@@ -220,14 +238,7 @@ jobs:
           registry-tag: next
           experimental: false
           "
-          prepare_main_target
-          if [[ -n "$main_target" ]]; then
-            git push --atomic origin \
-              "$main_target:refs/heads/main" \
-              "refs/tags/$TAG"
-          else
-            git push origin "refs/tags/$TAG"
-          fi
+          publish_git_refs true
 
       - name: Create draft prerelease and upload prepared assets
         env:


### PR DESCRIPTION
Candidate publication jobs can be dispatched concurrently from one release plan. GitHub concurrency groups keep only one pending job, which cancels older publications even when `cancel-in-progress` is disabled.

Replace the global job queue with optimistic CAS retries around the atomic main-and-tag push. Each retry refreshes main, revalidates that the target worker did not change, and joins its immutable prepared commit before publishing.

Validation:
- `python3 -m pytest .github/scripts/tests/test_release_workflows.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved candidate publication reliability by retrying when the main branch advances during publication.
  - Ensured candidate commits and tags are pushed safely and atomically across retry attempts.
  - Preserved correct behavior for tag-only, branch-only, and combined updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->