### PR TITLE
(MOT-4614) fix: use deployed Release Control routes

### DIFF
--- a/.github/scripts/release_control_contract.py
+++ b/.github/scripts/release_control_contract.py
@@ -315,7 +315,7 @@ def authorize_dispatch(args: argparse.Namespace) -> int:
     body = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
     digest = "sha256:" + hashlib.sha256(body).hexdigest()
     request = urllib.request.Request(
-        args.api_url.rstrip("/") + "/api/executor-dispatches/authorize",
+        args.api_url.rstrip("/") + "/executor-dispatches/authorize",
         data=body,
         method="POST",
         headers={
@@ -337,7 +337,7 @@ def post_result(args: argparse.Namespace) -> int:
         raise ValueError("release result has the wrong contract")
     digest = "sha256:" + hashlib.sha256(body).hexdigest()
     request = urllib.request.Request(
-        args.api_url.rstrip("/") + "/api/executor-results",
+        args.api_url.rstrip("/") + "/executor-results",
         data=body,
         method="POST",
         headers={

--- a/.github/scripts/tests/test_release_control_contract.py
+++ b/.github/scripts/tests/test_release_control_contract.py
@@ -123,6 +123,7 @@ def test_authorize_posts_nested_canonical_body_and_its_digest(monkeypatch):
     request = captured["request"]
     body = request.data
     payload = json.loads(body)
+    assert request.full_url == "https://release-control.example/executor-dispatches/authorize"
     assert set(payload) == {"identity", "executor", "subject"}
     assert set(payload["subject"]) == {"worker", "source_sha", "descriptor_sha256"}
     assert request.get_header("X-release-result-sha256") == "sha256:" + hashlib.sha256(body).hexdigest()
@@ -144,6 +145,7 @@ def test_post_result_sends_the_file_bytes_without_reserializing(tmp_path, monkey
     args = SimpleNamespace(result=result, api_url="https://release-control.example", audience="release-control-workers")
     assert contract.post_result(args) == 0
     request = captured["request"]
+    assert request.full_url == "https://release-control.example/executor-results"
     assert request.data == body
     assert request.get_header("X-release-result-sha256") == "sha256:" + hashlib.sha256(body).hexdigest()
 


### PR DESCRIPTION
The release executor now posts dispatch authorization and byte-exact results to the root-mounted production routes exposed by Release Control. Focused contract tests pin both URLs.

Refs MOT-4614