### PR TITLE
(MOT-4419) feat(console): paginate compact trace summaries

### DIFF
--- a/console/ui/src/catalog/ActivityFeed.tsx
+++ b/console/ui/src/catalog/ActivityFeed.tsx
@@ -4,7 +4,7 @@
  *
  * The old console could not show this. It exists here because the console
  * worker already streams: the `trace` trigger is a coalesced "spans changed"
- * tick, so the feed re-reads `engine::traces::list` filtered to this
+ * tick, so the feed re-reads `engine::traces::spans` filtered to this
  * function's span name on each beat instead of polling a timer.
  *
  * Every row is replayable — the recorded input becomes the invoke editor's
@@ -87,7 +87,7 @@ export function ActivityFeed({
   if (calls.error) {
     return (
       <div className="console-catalog-error">
-        engine::traces::list failed — {calls.error}
+        engine::traces::spans failed — {calls.error}
       </div>
     )
   }

--- a/console/ui/src/catalog/engine.ts
+++ b/console/ui/src/catalog/engine.ts
@@ -82,6 +82,12 @@ function rows(value: unknown, key: string): unknown[] {
   return Array.isArray(list) ? list : []
 }
 
+function isFunctionUnavailable(err: unknown): boolean {
+  return /function_not_found|function .*not (?:found|registered)|not registered/i.test(
+    errorMessage(err),
+  )
+}
+
 function functionSummary(row: unknown): FunctionSummary | null {
   if (!isRecord(row)) return null
   const function_id = str(row.function_id)
@@ -404,11 +410,18 @@ export async function listCalls(
   functionId: string,
   limit = 25,
 ): Promise<CallRecord[]> {
-  const out = await host.iii.trigger('engine::traces::spans', {
+  const payload = {
     name: `execute ${functionId}`,
     limit,
     include_internal: true,
-  })
+  }
+  let out: unknown
+  try {
+    out = await host.iii.trigger('engine::traces::spans', payload)
+  } catch (err) {
+    if (!isFunctionUnavailable(err)) throw err
+    out = await host.iii.trigger('engine::traces::list', payload)
+  }
   return rows(out, 'spans')
     .map((span): CallRecord | null => {
       if (!isRecord(span)) return null

--- a/console/ui/src/catalog/engine.ts
+++ b/console/ui/src/catalog/engine.ts
@@ -296,7 +296,7 @@ let hubSeq = 0
  * - `engine::workers-available` fires when a worker connects or disconnects
  * - `trace` is a coalesced "spans changed" tick carrying the affected trace
  *   ids; it is a refetch beat, not a span feed, so a live view re-reads
- *   `engine::traces::list` when it ticks
+ *   `engine::traces::spans` when it ticks
  */
 export type LiveSignal =
   | 'engine::functions-available'
@@ -404,7 +404,7 @@ export async function listCalls(
   functionId: string,
   limit = 25,
 ): Promise<CallRecord[]> {
-  const out = await host.iii.trigger('engine::traces::list', {
+  const out = await host.iii.trigger('engine::traces::spans', {
     name: `execute ${functionId}`,
     limit,
     include_internal: true,

--- a/console/web/src/demo/LandingDemo.tsx
+++ b/console/web/src/demo/LandingDemo.tsx
@@ -333,6 +333,7 @@ export function LandingDemo({ active = true, loop = false }: LandingDemoProps) {
               onClearWarnings={traceFilters.clearValidationWarnings}
               stats={{
                 totalTraces: 1,
+                pageTraceCount: 1,
                 errorCount: player.waterfall
                   ? player.waterfall.spans.filter((s) => s.status === 'error')
                       .length

--- a/console/web/src/pages/TracesV2/api/traces.test.ts
+++ b/console/web/src/pages/TracesV2/api/traces.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  fetchTraceSpans,
+  normalizeTracesResponse,
+  type StoredSpan,
+  TRACES_RPC_FUNCTIONS,
+  type TracesResponse,
+} from './traces'
+
+const triggerMock = vi.fn()
+
+vi.mock('@/lib/iii-client', () => ({
+  getIiiClient: async () => ({ trigger: triggerMock }),
+}))
+
+function span(overrides: Partial<StoredSpan> = {}): StoredSpan {
+  return {
+    trace_id: 'trace-1',
+    span_id: 'root',
+    name: 'root operation',
+    start_time_unix_nano: 1_000_000,
+    end_time_unix_nano: 5_000_000,
+    status: 'ok',
+    attributes: [['function_id', 'root::function']],
+    events: [],
+    links: [],
+    service_name: 'service-a',
+    ...overrides,
+  }
+}
+
+beforeEach(() => triggerMock.mockReset())
+
+describe('normalizeTracesResponse', () => {
+  it('keeps the compact response untouched', () => {
+    const response: TracesResponse = {
+      traces: [],
+      total: 123,
+      offset: 50,
+      limit: 50,
+    }
+
+    expect(normalizeTracesResponse(response)).toBe(response)
+  })
+
+  it('aggregates legacy spans into one trace summary', () => {
+    const response = normalizeTracesResponse(
+      {
+        spans: [
+          span(),
+          span({
+            span_id: 'child',
+            parent_span_id: 'root',
+            name: 'child operation',
+            start_time_unix_nano: 2_000_000,
+            end_time_unix_nano: 7_000_000,
+            status: 'error',
+            attributes: [
+              ['custom.label', 'projected'],
+              ['iii.tag.outcome', 'failed'],
+            ],
+          }),
+        ],
+        total: 2,
+        offset: 0,
+        limit: 50,
+      },
+      { attribute_projection: ['custom.label'] },
+    )
+
+    expect(response).toEqual({
+      traces: [
+        expect.objectContaining({
+          trace_id: 'trace-1',
+          name: 'root operation',
+          start_time_unix_nano: 1_000_000,
+          end_time_unix_nano: 7_000_000,
+          status: 'error',
+          function_id: 'root::function',
+          span_count: 2,
+          error_count: 1,
+          trace_tags: { 'iii.tag.outcome': 'failed' },
+          attributes: { 'custom.label': 'projected' },
+        }),
+      ],
+      total: 1,
+      offset: 0,
+      limit: 50,
+    })
+  })
+})
+
+describe('fetchTraceSpans', () => {
+  it('falls back to the legacy list RPC only when spans is unavailable', async () => {
+    const legacy = {
+      spans: [span()],
+      total: 1,
+      offset: 0,
+      limit: 100,
+    }
+    triggerMock
+      .mockRejectedValueOnce(new Error('function_not_found: not registered'))
+      .mockResolvedValueOnce(legacy)
+
+    await expect(fetchTraceSpans()).resolves.toEqual(legacy)
+    expect(triggerMock).toHaveBeenNthCalledWith(1, TRACES_RPC_FUNCTIONS.spans, {
+      offset: 0,
+      limit: 100,
+    })
+    expect(triggerMock).toHaveBeenNthCalledWith(2, TRACES_RPC_FUNCTIONS.list, {
+      offset: 0,
+      limit: 100,
+    })
+  })
+
+  it('does not hide real spans RPC failures behind the legacy endpoint', async () => {
+    triggerMock.mockRejectedValueOnce(new Error('archive read failed'))
+
+    await expect(fetchTraceSpans()).rejects.toThrow('archive read failed')
+    expect(triggerMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/console/web/src/pages/TracesV2/api/traces.test.ts
+++ b/console/web/src/pages/TracesV2/api/traces.test.ts
@@ -86,6 +86,7 @@ describe('normalizeTracesResponse', () => {
       total: 1,
       offset: 0,
       limit: 50,
+      legacyContract: true,
     })
   })
 })
@@ -121,5 +122,26 @@ describe('fetchTraceSpans', () => {
 
     await expect(fetchTraceSpans()).rejects.toThrow('archive read failed')
     expect(triggerMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the full-span contract safe when a mixed-version fallback returns summaries', async () => {
+    triggerMock
+      .mockRejectedValueOnce({
+        code: 'function_not_found',
+        message: "Function 'engine::traces::spans' is not registered.",
+      })
+      .mockResolvedValueOnce({
+        traces: [],
+        total: 3,
+        offset: 0,
+        limit: 100,
+      })
+
+    await expect(fetchTraceSpans()).resolves.toEqual({
+      spans: [],
+      total: 0,
+      offset: 0,
+      limit: 100,
+    })
   })
 })

--- a/console/web/src/pages/TracesV2/api/traces.test.ts
+++ b/console/web/src/pages/TracesV2/api/traces.test.ts
@@ -99,7 +99,10 @@ describe('fetchTraceSpans', () => {
       limit: 100,
     }
     triggerMock
-      .mockRejectedValueOnce(new Error('function_not_found: not registered'))
+      .mockRejectedValueOnce({
+        code: 'function_not_found',
+        message: "Function 'engine::traces::spans' is not registered.",
+      })
       .mockResolvedValueOnce(legacy)
 
     await expect(fetchTraceSpans()).resolves.toEqual(legacy)

--- a/console/web/src/pages/TracesV2/api/traces.ts
+++ b/console/web/src/pages/TracesV2/api/traces.ts
@@ -93,6 +93,8 @@ export interface TraceSpansResponse {
   memoryExporterDisabled?: true
 }
 
+type TracesWireResponse = TracesResponse | TraceSpansResponse
+
 export interface TracesFilterParams {
   trace_id?: string
   /** Fetch a specific set of traces (grouped-view member expansion).
@@ -191,6 +193,139 @@ function isMemoryExporterNotEnabled(err: unknown): boolean {
   return /memory exporter (is )?not enabled/i.test(msg)
 }
 
+function isFunctionUnavailable(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err)
+  return /function_not_found|function .*not (?:found|registered)|not registered/i.test(
+    msg,
+  )
+}
+
+function spanAttributes(span: StoredSpan): Record<string, unknown> {
+  if (Array.isArray(span.attributes)) {
+    return Object.fromEntries(span.attributes)
+  }
+  if (span.attributes && typeof span.attributes === 'object') {
+    return span.attributes as unknown as Record<string, unknown>
+  }
+  return {}
+}
+
+function summarizeLegacySpans(
+  spans: StoredSpan[],
+  attributeProjection: string[] = [],
+): TraceSummary[] {
+  const byTrace = new Map<string, StoredSpan[]>()
+  for (const span of spans) {
+    const trace = byTrace.get(span.trace_id)
+    if (trace) trace.push(span)
+    else byTrace.set(span.trace_id, [span])
+  }
+
+  return [...byTrace.values()].flatMap((traceSpans) => {
+    const ordered = [...traceSpans].sort(
+      (a, b) =>
+        a.start_time_unix_nano - b.start_time_unix_nano ||
+        a.span_id.localeCompare(b.span_id),
+    )
+    const presentSpanIds = new Set(ordered.map((span) => span.span_id))
+    const representative =
+      ordered.find(
+        (span) =>
+          !span.parent_span_id || !presentSpanIds.has(span.parent_span_id),
+      ) ?? ordered[0]
+    if (!representative) return []
+
+    const traceTags: Record<string, string> = {}
+    const projectedAttributes: Record<string, string> = {}
+    for (const span of ordered) {
+      Object.assign(traceTags, span.trace_tags)
+      for (const [key, rawValue] of Object.entries(spanAttributes(span))) {
+        const value = String(rawValue)
+        if (
+          key.startsWith('iii.tag.') ||
+          key === 'iii.session.id' ||
+          key === 'iii.session.name' ||
+          key === 'iii.message.id'
+        ) {
+          traceTags[key] = value
+        }
+        if (attributeProjection.includes(key)) {
+          projectedAttributes[key] = value
+        }
+      }
+    }
+
+    const representativeAttributes = spanAttributes(representative)
+    const errorCount = ordered.filter(
+      (span) => span.status.toLowerCase() === 'error',
+    ).length
+    const pending = ordered.some(
+      (span) => span.pending === true || span.end_time_unix_nano === 0,
+    )
+    const outcome = traceTags['iii.tag.outcome']
+
+    return [
+      {
+        trace_id: representative.trace_id,
+        name: representative.name,
+        start_time_unix_nano: Math.min(
+          ...ordered.map((span) => span.start_time_unix_nano),
+        ),
+        end_time_unix_nano: pending
+          ? undefined
+          : Math.max(...ordered.map((span) => span.end_time_unix_nano)),
+        status:
+          errorCount > 0 || outcome === 'failed' || outcome === 'error'
+            ? 'error'
+            : pending
+              ? 'pending'
+              : 'ok',
+        service_name: representative.service_name || undefined,
+        function_id:
+          String(
+            representativeAttributes['faas.invoked_name'] ??
+              representativeAttributes.function_id ??
+              '',
+          ) || undefined,
+        topic:
+          String(
+            representativeAttributes['messaging.destination.name'] ?? '',
+          ) || undefined,
+        trace_tags: Object.keys(traceTags).length > 0 ? traceTags : undefined,
+        attributes:
+          Object.keys(projectedAttributes).length > 0
+            ? projectedAttributes
+            : undefined,
+        span_count: ordered.length,
+        error_count: errorCount,
+      } satisfies TraceSummary,
+    ]
+  })
+}
+
+/** Normalize the pre-summary `{ spans }` contract only when an older Engine
+ * answers the list RPC. New Engines return `{ traces }` unchanged, so the
+ * compact transport and server-side totals remain the normal path. */
+export function normalizeTracesResponse(
+  response: TracesWireResponse,
+  options?: TracesFilterParams,
+): TracesResponse {
+  if ('traces' in response) return response
+
+  const traces = summarizeLegacySpans(
+    response.spans,
+    options?.attribute_projection,
+  )
+  return {
+    traces,
+    // Legacy pagination is span-based. Report the unique rows actually known
+    // to this compatibility page instead of presenting a false trace total.
+    total: traces.length,
+    offset: response.offset,
+    limit: response.limit,
+  }
+}
+
 function asError(err: unknown, fallback: string): Error {
   if (err instanceof Error) return err
   return new Error(typeof err === 'string' ? err : fallback)
@@ -205,10 +340,11 @@ export async function fetchTraces(
 
   try {
     const client = await getIiiClient()
-    return await client.trigger<TracesResponse>(
+    const response = await client.trigger<TracesWireResponse>(
       TRACES_RPC_FUNCTIONS.list,
       payload,
     )
+    return normalizeTracesResponse(response, options)
   } catch (err) {
     if (isMemoryExporterNotEnabled(err)) {
       return {
@@ -232,10 +368,18 @@ export async function fetchTraceSpans(
 
   try {
     const client = await getIiiClient()
-    return await client.trigger<TraceSpansResponse>(
-      TRACES_RPC_FUNCTIONS.spans,
-      payload,
-    )
+    try {
+      return await client.trigger<TraceSpansResponse>(
+        TRACES_RPC_FUNCTIONS.spans,
+        payload,
+      )
+    } catch (err) {
+      if (!isFunctionUnavailable(err)) throw err
+      return await client.trigger<TraceSpansResponse>(
+        TRACES_RPC_FUNCTIONS.list,
+        payload,
+      )
+    }
   } catch (err) {
     if (isMemoryExporterNotEnabled(err)) {
       return {

--- a/console/web/src/pages/TracesV2/api/traces.ts
+++ b/console/web/src/pages/TracesV2/api/traces.ts
@@ -15,6 +15,7 @@
  * returns complete stored records.
  */
 
+import { errText } from '@/lib/errors'
 import { getIiiClient } from '@/lib/iii-client'
 
 export interface SpanEvent {
@@ -189,14 +190,12 @@ function stripUndefined<T extends Record<string, unknown>>(obj: T): T {
 }
 
 function isMemoryExporterNotEnabled(err: unknown): boolean {
-  const msg = err instanceof Error ? err.message : String(err)
-  return /memory exporter (is )?not enabled/i.test(msg)
+  return /memory exporter (is )?not enabled/i.test(errText(err))
 }
 
 function isFunctionUnavailable(err: unknown): boolean {
-  const msg = err instanceof Error ? err.message : String(err)
   return /function_not_found|function .*not (?:found|registered)|not registered/i.test(
-    msg,
+    errText(err),
   )
 }
 
@@ -328,7 +327,7 @@ export function normalizeTracesResponse(
 
 function asError(err: unknown, fallback: string): Error {
   if (err instanceof Error) return err
-  return new Error(typeof err === 'string' ? err : fallback)
+  return new Error(errText(err) || fallback)
 }
 
 export async function fetchTraces(

--- a/console/web/src/pages/TracesV2/api/traces.ts
+++ b/console/web/src/pages/TracesV2/api/traces.ts
@@ -75,6 +75,9 @@ export interface TracesResponse {
   total: number
   offset: number
   limit: number
+  /** Client-side marker: `engine::traces::list` answered with the legacy
+   *  full-span contract and was aggregated into summaries in the browser. */
+  legacyContract?: true
   /** Client-side marker: the engine answered "memory exporter not enabled".
    *  Set only by `fetchTraces`, never by the wire — it is what separates
    *  "observability is off" from an ordinary empty result, so the UI can
@@ -322,6 +325,26 @@ export function normalizeTracesResponse(
     total: traces.length,
     offset: response.offset,
     limit: response.limit,
+    legacyContract: true,
+  }
+}
+
+function normalizeTraceSpansResponse(
+  response: TracesWireResponse,
+  offset: number,
+  limit: number,
+): TraceSpansResponse {
+  if ('spans' in response && Array.isArray(response.spans)) return response
+
+  // A mixed-version Engine may expose the spans RPC but still answer with the
+  // compact list shape. Summaries cannot safely be treated as StoredSpan
+  // records (events and links would be lost), so keep the full-span contract
+  // valid and let the consumer render an empty detail instead of crashing.
+  return {
+    spans: [],
+    total: 0,
+    offset: response.offset ?? offset,
+    limit: response.limit ?? limit,
   }
 }
 
@@ -368,16 +391,18 @@ export async function fetchTraceSpans(
   try {
     const client = await getIiiClient()
     try {
-      return await client.trigger<TraceSpansResponse>(
+      const response = await client.trigger<TracesWireResponse>(
         TRACES_RPC_FUNCTIONS.spans,
         payload,
       )
+      return normalizeTraceSpansResponse(response, offset, limit)
     } catch (err) {
       if (!isFunctionUnavailable(err)) throw err
-      return await client.trigger<TraceSpansResponse>(
+      const response = await client.trigger<TracesWireResponse>(
         TRACES_RPC_FUNCTIONS.list,
         payload,
       )
+      return normalizeTraceSpansResponse(response, offset, limit)
     }
   } catch (err) {
     if (isMemoryExporterNotEnabled(err)) {

--- a/console/web/src/pages/TracesV2/api/traces.ts
+++ b/console/web/src/pages/TracesV2/api/traces.ts
@@ -3,14 +3,16 @@
  *
  * Mirrors `motia/console/.../api/observability/traces.ts`, but resolves
  * the iii-browser-sdk client from the shared `getIiiClient()` singleton
- * instead of taking the SDK as a parameter. Engine RPC paths are
- * identical, so the engine contract is unchanged.
+ * instead of taking the SDK as a parameter. The transport remains shared,
+ * while list summaries and full-span detail use separate RPC contracts.
  *
  * Timeout note: motia passes per-RPC timeouts to `sdk.trigger`. Our
  * `IiiClient.trigger` wrapper does not yet expose `timeoutMs`, so calls
  * here use the SDK's default invocation timeout (30s). If this becomes
  * a latency problem (long list requests, slow tree requests), extend
- * the wrapper rather than reaching past it.
+ * the wrapper rather than reaching past it. The list and detail contracts
+ * intentionally differ: list returns compact trace summaries, while spans
+ * returns complete stored records.
  */
 
 import { getIiiClient } from '@/lib/iii-client'
@@ -47,18 +49,45 @@ export interface StoredSpan {
    *  serialized when true. */
   pending?: boolean
   /** Trace-level tags (`iii.tag.*` + session/message identity attributes)
-   *  merged from every span of the trace by `engine::traces::list`. Only
-   *  present on list rows; live-streamed rows don't carry it. */
+   *  merged from every span of the trace by `engine::traces::spans`. */
   trace_tags?: Record<string, string>
 }
 
+export interface TraceSummary {
+  trace_id: string
+  name: string
+  start_time_unix_nano: number
+  end_time_unix_nano?: number
+  status: 'ok' | 'error' | 'pending'
+  service_name?: string
+  function_id?: string
+  topic?: string
+  trace_tags?: Record<string, string>
+  /** Only keys requested through `attribute_projection` are present. */
+  attributes?: Record<string, string>
+  span_count: number
+  error_count: number
+}
+
 export interface TracesResponse {
-  spans: StoredSpan[]
+  traces: TraceSummary[]
   total: number
   offset: number
   limit: number
   /** Client-side marker: the engine answered "memory exporter not enabled".
    *  Set only by `fetchTraces`, never by the wire — it is what separates
+   *  "observability is off" from an ordinary empty result, so the UI can
+   *  reserve its no-observability message for the real thing. */
+  memoryExporterDisabled?: true
+}
+
+export interface TraceSpansResponse {
+  spans: StoredSpan[]
+  total: number
+  offset: number
+  limit: number
+  /** Client-side marker: the engine answered "memory exporter not enabled".
+   *  Set only by `fetchTraceSpans`, never by the wire — it is what separates
    *  "observability is off" from an ordinary empty result, so the UI can
    *  reserve its no-observability message for the real thing. */
   memoryExporterDisabled?: true
@@ -71,7 +100,7 @@ export interface TracesFilterParams {
   trace_ids?: string[]
   service_name?: string
   name?: string
-  status?: 'ok' | 'error' | 'unset'
+  status?: 'ok' | 'error' | 'pending' | 'unset'
   span_id?: string
   parent_span_id?: string | null
   min_duration_ms?: number
@@ -89,6 +118,8 @@ export interface TracesFilterParams {
   limit?: number
   include_internal?: boolean
   search_all_spans?: boolean
+  /** Arbitrary attributes needed by the current list view. */
+  attribute_projection?: string[]
 }
 
 export interface SpanTreeNode {
@@ -143,6 +174,7 @@ export interface TracesGroupByResponse {
 
 export const TRACES_RPC_FUNCTIONS = {
   list: 'engine::traces::list',
+  spans: 'engine::traces::spans',
   tree: 'engine::traces::tree',
   clear: 'engine::traces::clear',
   groupBy: 'engine::traces::group_by',
@@ -179,9 +211,42 @@ export async function fetchTraces(
     )
   } catch (err) {
     if (isMemoryExporterNotEnabled(err)) {
-      return { spans: [], total: 0, offset, limit, memoryExporterDisabled: true }
+      return {
+        traces: [],
+        total: 0,
+        offset,
+        limit,
+        memoryExporterDisabled: true,
+      }
     }
     throw asError(err, 'Failed to fetch traces')
+  }
+}
+
+export async function fetchTraceSpans(
+  options?: TracesFilterParams,
+): Promise<TraceSpansResponse> {
+  const offset = options?.offset ?? 0
+  const limit = options?.limit ?? 100
+  const payload = stripUndefined({ ...options, offset, limit })
+
+  try {
+    const client = await getIiiClient()
+    return await client.trigger<TraceSpansResponse>(
+      TRACES_RPC_FUNCTIONS.spans,
+      payload,
+    )
+  } catch (err) {
+    if (isMemoryExporterNotEnabled(err)) {
+      return {
+        spans: [],
+        total: 0,
+        offset,
+        limit,
+        memoryExporterDisabled: true,
+      }
+    }
+    throw asError(err, 'Failed to fetch trace spans')
   }
 }
 

--- a/console/web/src/pages/TracesV2/components/GroupedTraceList.tsx
+++ b/console/web/src/pages/TracesV2/components/GroupedTraceList.tsx
@@ -24,8 +24,7 @@ import {
   summarizeGroup,
 } from '../lib/groupTraces'
 import {
-  dedupeToTraceRoots,
-  mapSpanToListItem,
+  mapTraceSummaryToListItem,
   type RowLabelConfig,
 } from '../lib/traceListItem'
 import { TraceListRow } from './TraceListRow'
@@ -279,14 +278,20 @@ function GroupMembers({
       group.value,
       group.trace_ids.length,
       showSystem,
+      label?.mode,
+      label?.attribute,
     ],
     queryFn: async () => {
-      const { spans } = await fetchTraces({
+      const { traces } = await fetchTraces({
         trace_ids: group.trace_ids.slice(0, MEMBER_FETCH_LIMIT),
         include_internal: showSystem,
         limit: MEMBER_FETCH_LIMIT,
+        attribute_projection:
+          label?.mode === 'attribute' && label.attribute
+            ? [label.attribute]
+            : undefined,
       })
-      const rows = dedupeToTraceRoots(spans).map(mapSpanToListItem)
+      const rows = traces.map(mapTraceSummaryToListItem)
       rows.sort((a, b) => b.startTime - a.startTime)
       return rows
     },

--- a/console/web/src/pages/TracesV2/components/TraceFilters.test.tsx
+++ b/console/web/src/pages/TracesV2/components/TraceFilters.test.tsx
@@ -1,0 +1,23 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { StatsBlock } from './TraceFilters'
+
+describe('StatsBlock', () => {
+  it('labels page-scoped error and duration metrics honestly', () => {
+    const html = renderToStaticMarkup(
+      <StatsBlock
+        stats={{
+          totalTraces: 2_601,
+          pageTraceCount: 50,
+          errorCount: 0,
+          avgDuration: 12,
+        }}
+      />,
+    )
+
+    expect(html).toContain('2601')
+    expect(html).toContain('50 traces on this page, 2601 total matching traces')
+    expect(html).toContain('Page errors')
+    expect(html).toContain('Page avg')
+  })
+})

--- a/console/web/src/pages/TracesV2/components/TraceFilters.tsx
+++ b/console/web/src/pages/TracesV2/components/TraceFilters.tsx
@@ -16,7 +16,7 @@
 //   • Time range presets.
 //   • Attribute key/value editor (via AttributesFilter).
 //   • Active-filter chips for one-click removal.
-//   • Stats summary (totalTraces, errorCount, avgDuration).
+//   • Stats summary (global total, current-page errors and average).
 
 import {
   AlertTriangle,
@@ -40,7 +40,7 @@ import type { GroupByOption } from '../lib/groupTraces'
 import { AttributesFilter } from './AttributesFilter'
 import { GroupByPicker } from './GroupByPicker'
 
-interface TraceFiltersProps {
+export interface TraceFiltersProps {
   filters: TraceFilterState
   onFilterChange: (key: keyof TraceFilterState, value: unknown) => void
   onClear: () => void
@@ -54,6 +54,7 @@ interface TraceFiltersProps {
   onSearchChange?: (value: string) => void
   stats?: {
     totalTraces: number
+    pageTraceCount: number
     errorCount: number
     avgDuration: number
   }
@@ -331,11 +332,14 @@ function SearchInput({
   )
 }
 
-function StatsBlock({ stats }: { stats: TraceFiltersProps['stats'] }) {
+export function StatsBlock({ stats }: { stats: TraceFiltersProps['stats'] }) {
   if (!stats) return null
   return (
     <div className="flex items-stretch rounded-md bg-surface">
-      <div className="flex items-center gap-1.5 px-2.5 py-1 font-mono text-[11px] text-ink-faint lowercase">
+      <div
+        className="flex items-center gap-1.5 px-2.5 py-1 font-mono text-[11px] text-ink-faint lowercase"
+        title={`${stats.pageTraceCount} traces on this page, ${stats.totalTraces} total matching traces`}
+      >
         <Hash className="size-4 text-ink-faint" />
         <span className="text-ink tabular-nums">{stats.totalTraces}</span>
         <span className="text-ink-ghost">Traces</span>
@@ -348,14 +352,14 @@ function StatsBlock({ stats }: { stats: TraceFiltersProps['stats'] }) {
       >
         <XCircle className="size-4" />
         <span className="tabular-nums">{stats.errorCount}</span>
-        <span className="text-ink-ghost">Errors</span>
+        <span className="text-ink-ghost">Page errors</span>
       </div>
       <div className="flex items-center gap-1.5 px-2.5 py-1 font-mono text-[11px] text-ink-faint lowercase">
         <Timer className="size-4" />
         <span className="text-ink tabular-nums">
           {formatDurationMs(stats.avgDuration)}
         </span>
-        <span className="text-ink-ghost">Avg</span>
+        <span className="text-ink-ghost">Page avg</span>
       </div>
     </div>
   )

--- a/console/web/src/pages/TracesV2/fixtures/traces-fixtures.ts
+++ b/console/web/src/pages/TracesV2/fixtures/traces-fixtures.ts
@@ -333,7 +333,7 @@ export const ALL_SPANS: StoredSpan[] = [
   ...TRACE_4_SPANS,
 ]
 
-/** Root-only spans (what an unscoped `engine::traces::list` returns). */
+/** Root-only spans used to derive compact list summaries in stories. */
 export const LIST_SPANS: StoredSpan[] = [
   TRACE_1_SPANS[0],
   TRACE_2_SPANS[0],

--- a/console/web/src/pages/TracesV2/hooks/useAllSpans.ts
+++ b/console/web/src/pages/TracesV2/hooks/useAllSpans.ts
@@ -1,6 +1,6 @@
 /**
  * Live feed of ALL spans across all traces for the masthead strip: one seed
- * read (`engine::traces::list` with `search_all_spans` and no name filter —
+ * read (`engine::traces::spans` with `search_all_spans` and no name filter —
  * which returns every stored span, newest first) then live appends from the
  * engine's `iii:devtools:all-spans` stream, keyed by `span_id` so a pending
  * live snapshot is replaced in place by its final close frame (never the
@@ -22,7 +22,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { getIiiClient } from '@/lib/iii-client'
 import { startTraceActivityFeed } from '@/lib/traces-activity'
-import { fetchTraces, type StoredSpan } from '../api/traces'
+import { fetchTraceSpans, type StoredSpan } from '../api/traces'
 import { isPendingSpan, toMs } from '../lib/traceTransform'
 
 /** Forget spans that ended this long ago (strip window + wide slack). */
@@ -103,7 +103,7 @@ export function useAllSpans(isPaused: boolean): readonly StoredSpan[] {
 
     const request = (async () => {
       try {
-        const res = await fetchTraces({
+        const res = await fetchTraceSpans({
           search_all_spans: true,
           include_internal: true,
           sort_by: 'start_time',

--- a/console/web/src/pages/TracesV2/hooks/useSpanFilteredTraceRows.ts
+++ b/console/web/src/pages/TracesV2/hooks/useSpanFilteredTraceRows.ts
@@ -19,8 +19,8 @@
 //    needed (the common case: most rows are rooted in unhidden work);
 // 2. the all-spans feed (`useAllSpans`) — the spans the strip draws;
 // 3. a one-shot batched read of the trace's stored spans for hidden-rooted
-//    rows the feed doesn't cover (the feed retains ~2min; the list's 500
-//    rows reach much further back).
+//    rows the feed doesn't cover (the feed retains ~2min; paged history
+//    can reach much further back).
 //
 // Failed rows always survive this composition filter even when every span is
 // hidden. Otherwise an early failure in a producer-default-hidden root (for
@@ -54,7 +54,7 @@
 // second, so the exemption never resurfaces them.
 
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { fetchTraces, type StoredSpan } from '../api/traces'
+import { fetchTraceSpans, type StoredSpan } from '../api/traces'
 import type { TimelineSpan } from '../components/timeline/layout'
 import {
   isSpanBarHidden,
@@ -311,7 +311,7 @@ export function useSpanFilteredTraceRows(
       for (let i = 0; i < unknown.length; i += FETCH_TRACE_CHUNK) {
         const chunk = unknown.slice(i, i + FETCH_TRACE_CHUNK)
         try {
-          const res = await fetchTraces({
+          const res = await fetchTraceSpans({
             trace_ids: chunk,
             search_all_spans: true,
             include_internal: true,

--- a/console/web/src/pages/TracesV2/hooks/useTraceData.test.ts
+++ b/console/web/src/pages/TracesV2/hooks/useTraceData.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { shouldDeferTraceUpdate } from './useTraceData'
+import {
+  buildTraceListRequestParams,
+  shouldDeferTraceUpdate,
+} from './useTraceData'
 
 describe('shouldDeferTraceUpdate', () => {
   it('renders the first answer of an empty scope while hovered', () => {
@@ -12,5 +15,47 @@ describe('shouldDeferTraceUpdate', () => {
 
   it('renders updates immediately when the list is not hovered', () => {
     expect(shouldDeferTraceUpdate(false, true)).toBe(false)
+  })
+})
+
+describe('buildTraceListRequestParams', () => {
+  it('preserves the requested server page and projects only requested attributes', () => {
+    expect(
+      buildTraceListRequestParams({
+        filterParams: { offset: 100, limit: 50, status: 'error' },
+        showSystem: false,
+        debouncedSearch: '',
+        hiddenFunctions: undefined,
+        attributeProjection: ['custom.label'],
+      }),
+    ).toMatchObject({
+      offset: 100,
+      limit: 50,
+      status: 'error',
+      include_internal: false,
+      attribute_projection: ['custom.label'],
+    })
+  })
+
+  it('adds child-span search and root exclusions without replacing pagination', () => {
+    expect(
+      buildTraceListRequestParams({
+        filterParams: { offset: 50, limit: 25 },
+        showSystem: true,
+        debouncedSearch: 'old failure',
+        hiddenFunctions: ['noisy::heartbeat'],
+        attributeProjection: undefined,
+      }),
+    ).toMatchObject({
+      offset: 50,
+      limit: 25,
+      name: 'old failure',
+      search_all_spans: true,
+      include_internal: true,
+      exclude_attributes: [
+        ['faas.invoked_name', 'noisy::heartbeat'],
+        ['function_id', 'noisy::heartbeat'],
+      ],
+    })
   })
 })

--- a/console/web/src/pages/TracesV2/hooks/useTraceData.test.ts
+++ b/console/web/src/pages/TracesV2/hooks/useTraceData.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildTraceListRequestParams,
+  filterHiddenTraceRows,
+  hiddenFunctionsKey,
   shouldDeferTraceUpdate,
+  type TraceListItem,
+  traceTotalForResponse,
 } from './useTraceData'
 
 describe('shouldDeferTraceUpdate', () => {
@@ -57,5 +61,33 @@ describe('buildTraceListRequestParams', () => {
         ['function_id', 'noisy::heartbeat'],
       ],
     })
+  })
+})
+
+describe('legacy hidden-function compatibility', () => {
+  const trace = (functionId: string): TraceListItem => ({
+    traceId: functionId,
+    rootOperation: functionId,
+    functionId,
+    status: 'ok',
+    startTime: 1,
+    spanCount: 1,
+    workers: [],
+  })
+
+  it('preserves commas inside function IDs', () => {
+    const key = hiddenFunctionsKey(['worker::function,variant'])
+    const rows = [trace('worker::function,variant'), trace('worker::function')]
+
+    expect(filterHiddenTraceRows(rows, key)).toEqual([
+      trace('worker::function'),
+    ])
+  })
+
+  it('uses the locally filtered total only for legacy responses', () => {
+    const base = { traces: [], total: 50, offset: 0, limit: 50 }
+
+    expect(traceTotalForResponse(base, 2)).toBe(50)
+    expect(traceTotalForResponse({ ...base, legacyContract: true }, 2)).toBe(2)
   })
 })

--- a/console/web/src/pages/TracesV2/hooks/useTraceData.ts
+++ b/console/web/src/pages/TracesV2/hooks/useTraceData.ts
@@ -7,31 +7,21 @@ import {
   type TracesFilterParams,
   type TracesResponse,
 } from '../api/traces'
-import { collectRecentSpanWindow } from '../lib/traceDetailPages'
+import { withHiddenFunctionExclusions } from '../lib/traceFilters'
 import {
-  dedupeToTraceRoots,
   fingerprintTraceList,
-  mapSpanToListItem,
+  mapTraceSummaryToListItem,
 } from '../lib/traceListItem'
 
-const DEFAULT_TRACE_LIMIT = 500
-/**
- * Span budget for `search_all_spans` seeds. Full-fat spans run 30-80KB and
- * the server-side scan costs ~3.4s PER CALL regardless of limit/offset
- * (measured live), so the window has to stay small: 250 recent spans cover a
- * session's recent turns in 2-3 parallel reads. Deeper history stays
- * reachable through the pager and text search.
- */
-const SEARCH_SEED_MAX_SPANS = 250
+const DEFAULT_TRACE_PAGE_SIZE = 50
 
 /** Client-side debounce over activity ticks before refetching. The engine
  *  already coalesces to ~one tick per 300ms window; this only collapses the
  *  invalidate → POST round-trips of a burst of consecutive windows. */
 const ACTIVITY_REFETCH_DEBOUNCE_MS = 250
 /** Minimum gap between activity-driven reseeds of a filtered/searched list.
- *  That seed sweeps parallel multi-MB windows (see the queryFn); riding the
- *  short tick debounce alone would re-run it back-to-back under a busy
- *  session and saturate the main thread with payload parses. */
+ *  The response is compact, but child-span search still scans the engine's
+ *  store; riding the short tick debounce would re-run that scan back-to-back. */
 const FILTERED_RESEED_COOLDOWN_MS = 10_000
 
 export function shouldDeferTraceUpdate(
@@ -65,15 +55,19 @@ export interface UseTraceDataOptions {
   isPaused: boolean
   /**
    * Root functions to drop from the list (exact `function_id` /
-   * `faas.invoked_name` match on the row). Applied client-side over both
-   * the seed read and streamed rows, so toggling is instant and the
-   * live-append cache path stays intact.
+   * `faas.invoked_name` match on the row). Sent to the engine so `total`
+   * and server pages describe the same result set; retained client-side as
+   * a defensive check for older engines.
    */
   hiddenFunctions?: string[]
+  /** Arbitrary attributes required by the active row-label view. */
+  attributeProjection?: string[]
 }
 
 export interface UseTraceDataReturn {
   traceGroups: TraceListItem[]
+  /** Total matching traces before server pagination. */
+  totalTraceCount: number
   newTraceIds: Set<string>
   setNewTraceIds: React.Dispatch<React.SetStateAction<Set<string>>>
   /** `false` ONLY on the engine's definitive "memory exporter not enabled"
@@ -87,14 +81,42 @@ export interface UseTraceDataReturn {
   flushPendingTraces: () => void
 }
 
+export function buildTraceListRequestParams({
+  filterParams,
+  showSystem,
+  debouncedSearch,
+  hiddenFunctions,
+  attributeProjection,
+}: Omit<UseTraceDataOptions, 'isPaused'>): TracesFilterParams {
+  const engineFilters = withHiddenFunctionExclusions(
+    filterParams,
+    hiddenFunctions,
+  )
+  const params = {
+    ...engineFilters,
+    ...(debouncedSearch && !engineFilters.name
+      ? { name: debouncedSearch, search_all_spans: true }
+      : {}),
+    include_internal: showSystem,
+    attribute_projection: attributeProjection,
+  }
+  return {
+    ...params,
+    offset: params.offset ?? 0,
+    limit: params.limit ?? DEFAULT_TRACE_PAGE_SIZE,
+  }
+}
+
 export function useTraceData({
   filterParams,
   showSystem,
   debouncedSearch,
   isPaused,
   hiddenFunctions,
+  attributeProjection,
 }: UseTraceDataOptions): UseTraceDataReturn {
   const [traceGroups, setTraceListItems] = useState<TraceListItem[]>([])
+  const [totalTraceCount, setTotalTraceCount] = useState(0)
   const [hasOtelConfigured, setHasOtelConfigured] = useState<boolean | null>(
     null,
   )
@@ -105,48 +127,34 @@ export function useTraceData({
 
   const isHoveredRef = useRef(false)
   const pendingTracesRef = useRef<TraceListItem[] | null>(null)
+  const hiddenKey = hiddenFunctions?.join(',') ?? ''
 
   const {
     data: tracesData,
     isLoading: isQueryLoading,
     refetch,
   } = useQuery({
-    queryKey: ['traces', filterParams, showSystem, debouncedSearch],
+    queryKey: [
+      'traces',
+      filterParams,
+      showSystem,
+      debouncedSearch,
+      attributeProjection,
+      hiddenKey,
+    ],
     queryFn: async (): Promise<TracesResponse> => {
-      const params = {
-        ...filterParams,
-        ...(debouncedSearch && !filterParams.name
-          ? { name: debouncedSearch, search_all_spans: true }
-          : {}),
-        include_internal: showSystem,
-      }
-      if (params.search_all_spans !== true) {
-        // Roots-only responses carry thin spans — one read is light & safe.
-        return fetchTraces({ ...params, offset: 0, limit: DEFAULT_TRACE_LIMIT })
-      }
-      // A search_all_spans seed (session scope, text search) returns FULL
-      // spans: one big read can exceed the transport's ~16MiB delivery cap
-      // and hang forever — no error. Collect a byte-priced recency window
-      // instead, windows in parallel because the server-side scan costs
-      // seconds per call regardless of limit/offset.
-      let exporterDisabled = false
-      const { spans, total } = await collectRecentSpanWindow(
-        async (offset, limit) => {
-          const page = await fetchTraces({ ...params, offset, limit })
-          if (page.memoryExporterDisabled) exporterDisabled = true
-          return page
-        },
-        SEARCH_SEED_MAX_SPANS,
+      // The engine returns one compact summary per trace even when child
+      // spans are searched. Preserve the caller's offset/limit so the list
+      // pages in the engine instead of retaining an arbitrary 500-row window.
+      return fetchTraces(
+        buildTraceListRequestParams({
+          filterParams,
+          showSystem,
+          debouncedSearch,
+          hiddenFunctions,
+          attributeProjection,
+        }),
       )
-      return exporterDisabled
-        ? {
-            spans: [],
-            total: 0,
-            offset: 0,
-            limit: SEARCH_SEED_MAX_SPANS,
-            memoryExporterDisabled: true,
-          }
-        : { spans, total, offset: 0, limit: SEARCH_SEED_MAX_SPANS }
     },
     // This query is the SEED read, re-run on demand: the `trace` trigger's
     // coalesced `{trace_ids}` tick invalidates it (notify-then-query, see
@@ -159,42 +167,58 @@ export function useTraceData({
     retry: 1,
   })
 
-  const hiddenKey = hiddenFunctions?.join(',') ?? ''
-
   // A scope/filter change is a DIFFERENT question — the previous answer's
   // rows must not linger under the new scope (measured live: the old
   // session's trace stayed on screen, under the new session's chip, for the
   // whole slow fetch). Dropping them also re-arms the loading skeleton.
-  const scopeKey = JSON.stringify([filterParams, showSystem, debouncedSearch])
+  const scopeKey = JSON.stringify([
+    filterParams,
+    showSystem,
+    debouncedSearch,
+    attributeProjection,
+    hiddenKey,
+  ])
+  // Pagination changes the page but not the result set. Keep the known total
+  // while a new page loads; reset it only when filters/scope actually change.
+  const resultSetKey = JSON.stringify([
+    Object.entries(filterParams).filter(
+      ([key]) => key !== 'offset' && key !== 'limit',
+    ),
+    showSystem,
+    debouncedSearch,
+    hiddenKey,
+  ])
   const scopeKeyRef = useRef(scopeKey)
+  const resultSetKeyRef = useRef(resultSetKey)
   useEffect(() => {
     if (scopeKeyRef.current === scopeKey) return
+    const resultSetChanged = resultSetKeyRef.current !== resultSetKey
     scopeKeyRef.current = scopeKey
+    resultSetKeyRef.current = resultSetKey
     setTraceListItems([])
+    if (resultSetChanged) setTotalTraceCount(0)
     fingerprintRef.current = ''
     prevTraceIdsRef.current = new Set()
     pendingTracesRef.current = null
     setNewTraceIds(new Set())
-  }, [scopeKey])
+  }, [scopeKey, resultSetKey])
 
   useEffect(() => {
     if (!tracesData) return
     if (tracesData.memoryExporterDisabled) {
       setTraceListItems([])
+      setTotalTraceCount(0)
       setHasOtelConfigured(false)
       return
     }
+    setTotalTraceCount(tracesData.total)
 
-    if (tracesData.spans && tracesData.spans.length > 0) {
-      // Search uses `search_all_spans`, which returns every span of each
-      // matching trace; collapse to one row per trace so the flat list stays
-      // trace-per-row (no-op for the non-search roots-only response).
-      let traces: TraceListItem[] = dedupeToTraceRoots(tracesData.spans).map(
-        mapSpanToListItem,
+    if (tracesData.traces && tracesData.traces.length > 0) {
+      let traces: TraceListItem[] = tracesData.traces.map(
+        mapTraceSummaryToListItem,
       )
 
-      // Hidden functions: root-match only, applied after mapping so both the
-      // seed read and streamed cache merges pass through the same gate.
+      // Defensive compatibility for engines that ignore exclude_attributes.
       const hidden = hiddenKey ? hiddenKey.split(',') : []
       if (hidden.length > 0) {
         traces = traces.filter(
@@ -272,9 +296,8 @@ export function useTraceData({
 
     const isHidden = () =>
       typeof document !== 'undefined' && document.visibilityState === 'hidden'
-    // The search_all_spans seed is EXPENSIVE (parallel multi-MB windows —
-    // see the queryFn): its reseed rides a trailing cooldown instead of the
-    // short tick debounce, so a busy session cannot re-run it back-to-back.
+    // A search_all_spans seed still performs an engine-side scan. Its reseed
+    // rides a trailing cooldown so a busy session cannot re-run it back-to-back.
     let reseedCooldownTimer: ReturnType<typeof setTimeout> | undefined
     let lastTracesReseed = 0
     const reseedTraces = () => {
@@ -376,6 +399,7 @@ export function useTraceData({
 
   return {
     traceGroups,
+    totalTraceCount,
     newTraceIds,
     setNewTraceIds,
     hasOtelConfigured,

--- a/console/web/src/pages/TracesV2/hooks/useTraceData.ts
+++ b/console/web/src/pages/TracesV2/hooks/useTraceData.ts
@@ -81,6 +81,28 @@ export interface UseTraceDataReturn {
   flushPendingTraces: () => void
 }
 
+export function hiddenFunctionsKey(hiddenFunctions?: string[]): string {
+  return JSON.stringify(hiddenFunctions ?? [])
+}
+
+export function filterHiddenTraceRows(
+  traces: TraceListItem[],
+  serializedHiddenFunctions: string,
+): TraceListItem[] {
+  const hidden = JSON.parse(serializedHiddenFunctions) as string[]
+  if (hidden.length === 0) return traces
+  return traces.filter(
+    (trace) => !(trace.functionId && hidden.includes(trace.functionId)),
+  )
+}
+
+export function traceTotalForResponse(
+  response: TracesResponse,
+  filteredTraceCount: number,
+): number {
+  return response.legacyContract ? filteredTraceCount : response.total
+}
+
 export function buildTraceListRequestParams({
   filterParams,
   showSystem,
@@ -127,7 +149,7 @@ export function useTraceData({
 
   const isHoveredRef = useRef(false)
   const pendingTracesRef = useRef<TraceListItem[] | null>(null)
-  const hiddenKey = hiddenFunctions?.join(',') ?? ''
+  const hiddenKey = hiddenFunctionsKey(hiddenFunctions)
 
   const {
     data: tracesData,
@@ -211,21 +233,20 @@ export function useTraceData({
       setHasOtelConfigured(false)
       return
     }
-    setTotalTraceCount(tracesData.total)
+    let traces: TraceListItem[] = (tracesData.traces ?? []).map(
+      mapTraceSummaryToListItem,
+    )
 
-    if (tracesData.traces && tracesData.traces.length > 0) {
-      let traces: TraceListItem[] = tracesData.traces.map(
-        mapTraceSummaryToListItem,
-      )
+    // Defensive compatibility for engines that ignore exclude_attributes.
+    // JSON preserves commas and other valid characters inside function IDs.
+    traces = filterHiddenTraceRows(traces, hiddenKey)
 
-      // Defensive compatibility for engines that ignore exclude_attributes.
-      const hidden = hiddenKey ? hiddenKey.split(',') : []
-      if (hidden.length > 0) {
-        traces = traces.filter(
-          (t) => !(t.functionId && hidden.includes(t.functionId)),
-        )
-      }
+    // New Engines already exclude hidden rows before pagination and own the
+    // global total. A legacy response was aggregated and filtered locally, so
+    // its only honest total is the number of compatible rows on this page.
+    setTotalTraceCount(traceTotalForResponse(tracesData, traces.length))
 
+    if (traces.length > 0) {
       traces.sort((a, b) => b.startTime - a.startTime)
 
       // The same rows can answer two different questions (for example the

--- a/console/web/src/pages/TracesV2/hooks/useTraceFilters.ts
+++ b/console/web/src/pages/TracesV2/hooks/useTraceFilters.ts
@@ -22,8 +22,8 @@ export interface TraceFilterState {
   groupBy?: GroupByOption
   /**
    * Root functions hidden from the list (exact `function_id` match).
-   * Applied client-side over the seed + streamed rows, so toggling never
-   * refetches and the live-append path stays intact.
+   * Sent as engine exclusions so totals and server pages stay accurate;
+   * the loaded page also applies the same check defensively.
    */
   hiddenFunctions?: string[]
   /** How each list row is labelled. Default 'function'. */

--- a/console/web/src/pages/TracesV2/index.tsx
+++ b/console/web/src/pages/TracesV2/index.tsx
@@ -51,7 +51,7 @@ import { requestChatMessageFocus } from '@/lib/trace-links'
 import { startTraceActivityFeed } from '@/lib/traces-activity'
 import { cn } from '@/lib/utils'
 import type { PageCommandsApi } from '@/types/injectable-ui'
-import { fetchTraces, type StoredSpan } from './api/traces'
+import { fetchTraceSpans, type StoredSpan } from './api/traces'
 import { GroupedTraceList } from './components/GroupedTraceList'
 import { SpanPanel } from './components/SpanPanel'
 import { TraceDetailSkeleton } from './components/TraceDetailSkeleton'
@@ -79,6 +79,7 @@ import { type TraceChatLink, traceChatLink } from './lib/traceChatLink'
 import { collectTraceDetailSpans } from './lib/traceDetailPages'
 import { withSessionScope } from './lib/traceFilters'
 import type { RowLabelConfig } from './lib/traceListItem'
+import { buildTracePageStats, tracePageCount } from './lib/tracePagination'
 import {
   applyViewConfig,
   captureViewConfig,
@@ -158,7 +159,7 @@ export function TracesV2({
     updateFilter,
     resetFilters,
     replaceFilters,
-    getFilterOnlyParams,
+    getApiParams,
     validationWarnings,
     clearValidationWarnings,
   } = useTraceFilters()
@@ -184,12 +185,13 @@ export function TracesV2({
       : null
 
   const filterParams = useMemo(
-    () => withSessionScope(getFilterOnlyParams(), sessionScope),
-    [getFilterOnlyParams, sessionScope],
+    () => withSessionScope(getApiParams(), sessionScope),
+    [getApiParams, sessionScope],
   )
 
   const {
     traceGroups,
+    totalTraceCount,
     newTraceIds,
     setNewTraceIds,
     hasOtelConfigured,
@@ -202,6 +204,10 @@ export function TracesV2({
     debouncedSearch,
     isPaused,
     hiddenFunctions: filterState.hiddenFunctions,
+    attributeProjection:
+      filterState.labelMode === 'attribute' && filterState.labelAttribute
+        ? [filterState.labelAttribute]
+        : undefined,
   })
 
   // ── Saved views (server-persisted via the `console` configuration entry) ──
@@ -330,12 +336,10 @@ export function TracesV2({
     spanFilter,
   )
 
-  const totalPages = Math.max(
-    1,
-    Math.ceil(visibleTraceGroups.length / filterState.pageSize),
-  )
-  const start = (filterState.page - 1) * filterState.pageSize
-  const paged = visibleTraceGroups.slice(start, start + filterState.pageSize)
+  const totalPages = tracePageCount(totalTraceCount, filterState.pageSize)
+  // `traceGroups` is already one server page. The local span-visibility pass
+  // may hide rows from that page, but it must never slice/paginate again.
+  const paged = visibleTraceGroups
 
   // Liveness evaluation instant for the list rows' pulsing dot — only ticked
   // while a visible row is actually live, mirroring the strip's clock
@@ -359,20 +363,14 @@ export function TracesV2({
   }, [anyRowLive])
 
   useEffect(() => {
-    if (filterState.page > totalPages) updateFilter('page', totalPages)
-  }, [filterState.page, totalPages, updateFilter])
+    if (!isQueryLoading && filterState.page > totalPages) {
+      updateFilter('page', totalPages)
+    }
+  }, [filterState.page, totalPages, updateFilter, isQueryLoading])
 
   const stats = useMemo(
-    () => ({
-      totalTraces: visibleTraceGroups.length,
-      errorCount: visibleTraceGroups.filter((t) => t.status === 'error').length,
-      avgDuration:
-        visibleTraceGroups.length > 0
-          ? visibleTraceGroups.reduce((sum, t) => sum + (t.duration ?? 0), 0) /
-            visibleTraceGroups.length
-          : 0,
-    }),
-    [visibleTraceGroups],
+    () => buildTracePageStats(visibleTraceGroups, totalTraceCount),
+    [visibleTraceGroups, totalTraceCount],
   )
 
   const containerRef = useRef<HTMLDivElement>(null)
@@ -433,7 +431,7 @@ export function TracesV2({
         const detailSpans = await collectTraceDetailSpans(
           (offset, limit) => {
             if (stale()) throw superseded
-            return fetchTraces({
+            return fetchTraceSpans({
               trace_id: traceId,
               search_all_spans: true,
               include_internal: false,
@@ -1028,7 +1026,7 @@ export function TracesV2({
                       <Pagination
                         currentPage={filterState.page}
                         totalPages={totalPages}
-                        totalItems={visibleTraceGroups.length}
+                        totalItems={totalTraceCount}
                         pageSize={filterState.pageSize}
                         onPageChange={(p) => updateFilter('page', p)}
                         onPageSizeChange={(s) => {

--- a/console/web/src/pages/TracesV2/lib/traceFilters.test.ts
+++ b/console/web/src/pages/TracesV2/lib/traceFilters.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { withSessionScope } from './traceFilters'
+import { withHiddenFunctionExclusions, withSessionScope } from './traceFilters'
 
 describe('withSessionScope', () => {
   it('is a no-op without a session', () => {
@@ -31,5 +31,34 @@ describe('withSessionScope', () => {
     const params = { attributes: [['a', 'b']] as [string, string][] }
     withSessionScope(params, 'console-1')
     expect(params.attributes).toEqual([['a', 'b']])
+  })
+})
+
+describe('withHiddenFunctionExclusions', () => {
+  it('is a no-op without hidden functions', () => {
+    const params = { service_name: 'harness' }
+    expect(withHiddenFunctionExclusions(params, [])).toBe(params)
+  })
+
+  it('excludes both supported root function attributes', () => {
+    expect(withHiddenFunctionExclusions({}, ['harness::turn'])).toEqual({
+      exclude_attributes: [
+        ['faas.invoked_name', 'harness::turn'],
+        ['function_id', 'harness::turn'],
+      ],
+    })
+  })
+
+  it('preserves existing exclusions and does not mutate them', () => {
+    const params = {
+      exclude_attributes: [['iii.tag.kind', 'internal']] as [string, string][],
+    }
+    const result = withHiddenFunctionExclusions(params, ['worker::hidden'])
+    expect(result.exclude_attributes).toEqual([
+      ['iii.tag.kind', 'internal'],
+      ['faas.invoked_name', 'worker::hidden'],
+      ['function_id', 'worker::hidden'],
+    ])
+    expect(params.exclude_attributes).toEqual([['iii.tag.kind', 'internal']])
   })
 })

--- a/console/web/src/pages/TracesV2/lib/traceFilters.ts
+++ b/console/web/src/pages/TracesV2/lib/traceFilters.ts
@@ -96,8 +96,8 @@ export function buildFilterParams(
  * nothing (verified against a live engine: 0 rows without
  * `search_all_spans`, the session's real traces with it). So the scope
  * rides the same wire shape as text search: match across all spans, and
- * let the list's `dedupeToTraceRoots` collapse the response back to one
- * row per trace. Appended after any user attribute filters, so both apply.
+ * the engine still returns one compact summary per matching trace. Appended
+ * after any user attribute filters, so both apply.
  */
 export function withSessionScope(
   params: TracesFilterParams,
@@ -111,6 +111,29 @@ export function withSessionScope(
       [SESSION_ID_ATTR, sessionId] as [string, string],
     ],
     search_all_spans: true,
+  }
+}
+
+/**
+ * Move hidden root functions into the engine query so server pagination and
+ * `total` describe the same visible result set as the list. Both attribute
+ * spellings are supported because iii spans may carry the OTel-standard
+ * `faas.invoked_name` or the engine-specific `function_id` fallback.
+ */
+export function withHiddenFunctionExclusions(
+  params: TracesFilterParams,
+  hiddenFunctions: readonly string[] | undefined,
+): TracesFilterParams {
+  if (!hiddenFunctions || hiddenFunctions.length === 0) return params
+  return {
+    ...params,
+    exclude_attributes: [
+      ...(params.exclude_attributes ?? []),
+      ...hiddenFunctions.flatMap((functionId) => [
+        ['faas.invoked_name', functionId] as [string, string],
+        ['function_id', functionId] as [string, string],
+      ]),
+    ],
   }
 }
 

--- a/console/web/src/pages/TracesV2/lib/traceListItem.test.ts
+++ b/console/web/src/pages/TracesV2/lib/traceListItem.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import type { StoredSpan } from '../api/traces'
-import { mapSpanToListItem } from './traceListItem'
+import type { StoredSpan, TraceSummary } from '../api/traces'
+import {
+  fingerprintTraceList,
+  mapSpanToListItem,
+  mapTraceSummaryToListItem,
+} from './traceListItem'
 
 function root(overrides: Partial<StoredSpan> = {}): StoredSpan {
   return {
@@ -28,5 +32,62 @@ describe('mapSpanToListItem', () => {
 
   it('keeps a trace healthy without an error status or failure tag', () => {
     expect(mapSpanToListItem(root()).status).toBe('ok')
+  })
+})
+
+describe('mapTraceSummaryToListItem', () => {
+  it('uses aggregate status, counts and projected attributes directly', () => {
+    const summary: TraceSummary = {
+      trace_id: 'trace-summary',
+      name: 'handle checkout',
+      start_time_unix_nano: 1_780_000_000_000_000_000,
+      end_time_unix_nano: 1_780_000_000_003_000_000,
+      status: 'error',
+      service_name: 'gateway',
+      function_id: 'checkout::handle',
+      topic: 'payments',
+      trace_tags: { 'iii.tag.outcome': 'failed' },
+      attributes: { 'custom.label': 'checkout' },
+      span_count: 7,
+      error_count: 1,
+    }
+
+    expect(mapTraceSummaryToListItem(summary)).toEqual({
+      traceId: 'trace-summary',
+      rootOperation: 'handle checkout',
+      functionId: 'checkout::handle',
+      topic: 'payments',
+      status: 'error',
+      startTime: 1_780_000_000_000,
+      endTime: 1_780_000_000_003,
+      duration: 3,
+      spanCount: 7,
+      workers: ['gateway'],
+      attributes: { 'custom.label': 'checkout' },
+      traceTags: { 'iii.tag.outcome': 'failed' },
+    })
+  })
+
+  it('invalidates the list fingerprint when aggregate fields change', () => {
+    const base = mapTraceSummaryToListItem({
+      trace_id: 'trace-summary',
+      name: 'handle checkout',
+      start_time_unix_nano: 1_780_000_000_000_000_000,
+      end_time_unix_nano: 1_780_000_000_003_000_000,
+      status: 'ok',
+      attributes: { 'custom.label': 'checkout' },
+      span_count: 2,
+      error_count: 0,
+    })
+    const changed = {
+      ...base,
+      endTime: (base.endTime ?? 0) + 10,
+      spanCount: 3,
+      attributes: { 'custom.label': 'payment' },
+    }
+
+    expect(fingerprintTraceList([changed])).not.toBe(
+      fingerprintTraceList([base]),
+    )
   })
 })

--- a/console/web/src/pages/TracesV2/lib/traceListItem.ts
+++ b/console/web/src/pages/TracesV2/lib/traceListItem.ts
@@ -4,7 +4,7 @@
 // same mapping in non-React contexts (e.g. tests, server-side render,
 // a different SDK transport that emits the same span shape).
 
-import type { StoredSpan } from '../api/traces'
+import type { StoredSpan, TraceSummary } from '../api/traces'
 import type { TraceListItem } from '../hooks/useTraceData'
 import { isPendingSpan, toMs } from './traceTransform'
 
@@ -93,6 +93,30 @@ export function mapSpanToListItem(span: StoredSpan): TraceListItem {
   }
 }
 
+/** Map the compact `engine::traces::list` contract directly to the row
+ *  view-model. Full span payloads are intentionally absent from this path. */
+export function mapTraceSummaryToListItem(trace: TraceSummary): TraceListItem {
+  const startTime = toMs(trace.start_time_unix_nano)
+  const endTime =
+    trace.end_time_unix_nano == null
+      ? undefined
+      : toMs(trace.end_time_unix_nano)
+  return {
+    traceId: trace.trace_id,
+    rootOperation: trace.name,
+    functionId: trace.function_id,
+    topic: trace.topic,
+    status: trace.status,
+    startTime,
+    endTime,
+    duration: endTime === undefined ? undefined : endTime - startTime,
+    spanCount: trace.span_count,
+    workers: [trace.service_name || 'unknown'],
+    attributes: trace.attributes,
+    traceTags: trace.trace_tags,
+  }
+}
+
 /** How a list row is labelled — mirrors `RowLabelConfig` in tracesViews. */
 export interface RowLabelConfig {
   mode: 'function' | 'span-name' | 'attribute'
@@ -136,12 +160,9 @@ export function resolveRowLabel(
  * Collapse a span list to one representative span per `trace_id` — the root
  * (no parent) when present, else the earliest-started span.
  *
- * The flat-list TRACES view is one row per trace. A plain `engine::traces::list`
- * already returns root spans only, but the SEARCH path passes
- * `search_all_spans: true`, which returns EVERY span of each matching trace
- * (so a query like `harness::send` matches a child span and the engine
- * hands back the whole turn). Collapsing here keeps the list one-row-per-trace
- * regardless, and is a no-op for the non-search response (already roots).
+ * Full-span fixtures and legacy `engine::traces::spans` consumers can still
+ * need a representative root. The compact `engine::traces::list` contract is
+ * already one-row-per-trace and does not use this helper.
  */
 export function dedupeToTraceRoots(
   spans: ReadonlyArray<StoredSpan>,
@@ -172,10 +193,9 @@ export function dedupeToTraceRoots(
  * the hook to dedupe back-to-back fetches that return the same rows.
  *
  * Joins all trace IDs in order, plus the row-visible fields that can
- * change for an UNCHANGED set of ids — status (pending→final) and the
- * trace tags (they arrive late, when a tag-bearing child span closes
- * after the root row was seeded/streamed). An id-only fingerprint
- * would swallow those in-place updates. Earlier versions sampled only
+ * change for an UNCHANGED set of ids — aggregate status/count/end time and
+ * projected attributes/tags can all change as child spans close. An id-only
+ * fingerprint would swallow those in-place updates. Earlier versions sampled only
  * first + last + count, which would have missed middle-only churn if
  * the sort order ever flipped. At the 500-trace ceiling the
  * fingerprint stays tens-of-KB — cheap to compare.
@@ -184,11 +204,24 @@ export function fingerprintTraceList(
   traces: ReadonlyArray<TraceListItem>,
 ): string {
   return `${traces.length}:${traces
-    .map(
-      (t) =>
-        `${t.traceId}/${t.status}/${
-          t.traceTags ? Object.entries(t.traceTags).flat().join('') : ''
-        }`,
-    )
+    .map((trace) => {
+      const tags = trace.traceTags
+        ? Object.entries(trace.traceTags).flat().join('|')
+        : ''
+      const attributes = trace.attributes
+        ? Object.entries(trace.attributes).flat().join('|')
+        : ''
+      return [
+        trace.traceId,
+        trace.status,
+        trace.startTime,
+        trace.endTime ?? '',
+        trace.spanCount,
+        trace.functionId ?? '',
+        trace.topic ?? '',
+        tags,
+        attributes,
+      ].join('/')
+    })
     .join(',')}`
 }

--- a/console/web/src/pages/TracesV2/lib/tracePagination.test.ts
+++ b/console/web/src/pages/TracesV2/lib/tracePagination.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import type { TraceListItem } from '../hooks/useTraceData'
+import { buildTracePageStats, tracePageCount } from './tracePagination'
+
+function trace(
+  traceId: string,
+  status: TraceListItem['status'],
+  duration: number,
+): TraceListItem {
+  return {
+    traceId,
+    rootOperation: `execute ${traceId}`,
+    status,
+    startTime: 0,
+    endTime: duration,
+    duration,
+    spanCount: 1,
+    workers: ['worker'],
+  }
+}
+
+describe('tracePageCount', () => {
+  it('uses the engine total instead of the loaded page length', () => {
+    expect(tracePageCount(2_601, 50)).toBe(53)
+    expect(tracePageCount(0, 50)).toBe(1)
+  })
+})
+
+describe('buildTracePageStats', () => {
+  it('keeps the global total separate from page-scoped errors and average', () => {
+    expect(
+      buildTracePageStats(
+        [trace('ok', 'ok', 10), trace('failed', 'error', 30)],
+        2_601,
+      ),
+    ).toEqual({
+      totalTraces: 2_601,
+      pageTraceCount: 2,
+      errorCount: 1,
+      avgDuration: 20,
+    })
+  })
+})

--- a/console/web/src/pages/TracesV2/lib/tracePagination.ts
+++ b/console/web/src/pages/TracesV2/lib/tracePagination.ts
@@ -1,0 +1,32 @@
+import type { TraceListItem } from '../hooks/useTraceData'
+
+export interface TracePageStats {
+  /** Total traces matching the engine-side filters, before pagination. */
+  totalTraces: number
+  /** Rows from the current server page that remain visible locally. */
+  pageTraceCount: number
+  /** Error rows on the current visible page, never presented as global. */
+  errorCount: number
+  /** Average duration of the current visible page. */
+  avgDuration: number
+}
+
+export function tracePageCount(totalTraces: number, pageSize: number): number {
+  return Math.max(1, Math.ceil(totalTraces / pageSize))
+}
+
+export function buildTracePageStats(
+  rows: readonly TraceListItem[],
+  totalTraces: number,
+): TracePageStats {
+  return {
+    totalTraces,
+    pageTraceCount: rows.length,
+    errorCount: rows.filter((trace) => trace.status === 'error').length,
+    avgDuration:
+      rows.length > 0
+        ? rows.reduce((sum, trace) => sum + (trace.duration ?? 0), 0) /
+          rows.length
+        : 0,
+  }
+}

--- a/console/web/src/pages/TracesV2/stories/TraceFilters.stories.tsx
+++ b/console/web/src/pages/TracesV2/stories/TraceFilters.stories.tsx
@@ -16,7 +16,12 @@ const INITIAL_FILTERS: TraceFilterState = {
   pageSize: 50,
 }
 
-const STATS = { totalTraces: 4, errorCount: 1, avgDuration: 377 }
+const STATS = {
+  totalTraces: 2_601,
+  pageTraceCount: 50,
+  errorCount: 1,
+  avgDuration: 377,
+}
 
 // TraceFilters is a controlled component: `filters` + `onFilterChange` and
 // `searchQuery` + `onSearchChange` are value/onChange pairs that Storybook
@@ -24,7 +29,12 @@ const STATS = { totalTraces: 4, errorCount: 1, avgDuration: 377 }
 // actually interactive in the story. Only the passthrough props (stats,
 // isLoading) come through as args.
 interface HarnessProps {
-  stats?: { totalTraces: number; errorCount: number; avgDuration: number }
+  stats?: {
+    totalTraces: number
+    pageTraceCount: number
+    errorCount: number
+    avgDuration: number
+  }
   isLoading?: boolean
 }
 

--- a/console/web/src/pages/TracesV2/stories/harness.tsx
+++ b/console/web/src/pages/TracesV2/stories/harness.tsx
@@ -24,7 +24,7 @@ import {
   __resetIiiClientForTests,
   __setIiiClientDepsForTests,
 } from '@/lib/iii-client'
-import type { SpanTreeNode, StoredSpan } from '../api/traces'
+import type { SpanTreeNode, StoredSpan, TraceSummary } from '../api/traces'
 import {
   ALL_SPANS,
   LIST_SPANS,
@@ -50,6 +50,41 @@ function buildTraceTree(traceId: string): SpanTreeNode[] {
   return roots
 }
 
+function toSummary(root: StoredSpan): TraceSummary {
+  const spans = ALL_SPANS.filter((span) => span.trace_id === root.trace_id)
+  const errors = spans.filter(
+    (span) => span.status.toLowerCase() === 'error',
+  ).length
+  const pending = spans.some((span) => span.pending)
+  const attributes = Object.fromEntries(
+    root.attributes.map(([key, value]) => [key, String(value)]),
+  )
+  return {
+    trace_id: root.trace_id,
+    name: root.name,
+    start_time_unix_nano: Math.min(
+      ...spans.map((span) => span.start_time_unix_nano),
+    ),
+    ...(pending
+      ? {}
+      : {
+          end_time_unix_nano: Math.max(
+            ...spans.map((span) => span.end_time_unix_nano),
+          ),
+        }),
+    status: errors > 0 ? 'error' : pending ? 'pending' : 'ok',
+    service_name: root.service_name,
+    function_id: String(
+      attributes['faas.invoked_name'] ?? attributes.function_id ?? '',
+    ),
+    topic: attributes['messaging.destination.name'] as string | undefined,
+    trace_tags: root.trace_tags,
+    attributes,
+    span_count: spans.length,
+    error_count: errors,
+  }
+}
+
 /** Route a bus trigger to a canned, fixture-backed response. */
 async function fakeTrigger({
   function_id,
@@ -58,35 +93,51 @@ async function fakeTrigger({
   const p = payload ?? {}
   switch (function_id) {
     case 'engine::traces::list': {
-      const traceId = p.trace_id as string | undefined
-      // A trace-scoped read (the detail seed) returns every span of that trace.
-      if (traceId) {
-        const spans = ALL_SPANS.filter((s) => s.trace_id === traceId)
-        return { spans, total: spans.length, offset: 0, limit: 10000 }
-      }
-      // The list read returns roots, with lightweight filter/search support so
+      // The list read returns summaries, with lightweight filter/search support so
       // the filter bar and search box visibly do something in the playground.
-      let spans: StoredSpan[] = LIST_SPANS
+      let traces = LIST_SPANS.map(toSummary)
       const name = p.name as string | undefined
       const worker = p.service_name as string | undefined
       const status = p.status as string | undefined
       if (name) {
         const q = name.toLowerCase()
-        spans = spans.filter((s) => s.name.toLowerCase().includes(q))
+        traces = traces.filter((trace) => trace.name.toLowerCase().includes(q))
       }
-      if (worker) spans = spans.filter((s) => s.service_name === worker)
+      if (worker)
+        traces = traces.filter((trace) => trace.service_name === worker)
       if (status) {
-        spans = spans.filter(
-          (s) =>
-            (s.status.toLowerCase() === 'error' ? 'error' : 'ok') === status,
+        traces = traces.filter((trace) => trace.status === status)
+      }
+      const excluded = p.exclude_attributes as
+        | Array<[string, string]>
+        | undefined
+      if (excluded?.length) {
+        traces = traces.filter(
+          (trace) =>
+            !excluded.some(([key, value]) => {
+              if (key === 'faas.invoked_name' || key === 'function_id') {
+                return trace.function_id === value
+              }
+              return trace.attributes?.[key] === value
+            }),
         )
       }
+      const total = traces.length
+      const offset = (p.offset as number) ?? 0
+      const limit = (p.limit as number) ?? 50
       return {
-        spans,
-        total: spans.length,
-        offset: (p.offset as number) ?? 0,
-        limit: (p.limit as number) ?? 500,
+        traces: traces.slice(offset, offset + limit),
+        total,
+        offset,
+        limit,
       }
+    }
+    case 'engine::traces::spans': {
+      const traceId = p.trace_id as string | undefined
+      const spans = traceId
+        ? ALL_SPANS.filter((span) => span.trace_id === traceId)
+        : ALL_SPANS
+      return { spans, total: spans.length, offset: 0, limit: 10000 }
     }
     case 'engine::traces::tree':
       return { roots: buildTraceTree((p.trace_id as string) ?? '') }

--- a/console/web/src/pages/TracesV2/stories/harness.tsx
+++ b/console/web/src/pages/TracesV2/stories/harness.tsx
@@ -74,9 +74,9 @@ function toSummary(root: StoredSpan): TraceSummary {
         }),
     status: errors > 0 ? 'error' : pending ? 'pending' : 'ok',
     service_name: root.service_name,
-    function_id: String(
-      attributes['faas.invoked_name'] ?? attributes.function_id ?? '',
-    ),
+    function_id:
+      String(attributes['faas.invoked_name'] ?? attributes.function_id ?? '') ||
+      undefined,
     topic: attributes['messaging.destination.name'] as string | undefined,
     trace_tags: root.trace_tags,
     attributes,


### PR DESCRIPTION
## Summary

- consume compact trace summaries from the Engine list endpoint
- fetch full spans only for the selected trace and the Traces Live surface
- move pagination and total counting to the Engine
- keep error aggregation and projected trace attributes visible in the list
- preserve compatibility with older Engines while the RC rolls out
- preserve filter, label, demo, and injected Console behavior

## Validation

- `pnpm --dir console/web test --run src/pages/TracesV2/api/traces.test.ts src/pages/TracesV2/components/TraceFilters.test.tsx src/pages/TracesV2/hooks/useTraceData.test.ts src/pages/TracesV2/lib/traceFilters.test.ts src/pages/TracesV2/lib/traceListItem.test.ts src/pages/TracesV2/lib/tracePagination.test.ts` — 26 passed
- `pnpm --dir console/web typecheck`
- `pnpm --dir console/ui build`
- `pnpm --dir console/web build`
- `git diff --check`

Depends on iii-hq/iii#2094.

Fixes MOT-4419

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved trace browsing with server-side pagination and accurate total counts.
  - Added support for pending traces, attribute filtering, projections, and hidden-function exclusions.
  - Trace lists now show compact summaries, with detailed span data loaded separately.
  - Statistics distinguish page-level metrics from overall totals.
  - Added compatibility fallback for environments without the latest trace endpoint.

- **Bug Fixes**
  - Improved filtering, pagination boundaries, and loading behavior for large result sets.

- **Tests**
  - Expanded coverage for trace loading, filtering, pagination, normalization, and statistics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
