### PR TITLE
fix(release): use managed Python for target builds

### DIFF
--- a/.github/scripts/tests/test_release_workflows.py
+++ b/.github/scripts/tests/test_release_workflows.py
@@ -321,11 +321,16 @@ def test_release_builds_use_the_dedicated_github_hosted_runners() -> None:
     assert binary["build"]["runs-on"] == "${{ matrix.runner }}"
 
 
-def test_cross_platform_build_jobs_install_manifest_tooling() -> None:
+def test_release_matrix_and_build_jobs_install_manifest_tooling() -> None:
     for filename in ("prepare-release.yml", "publish-stable.yml"):
-        steps = workflow(WORKFLOWS / filename)["jobs"]["build"]["steps"]
-        tooling = next(step for step in steps if step.get("name") == "Install manifest tooling")
-        assert tooling["run"] == "python3 -m pip install --user --break-system-packages --quiet pyyaml"
+        jobs = workflow(WORKFLOWS / filename)["jobs"]
+        for job_name in ("matrix", "build"):
+            steps = jobs[job_name]["steps"]
+            setup = next(step for step in steps if step.get("uses") == "actions/setup-python@v6")
+            tooling = next(step for step in steps if step.get("name") == "Install manifest tooling")
+            assert setup["with"]["python-version"] == "3.12"
+            assert steps.index(setup) < steps.index(tooling)
+            assert tooling["run"] == "python -m pip install --quiet pyyaml"
 
 
 def test_registry_publish_keeps_stdio_workers_alive_for_interface_collection() -> None:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -107,8 +107,11 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.source_sha }}
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
       - name: Install manifest tooling
-        run: python3 -m pip install --user --break-system-packages --quiet pyyaml
+        run: python -m pip install --quiet pyyaml
       - name: Compute exact target matrix
         id: compute
         env:
@@ -147,8 +150,11 @@ jobs:
           node-version: 22
           cache: pnpm
           cache-dependency-path: '**/pnpm-lock.yaml'
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
       - name: Install manifest tooling
-        run: python3 -m pip install --user --break-system-packages --quiet pyyaml
+        run: python -m pip install --quiet pyyaml
       - name: Install Linux cross compiler
         if: runner.os == 'Linux' && matrix.target != 'none'
         run: |

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -150,8 +150,11 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.source_sha }}
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
       - name: Install manifest tooling
-        run: python3 -m pip install --user --break-system-packages --quiet pyyaml
+        run: python -m pip install --quiet pyyaml
       - name: Compute exact target matrix
         id: compute
         env:
@@ -190,8 +193,11 @@ jobs:
           node-version: 22
           cache: pnpm
           cache-dependency-path: '**/pnpm-lock.yaml'
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
       - name: Install manifest tooling
-        run: python3 -m pip install --user --break-system-packages --quiet pyyaml
+        run: python -m pip install --quiet pyyaml
       - name: Install Linux cross compiler
         if: runner.os == 'Linux' && matrix.target != 'none'
         run: |


### PR DESCRIPTION
## Summary

- provision Python 3.12 with `actions/setup-python@v6` in RC/stable matrix and build jobs
- install PyYAML in that managed interpreter on Linux and macOS
- cover both matrix and build jobs with a workflow regression test

## Failure addressed

The macOS system Python is PEP 668 managed, while the larger Ubuntu runner has an older pip that rejects `--break-system-packages`. A setup-python interpreter avoids both system-pip variants.

## Validation

- `pytest -q .github/scripts/tests/` — 268 passed, 3 subtests passed
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized release workflows on Python 3.12 for more consistent release preparation and publishing.
  * Simplified manifest tooling installation across release jobs.

* **Tests**
  * Expanded workflow validation to cover both matrix and build jobs in release pipelines.
  * Verified that the required Python environment is configured before manifest tooling is installed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->