### PR TITLE
fix(harness): compact compose mutation results

### DIFF
--- a/harness/src/clients/engine.rs
+++ b/harness/src/clients/engine.rs
@@ -108,6 +108,9 @@ impl EngineClient {
             .map_err(|e| {
                 let raw = e.to_string();
                 let mut parsed = parse_dispatch_error_message(&raw);
+                if is_compose_mutation(function_id) {
+                    parsed.message = truncate_chars(&parsed.message, 1_000);
+                }
                 parsed.message = format!("{function_id}: {}", parsed.message);
                 parsed
             })
@@ -229,16 +232,20 @@ fn dispatch_namespace<'a>(
 /// complete up/down container inventory). Those diagnostics belong in Compose
 /// traces and logs, not in an agent transcript. Keep the public function
 /// result bounded while preserving the mutation outcome and actionable errors.
+fn is_compose_mutation(function_id: &str) -> bool {
+    matches!(
+        function_id,
+        "compose::add"
+            | "compose::remove"
+            | "compose::update"
+            | "compose::up"
+            | "compose::down"
+            | "compose::restart"
+    )
+}
+
 fn compact_compose_mutation_result(function_id: &str, value: Value) -> Value {
-    const MUTATIONS: &[&str] = &[
-        "compose::add",
-        "compose::remove",
-        "compose::update",
-        "compose::up",
-        "compose::down",
-        "compose::restart",
-    ];
-    if !MUTATIONS.contains(&function_id) {
+    if !is_compose_mutation(function_id) {
         return value;
     }
 

--- a/harness/src/clients/engine.rs
+++ b/harness/src/clients/engine.rs
@@ -103,17 +103,12 @@ impl EngineClient {
             // interrupted from an untrusted baseline and re-running it.
             None => call.await,
         };
-        result
-            .map(|value| compact_compose_mutation_result(function_id, value))
-            .map_err(|e| {
-                let raw = e.to_string();
-                let mut parsed = parse_dispatch_error_message(&raw);
-                if is_compose_mutation(function_id) {
-                    parsed.message = truncate_chars(&parsed.message, 1_000);
-                }
-                parsed.message = format!("{function_id}: {}", parsed.message);
-                parsed
-            })
+        result.map_err(|e| {
+            let raw = e.to_string();
+            let mut parsed = parse_dispatch_error_message(&raw);
+            parsed.message = format!("{function_id}: {}", parsed.message);
+            parsed
+        })
     }
 
     /// List registry function descriptors (best-effort; empty on failure).
@@ -228,124 +223,6 @@ fn dispatch_namespace<'a>(
     }
 }
 
-/// Compose mutation responses include daemon reconciliation internals (the
-/// complete up/down container inventory). Those diagnostics belong in Compose
-/// traces and logs, not in an agent transcript. Keep the public function
-/// result bounded while preserving the mutation outcome and actionable errors.
-fn is_compose_mutation(function_id: &str) -> bool {
-    matches!(
-        function_id,
-        "compose::add"
-            | "compose::remove"
-            | "compose::update"
-            | "compose::up"
-            | "compose::down"
-            | "compose::restart"
-    )
-}
-
-fn compact_compose_mutation_result(function_id: &str, value: Value) -> Value {
-    if !is_compose_mutation(function_id) {
-        return value;
-    }
-
-    let Some(source) = value.as_object() else {
-        return value;
-    };
-    let mut compact = serde_json::Map::new();
-    for key in ["status", "changed", "container", "workers", "declared"] {
-        if let Some(field) = source.get(key) {
-            compact.insert(key.to_string(), field.clone());
-        }
-    }
-
-    let mut errors = Vec::new();
-    collect_compose_errors(&value, None, &mut errors);
-    let has_errors = !errors.is_empty();
-    if has_errors {
-        compact.insert("errors".to_string(), Value::Array(errors));
-    }
-    if source.get("status").and_then(Value::as_str) == Some("failed") && !has_errors {
-        if let Some(detail) = source.get("detail").and_then(Value::as_str) {
-            compact.insert(
-                "detail".to_string(),
-                Value::String(truncate_chars(detail, 1_000)),
-            );
-        }
-    }
-
-    Value::Object(compact)
-}
-
-fn collect_compose_errors(
-    value: &Value,
-    inherited_container: Option<&str>,
-    errors: &mut Vec<Value>,
-) {
-    if errors.len() >= 8 {
-        return;
-    }
-    match value {
-        Value::Object(object) => {
-            let container = object
-                .get("container")
-                .and_then(Value::as_str)
-                .or(inherited_container);
-            if let Some(error) = object.get("error") {
-                let mut item = serde_json::Map::new();
-                if let Some(container) = container {
-                    item.insert(
-                        "container".to_string(),
-                        Value::String(container.to_string()),
-                    );
-                }
-                match error {
-                    Value::Object(error) => {
-                        for key in ["code", "message"] {
-                            if let Some(text) = error.get(key).and_then(Value::as_str) {
-                                item.insert(
-                                    key.to_string(),
-                                    Value::String(truncate_chars(text, 1_000)),
-                                );
-                            }
-                        }
-                    }
-                    Value::String(message) => {
-                        item.insert(
-                            "message".to_string(),
-                            Value::String(truncate_chars(message, 1_000)),
-                        );
-                    }
-                    _ => {}
-                }
-                if !item.is_empty() {
-                    errors.push(Value::Object(item));
-                }
-            }
-            for (key, child) in object {
-                if key != "error" {
-                    collect_compose_errors(child, container, errors);
-                }
-            }
-        }
-        Value::Array(items) => {
-            for item in items {
-                collect_compose_errors(item, inherited_container, errors);
-            }
-        }
-        _ => {}
-    }
-}
-
-fn truncate_chars(value: &str, max_chars: usize) -> String {
-    let mut chars = value.chars();
-    let truncated: String = chars.by_ref().take(max_chars).collect();
-    if chars.next().is_some() {
-        format!("{truncated}…")
-    } else {
-        truncated
-    }
-}
 fn nonempty_env(name: &str) -> Option<String> {
     std::env::var(name)
         .ok()
@@ -625,79 +502,6 @@ mod tests {
         assert_eq!(
             err.message,
             "remote error (S215): path escapes the fs jail roots [/private/tmp]: /Users/example filesystem_access_request={\"v\":1,\"requested_root\":\"/Users/example\",\"attempted_path\":\"/Users/example\",\"error_code\":\"S215\"}"
-        );
-    }
-
-    #[test]
-    fn compose_mutation_results_omit_reconciliation_inventory() {
-        let result = json!({
-            "status": "ok",
-            "changed": true,
-            "container": "database",
-            "workers": ["database"],
-            "up": {
-                "operation_id": "large-internal-id",
-                "containers": [
-                    { "container": "queue", "state": "ready", "changed": false },
-                    { "container": "database", "state": "ready", "changed": true }
-                ]
-            },
-            "restarted": [{ "containers": [{ "container": "console", "state": "ready" }] }]
-        });
-
-        assert_eq!(
-            compact_compose_mutation_result("compose::add", result),
-            json!({
-                "status": "ok",
-                "changed": true,
-                "container": "database",
-                "workers": ["database"]
-            })
-        );
-    }
-
-    #[test]
-    fn compose_mutation_results_keep_only_actionable_failure() {
-        let long_message = "x".repeat(2_000);
-        let result = json!({
-            "status": "failed",
-            "changed": false,
-            "up": {
-                "containers": [
-                    { "container": "queue", "state": "ready" },
-                    { "container": "database", "state": "failed", "error": {
-                        "code": "CHILD_EXITED_BEFORE_REGISTRATION",
-                        "message": long_message,
-                        "stdout": "not model context"
-                    }}
-                ]
-            }
-        });
-
-        let compact = compact_compose_mutation_result("compose::add", result);
-        assert_eq!(compact["status"], "failed");
-        assert_eq!(compact["errors"][0]["container"], "database");
-        assert_eq!(
-            compact["errors"][0]["code"],
-            "CHILD_EXITED_BEFORE_REGISTRATION"
-        );
-        assert!(
-            compact["errors"][0]["message"]
-                .as_str()
-                .unwrap()
-                .chars()
-                .count()
-                <= 1_001
-        );
-        assert!(compact.get("up").is_none());
-    }
-
-    #[test]
-    fn non_mutating_compose_results_are_unchanged() {
-        let status = json!({ "containers": [{ "container": "queue", "state": "ready" }] });
-        assert_eq!(
-            compact_compose_mutation_result("compose::status", status.clone()),
-            status
         );
     }
 }

--- a/harness/src/clients/engine.rs
+++ b/harness/src/clients/engine.rs
@@ -103,12 +103,14 @@ impl EngineClient {
             // interrupted from an untrusted baseline and re-running it.
             None => call.await,
         };
-        result.map_err(|e| {
-            let raw = e.to_string();
-            let mut parsed = parse_dispatch_error_message(&raw);
-            parsed.message = format!("{function_id}: {}", parsed.message);
-            parsed
-        })
+        result
+            .map(|value| compact_compose_mutation_result(function_id, value))
+            .map_err(|e| {
+                let raw = e.to_string();
+                let mut parsed = parse_dispatch_error_message(&raw);
+                parsed.message = format!("{function_id}: {}", parsed.message);
+                parsed
+            })
     }
 
     /// List registry function descriptors (best-effort; empty on failure).
@@ -223,6 +225,120 @@ fn dispatch_namespace<'a>(
     }
 }
 
+/// Compose mutation responses include daemon reconciliation internals (the
+/// complete up/down container inventory). Those diagnostics belong in Compose
+/// traces and logs, not in an agent transcript. Keep the public function
+/// result bounded while preserving the mutation outcome and actionable errors.
+fn compact_compose_mutation_result(function_id: &str, value: Value) -> Value {
+    const MUTATIONS: &[&str] = &[
+        "compose::add",
+        "compose::remove",
+        "compose::update",
+        "compose::up",
+        "compose::down",
+        "compose::restart",
+    ];
+    if !MUTATIONS.contains(&function_id) {
+        return value;
+    }
+
+    let Some(source) = value.as_object() else {
+        return value;
+    };
+    let mut compact = serde_json::Map::new();
+    for key in ["status", "changed", "container", "workers", "declared"] {
+        if let Some(field) = source.get(key) {
+            compact.insert(key.to_string(), field.clone());
+        }
+    }
+
+    let mut errors = Vec::new();
+    collect_compose_errors(&value, None, &mut errors);
+    let has_errors = !errors.is_empty();
+    if has_errors {
+        compact.insert("errors".to_string(), Value::Array(errors));
+    }
+    if source.get("status").and_then(Value::as_str) == Some("failed") && !has_errors {
+        if let Some(detail) = source.get("detail").and_then(Value::as_str) {
+            compact.insert(
+                "detail".to_string(),
+                Value::String(truncate_chars(detail, 1_000)),
+            );
+        }
+    }
+
+    Value::Object(compact)
+}
+
+fn collect_compose_errors(
+    value: &Value,
+    inherited_container: Option<&str>,
+    errors: &mut Vec<Value>,
+) {
+    if errors.len() >= 8 {
+        return;
+    }
+    match value {
+        Value::Object(object) => {
+            let container = object
+                .get("container")
+                .and_then(Value::as_str)
+                .or(inherited_container);
+            if let Some(error) = object.get("error") {
+                let mut item = serde_json::Map::new();
+                if let Some(container) = container {
+                    item.insert(
+                        "container".to_string(),
+                        Value::String(container.to_string()),
+                    );
+                }
+                match error {
+                    Value::Object(error) => {
+                        for key in ["code", "message"] {
+                            if let Some(text) = error.get(key).and_then(Value::as_str) {
+                                item.insert(
+                                    key.to_string(),
+                                    Value::String(truncate_chars(text, 1_000)),
+                                );
+                            }
+                        }
+                    }
+                    Value::String(message) => {
+                        item.insert(
+                            "message".to_string(),
+                            Value::String(truncate_chars(message, 1_000)),
+                        );
+                    }
+                    _ => {}
+                }
+                if !item.is_empty() {
+                    errors.push(Value::Object(item));
+                }
+            }
+            for (key, child) in object {
+                if key != "error" {
+                    collect_compose_errors(child, container, errors);
+                }
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_compose_errors(item, inherited_container, errors);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn truncate_chars(value: &str, max_chars: usize) -> String {
+    let mut chars = value.chars();
+    let truncated: String = chars.by_ref().take(max_chars).collect();
+    if chars.next().is_some() {
+        format!("{truncated}…")
+    } else {
+        truncated
+    }
+}
 fn nonempty_env(name: &str) -> Option<String> {
     std::env::var(name)
         .ok()
@@ -502,6 +618,79 @@ mod tests {
         assert_eq!(
             err.message,
             "remote error (S215): path escapes the fs jail roots [/private/tmp]: /Users/example filesystem_access_request={\"v\":1,\"requested_root\":\"/Users/example\",\"attempted_path\":\"/Users/example\",\"error_code\":\"S215\"}"
+        );
+    }
+
+    #[test]
+    fn compose_mutation_results_omit_reconciliation_inventory() {
+        let result = json!({
+            "status": "ok",
+            "changed": true,
+            "container": "database",
+            "workers": ["database"],
+            "up": {
+                "operation_id": "large-internal-id",
+                "containers": [
+                    { "container": "queue", "state": "ready", "changed": false },
+                    { "container": "database", "state": "ready", "changed": true }
+                ]
+            },
+            "restarted": [{ "containers": [{ "container": "console", "state": "ready" }] }]
+        });
+
+        assert_eq!(
+            compact_compose_mutation_result("compose::add", result),
+            json!({
+                "status": "ok",
+                "changed": true,
+                "container": "database",
+                "workers": ["database"]
+            })
+        );
+    }
+
+    #[test]
+    fn compose_mutation_results_keep_only_actionable_failure() {
+        let long_message = "x".repeat(2_000);
+        let result = json!({
+            "status": "failed",
+            "changed": false,
+            "up": {
+                "containers": [
+                    { "container": "queue", "state": "ready" },
+                    { "container": "database", "state": "failed", "error": {
+                        "code": "CHILD_EXITED_BEFORE_REGISTRATION",
+                        "message": long_message,
+                        "stdout": "not model context"
+                    }}
+                ]
+            }
+        });
+
+        let compact = compact_compose_mutation_result("compose::add", result);
+        assert_eq!(compact["status"], "failed");
+        assert_eq!(compact["errors"][0]["container"], "database");
+        assert_eq!(
+            compact["errors"][0]["code"],
+            "CHILD_EXITED_BEFORE_REGISTRATION"
+        );
+        assert!(
+            compact["errors"][0]["message"]
+                .as_str()
+                .unwrap()
+                .chars()
+                .count()
+                <= 1_001
+        );
+        assert!(compact.get("up").is_none());
+    }
+
+    #[test]
+    fn non_mutating_compose_results_are_unchanged() {
+        let status = json!({ "containers": [{ "container": "queue", "state": "ready" }] });
+        assert_eq!(
+            compact_compose_mutation_result("compose::status", status.clone()),
+            status
         );
     }
 }

--- a/harness/src/deferred.rs
+++ b/harness/src/deferred.rs
@@ -57,16 +57,22 @@ pub async fn resolve(
         "deliver" => {
             let function_id = checkpoint.function_id.clone().unwrap_or_default();
             let entry_id = ids::function_result_entry_id(&record.turn_id, &req.function_call_id);
+            let data = crate::trigger::ResultData {
+                content: crate::trigger::bound_model_content(
+                    req.content
+                        .clone()
+                        .unwrap_or_else(|| vec![ContentBlock::text("")]),
+                ),
+                details: req.details.clone().unwrap_or(Value::Null),
+                is_error: req.is_error.unwrap_or(false),
+            };
             let message = AgentMessage::FunctionResult(FunctionResultMessage {
                 role: FunctionResultRoleTag::FunctionResult,
                 function_call_id: req.function_call_id.clone(),
                 function_id,
-                content: req
-                    .content
-                    .clone()
-                    .unwrap_or_else(|| vec![ContentBlock::text("")]),
-                details: req.details.clone().unwrap_or(Value::Null),
-                is_error: req.is_error.unwrap_or(false),
+                content: data.content.clone(),
+                details: crate::trigger::persisted_result_details(&data),
+                is_error: data.is_error,
                 timestamp: AgentMessage::now_ms(),
             });
             // Idempotent on the deterministic entry id.
@@ -144,8 +150,8 @@ pub async fn resolve(
                         role: FunctionResultRoleTag::FunctionResult,
                         function_call_id: req.function_call_id.clone(),
                         function_id,
-                        content: data.content,
-                        details: data.details,
+                        content: data.content.clone(),
+                        details: crate::trigger::persisted_result_details(&data),
                         is_error: data.is_error,
                         timestamp: AgentMessage::now_ms(),
                     });
@@ -226,8 +232,8 @@ pub async fn resolve(
                     role: FunctionResultRoleTag::FunctionResult,
                     function_call_id: req.function_call_id.clone(),
                     function_id,
-                    content: data.content,
-                    details: data.details,
+                    content: data.content.clone(),
+                    details: crate::trigger::persisted_result_details(&data),
                     is_error: data.is_error,
                     timestamp: AgentMessage::now_ms(),
                 });
@@ -368,8 +374,8 @@ pub async fn resolve(
                 role: FunctionResultRoleTag::FunctionResult,
                 function_call_id: req.function_call_id.clone(),
                 function_id,
-                content: data.content,
-                details: data.details,
+                content: data.content.clone(),
+                details: crate::trigger::persisted_result_details(&data),
                 is_error: data.is_error,
                 timestamp: AgentMessage::now_ms(),
             });

--- a/harness/src/trigger.rs
+++ b/harness/src/trigger.rs
@@ -18,6 +18,10 @@ use crate::policy::CompiledPolicy;
 use crate::types::content::ContentBlock;
 use crate::types::turn::FunctionContractLedgerEntry;
 
+pub const MAX_MODEL_RESULT_CHARS: usize = 12_000;
+const RESULT_TRUNCATED_SUFFIX: &str =
+    "\n…[function result truncated; request a narrower result or use a diagnostic function]";
+
 /// A normalised function result ready to become a `function_result` entry.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ResultData {
@@ -345,6 +349,8 @@ pub async fn invoke_target(
                 post_filter_discovery(&mut value, policy);
             } else if function_id == "engine::functions::info" {
                 post_filter_info(&mut value, policy);
+            } else if function_id == "compose::schema" {
+                overlay_compose_schema(&mut value, arguments);
             }
             normalized_result(value)
         }
@@ -357,15 +363,22 @@ pub async fn invoke_target(
 pub(crate) fn normalized_result(value: Value) -> ResultData {
     let (content, is_error) = normalize(&value);
     ResultData {
-        content,
+        content: bound_model_content(content),
         is_error,
         details: value,
     }
 }
 
+pub(crate) fn persisted_result_details(data: &ResultData) -> Value {
+    if !data.is_error {
+        return Value::Null;
+    }
+    compact_json_value(&data.details, 2_000)
+}
+
 pub(crate) fn invocation_error_result(code: Option<String>, message: String) -> ResultData {
     ResultData {
-        content: vec![ContentBlock::text(message.clone())],
+        content: bound_model_content(vec![ContentBlock::text(message.clone())]),
         is_error: true,
         details: json!({ "error": { "code": code, "message": message } }),
     }
@@ -413,6 +426,55 @@ fn post_filter_info(value: &mut Value, policy: &CompiledPolicy) {
 /// `once`/`lifecycle`/`conditions`) is NOT the contract an agent calls.
 /// Discovery must describe the intercept, or an agent that reads
 /// `functions::info` "learns" its tool schema is wrong.
+fn overlay_compose_schema(value: &mut Value, arguments: &Value) {
+    let Some(function_id) = arguments.get("function_id").and_then(Value::as_str) else {
+        return;
+    };
+    if !matches!(
+        function_id,
+        "compose::add"
+            | "compose::remove"
+            | "compose::update"
+            | "compose::up"
+            | "compose::down"
+            | "compose::restart"
+    ) {
+        return;
+    }
+    let Some(object) = value.as_object_mut() else {
+        return;
+    };
+    let key = if object.contains_key("response_schema") {
+        "response_schema"
+    } else if object.contains_key("response_format") {
+        "response_format"
+    } else {
+        return;
+    };
+    object.insert(key.into(), json!({
+        "type": "object",
+        "description": "Concise Compose mutation outcome; full reconciliation diagnostics remain in Compose logs.",
+        "properties": {
+            "status": { "type": "string" },
+            "changed": { "type": "boolean" },
+            "container": { "type": "string" },
+            "workers": { "type": "array", "items": { "type": "string" } },
+            "declared": { "type": "array", "items": { "type": "string" } },
+            "detail": { "type": "string", "maxLength": 1001 },
+            "errors": { "type": "array", "maxItems": 8, "items": {
+                "type": "object",
+                "properties": {
+                    "container": { "type": "string" },
+                    "code": { "type": "string" },
+                    "message": { "type": "string", "maxLength": 1001 }
+                },
+                "additionalProperties": false
+            }}
+        },
+        "additionalProperties": false
+    }));
+}
+
 fn overlay_control_contract(item: &mut Value, id: &str) {
     let Some((description, schema)) = crate::functions::subscribe::control_contract(id) else {
         return;
@@ -502,7 +564,6 @@ fn normalize(value: &Value) -> (Vec<ContentBlock>, bool) {
         .get("is_error")
         .and_then(Value::as_bool)
         .unwrap_or(false);
-
     if let Value::String(s) = value {
         return (vec![ContentBlock::text(s.clone())], is_error);
     }
@@ -515,6 +576,47 @@ fn normalize(value: &Value) -> (Vec<ContentBlock>, bool) {
     }
     let rendered = serde_json::to_string(value).unwrap_or_else(|_| "<unserializable>".to_string());
     (vec![ContentBlock::text(rendered)], is_error)
+}
+
+pub(crate) fn bound_model_content(content: Vec<ContentBlock>) -> Vec<ContentBlock> {
+    let text_chars: usize = content
+        .iter()
+        .map(|block| match block {
+            ContentBlock::Text { text } => text.chars().count(),
+            _ => 0,
+        })
+        .sum();
+    if text_chars <= MAX_MODEL_RESULT_CHARS {
+        return content;
+    }
+    let marker_chars = RESULT_TRUNCATED_SUFFIX.chars().count();
+    let mut remaining = MAX_MODEL_RESULT_CHARS.saturating_sub(marker_chars + 1);
+    let mut bounded = Vec::with_capacity(content.len() + 1);
+    for block in content {
+        match block {
+            ContentBlock::Text { text } => {
+                if remaining > 0 {
+                    let kept: String = text.chars().take(remaining).collect();
+                    remaining = remaining.saturating_sub(kept.chars().count());
+                    bounded.push(ContentBlock::text(kept));
+                }
+            }
+            other => bounded.push(other),
+        }
+    }
+    bounded.push(ContentBlock::text(RESULT_TRUNCATED_SUFFIX));
+    bounded
+}
+
+fn compact_json_value(value: &Value, max_chars: usize) -> Value {
+    let rendered = serde_json::to_string(value).unwrap_or_else(|_| "null".to_string());
+    if rendered.chars().count() <= max_chars {
+        return value.clone();
+    }
+    json!({
+        "truncated": true,
+        "preview": rendered.chars().take(max_chars).collect::<String>()
+    })
 }
 
 /// Drop functions the agent cannot call from an `engine::functions::list`
@@ -1289,5 +1391,33 @@ mod tests {
         let mut denied = json!({ "function_id": "fs::read", "request_schema": {} });
         post_filter_info(&mut denied, &policy);
         assert!(denied.is_null());
+    }
+
+    #[test]
+    fn large_generic_results_are_bounded_for_the_model() {
+        let value = json!({ "rows": ["x".repeat(MAX_MODEL_RESULT_CHARS * 2)] });
+        let result = normalized_result(value.clone());
+        let rendered = ContentBlock::join_text(&result.content);
+        assert!(rendered.contains("function result truncated"));
+        assert!(rendered.chars().count() <= MAX_MODEL_RESULT_CHARS);
+        assert_eq!(result.details, value);
+    }
+
+    #[test]
+    fn successful_results_do_not_duplicate_raw_details_in_transcripts() {
+        let result = normalized_result(json!({ "large": "x".repeat(5_000) }));
+        assert_eq!(persisted_result_details(&result), Value::Null);
+    }
+
+    #[test]
+    fn failed_transcript_details_are_bounded() {
+        let result = ResultData {
+            content: vec![ContentBlock::text("failed")],
+            is_error: true,
+            details: json!({ "error": { "message": "x".repeat(5_000) } }),
+        };
+        let details = persisted_result_details(&result);
+        assert_eq!(details["truncated"], true);
+        assert!(details["preview"].as_str().unwrap().chars().count() <= 2_000);
     }
 }

--- a/harness/src/trigger.rs
+++ b/harness/src/trigger.rs
@@ -349,8 +349,6 @@ pub async fn invoke_target(
                 post_filter_discovery(&mut value, policy);
             } else if function_id == "engine::functions::info" {
                 post_filter_info(&mut value, policy);
-            } else if function_id == "compose::schema" {
-                overlay_compose_schema(&mut value, arguments);
             }
             normalized_result(value)
         }
@@ -426,55 +424,6 @@ fn post_filter_info(value: &mut Value, policy: &CompiledPolicy) {
 /// `once`/`lifecycle`/`conditions`) is NOT the contract an agent calls.
 /// Discovery must describe the intercept, or an agent that reads
 /// `functions::info` "learns" its tool schema is wrong.
-fn overlay_compose_schema(value: &mut Value, arguments: &Value) {
-    let Some(function_id) = arguments.get("function_id").and_then(Value::as_str) else {
-        return;
-    };
-    if !matches!(
-        function_id,
-        "compose::add"
-            | "compose::remove"
-            | "compose::update"
-            | "compose::up"
-            | "compose::down"
-            | "compose::restart"
-    ) {
-        return;
-    }
-    let Some(object) = value.as_object_mut() else {
-        return;
-    };
-    let key = if object.contains_key("response_schema") {
-        "response_schema"
-    } else if object.contains_key("response_format") {
-        "response_format"
-    } else {
-        return;
-    };
-    object.insert(key.into(), json!({
-        "type": "object",
-        "description": "Concise Compose mutation outcome; full reconciliation diagnostics remain in Compose logs.",
-        "properties": {
-            "status": { "type": "string" },
-            "changed": { "type": "boolean" },
-            "container": { "type": "string" },
-            "workers": { "type": "array", "items": { "type": "string" } },
-            "declared": { "type": "array", "items": { "type": "string" } },
-            "detail": { "type": "string", "maxLength": 1001 },
-            "errors": { "type": "array", "maxItems": 8, "items": {
-                "type": "object",
-                "properties": {
-                    "container": { "type": "string" },
-                    "code": { "type": "string" },
-                    "message": { "type": "string", "maxLength": 1001 }
-                },
-                "additionalProperties": false
-            }}
-        },
-        "additionalProperties": false
-    }));
-}
-
 fn overlay_control_contract(item: &mut Value, id: &str) {
     let Some((description, schema)) = crate::functions::subscribe::control_contract(id) else {
         return;
@@ -1419,26 +1368,5 @@ mod tests {
         let details = persisted_result_details(&result);
         assert_eq!(details["truncated"], true);
         assert!(details["preview"].as_str().unwrap().chars().count() <= 2_000);
-    }
-
-    #[test]
-    fn compose_schema_advertises_the_compact_mutation_result() {
-        let mut schema = json!({
-            "function_id": "compose::add",
-            "response_schema": {
-                "properties": {
-                    "up": {},
-                    "down": {},
-                    "restarted": {}
-                }
-            }
-        });
-        overlay_compose_schema(&mut schema, &json!({ "function_id": "compose::add" }));
-        let response = &schema["response_schema"];
-        assert!(response["properties"].get("status").is_some());
-        assert!(response["properties"].get("errors").is_some());
-        assert!(response["properties"].get("up").is_none());
-        assert!(response["properties"].get("down").is_none());
-        assert!(response["properties"].get("restarted").is_none());
     }
 }

--- a/harness/src/trigger.rs
+++ b/harness/src/trigger.rs
@@ -1420,4 +1420,25 @@ mod tests {
         assert_eq!(details["truncated"], true);
         assert!(details["preview"].as_str().unwrap().chars().count() <= 2_000);
     }
+
+    #[test]
+    fn compose_schema_advertises_the_compact_mutation_result() {
+        let mut schema = json!({
+            "function_id": "compose::add",
+            "response_schema": {
+                "properties": {
+                    "up": {},
+                    "down": {},
+                    "restarted": {}
+                }
+            }
+        });
+        overlay_compose_schema(&mut schema, &json!({ "function_id": "compose::add" }));
+        let response = &schema["response_schema"];
+        assert!(response["properties"].get("status").is_some());
+        assert!(response["properties"].get("errors").is_some());
+        assert!(response["properties"].get("up").is_none());
+        assert!(response["properties"].get("down").is_none());
+        assert!(response["properties"].get("restarted").is_none());
+    }
 }

--- a/harness/src/turn_loop.rs
+++ b/harness/src/turn_loop.rs
@@ -2499,7 +2499,7 @@ async fn append_function_result(
         function_call_id: call.id.clone(),
         function_id: call.function_id.clone(),
         content: data.content.clone(),
-        details: data.details.clone(),
+        details: trigger::persisted_result_details(data),
         is_error: data.is_error,
         timestamp: AgentMessage::now_ms(),
     });
@@ -2685,7 +2685,16 @@ async fn assemble_context(
 
     let candidate_values: Vec<Value> = candidate
         .iter()
-        .map(|(_, m)| serde_json::to_value(m).unwrap_or(Value::Null))
+        .map(|(_, message)| {
+            let mut model_message = message.clone();
+            if let AgentMessage::FunctionResult(result) = &mut model_message {
+                let denied = result.details.get("status").and_then(Value::as_str) == Some("denied");
+                if !denied {
+                    result.details = Value::Null;
+                }
+            }
+            serde_json::to_value(model_message).unwrap_or(Value::Null)
+        })
         .collect();
 
     let context = deps.context().await;


### PR DESCRIPTION
## Summary

Prevent large function results from unnecessarily inflating Harness transcripts and model context.

Harness previously serialized function results into model-visible `content` while also persisting the complete raw value in structured `details`. This duplicated successful responses in durable session history and increased context-assembly payload size, trace volume, and compaction pressure.

This change introduces function-agnostic safeguards. It does not special-case Compose or rewrite another function’s contract.

## Changes

### Bound model-visible function results

All function results now have a hard model-visible text limit of 12,000 characters.

Oversized results end with an explicit marker:

```text
…[function result truncated; request a narrower result or use a diagnostic function]
```

The complete rendered result, including the marker, remains within the limit. This applies uniformly to every iii function.

### Stop duplicating successful results

Raw function values remain available during execution for processing that needs them, including:

- post-function hooks
- contract handling
- discovery filtering

After that processing completes, successful results are persisted with `details: null`.

The model-visible `content` remains in the transcript, but the complete raw response is no longer stored beside it as a second copy.

### Bound failure metadata

Failed function results may require structured metadata for diagnostics.

Failure `details` are retained when small. Oversized failure details are replaced with a bounded representation containing:

- `truncated: true`
- a 2,000-character JSON preview

Model-visible invocation error text is also subject to the general 12,000-character limit.

### Cover deferred function completions

Deferred function results previously constructed transcript messages directly and bypassed the normal append path.

The same bounds and persistence policy now apply to:

- externally delivered deferred results
- released held functions
- deferred function denials
- deferred agent-spawn results

### Remove unnecessary details before context assembly

Before transcript messages are sent to the context manager, ordinary function-result `details` are cleared from the model-facing copy.

Permission-denial details remain available because provider adapters use that structured information to communicate denials.

## Architectural scope

Harness remains function-agnostic.

This PR does not:

- inspect function IDs
- special-case Compose
- rewrite Compose responses
- replace another function’s response schema
- make assumptions about worker-specific result structures

Functions remain responsible for returning appropriately designed response payloads. These Harness safeguards provide a general upper bound and prevent duplicate persistence when a function legitimately—or accidentally—returns a large result.

Any change to Compose’s native mutation response must be made where the Compose functions are implemented and registered.

## Result

Before this change, a large successful response could be retained twice:

1. Serialized into model-visible `content`.
2. Stored again as the complete structured `details` value.

After this change:

- model-visible result text is bounded
- successful raw details are not duplicated
- failure metadata is bounded
- context assembly does not transport unnecessary result details
- immediate and deferred completion paths follow the same policy

## Validation

- `cargo test --manifest-path harness/Cargo.toml --lib`
  - 453 tests passed
- `cargo clippy --manifest-path harness/Cargo.toml --all-targets -- -D warnings`
- `cargo fmt --manifest-path harness/Cargo.toml`
- `git diff --check`

Regression coverage includes:

- bounded generic function results
- explicit truncation markers
- removal of duplicate successful-result details
- bounded failure details