### PR TITLE
chore(email): leave the version bump to Release Control

### DIFF
--- a/email/Cargo.lock
+++ b/email/Cargo.lock
@@ -572,7 +572,7 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "email"
-version = "0.2.0"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "async-imap",

--- a/email/Cargo.toml
+++ b/email/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "email"
-version = "0.2.0"
+version = "0.1.7"
 edition = "2021"
 publish = false
 license = "Apache-2.0"


### PR DESCRIPTION
PR #979 raised `email/Cargo.toml` from 0.1.7 to 0.2.0 by hand. Release Control owns worker versions: it derives the candidate from the registry base (0.1.7) and commits the `prepare vX` bump itself, so the hand bump made it plan `0.2.1-rc.1` and its prepare step failed at dispatch (`prepare_release:email: dispatch outcome is unknown`), leaving the `worker:email` lock held.

This puts the manifest back at 0.1.7 (Cargo.toml + Cargo.lock only). The intended release stays 0.2.0: pick the **minor** stable goal in Release Control and it will derive `0.2.0-rc.1`. The README already documents 0.2.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the email package version to 0.1.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->