### PR TITLE
fix(release): refresh local Cargo locks before tests

### DIFF
--- a/.github/scripts/release_train.py
+++ b/.github/scripts/release_train.py
@@ -84,11 +84,12 @@ def prepare(args: argparse.Namespace) -> int:
     run("python3", ".github/scripts/manifest_version.py", "sync-lock", str(root / manifest.manifest))
     if manifest.deploy == "binary":
         cargo = root / manifest.manifest
-        test_command = ["cargo", "test"]
-        if (root / "Cargo.lock").exists():
-            test_command.append("--locked")
-        test_command += ["--manifest-path", str(cargo)]
-        run(*test_command)
+        # Bumping a worker can also change the versions of path dependencies
+        # recorded in its lockfile (for example, an RC may depend on another
+        # worker that was prepared earlier in the train).  Allow Cargo to
+        # refresh those local package entries before the prepared commit is
+        # created; build() will use that committed lockfile with --locked.
+        run("cargo", "test", "--manifest-path", str(cargo))
     run("git", "config", "user.name", "workers-ci[bot]")
     run("git", "config", "user.email", "workers-ci[bot]@users.noreply.github.com")
     run("git", "add", str(root))

--- a/.github/scripts/tests/test_release_workflows.py
+++ b/.github/scripts/tests/test_release_workflows.py
@@ -310,6 +310,13 @@ def test_publish_stable_expands_the_computed_target_list_with_matrix_include() -
     }
 
 
+def test_cross_platform_build_jobs_install_manifest_tooling() -> None:
+    for filename in ("prepare-release.yml", "publish-stable.yml"):
+        steps = workflow(WORKFLOWS / filename)["jobs"]["build"]["steps"]
+        tooling = next(step for step in steps if step.get("name") == "Install manifest tooling")
+        assert tooling["run"] == "python3 -m pip install --quiet pyyaml"
+
+
 def test_registry_publish_keeps_stdio_workers_alive_for_interface_collection() -> None:
     body = (WORKFLOWS / "_publish-registry.yml").read_text()
     assert "start_worker_with_open_stdin" in body

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -147,6 +147,8 @@ jobs:
           node-version: 22
           cache: pnpm
           cache-dependency-path: '**/pnpm-lock.yaml'
+      - name: Install manifest tooling
+        run: python3 -m pip install --quiet pyyaml
       - name: Install Linux cross compiler
         if: runner.os == 'Linux' && matrix.target != 'none'
         run: |

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -190,6 +190,8 @@ jobs:
           node-version: 22
           cache: pnpm
           cache-dependency-path: '**/pnpm-lock.yaml'
+      - name: Install manifest tooling
+        run: python3 -m pip install --quiet pyyaml
       - name: Install Linux cross compiler
         if: runner.os == 'Linux' && matrix.target != 'none'
         run: |


### PR DESCRIPTION
## Summary
- let the release prepare step refresh path-dependency versions in Cargo.lock after an RC bump
- keep build jobs locked against the committed prepared lockfile

## Verification
- `pytest -q .github/scripts/tests/test_release_workflows.py .github/scripts/tests/test_manifest_version.py`
- reproduced approval-gate RC bump: unlocked check refreshes harness path version, subsequent `cargo check --locked` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release preparation so dependency lockfiles are refreshed correctly before final builds.
  - Increased reliability of binary builds across supported platforms.

- **Chores**
  - Updated release automation to install required manifest-processing tooling consistently for preparation and stable publishing workflows.
  - Added automated checks to ensure cross-platform release jobs remain properly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->