### PR TITLE
(MOT-4613) fix(release): split macOS release runner pools

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -4,3 +4,4 @@ self-hosted-runner:
     - rust
     - workers-release-linux-8core
     - workers-release-macos-12core
+    - workers-release-macos-arm-5core

--- a/.github/scripts/release_targets.py
+++ b/.github/scripts/release_targets.py
@@ -28,7 +28,9 @@ TARGET_RUNNERS = {
 # Release Control path uses the same isolated GitHub-hosted capacity.
 TARGET_LARGER_RUNNERS = {
     "x86_64-apple-darwin": "workers-release-macos-12core",
-    "aarch64-apple-darwin": "workers-release-macos-12core",
+    # Build Apple Silicon artifacts on a dedicated native M2 pool. This keeps
+    # the Intel and ARM macOS targets independently schedulable.
+    "aarch64-apple-darwin": "workers-release-macos-arm-5core",
     "x86_64-unknown-linux-gnu": "workers-release-linux-8core",
     "x86_64-unknown-linux-musl": "workers-release-linux-8core",
     "aarch64-unknown-linux-gnu": "workers-release-linux-8core",

--- a/.github/scripts/tests/test_release_targets.py
+++ b/.github/scripts/tests/test_release_targets.py
@@ -38,12 +38,22 @@ def test_explicit_subsets_are_canonicalized_and_non_binary_has_one_build() -> No
 
 def test_matrix_routes_apple_and_linux_targets_to_the_release_runner_group() -> None:
     assert release_targets.matrix_targets(
-        ["x86_64-apple-darwin", "x86_64-unknown-linux-gnu"], deploy="binary"
+        [
+            "x86_64-apple-darwin",
+            "aarch64-apple-darwin",
+            "x86_64-unknown-linux-gnu",
+        ],
+        deploy="binary",
     ) == [
         {
             "target": "x86_64-apple-darwin",
             "os": "macos-latest",
             "runner": "workers-release-macos-12core",
+        },
+        {
+            "target": "aarch64-apple-darwin",
+            "os": "macos-latest",
+            "runner": "workers-release-macos-arm-5core",
         },
         {
             "target": "x86_64-unknown-linux-gnu",

--- a/.github/scripts/tests/test_release_workflows.py
+++ b/.github/scripts/tests/test_release_workflows.py
@@ -321,6 +321,15 @@ def test_release_builds_use_the_dedicated_github_hosted_runners() -> None:
     assert binary["build"]["runs-on"] == "${{ matrix.runner }}"
 
 
+def test_rust_binary_routes_apple_targets_to_independent_runner_pools() -> None:
+    lines = (WORKFLOWS / "_rust-binary.yml").read_text().splitlines()
+    intel = next(line for line in lines if '"target": "x86_64-apple-darwin"' in line)
+    arm = next(line for line in lines if '"target": "aarch64-apple-darwin"' in line)
+
+    assert '"runner": "workers-release-macos-12core"' in intel
+    assert '"runner": "workers-release-macos-arm-5core"' in arm
+
+
 def test_release_matrix_and_build_jobs_install_manifest_tooling() -> None:
     for filename in ("prepare-release.yml", "publish-stable.yml"):
         jobs = workflow(WORKFLOWS / filename)["jobs"]

--- a/.github/scripts/tests/test_rust_ci_workflows.py
+++ b/.github/scripts/tests/test_rust_ci_workflows.py
@@ -65,6 +65,7 @@ def test_actionlint_knows_the_repository_runner_pool_labels() -> None:
         "rust",
         "workers-release-linux-8core",
         "workers-release-macos-12core",
+        "workers-release-macos-arm-5core",
     ]
 
 

--- a/.github/workflows/_rust-binary.yml
+++ b/.github/workflows/_rust-binary.yml
@@ -49,7 +49,7 @@ jobs:
           import json, os, sys
           all_targets = [
               {"target": "x86_64-apple-darwin",            "os": "macos-latest", "runner": "workers-release-macos-12core"},
-              {"target": "aarch64-apple-darwin",           "os": "macos-latest", "runner": "workers-release-macos-12core"},
+              {"target": "aarch64-apple-darwin",           "os": "macos-latest", "runner": "workers-release-macos-arm-5core"},
               {"target": "x86_64-unknown-linux-gnu",       "os": "ubuntu-22.04", "runner": "workers-release-linux-8core"},
               {"target": "x86_64-unknown-linux-musl",      "os": "ubuntu-latest", "runner": "workers-release-linux-8core"},
               {"target": "aarch64-unknown-linux-gnu",      "os": "ubuntu-22.04", "runner": "workers-release-linux-8core"},


### PR DESCRIPTION
Refs MOT-4613

Routes Apple Intel and Apple Silicon artifacts to dedicated GitHub-hosted macOS pools so their builds can be scheduled independently.

Validation:
- python3 -m pytest .github/scripts/tests
- /tmp/actionlint -color -config-file .github/actionlint.yaml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Infrastructure**
  * Apple Silicon macOS release builds now run on a dedicated native ARM runner pool.
  * Intel and ARM macOS release builds are independently schedulable, improving build routing and capacity.

* **Validation**
  * Added checks to verify that Apple platform targets use their designated runner pools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->