### PR TITLE
(MOT-4613) feat(release): use larger GitHub-hosted runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,3 +2,5 @@ self-hosted-runner:
   labels:
     - general
     - rust
+    - workers-release-linux-8core
+    - workers-release-macos-12core

--- a/.github/scripts/release_targets.py
+++ b/.github/scripts/release_targets.py
@@ -23,6 +23,18 @@ TARGET_RUNNERS = {
     "armv7-unknown-linux-gnueabihf": "ubuntu-22.04",
 }
 
+# The release runner group is restricted to the release workflows on main.
+# Keep the execution label alongside the target-to-OS policy so every
+# Release Control path uses the same isolated GitHub-hosted capacity.
+TARGET_LARGER_RUNNERS = {
+    "x86_64-apple-darwin": "workers-release-macos-12core",
+    "aarch64-apple-darwin": "workers-release-macos-12core",
+    "x86_64-unknown-linux-gnu": "workers-release-linux-8core",
+    "x86_64-unknown-linux-musl": "workers-release-linux-8core",
+    "aarch64-unknown-linux-gnu": "workers-release-linux-8core",
+    "armv7-unknown-linux-gnueabihf": "workers-release-linux-8core",
+}
+
 
 def normalize_targets(raw: object, *, deploy: str | None = "binary") -> list[str]:
     """Return canonical targets, rejecting Windows and unknown triples.
@@ -62,5 +74,18 @@ def normalize_targets(raw: object, *, deploy: str | None = "binary") -> list[str
 def matrix_targets(raw: object, *, deploy: str | None) -> list[dict[str, str]]:
     targets = normalize_targets(raw, deploy=deploy)
     if deploy != "binary":
-        return [{"target": "none", "os": "ubuntu-latest"}]
-    return [{"target": target, "os": TARGET_RUNNERS[target]} for target in targets]
+        return [
+            {
+                "target": "none",
+                "os": "ubuntu-latest",
+                "runner": "workers-release-linux-8core",
+            }
+        ]
+    return [
+        {
+            "target": target,
+            "os": TARGET_RUNNERS[target],
+            "runner": TARGET_LARGER_RUNNERS[target],
+        }
+        for target in targets
+    ]

--- a/.github/scripts/tests/test_release_targets.py
+++ b/.github/scripts/tests/test_release_targets.py
@@ -28,5 +28,26 @@ def test_explicit_subsets_are_canonicalized_and_non_binary_has_one_build() -> No
         ["aarch64-unknown-linux-gnu", "x86_64-apple-darwin"], deploy="binary"
     ) == ["x86_64-apple-darwin", "aarch64-unknown-linux-gnu"]
     assert release_targets.matrix_targets(None, deploy="bundle") == [
-        {"target": "none", "os": "ubuntu-latest"}
+        {
+            "target": "none",
+            "os": "ubuntu-latest",
+            "runner": "workers-release-linux-8core",
+        }
+    ]
+
+
+def test_matrix_routes_apple_and_linux_targets_to_the_release_runner_group() -> None:
+    assert release_targets.matrix_targets(
+        ["x86_64-apple-darwin", "x86_64-unknown-linux-gnu"], deploy="binary"
+    ) == [
+        {
+            "target": "x86_64-apple-darwin",
+            "os": "macos-latest",
+            "runner": "workers-release-macos-12core",
+        },
+        {
+            "target": "x86_64-unknown-linux-gnu",
+            "os": "ubuntu-22.04",
+            "runner": "workers-release-linux-8core",
+        },
     ]

--- a/.github/scripts/tests/test_release_workflows.py
+++ b/.github/scripts/tests/test_release_workflows.py
@@ -310,6 +310,17 @@ def test_publish_stable_expands_the_computed_target_list_with_matrix_include() -
     }
 
 
+def test_release_builds_use_the_dedicated_github_hosted_runners() -> None:
+    for filename in ("prepare-release.yml", "publish-stable.yml"):
+        jobs = workflow(WORKFLOWS / filename)["jobs"]
+        assert jobs["prepare"]["runs-on"] == "workers-release-linux-8core"
+        assert jobs["build"]["runs-on"] == "${{ matrix.runner }}"
+
+    binary = workflow(WORKFLOWS / "_rust-binary.yml")["jobs"]
+    assert binary["web-build"]["runs-on"] == "workers-release-linux-8core"
+    assert binary["build"]["runs-on"] == "${{ matrix.runner }}"
+
+
 def test_cross_platform_build_jobs_install_manifest_tooling() -> None:
     for filename in ("prepare-release.yml", "publish-stable.yml"):
         steps = workflow(WORKFLOWS / filename)["jobs"]["build"]["steps"]

--- a/.github/scripts/tests/test_rust_ci_workflows.py
+++ b/.github/scripts/tests/test_rust_ci_workflows.py
@@ -60,7 +60,12 @@ def test_actionlint_knows_the_repository_runner_pool_labels() -> None:
     config = yaml.load(
         (GITHUB / "actionlint.yaml").read_text(), Loader=yaml.BaseLoader
     )
-    assert config["self-hosted-runner"]["labels"] == ["general", "rust"]
+    assert config["self-hosted-runner"]["labels"] == [
+        "general",
+        "rust",
+        "workers-release-linux-8core",
+        "workers-release-macos-12core",
+    ]
 
 
 def test_interface_smoke_bounds_each_engine_readiness_probe() -> None:

--- a/.github/workflows/_rust-binary.yml
+++ b/.github/workflows/_rust-binary.yml
@@ -48,12 +48,12 @@ jobs:
           python3 - <<'PY'
           import json, os, sys
           all_targets = [
-              {"target": "x86_64-apple-darwin",            "os": "macos-latest"},
-              {"target": "aarch64-apple-darwin",           "os": "macos-latest"},
-              {"target": "x86_64-unknown-linux-gnu",       "os": "ubuntu-22.04"},
-              {"target": "x86_64-unknown-linux-musl",      "os": "ubuntu-latest"},
-              {"target": "aarch64-unknown-linux-gnu",      "os": "ubuntu-22.04"},
-              {"target": "armv7-unknown-linux-gnueabihf",  "os": "ubuntu-22.04"},
+              {"target": "x86_64-apple-darwin",            "os": "macos-latest", "runner": "workers-release-macos-12core"},
+              {"target": "aarch64-apple-darwin",           "os": "macos-latest", "runner": "workers-release-macos-12core"},
+              {"target": "x86_64-unknown-linux-gnu",       "os": "ubuntu-22.04", "runner": "workers-release-linux-8core"},
+              {"target": "x86_64-unknown-linux-musl",      "os": "ubuntu-latest", "runner": "workers-release-linux-8core"},
+              {"target": "aarch64-unknown-linux-gnu",      "os": "ubuntu-22.04", "runner": "workers-release-linux-8core"},
+              {"target": "armv7-unknown-linux-gnueabihf",  "os": "ubuntu-22.04", "runner": "workers-release-linux-8core"},
           ]
           raw = (os.environ.get("TARGETS") or "").strip()
           if raw:
@@ -84,7 +84,7 @@ jobs:
     name: Pre-build SPA bundle
     needs: [matrix]
     if: inputs.web_bundle
-    runs-on: ubuntu-latest
+    runs-on: workers-release-linux-8core
     outputs:
       frontend_digest: ${{ steps.stage.outputs.frontend_digest }}
       frontends: ${{ steps.dirs.outputs.frontends }}
@@ -209,7 +209,7 @@ jobs:
     # succeeded", which would cascade-skip every matrix shard and leak
     # downstream as an empty GitHub Release — see #66 (database/v0.1.0).
     if: ${{ !failure() && !cancelled() }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: write
     strategy:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -38,7 +38,7 @@ env:
 jobs:
   prepare:
     name: Prepare ${{ inputs.worker }} ${{ inputs.candidate_version }}
-    runs-on: ubuntu-latest
+    runs-on: workers-release-linux-8core
     timeout-minutes: 45
     outputs:
       prepared_sha: ${{ steps.meta.outputs.prepared_sha }}
@@ -127,7 +127,7 @@ jobs:
       fail-fast: false
       matrix:
         include: ${{ fromJSON(needs.matrix.outputs.include) }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
     steps:
       - name: Generate token

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -80,7 +80,7 @@ jobs:
   prepare:
     name: Prepare ${{ inputs.worker }} ${{ inputs.stable_version }}
     if: inputs.recovery_run_id == '0'
-    runs-on: ubuntu-latest
+    runs-on: workers-release-linux-8core
     timeout-minutes: 45
     outputs:
       prepared_sha: ${{ steps.meta.outputs.prepared_sha }}
@@ -170,7 +170,7 @@ jobs:
       fail-fast: false
       matrix:
         include: ${{ fromJSON(needs.matrix.outputs.include) }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
     steps:
       - name: Generate token


### PR DESCRIPTION
Fixes MOT-4613

Routes release preparation and platform builds to dedicated GitHub-hosted Linux and macOS runners. Keeps the runner group scoped to the Workers release workflows with single-job autoscaling and no static IPs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Release builds now use dedicated, higher-capacity runners tailored to each platform and target.
  * Linux and macOS release workflows have expanded runner support.
  * Web builds and release preparation tasks now run on dedicated release infrastructure, improving consistency and capacity during publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->