### PR TITLE
feat: build complete Unix matrix for release train

### DIFF
--- a/.github/scripts/release_targets.py
+++ b/.github/scripts/release_targets.py
@@ -1,0 +1,66 @@
+"""Release target policy shared by the release train and Registry publisher."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+
+DEFAULT_TARGETS = [
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+    "x86_64-unknown-linux-gnu",
+    "x86_64-unknown-linux-musl",
+    "aarch64-unknown-linux-gnu",
+    "armv7-unknown-linux-gnueabihf",
+]
+
+TARGET_RUNNERS = {
+    "x86_64-apple-darwin": "macos-latest",
+    "aarch64-apple-darwin": "macos-latest",
+    "x86_64-unknown-linux-gnu": "ubuntu-22.04",
+    "x86_64-unknown-linux-musl": "ubuntu-latest",
+    "aarch64-unknown-linux-gnu": "ubuntu-22.04",
+    "armv7-unknown-linux-gnueabihf": "ubuntu-22.04",
+}
+
+
+def normalize_targets(raw: object, *, deploy: str | None = "binary") -> list[str]:
+    """Return canonical targets, rejecting Windows and unknown triples.
+
+    An omitted target list means every supported Unix target for binaries. A
+    non-binary worker has no executable target matrix, but an explicit Windows
+    entry is still rejected so manifests cannot silently advertise unsupported
+    artifacts.
+    """
+    if raw is None or raw == "":
+        return list(DEFAULT_TARGETS) if deploy == "binary" else []
+    if isinstance(raw, str):
+        values: Iterable[object] = raw.split(",")
+    elif isinstance(raw, list):
+        values = raw
+    else:
+        raise ValueError("`targets` must be a comma-separated string or list")
+
+    requested: list[str] = []
+    for value in values:
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError("`targets` entries must be non-empty strings")
+        target = value.strip()
+        if target not in TARGET_RUNNERS:
+            if "windows" in target:
+                raise ValueError(f"Windows release target is not supported: {target}")
+            raise ValueError(f"unknown release target: {target}")
+        if target in requested:
+            raise ValueError(f"duplicate release target: {target}")
+        requested.append(target)
+
+    if deploy == "binary" and not requested:
+        raise ValueError("binary workers must declare at least one Unix release target")
+    return [target for target in DEFAULT_TARGETS if target in requested]
+
+
+def matrix_targets(raw: object, *, deploy: str | None) -> list[dict[str, str]]:
+    targets = normalize_targets(raw, deploy=deploy)
+    if deploy != "binary":
+        return [{"target": "none", "os": "ubuntu-latest"}]
+    return [{"target": target, "os": TARGET_RUNNERS[target]} for target in targets]

--- a/.github/scripts/release_train.py
+++ b/.github/scripts/release_train.py
@@ -1,10 +1,5 @@
 #!/usr/bin/env python3
-"""Build and package one immutable Release Train attempt.
-
-The script deliberately has no GitHub Release, Registry, or final tag logic.
-Those effects belong to the publish workflows, which consume this attempt's
-artifact and prepared commit identity.
-"""
+"""Prepare, build, and assemble one immutable Release Train attempt."""
 
 from __future__ import annotations
 
@@ -12,11 +7,13 @@ import argparse
 import hashlib
 import json
 import os
+import shutil
 import subprocess
 import tarfile
 from pathlib import Path
 
 import _lib
+import release_targets
 
 
 def run(*command: str, cwd: Path | None = None) -> None:
@@ -37,6 +34,26 @@ def manifest_for(worker: str) -> tuple[Path, _lib.WorkerManifest]:
     return root, _lib.read_iii_worker_yaml(root)
 
 
+def target_policy(manifest: _lib.WorkerManifest, requested: str | None) -> list[str]:
+    raw = requested if requested is not None else manifest.raw.get("targets")
+    targets = release_targets.normalize_targets(raw, deploy=manifest.deploy)
+    declared = release_targets.normalize_targets(manifest.raw.get("targets"), deploy=manifest.deploy)
+    if requested is not None and targets != declared:
+        raise SystemExit(
+            f"{manifest.name}: workflow targets {targets} do not match manifest targets {declared}"
+        )
+    return targets
+
+
+def package_binary(binary_path: Path, binary: str, target: str, out: Path) -> list[Path]:
+    archive = out / f"{binary}-{target}.tar.gz"
+    with tarfile.open(archive, "w:gz") as handle:
+        handle.add(binary_path, arcname=binary)
+    checksum = out / f"{binary}-{target}.sha256"
+    checksum.write_text(f"{sha256(archive)}  {archive.name}\n", encoding="utf-8")
+    return [archive, checksum]
+
+
 def package_source(worker: str, out: Path) -> Path:
     archive = out / f"{worker}.tar.gz"
     with tarfile.open(archive, "w:gz") as handle:
@@ -44,73 +61,7 @@ def package_source(worker: str, out: Path) -> Path:
     return archive
 
 
-def build_attempt(worker: str, out: Path) -> list[Path]:
-    root, manifest = manifest_for(worker)
-    out.mkdir(parents=True, exist_ok=True)
-    artifacts: list[Path] = []
-    if manifest.deploy == "binary":
-        cargo = root / "Cargo.toml"
-        if not cargo.exists():
-            raise SystemExit(f"{worker}: deploy=binary requires Cargo.toml")
-        locked = (root / "Cargo.lock").exists()
-        test_command = ["cargo", "test"]
-        build_command = ["cargo", "build", "--release"]
-        if locked:
-            test_command.append("--locked")
-            build_command.append("--locked")
-        test_command += ["--manifest-path", str(cargo)]
-        build_command += ["--manifest-path", str(cargo)]
-        run(*test_command)
-        run(*build_command)
-        binary = manifest.bin or manifest.name
-        # Workers are standalone crates (no root workspace): cargo places the
-        # artifacts under the worker's own target directory.
-        binary_path = root / "target" / "release" / binary
-        if not binary_path.exists():
-            raise SystemExit(f"{worker}: built binary not found at {binary_path}")
-        archive = out / f"{binary}-x86_64-unknown-linux-gnu.tar.gz"
-        with tarfile.open(archive, "w:gz") as handle:
-            handle.add(binary_path, arcname=binary)
-        artifacts.append(archive)
-        # The Registry resolver reads a .sha256 sibling for every binary asset.
-        checksum = out / f"{binary}-x86_64-unknown-linux-gnu.sha256"
-        checksum.write_text(f"{sha256(archive)}  {archive.name}\n", encoding="utf-8")
-        artifacts.append(checksum)
-    elif manifest.deploy == "image":
-        image = f"release-attempt/{worker}:{os.environ.get('RELEASE_ATTEMPT_ID', 'local')}"
-        run("docker", "build", "--tag", image, str(root))
-        image_tar = out / f"{worker}-image.tar"
-        run("docker", "save", "--output", str(image_tar), image)
-        artifacts.append(image_tar)
-    elif manifest.deploy == "bundle":
-        package = root / "package.json"
-        if package.exists():
-            lock = Path("pnpm-lock.yaml")
-            if lock.exists():
-                run("pnpm", "install", "--frozen-lockfile", "--ignore-workspace", cwd=root)
-            else:
-                run("pnpm", "install", "--ignore-workspace", cwd=root)
-            package_json = json.loads(package.read_text(encoding="utf-8"))
-            if "build:bundle" in (package_json.get("scripts") or {}):
-                run("pnpm", "run", "build:bundle", cwd=root)
-        archive = package_source(worker, out)
-        artifacts.append(archive)
-    else:
-        raise SystemExit(f"{worker}: unsupported deploy mode {manifest.deploy}")
-    return artifacts
-
-
-def main() -> int:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--worker", required=True)
-    parser.add_argument("--source-sha", required=True)
-    parser.add_argument("--candidate-version", required=True)
-    parser.add_argument("--intent-id", required=True)
-    parser.add_argument("--attempt-id", required=True)
-    parser.add_argument("--branch", required=True)
-    parser.add_argument("--out", type=Path, default=Path("release-prepared"))
-    args = parser.parse_args()
-
+def prepare(args: argparse.Namespace) -> int:
     actual = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
     if actual != args.source_sha:
         raise SystemExit(f"source SHA mismatch: checkout={actual}, requested={args.source_sha}")
@@ -118,6 +69,7 @@ def main() -> int:
         raise SystemExit(f"invalid candidate version: {args.candidate_version}")
 
     root, manifest = manifest_for(args.worker)
+    targets = target_policy(manifest, args.targets)
     run(
         "python3",
         ".github/scripts/manifest_version.py",
@@ -130,6 +82,13 @@ def main() -> int:
     )
     run("python3", ".github/scripts/manifest_version.py", "verify", str(root / manifest.manifest), "--expected", args.candidate_version)
     run("python3", ".github/scripts/manifest_version.py", "sync-lock", str(root / manifest.manifest))
+    if manifest.deploy == "binary":
+        cargo = root / manifest.manifest
+        test_command = ["cargo", "test"]
+        if (root / "Cargo.lock").exists():
+            test_command.append("--locked")
+        test_command += ["--manifest-path", str(cargo)]
+        run(*test_command)
     run("git", "config", "user.name", "workers-ci[bot]")
     run("git", "config", "user.email", "workers-ci[bot]@users.noreply.github.com")
     run("git", "add", str(root))
@@ -138,9 +97,8 @@ def main() -> int:
     prepared_sha = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
     run("git", "push", "origin", f"HEAD:{args.branch}")
 
-    artifacts = build_attempt(args.worker, args.out)
     metadata = {
-        "schema_version": 1,
+        "schema_version": 2,
         "worker": args.worker,
         "source_sha": args.source_sha,
         "prepared_sha": prepared_sha,
@@ -148,15 +106,138 @@ def main() -> int:
         "release_intent_id": args.intent_id,
         "release_attempt_id": args.attempt_id,
         "deploy": manifest.deploy,
-        "artifacts": [
-            {"name": artifact.name, "sha256": sha256(artifact), "path": artifact.name}
-            for artifact in artifacts
-        ],
+        "bin": manifest.bin or manifest.name,
+        "targets": targets,
     }
+    args.out.mkdir(parents=True, exist_ok=True)
+    (args.out / "identity.json").write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(metadata, sort_keys=True))
+    return 0
+
+
+def build(args: argparse.Namespace) -> int:
+    actual = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+    if actual != args.prepared_sha:
+        raise SystemExit(f"prepared SHA mismatch: checkout={actual}, requested={args.prepared_sha}")
+    root, manifest = manifest_for(args.worker)
+    targets = target_policy(manifest, args.targets)
+    target = args.target
+    args.out.mkdir(parents=True, exist_ok=True)
+    if manifest.deploy == "binary":
+        if target not in targets:
+            raise SystemExit(f"{args.worker}: target {target} is not in the release target policy")
+        cargo = root / manifest.manifest
+        command = ["cargo", "build", "--release", "--target", target]
+        if (root / "Cargo.lock").exists():
+            command.append("--locked")
+        command += ["--manifest-path", str(cargo)]
+        run(*command)
+        binary = manifest.bin or manifest.name
+        binary_path = root / "target" / target / "release" / binary
+        if not binary_path.exists():
+            raise SystemExit(f"{args.worker}: built binary not found at {binary_path}")
+        artifacts = package_binary(binary_path, binary, target, args.out)
+    elif target != "none":
+        raise SystemExit(f"{args.worker}: non-binary builds use target=none")
+    elif manifest.deploy == "image":
+        image = f"release-attempt/{args.worker}:{os.environ.get('RELEASE_ATTEMPT_ID', 'local')}"
+        run("docker", "build", "--tag", image, str(root))
+        image_tar = args.out / f"{args.worker}-image.tar"
+        run("docker", "save", "--output", str(image_tar), image)
+        artifacts = [image_tar]
+    elif manifest.deploy == "bundle":
+        package = root / "package.json"
+        if package.exists():
+            lock = Path("pnpm-lock.yaml")
+            if lock.exists():
+                run("pnpm", "install", "--frozen-lockfile", "--ignore-workspace", cwd=root)
+            else:
+                run("pnpm", "install", "--ignore-workspace", cwd=root)
+            package_json = json.loads(package.read_text(encoding="utf-8"))
+            if "build:bundle" in (package_json.get("scripts") or {}):
+                run("pnpm", "run", "build:bundle", cwd=root)
+        artifacts = [package_source(args.worker, args.out)]
+    else:
+        raise SystemExit(f"{args.worker}: unsupported deploy mode {manifest.deploy}")
+
+    metadata = {
+        "worker": args.worker,
+        "prepared_sha": args.prepared_sha,
+        "target": target,
+        "artifacts": [{"name": artifact.name, "sha256": sha256(artifact), "path": artifact.name} for artifact in artifacts],
+    }
+    (args.out / "target.json").write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0
+
+
+def assemble(args: argparse.Namespace) -> int:
+    identity = json.loads(args.identity.read_text(encoding="utf-8"))
+    args.out.mkdir(parents=True, exist_ok=True)
+    artifacts: list[dict[str, str]] = []
+    for source in sorted(args.artifacts_dir.rglob("*")):
+        if not source.is_file() or source.name in {"identity.json", "target.json", "prepared.json"}:
+            continue
+        destination = args.out / source.name
+        if source.resolve() != destination.resolve():
+            shutil.copy2(source, destination)
+        artifacts.append({"name": destination.name, "sha256": sha256(destination), "path": destination.name})
+    if identity["deploy"] == "binary":
+        prefix = identity["bin"]
+        expected = {f"{prefix}-{target}.tar.gz" for target in identity["targets"]}
+        actual = {entry["name"] for entry in artifacts if entry["name"].endswith(".tar.gz")}
+        if expected != actual:
+            raise SystemExit(
+                f"assembled binary artifacts do not match targets: expected={sorted(expected)} actual={sorted(actual)}"
+            )
+    metadata = {**identity, "artifacts": artifacts}
     (args.out / "prepared.json").write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     print(json.dumps(metadata, sort_keys=True))
     return 0
 
 
+def print_targets(args: argparse.Namespace) -> int:
+    _, manifest = manifest_for(args.worker)
+    raw = args.targets if args.targets is not None else manifest.raw.get("targets")
+    print(json.dumps(release_targets.matrix_targets(raw, deploy=manifest.deploy), separators=(",", ":")))
+    return 0
+
+
+def make_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser()
+    sub = p.add_subparsers(dest="command", required=True)
+
+    prepare_parser = sub.add_parser("prepare")
+    prepare_parser.set_defaults(handler=prepare)
+    prepare_parser.add_argument("--worker", required=True)
+    prepare_parser.add_argument("--source-sha", required=True)
+    prepare_parser.add_argument("--candidate-version", required=True)
+    prepare_parser.add_argument("--intent-id", required=True)
+    prepare_parser.add_argument("--attempt-id", required=True)
+    prepare_parser.add_argument("--branch", required=True)
+    prepare_parser.add_argument("--targets")
+    prepare_parser.add_argument("--out", type=Path, default=Path("release-identity"))
+
+    build_parser = sub.add_parser("build")
+    build_parser.set_defaults(handler=build)
+    build_parser.add_argument("--worker", required=True)
+    build_parser.add_argument("--prepared-sha", required=True)
+    build_parser.add_argument("--target", required=True)
+    build_parser.add_argument("--targets")
+    build_parser.add_argument("--out", type=Path, required=True)
+
+    assemble_parser = sub.add_parser("assemble")
+    assemble_parser.set_defaults(handler=assemble)
+    assemble_parser.add_argument("--identity", type=Path, required=True)
+    assemble_parser.add_argument("--artifacts-dir", type=Path, required=True)
+    assemble_parser.add_argument("--out", type=Path, required=True)
+
+    targets_parser = sub.add_parser("print-targets")
+    targets_parser.set_defaults(handler=print_targets)
+    targets_parser.add_argument("--worker", required=True)
+    targets_parser.add_argument("--targets")
+    return p
+
+
 if __name__ == "__main__":
-    raise SystemExit(main())
+    arguments = make_parser().parse_args()
+    raise SystemExit(arguments.handler(arguments))

--- a/.github/scripts/resolve_binary_artifacts.py
+++ b/.github/scripts/resolve_binary_artifacts.py
@@ -6,18 +6,7 @@ import sys
 import urllib.request
 from collections.abc import Callable
 
-
-DEFAULT_TARGETS = [
-    "x86_64-apple-darwin",
-    "aarch64-apple-darwin",
-    "x86_64-pc-windows-msvc",
-    "i686-pc-windows-msvc",
-    "aarch64-pc-windows-msvc",
-    "x86_64-unknown-linux-gnu",
-    "x86_64-unknown-linux-musl",
-    "aarch64-unknown-linux-gnu",
-    "armv7-unknown-linux-gnueabihf",
-]
+import release_targets
 
 
 def read_checksum_url(url: str) -> str:
@@ -36,8 +25,11 @@ def build_binary_artifact_map(
 ) -> dict[str, dict[str, str]]:
     base = f"{repo_url}/releases/download/{tag}"
     binaries = {}
+    missing = []
     for target in targets:
-        ext = "zip" if "windows" in target else "tar.gz"
+        if target not in release_targets.TARGET_RUNNERS:
+            raise ValueError(f"unsupported release target: {target}")
+        ext = "tar.gz"
         asset_url = f"{base}/{bin_name}-{target}.{ext}"
         sha_url = f"{base}/{bin_name}-{target}.sha256"
         try:
@@ -46,7 +38,10 @@ def build_binary_artifact_map(
                 "sha256": read_checksum(sha_url),
             }
         except Exception as exc:
-            print(f"::warning::missing checksum for {target}: {exc}", file=sys.stderr)
+            missing.append(target)
+            print(f"::error::missing checksum for {target}: {exc}", file=sys.stderr)
+    if missing:
+        raise RuntimeError(f"missing binary artefacts for targets: {', '.join(missing)}")
     if not binaries:
         raise RuntimeError("no binary artefacts could be resolved")
     return binaries
@@ -57,6 +52,11 @@ def main() -> int:
     parser.add_argument("--repo-url", required=True)
     parser.add_argument("--tag", required=True)
     parser.add_argument("--bin", required=True)
+    parser.add_argument(
+        "--targets",
+        default=",".join(release_targets.DEFAULT_TARGETS),
+        help="Exact comma-separated Unix targets; Windows targets are rejected",
+    )
     parser.add_argument("--out", default="binaries.json")
     args = parser.parse_args()
 
@@ -64,7 +64,7 @@ def main() -> int:
         repo_url=args.repo_url,
         tag=args.tag,
         bin_name=args.bin,
-        targets=DEFAULT_TARGETS,
+        targets=release_targets.normalize_targets(args.targets),
         read_checksum=read_checksum_url,
     )
     pathlib.Path(args.out).write_text(json.dumps(binaries, indent=2) + "\n", encoding="utf-8")

--- a/.github/scripts/tests/test_release_targets.py
+++ b/.github/scripts/tests/test_release_targets.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pytest
+
+import release_targets
+
+
+def test_binary_default_is_the_complete_unix_matrix() -> None:
+    assert release_targets.normalize_targets(None, deploy="binary") == [
+        "x86_64-apple-darwin",
+        "aarch64-apple-darwin",
+        "x86_64-unknown-linux-gnu",
+        "x86_64-unknown-linux-musl",
+        "aarch64-unknown-linux-gnu",
+        "armv7-unknown-linux-gnueabihf",
+    ]
+
+
+def test_windows_and_unknown_targets_are_rejected() -> None:
+    with pytest.raises(ValueError, match="Windows release target"):
+        release_targets.normalize_targets("x86_64-pc-windows-msvc")
+    with pytest.raises(ValueError, match="unknown release target"):
+        release_targets.normalize_targets("sparc64-unknown-linux-gnu")
+
+
+def test_explicit_subsets_are_canonicalized_and_non_binary_has_one_build() -> None:
+    assert release_targets.normalize_targets(
+        ["aarch64-unknown-linux-gnu", "x86_64-apple-darwin"], deploy="binary"
+    ) == ["x86_64-apple-darwin", "aarch64-unknown-linux-gnu"]
+    assert release_targets.matrix_targets(None, deploy="bundle") == [
+        {"target": "none", "os": "ubuntu-latest"}
+    ]

--- a/.github/scripts/tests/test_release_workflows.py
+++ b/.github/scripts/tests/test_release_workflows.py
@@ -20,6 +20,7 @@ EXPECTED_INPUTS = {
         "stable_version",
         "candidate_version",
         "source_sha",
+        "targets",
         "plan_hash",
         "dispatch_nonce",
     },
@@ -32,6 +33,7 @@ EXPECTED_INPUTS = {
         "stable_version",
         "candidate_version",
         "source_sha",
+        "targets",
         "prepared_sha",
         "prepared_run_id",
         "prepared_artifact",
@@ -49,6 +51,7 @@ EXPECTED_INPUTS = {
         "stable_version",
         "source_operation_id",
         "source_sha",
+        "targets",
         "plan_hash",
         "expected_next_version",
         "expected_latest_version",
@@ -276,6 +279,15 @@ def test_reusable_release_executors_have_no_implicit_inputs() -> None:
 def test_registry_publish_authenticates_iii_installer() -> None:
     body = (WORKFLOWS / "_publish-registry.yml").read_text()
     assert "GITHUB_TOKEN: ${{ github.token }}" in body
+
+
+def test_release_target_policy_excludes_windows_and_requires_complete_assets() -> None:
+    body = (WORKFLOWS / "_rust-binary.yml").read_text()
+    assert "windows-latest" not in body
+    assert "x86_64-pc-windows-msvc" not in body
+
+    resolver = (WORKFLOWS.parent / "scripts" / "resolve_binary_artifacts.py").read_text()
+    assert "missing binary artefacts for targets" in resolver
 
 
 def test_registry_publish_keeps_stdio_workers_alive_for_interface_collection() -> None:

--- a/.github/workflows/_publish-registry.yml
+++ b/.github/workflows/_publish-registry.yml
@@ -36,6 +36,10 @@ on:
         description: 'Cargo binary name (binary deploy only)'
         required: true
         type: string
+      targets:
+        description: 'Exact comma-separated Unix target list (binary deploy only)'
+        required: true
+        type: string
       image_tag:
         description: 'Fully-qualified image reference (image deploy only)'
         required: true
@@ -323,11 +327,13 @@ jobs:
           BIN: ${{ inputs.bin }}
           WORKER: ${{ inputs.worker }}
           REPO_URL: ${{ format('https://github.com/{0}', github.repository) }}
+          TARGETS: ${{ inputs.targets }}
         run: |
           python3 .github/scripts/resolve_binary_artifacts.py \
             --repo-url "$REPO_URL" \
             --tag "$TAG" \
             --bin "${BIN:-$WORKER}" \
+            --targets "$TARGETS" \
             --out binaries.json
 
       - name: Create empty binary artifacts

--- a/.github/workflows/_rust-binary.yml
+++ b/.github/workflows/_rust-binary.yml
@@ -20,7 +20,7 @@ on:
         required: true
         type: string
       targets:
-        description: 'Exact comma-separated target subset; empty means all supported targets'
+        description: 'Exact comma-separated Unix target subset; empty means all supported Unix targets'
         required: true
         type: string
       web_bundle:
@@ -50,9 +50,6 @@ jobs:
           all_targets = [
               {"target": "x86_64-apple-darwin",            "os": "macos-latest"},
               {"target": "aarch64-apple-darwin",           "os": "macos-latest"},
-              {"target": "x86_64-pc-windows-msvc",         "os": "windows-latest"},
-              {"target": "i686-pc-windows-msvc",           "os": "windows-latest"},
-              {"target": "aarch64-pc-windows-msvc",        "os": "windows-latest"},
               {"target": "x86_64-unknown-linux-gnu",       "os": "ubuntu-22.04"},
               {"target": "x86_64-unknown-linux-musl",      "os": "ubuntu-latest"},
               {"target": "aarch64-unknown-linux-gnu",      "os": "ubuntu-22.04"},

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -4,42 +4,24 @@ run-name: RC · prepare_release · ${{ inputs.operation_id }} · ${{ inputs.step
 on:
   workflow_dispatch:
     inputs:
-      operation_id:
-        description: Release Control operation UUID
-        required: true
-        type: string
-      step_id:
-        description: Release Control step UUID
-        required: true
-        type: string
-      release_intent_id:
-        required: true
-        type: string
-      candidate_id:
-        required: true
-        type: string
-      release_attempt_id:
-        required: true
-        type: string
-      worker:
-        required: true
-        type: string
-      stable_version:
-        required: true
-        type: string
-      candidate_version:
-        required: true
-        type: string
+      operation_id: { required: true, type: string }
+      step_id: { required: true, type: string }
+      release_intent_id: { required: true, type: string }
+      candidate_id: { required: true, type: string }
+      release_attempt_id: { required: true, type: string }
+      worker: { required: true, type: string }
+      stable_version: { required: true, type: string }
+      candidate_version: { required: true, type: string }
       source_sha:
         description: Immutable source commit used by the plan
         required: true
         type: string
-      plan_hash:
+      targets:
+        description: Exact comma-separated Unix target list from Release Control
         required: true
         type: string
-      dispatch_nonce:
-        required: true
-        type: string
+      plan_hash: { required: true, type: string }
+      dispatch_nonce: { required: true, type: string }
 
 permissions:
   contents: write
@@ -48,11 +30,18 @@ concurrency:
   group: release-prepare-${{ inputs.worker }}
   cancel-in-progress: false
 
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+  CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER: arm-linux-gnueabihf-gcc
+
 jobs:
   prepare:
-    name: Build ${{ inputs.worker }} ${{ inputs.candidate_version }}
+    name: Prepare ${{ inputs.worker }} ${{ inputs.candidate_version }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    outputs:
+      prepared_sha: ${{ steps.meta.outputs.prepared_sha }}
     steps:
       - name: Generate token
         id: token
@@ -60,24 +49,18 @@ jobs:
         with:
           app-id: ${{ secrets.III_CI_APP_ID }}
           private-key: ${{ secrets.III_CI_APP_PRIVATE_KEY }}
-
       - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.source_sha }}
           fetch-depth: 0
           fetch-tags: true
           token: ${{ steps.token.outputs.token }}
-
-      # pnpm before setup-node so the pnpm cache resolves the binary — the
-      # worker build.rs compiles its UI with pnpm (same setup as _rust-binary).
       - uses: pnpm/action-setup@v5
-
       - uses: actions/setup-node@v5
         with:
           node-version: 22
-          cache: 'pnpm'
+          cache: pnpm
           cache-dependency-path: '**/pnpm-lock.yaml'
-
       - name: Validate exact dispatch and inputs
         env:
           RELEASE_CONTROL_BOT_LOGIN: ${{ vars.RELEASE_CONTROL_BOT_LOGIN }}
@@ -91,34 +74,166 @@ jobs:
           --stable-version '${{ inputs.stable_version }}'
           --source-sha '${{ inputs.source_sha }}'
           --mutating
-
-      - name: Prepare, test and package without publishing
+      - name: Prepare and test exact source commit
         env:
           RELEASE_ATTEMPT_ID: ${{ inputs.release_attempt_id }}
         run: >-
-          python3 .github/scripts/release_train.py
+          python3 .github/scripts/release_train.py prepare
           --worker '${{ inputs.worker }}'
           --source-sha '${{ inputs.source_sha }}'
           --candidate-version '${{ inputs.candidate_version }}'
           --intent-id '${{ inputs.release_intent_id }}'
           --attempt-id '${{ inputs.release_attempt_id }}'
+          --targets '${{ inputs.targets }}'
           --branch 'refs/heads/release-control/${{ inputs.release_intent_id }}/${{ inputs.release_attempt_id }}'
-          --out release-prepared
+          --out release-identity
+      - name: Expose prepared commit
+        id: meta
+        run: echo "prepared_sha=$(jq -r .prepared_sha release-identity/identity.json)" >> "$GITHUB_OUTPUT"
+      - uses: actions/upload-artifact@v6
+        with:
+          name: release-identity-${{ inputs.operation_id }}-${{ inputs.step_id }}
+          path: release-identity/identity.json
+          retention-days: 30
+          if-no-files-found: error
 
-      - name: Upload prepared artifacts
-        if: always()
-        uses: actions/upload-artifact@v6
+  matrix:
+    name: Compute Unix target matrix
+    needs: prepare
+    runs-on: ubuntu-latest
+    outputs:
+      include: ${{ steps.compute.outputs.include }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.source_sha }}
+      - name: Install manifest tooling
+        run: python3 -m pip install --quiet pyyaml
+      - name: Compute exact target matrix
+        id: compute
+        env:
+          TARGETS: ${{ inputs.targets }}
+          WORKER: ${{ inputs.worker }}
+        run: |
+          set -euo pipefail
+          matrix=$(python3 .github/scripts/release_train.py print-targets --worker "$WORKER" --targets "$TARGETS")
+          echo "include=$matrix" >> "$GITHUB_OUTPUT"
+          echo "$matrix"
+
+  build:
+    name: Build ${{ matrix.target }}
+    needs: [prepare, matrix]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.matrix.outputs.include) }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    steps:
+      - name: Generate token
+        id: token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.III_CI_APP_ID }}
+          private-key: ${{ secrets.III_CI_APP_PRIVATE_KEY }}
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare.outputs.prepared_sha }}
+          fetch-depth: 0
+          token: ${{ steps.token.outputs.token }}
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: '**/pnpm-lock.yaml'
+      - name: Install Linux cross compiler
+        if: runner.os == 'Linux' && matrix.target != 'none'
+        run: |
+          set -euo pipefail
+          case '${{ matrix.target }}' in
+            x86_64-unknown-linux-musl) sudo apt-get update && sudo apt-get install -y musl-tools ;;
+            aarch64-unknown-linux-gnu) sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu ;;
+            armv7-unknown-linux-gnueabihf) sudo apt-get update && sudo apt-get install -y gcc-arm-linux-gnueabihf ;;
+          esac
+      - name: Install Rust target
+        if: matrix.target != 'none'
+        run: rustup target add '${{ matrix.target }}'
+      - name: Build exact target artifact
+        env:
+          RELEASE_ATTEMPT_ID: ${{ inputs.release_attempt_id }}
+        run: >-
+          python3 .github/scripts/release_train.py build
+          --worker '${{ inputs.worker }}'
+          --prepared-sha '${{ needs.prepare.outputs.prepared_sha }}'
+          --targets '${{ inputs.targets }}'
+          --target '${{ matrix.target }}'
+          --out release-target
+      - uses: actions/upload-artifact@v6
+        with:
+          name: release-target-${{ inputs.operation_id }}-${{ inputs.step_id }}-${{ matrix.target }}
+          path: |
+            release-target/*.tar*
+            release-target/*.sha256
+          retention-days: 30
+          if-no-files-found: error
+
+  assemble:
+    name: Assemble prepared release
+    needs: [prepare, build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v7
+        with:
+          name: release-identity-${{ inputs.operation_id }}-${{ inputs.step_id }}
+          path: release-identity
+          github-token: ${{ github.token }}
+      - uses: actions/download-artifact@v7
+        with:
+          pattern: release-target-${{ inputs.operation_id }}-${{ inputs.step_id }}-*
+          path: release-targets
+          merge-multiple: true
+          github-token: ${{ github.token }}
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare.outputs.prepared_sha }}
+      - name: Assemble exact artifact set
+        run: >-
+          python3 .github/scripts/release_train.py assemble
+          --identity release-identity/identity.json
+          --artifacts-dir release-targets
+          --out release-prepared
+      - uses: actions/upload-artifact@v6
         with:
           name: release-prepared-${{ inputs.operation_id }}-${{ inputs.step_id }}
           path: release-prepared/
           retention-days: 30
-          if-no-files-found: warn
+          if-no-files-found: error
 
-      - name: Write factual preparation result
-        if: always()
+  evidence:
+    name: Record factual preparation result
+    needs: [prepare, matrix, build, assemble]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.III_CI_APP_ID }}
+          private-key: ${{ secrets.III_CI_APP_PRIVATE_KEY }}
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+          token: ${{ steps.token.outputs.token }}
+      - uses: actions/download-artifact@v7
+        continue-on-error: true
+        with:
+          name: release-prepared-${{ inputs.operation_id }}-${{ inputs.step_id }}
+          path: release-prepared
+          github-token: ${{ steps.token.outputs.token }}
+      - name: Write factual result
         env:
           JOB_STATUS: ${{ job.status }}
-          PREPARED: ${{ inputs.candidate_version }}
         run: |
           set -euo pipefail
           prepared_sha=$(jq -r '.prepared_sha // empty' release-prepared/prepared.json 2>/dev/null || true)
@@ -145,10 +260,7 @@ jobs:
             --candidate-version '${{ inputs.candidate_version }}' --stable-version '${{ inputs.stable_version }}' \
             --source-sha '${{ inputs.source_sha }}' --prepared-sha "$prepared_sha" \
             --digests-json "$artifact_sha" --output execution-result.json
-
-      - name: Upload factual result
-        if: always()
-        uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v6
         with:
           name: execution-result-${{ inputs.operation_id }}-${{ inputs.step_id }}
           path: execution-result.json

--- a/.github/workflows/publish-candidate.yml
+++ b/.github/workflows/publish-candidate.yml
@@ -31,6 +31,10 @@ on:
       source_sha:
         required: true
         type: string
+      targets:
+        description: Exact comma-separated Unix target list from Release Control
+        required: true
+        type: string
       expected_next_version:
         description: Exact current next version, or none during Registry bootstrap
         required: true
@@ -69,6 +73,7 @@ jobs:
       tag: ${{ steps.meta.outputs.tag }}
       deploy: ${{ steps.meta.outputs.deploy }}
       bin: ${{ steps.meta.outputs.bin }}
+      targets: ${{ steps.meta.outputs.targets }}
       image_tag: ${{ steps.image.outputs.image_tag }}
     steps:
       - name: Generate token
@@ -118,18 +123,23 @@ jobs:
           CANDIDATE: ${{ inputs.candidate_version }}
           SOURCE_SHA: ${{ inputs.source_sha }}
           PREPARED_SHA: ${{ inputs.prepared_sha }}
+          TARGETS: ${{ inputs.targets }}
         run: |
           set -euo pipefail
           jq -e --arg sha "$PREPARED_SHA" --arg worker "$WORKER" --arg version "$CANDIDATE" \
-            '.prepared_sha == $sha and .worker == $worker and .candidate_version == $version' \
+            --arg targets "$TARGETS" \
+            '.prepared_sha == $sha and .worker == $worker and .candidate_version == $version and ((.targets // []) | join(",")) == $targets' \
             release-prepared/prepared.json
           python3 - <<'PY' >> "$GITHUB_OUTPUT"
-          import os, yaml
+          import json, os, yaml
           worker = os.environ["WORKER"]
           manifest = yaml.safe_load(open(f"{worker}/iii.worker.yaml", encoding="utf-8"))
+          prepared = json.load(open("release-prepared/prepared.json", encoding="utf-8"))
+          prepared_targets = prepared.get("targets", [])
           print(f"tag={worker}/v{os.environ['CANDIDATE']}")
           print(f"deploy={manifest['deploy']}")
           print(f"bin={manifest.get('bin') or worker}")
+          print(f"targets={','.join(prepared_targets)}")
           PY
           test "$(git rev-parse HEAD)" = "$PREPARED_SHA"
           git merge-base --is-ancestor "$SOURCE_SHA" "$PREPARED_SHA"
@@ -298,6 +308,7 @@ jobs:
       tag: ${{ needs.publish.outputs.tag }}
       bin: ${{ needs.publish.outputs.bin }}
       image_tag: ${{ needs.publish.outputs.image_tag }}
+      targets: ${{ needs.publish.outputs.targets }}
       experimental: false
     secrets: inherit
 

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -34,6 +34,10 @@ on:
       source_sha:
         required: true
         type: string
+      targets:
+        description: Exact comma-separated Unix target list from Release Control
+        required: true
+        type: string
       plan_hash:
         required: true
         type: string
@@ -73,8 +77,186 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  prepare:
+    name: Prepare ${{ inputs.worker }} ${{ inputs.stable_version }}
+    if: inputs.recovery_run_id == '0'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    outputs:
+      prepared_sha: ${{ steps.meta.outputs.prepared_sha }}
+    steps:
+      - name: Generate token
+        id: token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.III_CI_APP_ID }}
+          private-key: ${{ secrets.III_CI_APP_PRIVATE_KEY }}
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.source_sha }}
+          fetch-depth: 0
+          fetch-tags: true
+          token: ${{ steps.token.outputs.token }}
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: '**/pnpm-lock.yaml'
+      - name: Validate exact dispatch
+        env:
+          RELEASE_CONTROL_BOT_LOGIN: ${{ vars.RELEASE_CONTROL_BOT_LOGIN }}
+        run: >-
+          python3 .github/scripts/release_control_contract.py validate-dispatch
+          --operation-id '${{ inputs.operation_id }}'
+          --step-id '${{ inputs.step_id }}'
+          --plan-hash '${{ inputs.plan_hash }}'
+          --dispatch-nonce '${{ inputs.dispatch_nonce }}'
+          --candidate-version '${{ inputs.candidate_version }}'
+          --stable-version '${{ inputs.stable_version }}'
+          --source-sha '${{ inputs.source_sha }}'
+          --mutating
+      - name: Prepare and test exact source commit
+        env:
+          RELEASE_ATTEMPT_ID: ${{ inputs.release_attempt_id }}
+        run: >-
+          python3 .github/scripts/release_train.py prepare
+          --worker '${{ inputs.worker }}'
+          --source-sha '${{ inputs.source_sha }}'
+          --candidate-version '${{ inputs.stable_version }}'
+          --intent-id '${{ inputs.release_intent_id }}'
+          --attempt-id '${{ inputs.release_attempt_id }}'
+          --targets '${{ inputs.targets }}'
+          --branch 'refs/heads/release-control/${{ inputs.release_intent_id }}/${{ inputs.release_attempt_id }}'
+          --out release-identity
+      - name: Expose prepared commit
+        id: meta
+        run: echo "prepared_sha=$(jq -r .prepared_sha release-identity/identity.json)" >> "$GITHUB_OUTPUT"
+      - uses: actions/upload-artifact@v6
+        with:
+          name: release-identity-${{ inputs.operation_id }}-${{ inputs.step_id }}
+          path: release-identity/identity.json
+          retention-days: 30
+          if-no-files-found: error
+
+  matrix:
+    name: Compute Unix target matrix
+    needs: prepare
+    if: inputs.recovery_run_id == '0'
+    runs-on: ubuntu-latest
+    outputs:
+      include: ${{ steps.compute.outputs.include }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.source_sha }}
+      - name: Install manifest tooling
+        run: python3 -m pip install --quiet pyyaml
+      - name: Compute exact target matrix
+        id: compute
+        env:
+          TARGETS: ${{ inputs.targets }}
+          WORKER: ${{ inputs.worker }}
+        run: |
+          set -euo pipefail
+          matrix=$(python3 .github/scripts/release_train.py print-targets --worker "$WORKER" --targets "$TARGETS")
+          echo "include=$matrix" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build ${{ matrix.target }}
+    needs: [prepare, matrix]
+    if: inputs.recovery_run_id == '0'
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.matrix.outputs.include) }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    steps:
+      - name: Generate token
+        id: token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.III_CI_APP_ID }}
+          private-key: ${{ secrets.III_CI_APP_PRIVATE_KEY }}
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare.outputs.prepared_sha }}
+          fetch-depth: 0
+          token: ${{ steps.token.outputs.token }}
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: '**/pnpm-lock.yaml'
+      - name: Install Linux cross compiler
+        if: runner.os == 'Linux' && matrix.target != 'none'
+        run: |
+          set -euo pipefail
+          case '${{ matrix.target }}' in
+            x86_64-unknown-linux-musl) sudo apt-get update && sudo apt-get install -y musl-tools ;;
+            aarch64-unknown-linux-gnu) sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu ;;
+            armv7-unknown-linux-gnueabihf) sudo apt-get update && sudo apt-get install -y gcc-arm-linux-gnueabihf ;;
+          esac
+      - name: Install Rust target
+        if: matrix.target != 'none'
+        run: rustup target add '${{ matrix.target }}'
+      - name: Build exact target artifact
+        env:
+          RELEASE_ATTEMPT_ID: ${{ inputs.release_attempt_id }}
+        run: >-
+          python3 .github/scripts/release_train.py build
+          --worker '${{ inputs.worker }}'
+          --prepared-sha '${{ needs.prepare.outputs.prepared_sha }}'
+          --targets '${{ inputs.targets }}'
+          --target '${{ matrix.target }}'
+          --out release-target
+      - uses: actions/upload-artifact@v6
+        with:
+          name: release-target-${{ inputs.operation_id }}-${{ inputs.step_id }}-${{ matrix.target }}
+          path: |
+            release-target/*.tar*
+            release-target/*.sha256
+          retention-days: 30
+          if-no-files-found: error
+
+  assemble:
+    name: Assemble stable release
+    needs: [prepare, build]
+    if: inputs.recovery_run_id == '0'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v7
+        with:
+          name: release-identity-${{ inputs.operation_id }}-${{ inputs.step_id }}
+          path: release-identity
+          github-token: ${{ github.token }}
+      - uses: actions/download-artifact@v7
+        with:
+          pattern: release-target-${{ inputs.operation_id }}-${{ inputs.step_id }}-*
+          path: release-targets
+          merge-multiple: true
+          github-token: ${{ github.token }}
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare.outputs.prepared_sha }}
+      - name: Assemble exact artifact set
+        run: >-
+          python3 .github/scripts/release_train.py assemble
+          --identity release-identity/identity.json
+          --artifacts-dir release-targets
+          --out release-stable
+      - uses: actions/upload-artifact@v6
+        with:
+          name: release-stable-${{ inputs.operation_id }}-${{ inputs.step_id }}
+          path: release-stable/
+          retention-days: 30
+          if-no-files-found: error
+
   publish:
     name: Rebuild and publish ${{ inputs.worker }} ${{ inputs.stable_version }}
+    needs: [prepare, matrix, build, assemble]
+    if: ${{ always() && (inputs.recovery_run_id != '0' || needs.assemble.result == 'success') }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     outputs:
@@ -82,6 +264,7 @@ jobs:
       prepared_sha: ${{ steps.meta.outputs.prepared_sha }}
       deploy: ${{ steps.meta.outputs.deploy }}
       bin: ${{ steps.meta.outputs.bin }}
+      targets: ${{ steps.meta.outputs.targets }}
       image_tag: ${{ steps.image.outputs.image_tag }}
     steps:
       - name: Generate token
@@ -131,6 +314,14 @@ jobs:
           run-id: ${{ inputs.recovery_run_id }}
           github-token: ${{ steps.token.outputs.token }}
 
+      - name: Download stable artifacts from this matrix
+        if: inputs.recovery_run_id == '0'
+        uses: actions/download-artifact@v7
+        with:
+          name: release-stable-${{ inputs.operation_id }}-${{ inputs.step_id }}
+          path: release-stable
+          github-token: ${{ steps.token.outputs.token }}
+
       - name: Checkout the recovered prepared commit
         if: inputs.recovery_run_id != '0'
         run: |
@@ -140,19 +331,12 @@ jobs:
           git fetch origin "$prepared_sha" --quiet
           git checkout --detach "$prepared_sha"
 
-      - name: Rebuild stable artifacts from the exact stable commit
+      - name: Checkout the fresh prepared commit
         if: inputs.recovery_run_id == '0'
-        env:
-          RELEASE_ATTEMPT_ID: ${{ inputs.release_attempt_id }}
-        run: >-
-          python3 .github/scripts/release_train.py
-          --worker '${{ inputs.worker }}'
-          --source-sha '${{ inputs.source_sha }}'
-          --candidate-version '${{ inputs.stable_version }}'
-          --intent-id '${{ inputs.release_intent_id }}'
-          --attempt-id '${{ inputs.release_attempt_id }}'
-          --branch 'refs/heads/release-control/${{ inputs.release_intent_id }}/${{ inputs.release_attempt_id }}'
-          --out release-stable
+        run: |
+          set -euo pipefail
+          git fetch origin '${{ needs.prepare.outputs.prepared_sha }}' --quiet
+          git checkout --detach '${{ needs.prepare.outputs.prepared_sha }}'
 
       - name: Install pyyaml
         run: python3 -m pip install --quiet pyyaml
@@ -163,6 +347,7 @@ jobs:
           WORKER: ${{ inputs.worker }}
           STABLE: ${{ inputs.stable_version }}
           SOURCE_SHA: ${{ inputs.source_sha }}
+          TARGETS: ${{ inputs.targets }}
         run: |
           set -euo pipefail
           jq -e --arg worker "$WORKER" --arg version "$STABLE" \
@@ -177,6 +362,7 @@ jobs:
           print(f"prepared_sha={prepared['prepared_sha']}")
           print(f"deploy={meta['deploy']}")
           print(f"bin={meta.get('bin') or worker}")
+          print(f"targets={os.environ['TARGETS']}")
           PY
           git fetch origin main --quiet
           main_sha=$(git rev-parse origin/main)
@@ -284,15 +470,6 @@ jobs:
           test -n "$digest"
           echo "image_tag=ghcr.io/${{ github.repository_owner }}/${WORKER}@${digest}" >> "$GITHUB_OUTPUT"
 
-      - name: Retain stable build metadata for factual evidence
-        if: always()
-        uses: actions/upload-artifact@v6
-        with:
-          name: release-stable-${{ inputs.operation_id }}-${{ inputs.step_id }}
-          path: release-stable/
-          retention-days: 30
-          if-no-files-found: warn
-
   registry-publish:
     name: Publish stable immutable version without a channel
     needs: [publish]
@@ -306,6 +483,7 @@ jobs:
       tag: ${{ needs.publish.outputs.tag }}
       bin: ${{ needs.publish.outputs.bin }}
       image_tag: ${{ needs.publish.outputs.image_tag }}
+      targets: ${{ needs.publish.outputs.targets }}
       experimental: false
     secrets: inherit
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,6 +178,7 @@ jobs:
       tag: ${{ needs.setup.outputs.tag }}
       bin: ${{ needs.setup.outputs.bin }}
       image_tag: ${{ needs.container-build.outputs.image_tag }}
+      targets: ${{ needs.setup.outputs.targets }}
       experimental: ${{ needs.setup.outputs.experimental == 'true' }}
     secrets: inherit
 

--- a/docs/architecture/deploy-modes.md
+++ b/docs/architecture/deploy-modes.md
@@ -15,8 +15,8 @@ Release dispatcher: [`release.yml`](../../.github/workflows/release.yml) reads
 
 ## Binary
 
-- **Build:** up to 9 cross-compiled targets (or `targets:` subset).
-- **Assets:** `<bin>-<triple>.tar.gz` / `.zip` + `.sha256` checksums.
+- **Build:** up to 6 Unix cross-compiled targets (or `targets:` subset); Windows is excluded.
+- **Assets:** `<bin>-<triple>.tar.gz` + `.sha256` checksums for every Unix target.
 - **Publish boot:** downloads `*-x86_64-unknown-linux-gnu.tar.gz` from the
   Release, runs the binary for interface collection.
 - **Registry payload:** per-target download URLs resolved by

--- a/docs/architecture/iii-worker-yaml.md
+++ b/docs/architecture/iii-worker-yaml.md
@@ -21,9 +21,9 @@ release routing, and registry publish all read this file.
 | `bin` | Cargo binary name (defaults to `name`) | `_rust-binary.yml`, publish boot |
 | `targets` | Optional list of Rust triples to build | `_rust-binary.yml` matrix subset; `supported_targets` in manifest |
 
-When `targets` is omitted, all nine default triples are built: macOS
-x86_64/aarch64, Windows x86_64/i686/aarch64, Linux x86_64 gnu/musl,
-aarch64 gnu, and armv7 gnueabihf (the matrix lives in
+When `targets` is omitted, all six default Unix triples are built: macOS
+x86_64/aarch64, Linux x86_64 gnu/musl, aarch64 gnu, and armv7 gnueabihf.
+Windows targets are not part of the release matrix (the matrix lives in
 [`_rust-binary.yml`](../../.github/workflows/_rust-binary.yml)).
 
 ## Opt-outs and runtime


### PR DESCRIPTION
## Summary
- split release-train prepare/build/assemble phases across compatible GitHub runners
- build and package macOS and Linux targets for RC and stable release workflows
- exclude Windows and fail Registry publication when any expected Unix binary is missing

## Validation
- pytest -q .github/scripts/tests/
- Python compilation and workflow YAML parsing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable Unix release targets, with support for selecting exact target subsets.
  - Added target validation and consistent release matrix generation.
  - Release workflows now carry target selections through preparation, building, assembly, and publishing.
  - Binary releases now provide Unix `.tar.gz` archives with checksums.

- **Bug Fixes**
  - Unsupported, duplicate, empty, and missing binary targets are now rejected instead of silently continuing.

- **Documentation**
  - Updated release documentation to reflect six supported Unix targets and the exclusion of Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->