### PR TITLE
fix(release): preserve downloaded assembly artifacts

### DIFF
--- a/.github/scripts/tests/test_release_workflows.py
+++ b/.github/scripts/tests/test_release_workflows.py
@@ -342,6 +342,17 @@ def test_cross_platform_release_builds_disable_pnpm_cache() -> None:
         assert "cache-dependency-path" not in setup_node["with"]
 
 
+def test_release_assembly_downloads_artifacts_after_checkout() -> None:
+    for filename in ("prepare-release.yml", "publish-stable.yml"):
+        steps = workflow(WORKFLOWS / filename)["jobs"]["assemble"]["steps"]
+        checkout_index = next(index for index, step in enumerate(steps) if step.get("uses") == "actions/checkout@v5")
+        download_indexes = [
+            index for index, step in enumerate(steps) if step.get("uses") == "actions/download-artifact@v7"
+        ]
+        assert download_indexes
+        assert checkout_index < min(download_indexes)
+
+
 def test_registry_publish_keeps_stdio_workers_alive_for_interface_collection() -> None:
     body = (WORKFLOWS / "_publish-registry.yml").read_text()
     assert "start_worker_with_open_stdin" in body

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -190,6 +190,9 @@ jobs:
     needs: [prepare, build]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare.outputs.prepared_sha }}
       - uses: actions/download-artifact@v7
         with:
           name: release-identity-${{ inputs.operation_id }}-${{ inputs.step_id }}
@@ -201,9 +204,6 @@ jobs:
           path: release-targets
           merge-multiple: true
           github-token: ${{ github.token }}
-      - uses: actions/checkout@v5
-        with:
-          ref: ${{ needs.prepare.outputs.prepared_sha }}
       - name: Assemble exact artifact set
         run: >-
           python3 .github/scripts/release_train.py assemble

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -234,6 +234,9 @@ jobs:
     if: inputs.recovery_run_id == '0'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare.outputs.prepared_sha }}
       - uses: actions/download-artifact@v7
         with:
           name: release-identity-${{ inputs.operation_id }}-${{ inputs.step_id }}
@@ -245,9 +248,6 @@ jobs:
           path: release-targets
           merge-multiple: true
           github-token: ${{ github.token }}
-      - uses: actions/checkout@v5
-        with:
-          ref: ${{ needs.prepare.outputs.prepared_sha }}
       - name: Assemble exact artifact set
         run: >-
           python3 .github/scripts/release_train.py assemble


### PR DESCRIPTION
## Summary

- checkout the prepared source before downloading release identity/target artifacts
- preserve downloaded artifacts for RC and stable assembly
- add a regression test for step ordering

## Failure addressed

`actions/checkout` ran after artifact downloads with `clean: true`, deleting `release-identity/identity.json` and all downloaded target archives before assembly.

## Validation

- `pytest -q .github/scripts/tests/` — 270 passed, 3 subtests passed
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release assembly reliability by checking out the prepared source before downloading release artifacts.
  - Applied the corrected workflow order to release preparation and stable publishing.

- **Tests**
  - Added regression coverage to verify the correct checkout and artifact-download sequence in release workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->