### PR TITLE
fix(code-runner): remove unsupported Windows release targets

### DIFF
--- a/code-runner/iii.worker.yaml
+++ b/code-runner/iii.worker.yaml
@@ -15,14 +15,11 @@ dependencies:
 #   1. rusty_v8 150.4.0 (via deno_core) publishes no prebuilt for
 #      i686-pc-windows-msvc or armv7-unknown-linux-gnueabihf.
 #   2. Cranelift (wasmtime's compiler) has no backend for those same two.
-# With no `targets:` the release matrix fans out to all 9 default triples,
-# those two shards fail, and `publish` is gated `if: !failure()` — so a
-# code-runner/v* tag would build red and never reach the registry.
+# Its explicit target list below keeps the release matrix on the supported
+# Unix triples while avoiding those platform-restricted shards.
 targets:
   - x86_64-apple-darwin
   - aarch64-apple-darwin
-  - x86_64-pc-windows-msvc
-  - aarch64-pc-windows-msvc
   - x86_64-unknown-linux-gnu
   - x86_64-unknown-linux-musl
   - aarch64-unknown-linux-gnu


### PR DESCRIPTION
## Summary
- remove the two Windows targets that remained in code-runner's explicit release matrix
- keep the supported Unix targets, including macOS and Linux
- unblock the Release Control catalog's no-Windows target validation

## Validation
- manifest is valid YAML and contains no Windows target
