### PR TITLE
(MOT-4614) fix(release): report failed prepare effects as absent

### DIFF
--- a/.github/scripts/tests/test_release_workflows.py
+++ b/.github/scripts/tests/test_release_workflows.py
@@ -144,6 +144,12 @@ def test_release_prepare_fans_one_job_per_compiled_build_unit():
     assert "unit: ${{ matrix.unit }}" in text
 
 
+def test_release_prepare_reports_failed_source_snapshots_as_absent():
+    text = body("release-prepare.yml")
+    assert 'state=absent; [[ "$outcome" == succeeded ]] && state=present' in text
+    assert 'state=unknown; [[ "$outcome" == succeeded ]] && state=present' not in text
+
+
 def test_release_build_validates_rust_targets_and_oci_platforms():
     text = body("_release-build.yml")
     assert '(.target // .platform // "none") == $target' in text

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -427,7 +427,7 @@ jobs:
           fi
           artifacts='[]'
           if [[ -f release-prepared/release-evidence.json ]]; then artifacts=$(jq -c '[.artifacts[] | del(.unit)]' release-prepared/release-evidence.json); fi
-          state=unknown; [[ "$outcome" == succeeded ]] && state=present
+          state=absent; [[ "$outcome" == succeeded ]] && state=present
           effects=$(jq -nc --arg id "$SOURCE_SHA" --arg state "$state" '[{surface:"source-snapshot",state:$state,immutable_id:$id}]')
           python3 .github/scripts/release_control_contract.py write-result \
             --repository '${{ github.repository }}' \


### PR DESCRIPTION
## Summary

- report a failed or canceled prepare source snapshot as absent
- reserve the present state for successful preparation
- cover the release workflow contract with a regression test

## Validation

- `python3 -m pytest .github/scripts/tests/ -q` (289 tests, 3 subtests)
- `git diff --check`

Refs MOT-4614