### PR TITLE
(MOT-4613) feat(release): announce successful worker preparations

### DIFF
--- a/.github/scripts/tests/test_release_workflows.py
+++ b/.github/scripts/tests/test_release_workflows.py
@@ -300,6 +300,26 @@ def test_prepare_release_expands_the_computed_target_list_with_matrix_include() 
     }
 
 
+def test_prepare_release_announces_only_successful_first_attempts() -> None:
+    notification = workflow(WORKFLOWS / "prepare-release.yml")["jobs"]["notify-success"]
+
+    assert notification["needs"] == ["prepare", "matrix", "build", "assemble", "evidence"]
+    assert notification["continue-on-error"] == "true"
+    assert "github.run_attempt == 1" in notification["if"]
+    for job in ("prepare", "matrix", "build", "assemble", "evidence"):
+        assert f"needs.{job}.result == 'success'" in notification["if"]
+
+    step = notification["steps"][0]
+    assert step["env"] == {
+        "CHANNEL": "${{ vars.RELEASE_STATUS_SLACK_CHANNEL_ID }}",
+        "SLACK_BOT_TOKEN": "${{ secrets.SLACK_BOT_TOKEN }}",
+        "WORKER": "${{ inputs.worker }}",
+        "VERSION": "${{ inputs.candidate_version }}",
+    }
+    assert 'text "$WORKER@$VERSION :white_check_mark:"' in step["run"]
+    assert "https://slack.com/api/chat.postMessage" in step["run"]
+
+
 def test_publish_stable_expands_the_computed_target_list_with_matrix_include() -> None:
     jobs = workflow(WORKFLOWS / "publish-stable.yml")["jobs"]
     strategy = jobs["build"]["strategy"]

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -274,3 +274,30 @@ jobs:
           path: execution-result.json
           retention-days: 30
           if-no-files-found: error
+
+  notify-success:
+    name: Announce successful worker preparation
+    needs: [prepare, matrix, build, assemble, evidence]
+    if: >-
+      ${{ github.run_attempt == 1 && needs.prepare.result == 'success' &&
+          needs.matrix.result == 'success' && needs.build.result == 'success' &&
+          needs.assemble.result == 'success' && needs.evidence.result == 'success' }}
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Send success to project-iii
+        env:
+          CHANNEL: ${{ vars.RELEASE_STATUS_SLACK_CHANNEL_ID }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          WORKER: ${{ inputs.worker }}
+          VERSION: ${{ inputs.candidate_version }}
+        run: |
+          set -euo pipefail
+          test -n "$CHANNEL"
+          payload=$(jq -cn --arg channel "$CHANNEL" --arg text "$WORKER@$VERSION :white_check_mark:" \
+            '{channel:$channel,text:$text}')
+          curl --fail-with-body --silent --show-error \
+            --request POST https://slack.com/api/chat.postMessage \
+            --header "Authorization: Bearer $SLACK_BOT_TOKEN" \
+            --header 'Content-Type: application/json; charset=utf-8' \
+            --data "$payload" | jq -e '.ok == true' >/dev/null


### PR DESCRIPTION
Refs MOT-4613

Posts `worker@candidate-version :white_check_mark:` to #project-iii only after every preparation job and recorded evidence succeeds on the initial workflow attempt.

Validation:
- python3 -m pytest .github/scripts/tests
- /tmp/actionlint -color -config-file .github/actionlint.yaml