### PR TITLE
(MOT-4504) fix(console): keep failed traces visible

### DIFF
--- a/console/web/src/pages/TracesV2/hooks/useSpanFilteredTraceRows.test.ts
+++ b/console/web/src/pages/TracesV2/hooks/useSpanFilteredTraceRows.test.ts
@@ -159,6 +159,25 @@ describe('reconcileTraceVisibility', () => {
     expect(kept).toEqual([])
   })
 
+  it('keeps failed traces visible even when every span is hidden', () => {
+    const bars = [
+      bar({ id: 's1', groupKey: 'harness::send', workerKey: 'harness' }),
+    ]
+    const kept = reconcileTraceVisibility(
+      new Map(),
+      bars,
+      [
+        row('t-error', 'harness::send', {
+          status: 'error',
+          workers: ['harness'],
+        }),
+      ],
+      selection({ hiddenGroups: new Set(['harness::send']) }),
+    )
+
+    expect(ids(kept)).toEqual(['t-error'])
+  })
+
   it('hides default-hidden internal fan-outs, shows them once the family is revealed', () => {
     const bars = [bar({ id: 's1', internalKey: 'session events' })]
     const rows = [

--- a/console/web/src/pages/TracesV2/hooks/useSpanFilteredTraceRows.ts
+++ b/console/web/src/pages/TracesV2/hooks/useSpanFilteredTraceRows.ts
@@ -22,6 +22,11 @@
 //    rows the feed doesn't cover (the feed retains ~2min; the list's 500
 //    rows reach much further back).
 //
+// Failed rows always survive this composition filter even when every span is
+// hidden. Otherwise an early failure in a producer-default-hidden root (for
+// example `harness::send` failing before it creates a child) disappears from
+// the only surface where the user can diagnose it.
+//
 // Both span sources count only what the DETAIL views can render: engine
 // builtin spans (`include_internal: false` drops them from the detail
 // read) never keep a row alive, so a kept row always opens to a non-empty
@@ -168,7 +173,10 @@ export function reconcileTraceVisibility(
     }
   }
   const kept = rows.filter(
-    (r) => verdicts.get(r.traceId) !== false || liveTraces.has(r.traceId),
+    (r) =>
+      r.status === 'error' ||
+      verdicts.get(r.traceId) !== false ||
+      liveTraces.has(r.traceId),
   )
   // Identity-stable when nothing is hidden, so downstream memos hold.
   return kept.length === rows.length ? rows : kept

--- a/console/web/src/pages/TracesV2/hooks/useTraceData.test.ts
+++ b/console/web/src/pages/TracesV2/hooks/useTraceData.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { shouldDeferTraceUpdate } from './useTraceData'
+
+describe('shouldDeferTraceUpdate', () => {
+  it('renders the first answer of an empty scope while hovered', () => {
+    expect(shouldDeferTraceUpdate(true, false)).toBe(false)
+  })
+
+  it('freezes updates to an existing list while hovered', () => {
+    expect(shouldDeferTraceUpdate(true, true)).toBe(true)
+  })
+
+  it('renders updates immediately when the list is not hovered', () => {
+    expect(shouldDeferTraceUpdate(false, true)).toBe(false)
+  })
+})

--- a/console/web/src/pages/TracesV2/hooks/useTraceData.ts
+++ b/console/web/src/pages/TracesV2/hooks/useTraceData.ts
@@ -34,6 +34,13 @@ const ACTIVITY_REFETCH_DEBOUNCE_MS = 250
  *  session and saturate the main thread with payload parses. */
 const FILTERED_RESEED_COOLDOWN_MS = 10_000
 
+export function shouldDeferTraceUpdate(
+  isHovered: boolean,
+  hadPreviousRows: boolean,
+): boolean {
+  return isHovered && hadPreviousRows
+}
+
 export interface TraceListItem {
   traceId: string
   rootOperation: string
@@ -197,12 +204,17 @@ export function useTraceData({
 
       traces.sort((a, b) => b.startTime - a.startTime)
 
-      const fingerprint = fingerprintTraceList(traces)
+      // The same rows can answer two different questions (for example the
+      // unfiltered list followed by a text search that matches its only
+      // row). Scope changes clear the rendered list, so a fingerprint from
+      // the previous scope must never suppress the new scope's first answer.
+      const fingerprint = `${scopeKey}\0${fingerprintTraceList(traces)}`
       if (fingerprint === fingerprintRef.current) return
       fingerprintRef.current = fingerprint
 
       const currentIds = new Set(traces.map((t) => t.traceId))
-      if (prevTraceIdsRef.current.size > 0) {
+      const hadPreviousRows = prevTraceIdsRef.current.size > 0
+      if (hadPreviousRows) {
         const freshIds = new Set<string>()
         for (const id of currentIds) {
           if (!prevTraceIdsRef.current.has(id)) freshIds.add(id)
@@ -211,7 +223,12 @@ export function useTraceData({
       }
       prevTraceIdsRef.current = currentIds
 
-      if (isHoveredRef.current) {
+      // Freeze churn only when there is already a rendered list whose row
+      // positions must stay stable under the pointer. A scope/search change
+      // clears the list first; deferring that scope's first answer while the
+      // user is still hovering the search field would leave an empty screen
+      // until the pointer happened to leave the traces pane.
+      if (shouldDeferTraceUpdate(isHoveredRef.current, hadPreviousRows)) {
         pendingTracesRef.current = traces
         return
       }
@@ -224,7 +241,7 @@ export function useTraceData({
       setTraceListItems([])
       setHasOtelConfigured(true)
     }
-  }, [tracesData, hiddenKey])
+  }, [tracesData, hiddenKey, scopeKey])
 
   // ── Trigger-driven refetch (notify-then-query) ──────────────────────────
   // The engine coalesces span activity into one `{ trace_ids }` tick per


### PR DESCRIPTION
## Summary
- keep failed traces visible even when producer-default filters hide every span
- render the first result of a cleared search scope while the pointer remains over the traces view
- scope trace-list fingerprints so equal rows from different searches are not suppressed

## Validation
- focused Vitest coverage: 23 tests passed
- `pnpm --dir console/web typecheck`
- `pnpm --dir console/web build`
- runtime harness quickstart reproduced `harness::send` failure and rendered trace `ad833e19150586b6ee963de735c21d19` with its exception message and stacktrace, with no browser errors

Refs MOT-4504

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failed traces now remain visible even when all their spans are hidden by filters.
  * The first result appears correctly when switching between filter or search scopes.
  * Trace updates now behave correctly when viewing a hovered trace list, preventing unnecessary freezing or delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->