### PR TITLE
fix(release): allow empty targets for bundles

### DIFF
--- a/.github/scripts/tests/test_release_workflows.py
+++ b/.github/scripts/tests/test_release_workflows.py
@@ -185,7 +185,10 @@ def test_release_control_workflow_input_contract_is_exact() -> None:
         inputs = dispatch.get("inputs", {}) if isinstance(dispatch, dict) else {}
         assert set(inputs) == expected, name
         optional_defaults = {
+            "prepare-release.yml": {"targets": ""},
+            "publish-candidate.yml": {"targets": ""},
             "publish-stable.yml": {
+                "targets": "",
                 "recovery_run_id": "0",
                 "recovery_operation_id": "none",
                 "recovery_step_id": "none",

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -17,8 +17,9 @@ on:
         required: true
         type: string
       targets:
-        description: Exact comma-separated Unix target list from Release Control
-        required: true
+        description: Exact comma-separated Unix target list; empty for non-binary workers
+        required: false
+        default: ''
         type: string
       plan_hash: { required: true, type: string }
       dispatch_nonce: { required: true, type: string }

--- a/.github/workflows/publish-candidate.yml
+++ b/.github/workflows/publish-candidate.yml
@@ -32,8 +32,9 @@ on:
         required: true
         type: string
       targets:
-        description: Exact comma-separated Unix target list from Release Control
-        required: true
+        description: Exact comma-separated Unix target list; empty for non-binary workers
+        required: false
+        default: ''
         type: string
       expected_next_version:
         description: Exact current next version, or none during Registry bootstrap

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -35,8 +35,9 @@ on:
         required: true
         type: string
       targets:
-        description: Exact comma-separated Unix target list from Release Control
-        required: true
+        description: Exact comma-separated Unix target list; empty for non-binary workers
+        required: false
+        default: ''
         type: string
       plan_hash:
         required: true


### PR DESCRIPTION
## Summary
- allow non-binary workers to dispatch release workflows with an empty target list
- keep binary target validation unchanged
- cover candidate, stable, and prepare workflow contracts

## Validation
- `python3 -m pytest -q .github/scripts/tests` (270 passed, 3 subtests)
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Release workflows now allow the target list to be left empty for non-binary workers.
  * Target lists support exact, comma-separated Unix targets when specified.
  * Release workflow input validation has been updated to reflect the optional target setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->