### PR TITLE
chore: regenerate provider lockfiles for llm-router 1.4.15-rc.2

### DIFF
--- a/crates/provider-integration-testkit/Cargo.lock
+++ b/crates/provider-integration-testkit/Cargo.lock
@@ -1048,7 +1048,7 @@ checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "llm-router"
-version = "1.4.14"
+version = "1.4.15-rc.2"
 dependencies = [
  "async-trait",
  "clap",
@@ -1326,7 +1326,7 @@ dependencies = [
 
 [[package]]
 name = "provider-anthropic"
-version = "1.2.10"
+version = "1.2.11-rc.2"
 dependencies = [
  "clap",
  "futures",
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "provider-claude-code"
-version = "0.1.7"
+version = "0.1.8-rc.2"
 dependencies = [
  "clap",
  "futures",
@@ -1377,7 +1377,7 @@ dependencies = [
 
 [[package]]
 name = "provider-deepseek"
-version = "0.1.8"
+version = "0.1.9-rc.2"
 dependencies = [
  "clap",
  "futures",
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "provider-kimi"
-version = "1.1.6"
+version = "1.1.7-rc.2"
 dependencies = [
  "clap",
  "futures",
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "provider-openai"
-version = "1.2.8"
+version = "1.2.9-rc.2"
 dependencies = [
  "clap",
  "futures",
@@ -1453,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "provider-openai-codex"
-version = "0.4.5"
+version = "0.4.6-rc.2"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -1489,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "provider-xai"
-version = "1.3.6"
+version = "1.3.7-rc.2"
 dependencies = [
  "clap",
  "futures",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "provider-zai"
-version = "0.5.6"
+version = "0.5.7-rc.2"
 dependencies = [
  "clap",
  "futures",

--- a/provider-anthropic/Cargo.lock
+++ b/provider-anthropic/Cargo.lock
@@ -996,7 +996,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.14"
+version = "1.4.15-rc.2"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-claude-code/Cargo.lock
+++ b/provider-claude-code/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.14"
+version = "1.4.15-rc.2"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-command-code/Cargo.lock
+++ b/provider-command-code/Cargo.lock
@@ -965,7 +965,7 @@ checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "llm-router"
-version = "1.4.14"
+version = "1.4.15-rc.2"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-deepseek/Cargo.lock
+++ b/provider-deepseek/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.14"
+version = "1.4.15-rc.2"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-github-copilot/Cargo.lock
+++ b/provider-github-copilot/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.14"
+version = "1.4.15-rc.2"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-kimi/Cargo.lock
+++ b/provider-kimi/Cargo.lock
@@ -943,7 +943,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.14"
+version = "1.4.15-rc.2"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-llamacpp/Cargo.lock
+++ b/provider-llamacpp/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.14"
+version = "1.4.15-rc.2"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-openai-codex/Cargo.lock
+++ b/provider-openai-codex/Cargo.lock
@@ -1008,7 +1008,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.14"
+version = "1.4.15-rc.2"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-openai/Cargo.lock
+++ b/provider-openai/Cargo.lock
@@ -996,7 +996,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.14"
+version = "1.4.15-rc.2"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-opencode-go/Cargo.lock
+++ b/provider-opencode-go/Cargo.lock
@@ -976,7 +976,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.14"
+version = "1.4.15-rc.2"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-openrouter/Cargo.lock
+++ b/provider-openrouter/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.14"
+version = "1.4.15-rc.2"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-xai/Cargo.lock
+++ b/provider-xai/Cargo.lock
@@ -996,7 +996,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.14"
+version = "1.4.15-rc.2"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-zai/Cargo.lock
+++ b/provider-zai/Cargo.lock
@@ -996,7 +996,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.14"
+version = "1.4.15-rc.2"
 dependencies = [
  "async-trait",
  "clap",


### PR DESCRIPTION
The v1.4.15-rc.2 release prep (`63eaacb68`, merged `81ed66bf5`) bumped llm-router's — and several providers' — manifest versions without regenerating the provider `Cargo.lock`s. `test_provider_related_lockfiles_track_llm_router_version` has been failing on main and on every PR merge ref since (e.g. blocking #970 and #973).

`cargo update -p llm-router` per workspace; diff is exclusively the path-dep version pins (llm-router 1.4.14 → 1.4.15-rc.2 plus each provider's own already-bumped manifest version). `.github/scripts` tests pass locally; `cargo check` on provider-anthropic passes.

https://claude.ai/code/session_012SUipeuKz6LhTxjXNRSQgV