### PR TITLE
(MOT-4504) fix(traces): keep failed sends visible by session

### DIFF
--- a/console/web/src/pages/TracesV2/components/timeline/TimelineStrip.tsx
+++ b/console/web/src/pages/TracesV2/components/timeline/TimelineStrip.tsx
@@ -6,10 +6,11 @@
  * through a 60s window; hovering a bar shows the span's details, clicking
  * it opens its owning trace.
  *
- * Bars come straight from the all-spans feed (`useAllSpans`: one seed read
- * + the engine's `iii:devtools:all-spans` stream): a pending span renders
- * as a LIVE bar growing along the now-edge and settles when its close frame
- * arrives, so liveness is span-accurate — no trace-level correction needed.
+ * Bars come straight from the all-spans feed (`useAllSpans`: a compact
+ * trace-first seed + the engine's `iii:devtools:all-spans` stream): a pending
+ * span renders as a LIVE bar growing along the now-edge and settles when its
+ * close frame arrives, so liveness is span-accurate — no trace-level
+ * correction needed.
  * Engine routing wrappers are skipped (see `storedSpansToTimelineSpans`).
  *
  * The visualization: every parent sits on a line above the spans it

--- a/console/web/src/pages/TracesV2/components/timeline/spanVisibility.test.ts
+++ b/console/web/src/pages/TracesV2/components/timeline/spanVisibility.test.ts
@@ -180,6 +180,37 @@ describe('applyHiddenSpanFilters', () => {
     ])
   })
 
+  it('keeps a failed harness::send span visible when its group is hidden', () => {
+    const failedSend = waterfall([
+      vis({
+        span_id: 'send',
+        name: 'execute harness::send',
+        service_name: 'harness',
+        status: 'error',
+      }),
+      vis({
+        span_id: 'ensure',
+        name: 'execute session::ensure',
+        service_name: 'session-manager',
+        parent_span_id: 'send',
+        depth: 1,
+      }),
+    ])
+
+    const out = applyHiddenSpanFilters(
+      failedSend,
+      byName,
+      selection({
+        hiddenGroups: ['execute harness::send'],
+        hiddenWorkers: ['harness', 'session-manager'],
+      }),
+    )
+
+    expect(out.spans.map((s) => s.span_id)).toEqual(['send'])
+    expect(out.spans[0].status).toBe('error')
+    expect(out.span_count).toBe(1)
+  })
+
   it('survives malformed parent cycles without self-parenting', () => {
     const cyclic = waterfall([
       vis({ span_id: 'a', name: 'noise', parent_span_id: 'b' }),

--- a/console/web/src/pages/TracesV2/components/timeline/spanVisibility.ts
+++ b/console/web/src/pages/TracesV2/components/timeline/spanVisibility.ts
@@ -105,11 +105,13 @@ const MAX_PARENT_WALK = 1000
  * Apply the filter selection (hidden span groups + hidden workers +
  * default-hidden internal families) to the waterfall.
  *
- * Only the matched spans disappear. Each surviving span whose parent was
- * hidden re-parents to its nearest surviving ancestor, and `depth` is
- * recomputed from the rewritten chains so indentation stays consistent. A
- * parent id that was never in the trace is kept as-is (external/distributed
- * parents already render as local roots). The time window
+ * Only matched non-error spans disappear. Failed spans always remain visible,
+ * even when their group or worker is hidden, so a de-noising preference can
+ * never remove the evidence needed to diagnose a failed trace. Each surviving
+ * span whose parent was hidden re-parents to its nearest surviving ancestor,
+ * and `depth` is recomputed from the rewritten chains so indentation stays
+ * consistent. A parent id that was never in the trace is kept as-is
+ * (external/distributed parents already render as local roots). The time window
  * (`total_duration_ms`) is deliberately preserved — filtering noise out
  * must not rescale the remaining bars. Returns `data` unchanged when
  * nothing matches.
@@ -132,7 +134,7 @@ export function applyHiddenSpanFilters(
 
   const hidden = new Set<string>()
   for (const span of data.spans) {
-    if (matches(span)) hidden.add(span.span_id)
+    if (span.status !== 'error' && matches(span)) hidden.add(span.span_id)
   }
   if (hidden.size === 0) return data
 

--- a/console/web/src/pages/TracesV2/hooks/useAllSpans.test.ts
+++ b/console/web/src/pages/TracesV2/hooks/useAllSpans.test.ts
@@ -1,6 +1,21 @@
-import { describe, expect, it } from 'vitest'
-import type { StoredSpan } from '../api/traces'
-import { isContextFreeInternalSpan } from './useAllSpans'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { StoredSpan, TraceSummary } from '../api/traces'
+
+const { fetchTraceSpansMock, fetchTracesMock } = vi.hoisted(() => ({
+  fetchTraceSpansMock: vi.fn(),
+  fetchTracesMock: vi.fn(),
+}))
+
+vi.mock('../api/traces', () => ({
+  fetchTraceSpans: fetchTraceSpansMock,
+  fetchTraces: fetchTracesMock,
+}))
+
+import {
+  fetchLiveSpanSeed,
+  isContextFreeInternalSpan,
+  selectSeedTraceIds,
+} from './useAllSpans'
 
 function span(
   overrides: Partial<StoredSpan> & { span_id: string },
@@ -17,6 +32,22 @@ function span(
     ...overrides,
   }
 }
+
+function summary(traceId: string, spanCount: number): TraceSummary {
+  return {
+    trace_id: traceId,
+    name: `trace ${traceId}`,
+    start_time_unix_nano: 1,
+    status: 'ok',
+    span_count: spanCount,
+    error_count: 0,
+  }
+}
+
+beforeEach(() => {
+  fetchTraceSpansMock.mockReset()
+  fetchTracesMock.mockReset()
+})
 
 // Mirrors `is_context_free_internal_span` in the engine's observability
 // worker: the seed must exclude exactly what the live all-spans feed
@@ -65,5 +96,94 @@ describe('isContextFreeInternalSpan', () => {
         span({ span_id: 's4', name: 'execute harness::send' }),
       ),
     ).toBe(false)
+  })
+})
+
+describe('selectSeedTraceIds', () => {
+  it('selects newest traces until their span counts fill the seed budget', () => {
+    const traces = [summary('t-1', 220), summary('t-2', 280), summary('t-3', 5)]
+
+    expect(selectSeedTraceIds(traces)).toEqual(['t-1', 't-2'])
+  })
+
+  it('counts an empty legacy summary as at least one span', () => {
+    const traces = Array.from({ length: 501 }, (_, index) =>
+      summary(`t-${index}`, 0),
+    )
+
+    expect(selectSeedTraceIds(traces)).toHaveLength(500)
+  })
+})
+
+describe('fetchLiveSpanSeed', () => {
+  it('loads compact summaries before fetching recent spans by trace id', async () => {
+    const recentSpan = span({ span_id: 'recent' })
+    fetchTracesMock.mockResolvedValue({
+      traces: [summary('t-1', 300), summary('t-2', 200), summary('t-3', 100)],
+      total: 3,
+      offset: 0,
+      limit: 500,
+    })
+    fetchTraceSpansMock.mockResolvedValue({
+      spans: [recentSpan],
+      total: 1,
+      offset: 0,
+      limit: 500,
+    })
+
+    await expect(fetchLiveSpanSeed(1_000_000)).resolves.toEqual([recentSpan])
+    expect(fetchTracesMock).toHaveBeenCalledWith({
+      include_internal: false,
+      sort_by: 'start_time',
+      sort_order: 'desc',
+      limit: 500,
+    })
+    expect(fetchTraceSpansMock).toHaveBeenCalledWith({
+      trace_ids: ['t-1', 't-2'],
+      search_all_spans: true,
+      include_internal: true,
+      start_time: 880_000,
+      sort_by: 'start_time',
+      sort_order: 'desc',
+      limit: 500,
+    })
+  })
+
+  it('skips the full-span request when no trace summary exists', async () => {
+    fetchTracesMock.mockResolvedValue({
+      traces: [],
+      total: 0,
+      offset: 0,
+      limit: 500,
+    })
+
+    await expect(fetchLiveSpanSeed()).resolves.toEqual([])
+    expect(fetchTraceSpansMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps the global seed for engines that return the legacy list contract', async () => {
+    const legacySpan = span({ span_id: 'legacy' })
+    fetchTracesMock.mockResolvedValue({
+      traces: [summary('t-legacy', 1)],
+      total: 1,
+      offset: 0,
+      limit: 500,
+      legacyContract: true,
+    })
+    fetchTraceSpansMock.mockResolvedValue({
+      spans: [legacySpan],
+      total: 1,
+      offset: 0,
+      limit: 500,
+    })
+
+    await expect(fetchLiveSpanSeed()).resolves.toEqual([legacySpan])
+    expect(fetchTraceSpansMock).toHaveBeenCalledWith({
+      search_all_spans: true,
+      include_internal: true,
+      sort_by: 'start_time',
+      sort_order: 'desc',
+      limit: 500,
+    })
   })
 })

--- a/console/web/src/pages/TracesV2/hooks/useAllSpans.ts
+++ b/console/web/src/pages/TracesV2/hooks/useAllSpans.ts
@@ -1,10 +1,11 @@
 /**
- * Live feed of ALL spans across all traces for the masthead strip: one seed
- * read (`engine::traces::spans` with `search_all_spans` and no name filter —
- * which returns every stored span, newest first) then live appends from the
- * engine's `iii:devtools:all-spans` stream, keyed by `span_id` so a pending
- * live snapshot is replaced in place by its final close frame (never the
- * other way around).
+ * Live feed of ALL spans across all traces for the masthead strip. The seed
+ * first reads compact recent trace summaries, then fetches complete spans only
+ * for enough trace IDs to fill the strip. This avoids the expensive global
+ * full-span scan while preserving parented internal spans from real traces.
+ * Live appends then come from the engine's `iii:devtools:all-spans` stream,
+ * keyed by `span_id` so a pending snapshot is replaced in place by its final
+ * close frame (never the other way around).
  *
  * Retention is bounded twice: entries older than the strip's usable history
  * are pruned as frames arrive, and a hard cap keeps a busy engine from
@@ -22,13 +23,20 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { getIiiClient } from '@/lib/iii-client'
 import { startTraceActivityFeed } from '@/lib/traces-activity'
-import { fetchTraceSpans, type StoredSpan } from '../api/traces'
+import {
+  fetchTraceSpans,
+  fetchTraces,
+  type StoredSpan,
+  type TraceSummary,
+} from '../api/traces'
 import { isPendingSpan, toMs } from '../lib/traceTransform'
 
 /** Forget spans that ended this long ago (strip window + wide slack). */
 const RETENTION_MS = 120_000
 /** Seed read size — bounds a busy engine's history, not the live feed. */
 const SEED_LIMIT = 500
+/** Maximum compact summaries examined to find the seed's trace IDs. */
+const SEED_TRACE_LIMIT = 500
 /** Debounce over activity ticks before re-seeding the strip. */
 const ACTIVITY_RESEED_DEBOUNCE_MS = 300
 /** Hard ceiling on retained spans; oldest effective-end evicted first. */
@@ -86,6 +94,61 @@ export function isContextFreeInternalSpan(span: StoredSpan): boolean {
   )
 }
 
+/** Select newest traces until their non-internal span counts fill the seed. */
+export function selectSeedTraceIds(traces: readonly TraceSummary[]): string[] {
+  const traceIds: string[] = []
+  let spanCount = 0
+
+  for (const trace of traces) {
+    traceIds.push(trace.trace_id)
+    spanCount += Math.max(1, trace.span_count)
+    if (spanCount >= SEED_LIMIT) break
+  }
+
+  return traceIds
+}
+
+/**
+ * Build a bounded recent-span seed without asking the engine to page every
+ * stored span. The summary RPC is trace-first and compact; the detail RPC then
+ * uses the archive's trace-id index and filters the same retention window the
+ * client applies below.
+ */
+export async function fetchLiveSpanSeed(
+  now = Date.now(),
+): Promise<StoredSpan[]> {
+  const summaries = await fetchTraces({
+    include_internal: false,
+    sort_by: 'start_time',
+    sort_order: 'desc',
+    limit: SEED_TRACE_LIMIT,
+  })
+  if (summaries.legacyContract) {
+    const legacyResult = await fetchTraceSpans({
+      search_all_spans: true,
+      include_internal: true,
+      sort_by: 'start_time',
+      sort_order: 'desc',
+      limit: SEED_LIMIT,
+    })
+    return legacyResult.spans
+  }
+
+  const traceIds = selectSeedTraceIds(summaries.traces)
+  if (traceIds.length === 0) return []
+
+  const result = await fetchTraceSpans({
+    trace_ids: traceIds,
+    search_all_spans: true,
+    include_internal: true,
+    start_time: now - RETENTION_MS,
+    sort_by: 'start_time',
+    sort_order: 'desc',
+    limit: SEED_LIMIT,
+  })
+  return result.spans
+}
+
 export function useAllSpans(isPaused: boolean): readonly StoredSpan[] {
   const [spans, setSpans] = useState<ReadonlyMap<string, StoredSpan>>(new Map())
   const seedInFlightRef = useRef<Promise<void> | null>(null)
@@ -103,17 +166,11 @@ export function useAllSpans(isPaused: boolean): readonly StoredSpan[] {
 
     const request = (async () => {
       try {
-        const res = await fetchTraceSpans({
-          search_all_spans: true,
-          include_internal: true,
-          sort_by: 'start_time',
-          sort_order: 'desc',
-          limit: SEED_LIMIT,
-        })
+        const seedSpans = await fetchLiveSpanSeed()
         setSpans(
           mergeSpans(
             new Map(),
-            res.spans.filter((s) => !isContextFreeInternalSpan(s)),
+            seedSpans.filter((s) => !isContextFreeInternalSpan(s)),
             Date.now(),
           ),
         )
@@ -150,7 +207,7 @@ export function useAllSpans(isPaused: boolean): readonly StoredSpan[] {
       const client = await getIiiClient()
       if (disposed) return
       // Notify-then-query: each activity tick re-seeds the strip's recent
-      // window (REPLACE semantics, same read as the initial seed), debounced
+      // window (REPLACE semantics, same reads as the initial seed), debounced
       // so a burst of consecutive 300ms windows costs one read.
       let reseedTimer: ReturnType<typeof setTimeout> | undefined
       const offFeed = startTraceActivityFeed(client, () => {

--- a/harness/Cargo.lock
+++ b/harness/Cargo.lock
@@ -631,6 +631,7 @@ dependencies = [
  "iii-helpers 0.22.1-alpha.25",
  "iii-sdk 0.22.1-alpha.25",
  "jsonschema",
+ "opentelemetry_sdk",
  "schemars",
  "serde",
  "serde_json",

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -49,6 +49,7 @@ jsonschema = { version = "0.18", default-features = false }
 sha2 = "0.10"
 
 [dev-dependencies]
+opentelemetry_sdk = { version = "0.31", features = ["testing"] }
 serde_json = "1"
 tempfile = "3"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time"] }

--- a/harness/src/functions/send.rs
+++ b/harness/src/functions/send.rs
@@ -339,7 +339,10 @@ async fn start_with_delivery_lock(
         }
         None => session.create(title.as_deref(), metadata.as_ref()).await?,
     };
-    crate::budget::prepare_root(deps, &session_id, &mut options, prev.as_ref()).await?;
+    tag_failed_send_with_session(
+        &session_id,
+        crate::budget::prepare_root(deps, &session_id, &mut options, prev.as_ref()).await,
+    )?;
 
     // Entry id: idempotent when a dedupe key is set.
     let entry_id = req
@@ -350,24 +353,27 @@ async fn start_with_delivery_lock(
     // Queue path: a `Running` step may be streaming — park the message as a
     // durable queue row the loop drains after the stream ends, instead of
     // appending mid-transcript.
-    let (outcome, entry) = deliver(
-        deps,
-        &cfg,
+    let (outcome, entry) = tag_failed_send_with_session(
         &session_id,
-        options,
-        Delivery {
-            message: &message,
-            entry_id: entry_id.as_deref(),
-            origin: None,
-            lineage: &TurnLineage::default(),
-            caller_holds_session_lock: caller_holds_target_session_lock,
-            skills_explicit: req
-                .options
-                .as_ref()
-                .is_some_and(|options| options.skills.is_some()),
-        },
-    )
-    .await?;
+        deliver(
+            deps,
+            &cfg,
+            &session_id,
+            options,
+            Delivery {
+                message: &message,
+                entry_id: entry_id.as_deref(),
+                origin: None,
+                lineage: &TurnLineage::default(),
+                caller_holds_session_lock: caller_holds_target_session_lock,
+                skills_explicit: req
+                    .options
+                    .as_ref()
+                    .is_some_and(|options| options.skills.is_some()),
+            },
+        )
+        .await,
+    )?;
 
     // Record the idempotency mapping (TTL-bound by contract).
     if let Some(key) = &req.idempotency_key {
@@ -381,6 +387,23 @@ async fn start_with_delivery_lock(
     }
 
     Ok(outcome)
+}
+
+/// Attribute failures that happen after session creation but before the turn
+/// trace exists. Successful sends deliberately stay untagged here: their
+/// `harness::turn step` trace is the one the session-scoped Console should
+/// list, without a duplicate `harness::send` row.
+fn tag_failed_send_with_session<T>(
+    session_id: &str,
+    result: Result<T, HarnessError>,
+) -> Result<T, HarnessError> {
+    if result.is_err() {
+        iii_helpers::observability::set_current_span_attribute(
+            "iii.session.id",
+            session_id.to_string(),
+        );
+    }
+    result
 }
 
 fn caller_holds_target_session_lock(
@@ -1270,7 +1293,48 @@ pub(crate) async fn seed_new(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use iii_helpers::observability::opentelemetry::trace::{
+        TraceContextExt, Tracer, TracerProvider,
+    };
+    use iii_helpers::observability::opentelemetry::Context;
+    use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider, SimpleSpanProcessor};
     use std::sync::Arc;
+
+    fn failed_send_session_attribute(result: Result<(), HarnessError>) -> Option<String> {
+        let exporter = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_span_processor(SimpleSpanProcessor::new(exporter.clone()))
+            .build();
+        let tracer = provider.tracer("harness-send-test");
+        let span = tracer.start("execute harness::send");
+        let guard = Context::new().with_span(span).attach();
+
+        let _ = tag_failed_send_with_session("session-filter-test", result);
+
+        drop(guard);
+        exporter
+            .get_finished_spans()
+            .expect("exporter")
+            .into_iter()
+            .next()
+            .and_then(|span| {
+                span.attributes
+                    .into_iter()
+                    .find(|attribute| attribute.key.as_str() == "iii.session.id")
+                    .map(|attribute| attribute.value.as_str().to_string())
+            })
+    }
+
+    #[test]
+    fn failed_send_is_attributed_to_its_session_without_tagging_successes() {
+        assert_eq!(failed_send_session_attribute(Ok(())), None);
+        assert_eq!(
+            failed_send_session_attribute(Err(HarnessError::Dependency(
+                "enqueue harness::turn failed".into(),
+            ))),
+            Some("session-filter-test".into()),
+        );
+    }
 
     #[tokio::test]
     async fn omitted_delivery_cannot_overwrite_an_explicit_filter_writer() {


### PR DESCRIPTION
## Summary

- tag `harness::send` failures with the resolved session id when they happen before a turn trace exists
- keep failed spans visible in trace detail views even when their span group or worker is hidden
- cover successful and failed session attribution plus filtered `harness::send` visibility

## Validation

- `cargo test --lib functions::send::tests` — 47 passed
- `cargo clippy --lib --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- focused Console Vitest coverage — 47 passed
- `pnpm --dir console/web typecheck`
- `pnpm --dir console/web build`
- local stack with rebuilt iii, Harness, and Console: an invalid `max_total_tokens: 0` send produced one session-grouped error trace with four spans; with `harness::send` hidden, the failed span remained visible and opened the exact error message and stack trace with no browser errors

Refs MOT-4504

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Trace timelines now load a focused set of recent traces before retrieving detailed spans, improving bounded live-span loading.
  - Legacy trace-summary responses continue to be supported.

- **Bug Fixes**
  - Failed send operations remain visible even when related groups or worker services are hidden.
  - Failed sends are correctly associated with their session for easier troubleshooting.
  - Child spans remain filtered according to visibility settings.

- **Tests**
  - Added coverage for trace selection, live span loading, failed-span visibility, and session attribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->