### PR TITLE
(MOT-4588) fix(console): share registered trigger state

### DIFF
--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -102,6 +102,7 @@ import { Composer, type ComposerSubmitPayload } from './Composer'
 import { ContextUsage } from './ContextUsage'
 import { isSessionSubmitBlockedByHydration } from './chat-submit-blocking'
 import { MessageList } from './MessageList'
+import { RegisteredTriggerStatusProvider } from './RegisteredTriggerStatus'
 import { SessionTriggers } from './SessionTriggers'
 import {
   agentIdForSend,
@@ -381,6 +382,9 @@ export function ChatView({
   const [sessionTriggers, setSessionTriggers] = useState<SessionTriggerInfo[]>(
     [],
   )
+  const [triggersSnapshotSessionId, setTriggersSnapshotSessionId] = useState<
+    string | null
+  >(null)
   // Every full row this tab has EVER fetched, by subscription id. When a once
   // binding fires and retires, the refetch drops it — this cache lets the
   // fired ghost keep its full config/conditions after retirement.
@@ -393,15 +397,17 @@ export function ChatView({
     triggersLoaderRef.current?.refresh()
   }, [])
   useEffect(() => {
-    const listTriggers = backend.listTriggers
-    if (!listTriggers) return
     seenTriggersRef.current = new Map()
     setSessionTriggers([])
+    setTriggersSnapshotSessionId(null)
+    const listTriggers = backend.listTriggers
+    if (!listTriggers) return
     const loader = serialRefresh(
       () => listTriggers(conversation.id),
       (rows) => {
         for (const row of rows) seenTriggersRef.current.set(row.id, row)
         setSessionTriggers(rows)
+        setTriggersSnapshotSessionId(conversation.id)
       },
     )
     triggersLoaderRef.current = loader
@@ -2256,42 +2262,47 @@ export function ChatView({
         />
       ) : null}
 
-      <MessageList
-        messages={conversation.messages}
-        agentName={conversation.agentProfile?.name}
-        spawnContext={{
-          title: conversation.title,
-          model: effectiveModel,
-          appearance: conversation.subagentAppearance,
-        }}
-        transcriptHydrated={conversation.hydrated !== false}
-        isThinking={isThinking}
-        thinkingDetail={
-          conversation.status === 'working' && conversation.statusReason
-            ? conversation.statusReason
-            : (phaseDetail ??
-              (effectiveModel ? `dispatching ${effectiveModel}` : undefined))
-        }
-        density={density}
-        onResolveApproval={resolveApproval}
-        onAlwaysAllow={handleAlwaysAllow}
-        onResolveFilesystemAccess={handleFilesystemResolve}
-        onManageFilesystemAccess={handleManageFilesystemAccess}
-        onConfigureProvider={handleOpenModelPicker}
-        workingDir={conversation.workingDir ?? null}
-        onWorkingDirChange={
-          workingDirEnabled ? handleWorkingDirChange : undefined
-        }
-        defaultWorkingDir={defaultWorkingDir}
-        worktreePicker={
-          worktreeEnabled
-            ? { enabled: true, onPick: handlePickWorktree }
-            : undefined
-        }
+      <RegisteredTriggerStatusProvider
+        loaded={triggersSnapshotSessionId === conversation.id}
         triggersById={triggersById}
-        focusMessageId={focusMessageId}
-        onFocusMessageHandled={handleFocusMessageHandled}
-      />
+      >
+        <MessageList
+          messages={conversation.messages}
+          agentName={conversation.agentProfile?.name}
+          spawnContext={{
+            title: conversation.title,
+            model: effectiveModel,
+            appearance: conversation.subagentAppearance,
+          }}
+          transcriptHydrated={conversation.hydrated !== false}
+          isThinking={isThinking}
+          thinkingDetail={
+            conversation.status === 'working' && conversation.statusReason
+              ? conversation.statusReason
+              : (phaseDetail ??
+                (effectiveModel ? `dispatching ${effectiveModel}` : undefined))
+          }
+          density={density}
+          onResolveApproval={resolveApproval}
+          onAlwaysAllow={handleAlwaysAllow}
+          onResolveFilesystemAccess={handleFilesystemResolve}
+          onManageFilesystemAccess={handleManageFilesystemAccess}
+          onConfigureProvider={handleOpenModelPicker}
+          workingDir={conversation.workingDir ?? null}
+          onWorkingDirChange={
+            workingDirEnabled ? handleWorkingDirChange : undefined
+          }
+          defaultWorkingDir={defaultWorkingDir}
+          worktreePicker={
+            worktreeEnabled
+              ? { enabled: true, onPick: handlePickWorktree }
+              : undefined
+          }
+          triggersById={triggersById}
+          focusMessageId={focusMessageId}
+          onFocusMessageHandled={handleFocusMessageHandled}
+        />
+      </RegisteredTriggerStatusProvider>
       <LiveRegion announcement={announcer.announcement} />
 
       <footer className={footerPad}>

--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -31,7 +31,10 @@ import {
   type HarnessImageBlock,
   predictedUserEntryId,
 } from '@/lib/backend/harness-send'
-import { serialRefresh } from '@/lib/backend/serial-refresh'
+import {
+  type SessionTriggerLoader,
+  startSessionTriggerLoader,
+} from '@/lib/backend/session-trigger-loader'
 import {
   mergeFiredTriggers,
   type SessionTriggerInfo,
@@ -392,7 +395,7 @@ export function ChatView({
   // The current conversation's serialized list loader. Doorbells arrive
   // at-least-once and burst on rapid fires; serialRefresh coalesces them
   // behind one in-flight read so snapshots never apply out of order.
-  const triggersLoaderRef = useRef<{ refresh: () => void } | null>(null)
+  const triggersLoaderRef = useRef<SessionTriggerLoader | null>(null)
   const refreshTriggers = useCallback(() => {
     triggersLoaderRef.current?.refresh()
   }, [])
@@ -402,20 +405,17 @@ export function ChatView({
     setTriggersSnapshotSessionId(null)
     const listTriggers = backend.listTriggers
     if (!listTriggers) return
-    const loader = serialRefresh(
-      () => listTriggers(conversation.id),
-      (rows) => {
+    const loader = startSessionTriggerLoader({
+      sessionId: conversation.id,
+      listTriggers,
+      onTriggersChanged: backend.onTriggersChanged,
+      onSnapshot: (rows) => {
         for (const row of rows) seenTriggersRef.current.set(row.id, row)
         setSessionTriggers(rows)
         setTriggersSnapshotSessionId(conversation.id)
       },
-    )
+    })
     triggersLoaderRef.current = loader
-    // Subscribe BEFORE the first snapshot so a mutation in the setup gap
-    // rings instead of being missed (both ride the same client bootstrap, so
-    // the registration frames are queued ahead of the list read).
-    const off = backend.onTriggersChanged?.(conversation.id, loader.refresh)
-    loader.refresh()
     // Catch-up for doorbells missed while hidden (throttled tab). Missed
     // doorbells across a socket outage are reseeded by the backend's
     // reconnect listener.
@@ -424,11 +424,10 @@ export function ChatView({
     }
     document.addEventListener('visibilitychange', onVisible)
     return () => {
-      off?.()
       document.removeEventListener('visibilitychange', onVisible)
       // Discard any in-flight snapshot so the old conversation's rows can't
       // land in the next conversation's state.
-      loader.reset()
+      loader.dispose()
       if (triggersLoaderRef.current === loader) triggersLoaderRef.current = null
     }
   }, [backend.listTriggers, backend.onTriggersChanged, conversation.id])

--- a/console/web/src/components/chat/RegisteredTriggerStatus.tsx
+++ b/console/web/src/components/chat/RegisteredTriggerStatus.tsx
@@ -1,0 +1,42 @@
+import { createContext, type ReactNode, useContext, useMemo } from 'react'
+import type { SessionTriggerInfo } from '@/lib/backend/triggers'
+
+interface RegisteredTriggerSnapshot {
+  loaded: boolean
+  triggersById: ReadonlyMap<string, SessionTriggerInfo>
+}
+
+const RegisteredTriggerStatusContext =
+  createContext<RegisteredTriggerSnapshot | null>(null)
+
+export function RegisteredTriggerStatusProvider({
+  children,
+  loaded,
+  triggersById,
+}: RegisteredTriggerSnapshot & { children: ReactNode }) {
+  const value = useMemo(
+    () => ({ loaded, triggersById }),
+    [loaded, triggersById],
+  )
+
+  return (
+    <RegisteredTriggerStatusContext.Provider value={value}>
+      {children}
+    </RegisteredTriggerStatusContext.Provider>
+  )
+}
+
+export function useRegisteredTriggerActive({
+  subscriptionId,
+  registered,
+}: {
+  subscriptionId?: string
+  registered: boolean
+}): boolean {
+  const snapshot = useContext(RegisteredTriggerStatusContext)
+
+  if (!registered || !subscriptionId || !snapshot?.loaded) return registered
+
+  const trigger = snapshot.triggersById.get(subscriptionId)
+  return Boolean(trigger && trigger.fired !== true)
+}

--- a/console/web/src/components/chat/engine/RegisterTriggerView.tsx
+++ b/console/web/src/components/chat/engine/RegisterTriggerView.tsx
@@ -8,7 +8,6 @@ import {
   RadioTower,
   ShieldCheck,
 } from 'lucide-react'
-import { useEffect, useState } from 'react'
 import { registrationFromCall } from '@/components/trigger-activity/model'
 import {
   firstRenderedTriggerActivitySlot,
@@ -26,9 +25,9 @@ import { ActivityStatus } from '@/components/ui/ActivityStatus'
 import { OpenDetailsAffordance } from '@/components/ui/OpenDetailsAffordance'
 import { CardHighlight } from '@/components/ui/Surface'
 import { useRelativeClock } from '@/hooks/use-relative-clock'
-import { useConversationsCtxOptional } from '@/lib/conversations-context'
 import { formatElapsed, timestampMilliseconds } from '@/lib/relative-time'
 import { cn } from '@/lib/utils'
+import { useRegisteredTriggerActive } from '../RegisteredTriggerStatus'
 import {
   type RegisterTriggerRequest,
   type RegisterTriggerResponse,
@@ -135,7 +134,6 @@ export function RegisterTriggerView({
           {
             label: 'Expires',
             value: `in ${formatDurationMs(req.lifecycle.expires_in_ms)}`,
-
           },
         ]
       : []),
@@ -297,7 +295,6 @@ interface TriggerRegisteredDisplayProps {
   messageId?: string
   input: unknown
   output: unknown
-  sessionId?: string
   createdAt?: number
   now?: number
 }
@@ -308,7 +305,6 @@ export function TriggerRegisteredDisplay({
   messageId,
   input,
   output,
-  sessionId,
   createdAt,
   now,
 }: TriggerRegisteredDisplayProps) {
@@ -323,8 +319,7 @@ export function TriggerRegisteredDisplay({
   )
   const registrationId = resp?.subscription_id ?? resp?.id
   const active = useRegisteredTriggerActive({
-    sessionId,
-    subscriptionId: resp?.subscription_id,
+    subscriptionId: registrationId,
     registered: Boolean(registrationId),
   })
   const clock = useRelativeClock(createdAt)
@@ -416,46 +411,6 @@ export function TriggerRegisteredDisplay({
       </div>
     </div>
   )
-}
-
-function useRegisteredTriggerActive({
-  sessionId,
-  subscriptionId,
-  registered,
-}: {
-  sessionId?: string
-  subscriptionId?: string
-  registered: boolean
-}): boolean {
-  const ctx = useConversationsCtxOptional()
-  const [active, setActive] = useState(registered)
-
-  useEffect(() => {
-    setActive(registered)
-    const listTriggers = ctx?.backend.listTriggers
-    if (!registered || !sessionId || !subscriptionId || !listTriggers) {
-      return
-    }
-    let cancelled = false
-    const refresh = () => {
-      void listTriggers(sessionId)
-        .then((rows) => {
-          if (cancelled) return
-          setActive(
-            rows.some((row) => row.id === subscriptionId && row.fired !== true),
-          )
-        })
-        .catch(() => {})
-    }
-    refresh()
-    const off = ctx.backend.onTriggersChanged?.(sessionId, refresh)
-    return () => {
-      cancelled = true
-      off?.()
-    }
-  }, [ctx?.backend, registered, sessionId, subscriptionId])
-
-  return active
 }
 
 const isScalar = (v: unknown) =>

--- a/console/web/src/components/chat/engine/index.tsx
+++ b/console/web/src/components/chat/engine/index.tsx
@@ -163,7 +163,6 @@ function tryRenderRegisterTriggerDisplay(
           ? coerceJsonObject(unwrapEnvelope(message.output))
           : undefined
       }
-      sessionId={message.sessionId}
       createdAt={message.createdAt}
     />
   )

--- a/console/web/src/components/function-trigger/featured-renderers.test.tsx
+++ b/console/web/src/components/function-trigger/featured-renderers.test.tsx
@@ -5,6 +5,7 @@ import {
   TriggerRegisteredDisplay,
 } from '@/components/chat/engine/RegisterTriggerView'
 import { SpawnActivityCard } from '@/components/chat/harness/SpawnView'
+import { RegisteredTriggerStatusProvider } from '@/components/chat/RegisteredTriggerStatus'
 import {
   engineFunctionsListEmpty,
   engineRegisterTriggerSubscribe,
@@ -205,6 +206,69 @@ describe('trigger registration display', () => {
     expect(html).toContain('bg-ok-muted')
     expect(html).toContain('stroke-ok')
     expect(html).toContain('animate-pulse')
+  })
+
+  it('derives every receipt state from one shared trigger snapshot', () => {
+    const html = renderToStaticMarkup(
+      <RegisteredTriggerStatusProvider
+        loaded
+        triggersById={
+          new Map([
+            [
+              'sub-active',
+              {
+                id: 'sub-active',
+                triggerType: 'state',
+                delivery: { kind: 'notify' as const },
+                fired: false,
+              },
+            ],
+            [
+              'sub-fired',
+              {
+                id: 'sub-fired',
+                triggerType: 'state',
+                delivery: { kind: 'notify' as const },
+                fired: true,
+              },
+            ],
+          ])
+        }
+      >
+        <TriggerRegisteredDisplay
+          input={{ trigger_type: 'state', label: 'active trigger' }}
+          output={{ subscription_id: 'sub-active' }}
+        />
+        <TriggerRegisteredDisplay
+          input={{ trigger_type: 'state', label: 'fired trigger' }}
+          output={{ subscription_id: 'sub-fired' }}
+        />
+        <TriggerRegisteredDisplay
+          input={{ trigger_type: 'state', label: 'removed trigger' }}
+          output={{ subscription_id: 'sub-removed' }}
+        />
+      </RegisteredTriggerStatusProvider>,
+    )
+
+    expect(
+      html.match(/data-trigger-registration-state="active"/g),
+    ).toHaveLength(1)
+    expect(
+      html.match(/data-trigger-registration-state="inactive"/g),
+    ).toHaveLength(2)
+  })
+
+  it('keeps a receipt active until the shared snapshot is loaded', () => {
+    const html = renderToStaticMarkup(
+      <RegisteredTriggerStatusProvider loaded={false} triggersById={new Map()}>
+        <TriggerRegisteredDisplay
+          input={{ trigger_type: 'state', label: 'loading trigger' }}
+          output={{ subscription_id: 'sub-loading' }}
+        />
+      </RegisteredTriggerStatusProvider>,
+    )
+
+    expect(html).toContain('data-trigger-registration-state="active"')
   })
 
   it('keeps action hidden until the trigger fires', () => {

--- a/console/web/src/lib/backend/session-trigger-loader.test.ts
+++ b/console/web/src/lib/backend/session-trigger-loader.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest'
+import { startSessionTriggerLoader } from './session-trigger-loader'
+import type { SessionTriggerInfo } from './triggers'
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+function trigger(id: string): SessionTriggerInfo {
+  return {
+    id,
+    triggerType: 'state',
+    delivery: { kind: 'notify' },
+  }
+}
+
+function setup(
+  listTriggers: (sessionId: string) => Promise<SessionTriggerInfo[]>,
+) {
+  let notifyChanged = () => {}
+  const unsubscribe = vi.fn()
+  const onTriggersChanged = vi.fn((_sessionId: string, onEvent: () => void) => {
+    notifyChanged = onEvent
+    return unsubscribe
+  })
+  const onSnapshot = vi.fn()
+  const loader = startSessionTriggerLoader({
+    sessionId: 'session-1',
+    listTriggers,
+    onTriggersChanged,
+    onSnapshot,
+  })
+
+  return {
+    loader,
+    notifyChanged: () => notifyChanged(),
+    onSnapshot,
+    onTriggersChanged,
+    unsubscribe,
+  }
+}
+
+describe('startSessionTriggerLoader', () => {
+  it('uses one initial read and one listener for the shared snapshot', async () => {
+    const rows = [trigger('sub-1'), trigger('sub-2'), trigger('sub-3')]
+    const listTriggers = vi.fn(async () => rows)
+    const state = setup(listTriggers)
+
+    expect(state.onTriggersChanged).toHaveBeenCalledTimes(1)
+    expect(state.onTriggersChanged).toHaveBeenCalledWith(
+      'session-1',
+      expect.any(Function),
+    )
+    expect(listTriggers).toHaveBeenCalledTimes(1)
+    expect(state.onTriggersChanged.mock.invocationCallOrder[0]).toBeLessThan(
+      listTriggers.mock.invocationCallOrder[0],
+    )
+
+    await flush()
+    expect(state.onSnapshot).toHaveBeenCalledOnce()
+    expect(state.onSnapshot).toHaveBeenCalledWith(rows)
+
+    state.notifyChanged()
+    await flush()
+    expect(listTriggers).toHaveBeenCalledTimes(2)
+    expect(state.onTriggersChanged).toHaveBeenCalledTimes(1)
+
+    state.loader.dispose()
+    state.notifyChanged()
+    await flush()
+    expect(state.unsubscribe).toHaveBeenCalledOnce()
+    expect(listTriggers).toHaveBeenCalledTimes(2)
+  })
+
+  it('applies only successful reads and keeps the last snapshot on failure', async () => {
+    const initial = [trigger('sub-active')]
+    const recovered = [trigger('sub-active'), trigger('sub-new')]
+    const listTriggers = vi
+      .fn<(sessionId: string) => Promise<SessionTriggerInfo[]>>()
+      .mockRejectedValueOnce(new Error('initially unavailable'))
+      .mockResolvedValueOnce(initial)
+      .mockRejectedValueOnce(new Error('temporarily unavailable'))
+      .mockResolvedValueOnce(recovered)
+    const state = setup(listTriggers)
+
+    await flush()
+    expect(state.onSnapshot).not.toHaveBeenCalled()
+
+    state.notifyChanged()
+    await flush()
+    expect(state.onSnapshot.mock.calls).toEqual([[initial]])
+
+    state.notifyChanged()
+    await flush()
+    expect(state.onSnapshot.mock.calls).toEqual([[initial]])
+
+    state.notifyChanged()
+    await flush()
+    expect(state.onSnapshot.mock.calls).toEqual([[initial], [recovered]])
+
+    state.loader.dispose()
+  })
+})

--- a/console/web/src/lib/backend/session-trigger-loader.ts
+++ b/console/web/src/lib/backend/session-trigger-loader.ts
@@ -1,0 +1,40 @@
+import { serialRefresh } from './serial-refresh'
+import type { SessionTriggerInfo } from './triggers'
+
+export interface SessionTriggerLoader {
+  refresh: () => void
+  dispose: () => void
+}
+
+export function startSessionTriggerLoader({
+  sessionId,
+  listTriggers,
+  onTriggersChanged,
+  onSnapshot,
+}: {
+  sessionId: string
+  listTriggers: (sessionId: string) => Promise<SessionTriggerInfo[]>
+  onTriggersChanged?: (sessionId: string, onEvent: () => void) => () => void
+  onSnapshot: (rows: SessionTriggerInfo[]) => void
+}): SessionTriggerLoader {
+  const loader = serialRefresh(() => listTriggers(sessionId), onSnapshot)
+  let disposed = false
+  const refresh = () => {
+    if (!disposed) loader.refresh()
+  }
+
+  // Subscribe before the first read so a mutation in the setup gap cannot be
+  // missed. All registration receipts consume this one shared snapshot.
+  const off = onTriggersChanged?.(sessionId, refresh)
+  refresh()
+
+  return {
+    refresh,
+    dispose: () => {
+      if (disposed) return
+      disposed = true
+      off?.()
+      loader.reset()
+    },
+  }
+}

--- a/console/web/src/lib/backend/triggers.test.ts
+++ b/console/web/src/lib/backend/triggers.test.ts
@@ -116,13 +116,13 @@ describe('listSessionTriggers', () => {
     })
   })
 
-  it('returns empty on a failed call', async () => {
+  it('preserves a failed call as an error instead of an empty snapshot', async () => {
     const client = {
       trigger: async () => {
         throw new Error('down')
       },
     }
-    expect(await listSessionTriggers(client, 's')).toEqual([])
+    await expect(listSessionTriggers(client, 's')).rejects.toThrow('down')
   })
 })
 

--- a/console/web/src/lib/backend/triggers.ts
+++ b/console/web/src/lib/backend/triggers.ts
@@ -78,16 +78,19 @@ export function deliveryOf(target: string | undefined | null): TriggerDelivery {
   return { kind: 'call', functionId: target }
 }
 
-/** List the subscriptions `sessionId` owns — one call, straight from the store. */
+/**
+ * List the subscriptions `sessionId` owns — one call, straight from the
+ * store. Transport failures reject; an empty array means the store was read
+ * successfully and the session owns no subscriptions.
+ */
 export async function listSessionTriggers(
   client: Pick<IiiClient, 'trigger'>,
   sessionId: string,
 ): Promise<SessionTriggerInfo[]> {
-  const response = await client
-    .trigger<{ subscriptions: TriggerRow[] }>('harness::triggers::list', {
-      session_id: sessionId,
-    })
-    .catch(() => null)
+  const response = await client.trigger<{ subscriptions: TriggerRow[] }>(
+    'harness::triggers::list',
+    { session_id: sessionId },
+  )
   return (response?.subscriptions ?? []).map((row) => ({
     id: row.subscription_id,
     triggerId: row.trigger_id ?? undefined,

--- a/console/web/src/lib/backend/types.ts
+++ b/console/web/src/lib/backend/types.ts
@@ -333,6 +333,8 @@ export interface ChatBackend {
    * The session's registered trigger subscriptions — the harness's durable
    * binding rows (`harness::triggers::list`), source-generic: raw trigger
    * type + config, delivery = notify-this-chat or call-a-function.
+   * Rejects when the snapshot is unavailable; `[]` is a successful empty
+   * snapshot.
    */
   listTriggers?(sessionId: string): Promise<SessionTriggerInfo[]>
   /**


### PR DESCRIPTION
## Summary

- use the ChatView trigger snapshot as the single source of registration status
- remove per-card trigger list requests and change listeners
- keep registration receipts active until the first successful session snapshot
- preserve the last successful snapshot when `harness::triggers::list` is temporarily unavailable
- cover active, fired, removed, loading, recovery, and exact shared-loader cardinality

## Validation

- `pnpm --dir console/web exec vitest run src/lib/backend/session-trigger-loader.test.ts src/lib/backend/triggers.test.ts src/lib/backend/serial-refresh.test.ts src/components/function-trigger/featured-renderers.test.tsx` — 42/42
- `pnpm --dir console/web typecheck`
- `pnpm --dir console/web build`
- Biome on all changed Console files
- `git diff --check`

## Known unrelated test failures

The full Console suite passes 1837/1840 tests. The remaining three failures are in unchanged assertions: `TriggerActivityCard.test.tsx`, `redact-raw.test.tsx`, and `icon-size-conformance.test.ts`.

Fixes MOT-4588

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trigger status accuracy while conversation snapshots load or refresh.
  * Preserved the last successful trigger status when a subsequent refresh fails.
  * Backend errors are now surfaced instead of being treated as empty trigger lists.

* **Tests**
  * Added coverage for trigger status updates, loading behavior, refresh handling, and failure recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->