### PR TITLE
fix(release): disable pnpm cache in target jobs

### DIFF
--- a/.github/scripts/tests/test_release_workflows.py
+++ b/.github/scripts/tests/test_release_workflows.py
@@ -333,6 +333,15 @@ def test_release_matrix_and_build_jobs_install_manifest_tooling() -> None:
             assert tooling["run"] == "python -m pip install --quiet pyyaml"
 
 
+def test_cross_platform_release_builds_disable_pnpm_cache() -> None:
+    for filename in ("prepare-release.yml", "publish-stable.yml"):
+        steps = workflow(WORKFLOWS / filename)["jobs"]["build"]["steps"]
+        setup_node = next(step for step in steps if step.get("uses") == "actions/setup-node@v5")
+        assert setup_node["with"]["package-manager-cache"] == "false"
+        assert "cache" not in setup_node["with"]
+        assert "cache-dependency-path" not in setup_node["with"]
+
+
 def test_registry_publish_keeps_stdio_workers_alive_for_interface_collection() -> None:
     body = (WORKFLOWS / "_publish-registry.yml").read_text()
     assert "start_worker_with_open_stdin" in body

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -148,8 +148,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 22
-          cache: pnpm
-          cache-dependency-path: '**/pnpm-lock.yaml'
+          package-manager-cache: false
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -191,8 +191,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 22
-          cache: pnpm
-          cache-dependency-path: '**/pnpm-lock.yaml'
+          package-manager-cache: false
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'


### PR DESCRIPTION
## Summary

- disable setup-node package-manager caching only in cross-platform RC/stable build jobs
- retain Node and pnpm for bundle worker builds
- add a workflow regression test

## Failure addressed

The macOS binary compiled and uploaded successfully, but setup-node post-job cleanup failed with `Path Validation Error` because the pnpm cache path did not exist.

## Validation

- `pytest -q .github/scripts/tests/` — 269 passed, 3 subtests passed
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release build reliability by disabling package-manager caching during preparation and stable publishing workflows.
  * Prevented release builds from relying on pnpm cache configuration, supporting more consistent cross-platform execution and reducing cache-related failures.

* **Tests**
  * Added automated coverage to verify package-manager caching remains disabled in both release build workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->