### PR TITLE
(MOT-4600) fix(harness): AB-BA deadlock between in-turn spawn re-task and child completion

### DIFF
--- a/harness/src/deferred.rs
+++ b/harness/src/deferred.rs
@@ -478,6 +478,30 @@ pub async fn resolve_parent(
     result: Option<&Value>,
     reason: Option<&str>,
 ) -> bool {
+    // Lock-free pre-check. Every caller is a child-finalize tail that still
+    // holds the CHILD session lock; `resolve` below takes the PARENT lock. A
+    // parent turn holding its own lock while spawning into this child (the
+    // in-turn re-task) waits on the child lock — taking the parent lock here
+    // unconditionally is an AB-BA deadlock. Fire-and-forget children have no
+    // parked parent call, so skip the lock when there is nothing to resolve;
+    // a genuinely parked parent is between steps and its lock is free.
+    // `resolve` re-validates under the lock, so this stale read only skips.
+    let cfg = deps.cfg().await;
+    // On a state read error, fall through and let `resolve` report it.
+    if let Ok(record) =
+        crate::state::get_turn(&deps.iii, &parent.session_id, cfg.session_timeout_ms).await
+    {
+        let pending = record.is_some_and(|r| {
+            r.turn_id == parent.turn_id
+                && !r.status.is_terminal()
+                && r.calls
+                    .get(&parent.function_call_id)
+                    .is_some_and(|c| c.state == CallState::Pending)
+        });
+        if !pending {
+            return false;
+        }
+    }
     let (content, details, is_error) = if status == "completed" {
         let text = result.map(render_text).unwrap_or_default();
         (


### PR DESCRIPTION
## Problem

INT-018 (spawn-reuse-guard) times out deterministically on the self-hosted runner pool (found while landing #970): the re-task `harness::spawn`'s function_result never returns and the child's second turn never enqueues.

Root cause is an AB-BA deadlock:

- The **parent** turn holds its session lock through in-turn function execution (`turn_loop.rs` `generate_step` guard, held through `finish_step`). A re-task `harness::spawn` into an existing child reaches `send::deliver`, which waits on the **child** session lock.
- The **child**'s `finalize_completed` (still under the child's turn-loop lock) calls `deferred::resolve_parent`, whose `resolve` takes the **parent** session lock unconditionally — a legacy parked-call path that is a no-op for fire-and-forget children, but it locks before discovering that.

When the child's completion tail overlaps the parent's in-turn re-task, each side holds one lock and waits on the other. GH-hosted runners only avoided the overlap by scheduling luck.

Evidence (CI run 33120750228, artifacts `ir02931e3b35fd`): task-two appended at 22:24:37.018, then zero further spans/CAS/enqueue; the queue store has no re-task job; the child lock is never released until the 55s scenario deadline.

## Fix

Lock-free pre-check in `resolve_parent`: read the parent turn record and return early when there is no `Pending` checkpoint for the call — the common case since spawns became fire-and-forget. Only a genuinely parked parent proceeds to take the lock, and a parked parent is between steps, so its lock is free. `resolve` still re-validates under the lock, so the stale read can only skip, never mis-deliver. Covers all three finalize tails (completed/failed/cancelled) at their shared choke point.

No new unit test: reproducing the interleaving needs a live engine + state worker; INT-018 on the self-hosted pool is the regression test.

Fixes MOT-4600

https://claude.ai/code/session_012SUipeuKz6LhTxjXNRSQgV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parent call resolution to avoid potential deadlocks during child task completion.
  * Added validation to skip resolution when the parent call is no longer pending, preventing unnecessary processing while preserving error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->