### PR TITLE
(MOT-4614) fix: canonicalize descriptor numbers

### DIFF
--- a/.github/scripts/release_compiler.py
+++ b/.github/scripts/release_compiler.py
@@ -44,8 +44,31 @@ def fail(message: str) -> None:
     raise ValueError(message)
 
 
+def canonical_value(value: Any) -> Any:
+    """Normalize JSON numbers to the representation used by JSON.stringify.
+
+    YAML and TOML preserve ``2.0`` as a float, while JavaScript has one Number
+    type and serializes that value as ``2``. Descriptors are verified by the
+    TypeScript coordinator, so integral floats (including negative zero) must
+    not create a digest that cannot be reproduced after JSON parsing.
+    """
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    if isinstance(value, list):
+        return [canonical_value(item) for item in value]
+    if isinstance(value, dict):
+        return {key: canonical_value(item) for key, item in value.items()}
+    return value
+
+
 def canonical_bytes(value: Any) -> bytes:
-    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return json.dumps(
+        canonical_value(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
 
 
 def json_sha256(value: Any) -> str:

--- a/.github/scripts/tests/test_release_compiler.py
+++ b/.github/scripts/tests/test_release_compiler.py
@@ -1,0 +1,20 @@
+import pytest
+
+import release_compiler
+
+
+def test_canonical_numbers_match_json_stringify_representation():
+    assert release_compiler.canonical_bytes(
+        {
+            "analysis": {"max_cost_usd": 2.0, "max_turns": 4, "ratio": 0.5},
+            "negative_zero": -0.0,
+        }
+    ) == (
+        b'{"analysis":{"max_cost_usd":2,"max_turns":4,"ratio":0.5},'
+        b'"negative_zero":0}'
+    )
+
+
+def test_canonical_numbers_reject_non_json_values():
+    with pytest.raises(ValueError):
+        release_compiler.canonical_bytes({"budget": float("nan")})

--- a/.github/scripts/tests/test_release_workflows.py
+++ b/.github/scripts/tests/test_release_workflows.py
@@ -120,7 +120,7 @@ def test_descriptor_index_independently_verifies_approved_compiler_bytes():
     assert "Verify approved compiler bytes" in text
     assert (
         "APPROVED_COMPILER_DIGEST: "
-        "72b4a2c33f293d57235ad527f6f74c8d4bc2067e381554c94eb360250c2256f7"
+        "eb14d729ec032f62f356b9d3fa4f49f3cab4638b4391b0e8cca39c2be2fe32ce"
     ) in text
     assert 'digest.update(b"iii-workers-release-compiler\\0")' in text
     assert 'Path(".github/scripts/release_compiler.py").read_bytes()' in text

--- a/.github/workflows/release-descriptor-index.yml
+++ b/.github/workflows/release-descriptor-index.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Verify approved compiler bytes
         env:
-          APPROVED_COMPILER_DIGEST: 72b4a2c33f293d57235ad527f6f74c8d4bc2067e381554c94eb360250c2256f7
+          APPROVED_COMPILER_DIGEST: eb14d729ec032f62f356b9d3fa4f49f3cab4638b4391b0e8cca39c2be2fe32ce
         run: |
           set -euo pipefail
           python3 - <<'PY'


### PR DESCRIPTION
## Summary

- normalize integral YAML and TOML floats to JSON Number form before hashing descriptors
- reject non-JSON numeric values
- pin the updated compiler digest in the descriptor-index workflow

This makes descriptor and Registry projection digests reproducible by the TypeScript coordinator after JSON parsing.

## Validation

- 23 focused compiler and workflow tests
- all 69 descriptors compiled
- all 69 descriptor and Registry projection digests reproduced independently with Node.js
- `git diff --check`

Refs MOT-4614

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release metadata consistency by normalizing numeric values before generating verification hashes.
  - Prevented invalid numeric values, such as `NaN` and infinity, from being accepted during release data processing.
  - Ensured values like negative zero and whole-number decimals produce consistent representations.

- **Tests**
  - Added coverage for numeric normalization, serialization consistency, and rejection of unsupported values.
  - Updated approved release verification data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->