### PR TITLE
(MOT-4614) chore: prepare release train canaries

### DIFF
--- a/claude-code/package.json
+++ b/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code",
-  "version": "0.1.12",
+  "version": "0.1.13-rc.1",
   "private": true,
   "description": "Claude Code as an iii worker: headless turns over the iii bus, raw messages on claude::events, AgentEvent frames on agent::events.",
   "license": "Apache-2.0",

--- a/console/Cargo.lock
+++ b/console/Cargo.lock
@@ -251,7 +251,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "console"
-version = "1.9.15-rc.6"
+version = "1.9.15-rc.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "console"
-version = "1.9.15-rc.6"
+version = "1.9.15-rc.7"
 edition = "2021"
 publish = false
 

--- a/hermes/pyproject.toml
+++ b/hermes/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hermes"
-version = "0.1.6"
+version = "0.1.7-rc.1"
 description = "Hermes agent as an iii worker: headless turns over the iii bus, omnichannel send, and inbound platform events as iii triggers."
 authors = [{ name = "iii" }]
 license = "Apache-2.0"

--- a/hermes/uv.lock
+++ b/hermes/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "hermes"
-version = "0.1.6"
+version = "0.1.7rc1"
 source = { editable = "." }
 dependencies = [
     { name = "iii-helpers" },

--- a/scrapling/pyproject.toml
+++ b/scrapling/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 # project is a self-dependency and breaks `pip install`. The iii worker name
 # (folder + worker-compose.yaml) is still `scrapling` — CI validates that, not this.
 name = "scrapling-worker"
-version = "0.2.9-rc.3"
+version = "0.2.9-rc.4"
 description = "Scrapling as an iii worker: HTTP / anti-bot / browser fetch + CSS/XPath/regex/adaptive extraction as scrapling::* functions."
 authors = [{ name = "iii" }]
 license = "Apache-2.0"

--- a/scrapling/uv.lock
+++ b/scrapling/uv.lock
@@ -1084,7 +1084,7 @@ fetchers = [
 
 [[package]]
 name = "scrapling-worker"
-version = "0.2.9rc3"
+version = "0.2.9rc4"
 source = { editable = "." }
 dependencies = [
     { name = "iii-helpers" },


### PR DESCRIPTION
## Summary

- bump Console to 1.9.15-rc.7 for the Rust/frontend canary
- bump Claude Code to 0.1.13-rc.1 for the JavaScript bundle canary
- bump Scrapling to 0.2.9-rc.4 for the Python bundle canary
- bump Hermes to 0.1.7-rc.1 for the multi-architecture OCI canary

## Validation

- compiled the 69-worker release descriptor index
- verified Cargo, pnpm, and uv lockfiles
- confirmed the four descriptor versions and artifact kinds
- `git diff --check`

Refs MOT-4614

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Claude Code package to release candidate version 0.1.13-rc.1.
  * Updated the Console package to release candidate version 1.9.15-rc.7.
  * Updated the Hermes package to release candidate version 0.1.7-rc.1.
  * Updated the Scrapling package to release candidate version 0.2.9-rc.4.
  * These updates align package versions for the latest release candidate builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->