### PR TITLE
(MOT-4614) fix(ci): skip Harness for release metadata

### DIFF
--- a/.github/scripts/discover_changed_workers.py
+++ b/.github/scripts/discover_changed_workers.py
@@ -166,7 +166,7 @@ def suite_changed(
             not f.startswith(excluded_prefixes)
             and f.split("/", 1)[0] in workers
             and len(f.split("/", 1)) == 2
-            and not is_integration_doc(f.split("/", 1)[1])
+            and not is_metadata(f.split("/", 1)[1])
         )
         for f in files
     )

--- a/.github/scripts/tests/test_discover_changed_workers.py
+++ b/.github/scripts/tests/test_discover_changed_workers.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS))
+
+import discover_changed_workers as discover  # noqa: E402
+
+
+def harness_changed(files: list[str]) -> bool:
+    return discover.suite_changed(
+        files,
+        set(),
+        discover.INTEGRATION_WORKERS,
+        discover.INTEGRATION_INFRA_PATHS,
+        discover.INTEGRATION_EXCLUDED_PREFIXES,
+    )
+
+
+def test_harness_ignores_worker_release_metadata() -> None:
+    assert harness_changed(["console/Cargo.toml", "console/Cargo.lock"]) is False
+
+
+def test_harness_runs_for_worker_source_changes() -> None:
+    assert harness_changed(["console/src/main.rs"]) is True
+
+
+def test_harness_runs_for_integration_infrastructure_changes() -> None:
+    assert harness_changed([".github/workflows/_harness-integration.yml"]) is True


### PR DESCRIPTION
Treat worker release metadata consistently across per-worker and Harness CI selection. Version-only Cargo manifest and lockfile changes still run the affected worker checks without booting the complete Harness stack. Source, integration infrastructure, and forced worker changes continue to run the full integration suite.

Refs MOT-4614

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated change detection so worker release metadata updates do not incorrectly trigger integration or router suites.
  * Worker source changes and integration infrastructure updates continue to trigger the appropriate suites.

* **Tests**
  * Added coverage for metadata, worker source, and infrastructure change scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->