### PR TITLE
fix(release): install manifest tooling on managed Python

### DIFF
--- a/.github/scripts/tests/test_release_workflows.py
+++ b/.github/scripts/tests/test_release_workflows.py
@@ -314,7 +314,7 @@ def test_cross_platform_build_jobs_install_manifest_tooling() -> None:
     for filename in ("prepare-release.yml", "publish-stable.yml"):
         steps = workflow(WORKFLOWS / filename)["jobs"]["build"]["steps"]
         tooling = next(step for step in steps if step.get("name") == "Install manifest tooling")
-        assert tooling["run"] == "python3 -m pip install --quiet pyyaml"
+        assert tooling["run"] == "python3 -m pip install --user --break-system-packages --quiet pyyaml"
 
 
 def test_registry_publish_keeps_stdio_workers_alive_for_interface_collection() -> None:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -108,7 +108,7 @@ jobs:
         with:
           ref: ${{ inputs.source_sha }}
       - name: Install manifest tooling
-        run: python3 -m pip install --quiet pyyaml
+        run: python3 -m pip install --user --break-system-packages --quiet pyyaml
       - name: Compute exact target matrix
         id: compute
         env:
@@ -148,7 +148,7 @@ jobs:
           cache: pnpm
           cache-dependency-path: '**/pnpm-lock.yaml'
       - name: Install manifest tooling
-        run: python3 -m pip install --quiet pyyaml
+        run: python3 -m pip install --user --break-system-packages --quiet pyyaml
       - name: Install Linux cross compiler
         if: runner.os == 'Linux' && matrix.target != 'none'
         run: |

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -151,7 +151,7 @@ jobs:
         with:
           ref: ${{ inputs.source_sha }}
       - name: Install manifest tooling
-        run: python3 -m pip install --quiet pyyaml
+        run: python3 -m pip install --user --break-system-packages --quiet pyyaml
       - name: Compute exact target matrix
         id: compute
         env:
@@ -191,7 +191,7 @@ jobs:
           cache: pnpm
           cache-dependency-path: '**/pnpm-lock.yaml'
       - name: Install manifest tooling
-        run: python3 -m pip install --quiet pyyaml
+        run: python3 -m pip install --user --break-system-packages --quiet pyyaml
       - name: Install Linux cross compiler
         if: runner.os == 'Linux' && matrix.target != 'none'
         run: |


### PR DESCRIPTION
## Summary
- install PyYAML with the user scope and PEP 668 override on all release matrix jobs
- keep macOS runners compatible with the manifest parser

## Verification
- `pytest -q .github/scripts/tests/test_release_workflows.py` (16 passed)
- `python3 -m py_compile .github/scripts/release_train.py`

The previous macOS retry showed the Homebrew externally-managed-environment error while installing PyYAML.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release workflow compatibility with environments that restrict system-wide Python package installations.
  - Updated release preparation and publishing processes to install required manifest tooling in the user environment.
  - Updated automated checks to validate the revised installation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->