### PR TITLE
(MOT-4614) fix(release): validate OCI build platforms

### DIFF
--- a/.github/scripts/tests/test_release_workflows.py
+++ b/.github/scripts/tests/test_release_workflows.py
@@ -225,7 +225,7 @@ def test_bundle_caches_are_scoped_by_descriptor_lock_runtime_and_architecture():
     assert "python-version: ${{ steps.metadata.outputs.runtime_version }}" in reusable
     assert "version: ${{ steps.metadata.outputs.package_manager_version }}" in reusable
     assert "${{ runner.os }}-${{ runner.arch }}-${{ steps.metadata.outputs.lock_sha256 }}" in reusable
-    assert "package_json_file" not in reusable
+    assert "package_json_file: ${{ steps.metadata.outputs.source_path }}/package.json" in reusable
     assert "python-version: '3.12.13'" not in reusable
     assert "lockfile=\"$source_path" not in reusable
     assert "package-manager-cache" not in reusable

--- a/.github/scripts/tests/test_release_workflows.py
+++ b/.github/scripts/tests/test_release_workflows.py
@@ -144,6 +144,11 @@ def test_release_prepare_fans_one_job_per_compiled_build_unit():
     assert "unit: ${{ matrix.unit }}" in text
 
 
+def test_release_build_validates_rust_targets_and_oci_platforms():
+    text = body("_release-build.yml")
+    assert '(.target // .platform // "none") == $target' in text
+
+
 def test_prepare_runs_adapter_from_prepared_bytes_and_records_interface():
     text = body("release-prepare.yml")
     workflow = yaml.safe_load(text)

--- a/.github/scripts/tests/test_release_workflows.py
+++ b/.github/scripts/tests/test_release_workflows.py
@@ -164,6 +164,14 @@ def test_prepare_runs_adapter_from_prepared_bytes_and_records_interface():
     assert "worker-compose.yaml" not in adapter_text
 
 
+def test_release_runtime_uses_the_current_engine_config_shape():
+    expected = "workers:\\n  - name: iii-worker-manager\\n    config:"
+    for name in ("release-prepare.yml", "release-candidate-smoke.yml"):
+        text = body(name)
+        assert expected in text
+        assert "printf 'engine:" not in text
+
+
 def test_candidate_smoke_boots_registry_candidate_and_compares_prepared_interface():
     text = body("release-candidate-smoke.yml")
     assert '"worker": f"package://{worker}", "version": "next"' in text

--- a/.github/workflows/_release-build.yml
+++ b/.github/workflows/_release-build.yml
@@ -144,6 +144,7 @@ jobs:
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           version: ${{ steps.metadata.outputs.package_manager_version }}
+          package_json_file: ${{ steps.metadata.outputs.source_path }}/package.json
 
       - name: Install descriptor-pinned Node.js
         if: inputs.kind == 'javascript-bundle'

--- a/.github/workflows/_release-build.yml
+++ b/.github/workflows/_release-build.yml
@@ -89,7 +89,7 @@ jobs:
           test "$(jq -r .worker release-input/release-descriptor.json)" = "$WORKER"
           test "$(jq -r .source_sha release-input/release-descriptor.json)" = "$PREPARED_SHA"
           jq -e --arg unit "$UNIT" --arg target "$TARGET" \
-            '.build_units | any(.id == $unit and ((.target // "none") == $target))' \
+            '.build_units | any(.id == $unit and ((.target // .platform // "none") == $target))' \
             release-input/release-descriptor.json >/dev/null
 
       - name: Rewrite SSH to HTTPS for public dependencies

--- a/.github/workflows/release-candidate-smoke.yml
+++ b/.github/workflows/release-candidate-smoke.yml
@@ -138,7 +138,7 @@ jobs:
           trap cleanup EXIT
           engine_port=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')
           engine_url="ws://127.0.0.1:$engine_port"
-          printf 'engine:\n  workers:\n    iii-worker-manager:\n      host: 127.0.0.1\n      port: %s\nworkers: []\n' "$engine_port" >smoke/engine.yaml
+          printf 'workers:\n  - name: iii-worker-manager\n    config:\n      host: 127.0.0.1\n      port: %s\n' "$engine_port" >smoke/engine.yaml
           setsid iii --config smoke/engine.yaml --no-update-check >smoke/engine.log 2>&1 &
           engine_pid=$!
           for _ in $(seq 1 60); do

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -334,7 +334,7 @@ jobs:
           trap cleanup EXIT
           engine_port=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')
           engine_url="ws://127.0.0.1:$engine_port"
-          printf 'engine:\n  workers:\n    iii-worker-manager:\n      host: 127.0.0.1\n      port: %s\nworkers: []\n' "$engine_port" >interface-work/engine.yaml
+          printf 'workers:\n  - name: iii-worker-manager\n    config:\n      host: 127.0.0.1\n      port: %s\n' "$engine_port" >interface-work/engine.yaml
           setsid iii --config interface-work/engine.yaml --no-update-check >interface-work/engine.log 2>&1 &
           engine_pid=$!
           for _ in $(seq 1 60); do


### PR DESCRIPTION
Fix the first canary failures in the descriptor-owned release path:

- validate each build unit against either its Rust target or OCI platform;
- point pnpm setup at the descriptor-selected worker manifest;
- generate the current iii engine configuration shape for prepared-artifact and candidate smoke validation;
- keep immutable unit, source, descriptor, and interface checks intact.

Validated against the Hermes, Claude Code, Console, and Scrapling evidence from release batch 8fcfca3e-f7bc-4d36-aded-68645e8b4c58. The repository sccache variables were also restored from the verified production bucket and OIDC role configuration.

Refs MOT-4614