### PR TITLE
fix(release): expand computed target matrix

### DIFF
--- a/.github/scripts/tests/test_release_workflows.py
+++ b/.github/scripts/tests/test_release_workflows.py
@@ -300,6 +300,16 @@ def test_prepare_release_expands_the_computed_target_list_with_matrix_include() 
     }
 
 
+def test_publish_stable_expands_the_computed_target_list_with_matrix_include() -> None:
+    jobs = workflow(WORKFLOWS / "publish-stable.yml")["jobs"]
+    strategy = jobs["build"]["strategy"]
+
+    assert strategy["fail-fast"] == "false"
+    assert strategy["matrix"] == {
+        "include": "${{ fromJSON(needs.matrix.outputs.include) }}",
+    }
+
+
 def test_registry_publish_keeps_stdio_workers_alive_for_interface_collection() -> None:
     body = (WORKFLOWS / "_publish-registry.yml").read_text()
     assert "start_worker_with_open_stdin" in body

--- a/.github/scripts/tests/test_release_workflows.py
+++ b/.github/scripts/tests/test_release_workflows.py
@@ -290,6 +290,16 @@ def test_release_target_policy_excludes_windows_and_requires_complete_assets() -
     assert "missing binary artefacts for targets" in resolver
 
 
+def test_prepare_release_expands_the_computed_target_list_with_matrix_include() -> None:
+    jobs = workflow(WORKFLOWS / "prepare-release.yml")["jobs"]
+    strategy = jobs["build"]["strategy"]
+
+    assert strategy["fail-fast"] == "false"
+    assert strategy["matrix"] == {
+        "include": "${{ fromJSON(needs.matrix.outputs.include) }}",
+    }
+
+
 def test_registry_publish_keeps_stdio_workers_alive_for_interface_collection() -> None:
     body = (WORKFLOWS / "_publish-registry.yml").read_text()
     assert "start_worker_with_open_stdin" in body

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -125,7 +125,8 @@ jobs:
     needs: [prepare, matrix]
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.matrix.outputs.include) }}
+      matrix:
+        include: ${{ fromJSON(needs.matrix.outputs.include) }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     steps:

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -168,7 +168,8 @@ jobs:
     if: inputs.recovery_run_id == '0'
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.matrix.outputs.include) }}
+      matrix:
+        include: ${{ fromJSON(needs.matrix.outputs.include) }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     steps:


### PR DESCRIPTION
## Summary
- expand the computed Unix target array through the matrix `include` key
- ensure release build jobs are scheduled before assembly and evidence generation
- cover the workflow shape with a regression test

## Validation
- `pytest -q .github/scripts/tests/` (264 passed, 3 subtests passed)
- parsed `prepare-release.yml` and verified the matrix structure

Refs #983