### PR TITLE
(MOT-4614) fix(release): harden adapter execution and reporting

### DIFF
--- a/.github/scripts/tests/test_release_workflows.py
+++ b/.github/scripts/tests/test_release_workflows.py
@@ -168,6 +168,7 @@ def test_prepare_runs_adapter_from_prepared_bytes_and_records_interface():
     adapter_text = str(workflow["jobs"]["adapter"])
     assert "inputs.source_sha" not in adapter_text
     assert "worker-compose.yaml" not in adapter_text
+    assert 'sudo skopeo copy "oci-archive:$oci_archive" "docker-daemon:$image_name"' in text
 
 
 def test_release_runtime_uses_the_current_engine_config_shape():
@@ -176,6 +177,19 @@ def test_release_runtime_uses_the_current_engine_config_shape():
         text = body(name)
         assert expected in text
         assert "printf 'engine:" not in text
+
+
+def test_release_runtime_installs_use_authenticated_github_requests():
+    for name in ("release-prepare.yml", "release-candidate-smoke.yml"):
+        workflow = yaml.safe_load(body(name))
+        install_steps = [
+            step
+            for job in workflow["jobs"].values()
+            for step in job.get("steps", [])
+            if "install.iii.dev/iii/main/install.sh" in step.get("run", "")
+        ]
+        assert install_steps, name
+        assert all(step.get("env", {}).get("GITHUB_TOKEN") == "${{ github.token }}" for step in install_steps), name
 
 
 def test_candidate_smoke_boots_registry_candidate_and_compares_prepared_interface():
@@ -207,6 +221,8 @@ def test_mutating_phases_are_retry_safe_and_effect_states_are_probe_derived():
     alias = body("release-image-alias.yml")
     finalize = body("release-finalize.yml")
     assert "release_effects.py classify" in candidate
+    assert 'value=sys.argv[1].strip()' in candidate
+    assert 'all(.[]; .state == "absent" or .state == "present" or .state == "unknown")' in candidate
     assert "release_effects.py plan" in stable
     assert "latest changed outside the authorized compare-and-swap" in stable
     assert "release_effects.py classify" in stable

--- a/.github/workflows/release-candidate-publish.yml
+++ b/.github/workflows/release-candidate-publish.yml
@@ -404,13 +404,18 @@ jobs:
           kind=unknown
           if [[ -f release-prepared/release-evidence.json ]]; then artifacts=$(jq -c '[.artifacts[] | del(.unit)]' release-prepared/release-evidence.json); fi
           if [[ -f release-prepared/release-descriptor.json ]]; then kind=$(jq -r .artifact.kind release-prepared/release-descriptor.json); fi
-          github_state=${GITHUB_STATE:-unknown}; registry_state=${REGISTRY_STATE:-unknown}
+          normalize_state() {
+            python3 -c 'import sys; value=sys.argv[1].strip(); print(value if value in {"absent", "present", "unknown"} else "unknown")' "$1"
+          }
+          github_state=$(normalize_state "${GITHUB_STATE:-unknown}")
+          registry_state=$(normalize_state "${REGISTRY_STATE:-unknown}")
           effects=$(jq -nc --arg tag "$WORKER/v$CANDIDATE_VERSION" --arg version "$CANDIDATE_VERSION" --arg github_state "$github_state" --arg registry_state "$registry_state" '[{surface:"github-release",state:$github_state,immutable_id:$tag},{surface:"registry-next",state:$registry_state,after:$version}]')
           if [[ "$kind" == oci-image ]]; then
-            image_state=${IMAGE_STATE:-unknown}
+            image_state=$(normalize_state "${IMAGE_STATE:-unknown}")
             image_effect=$(jq -nc --arg state "$image_state" --arg digest "$IMAGE_DIGEST" 'if $digest == "" then {surface:"registry-image",state:$state} else {surface:"registry-image",state:$state,immutable_id:$digest} end')
             effects=$(jq -cn --argjson effects "$effects" --argjson image "$image_effect" '$effects + [$image]')
           fi
+          jq -e 'all(.[]; .state == "absent" or .state == "present" or .state == "unknown")' <<<"$effects" >/dev/null
           python3 .github/scripts/release_control_contract.py write-result --repository '${{ github.repository }}' --operation-id "$OPERATION_ID" --step-id "$STEP_ID" --run-id '${{ github.run_id }}' --run-attempt '${{ github.run_attempt }}' --workflow 'release-candidate-publish.yml' --event '${{ github.event_name }}' --sha '${{ github.sha }}' --release-intent-id "$RELEASE_INTENT_ID" --candidate-id "$CANDIDATE_ID" --attempt-id "$ATTEMPT_ID" --dispatch-nonce "$DISPATCH_NONCE" --plan-hash "$PLAN_HASH" --worker "$WORKER" --phase candidate_publish --source-sha "$SOURCE_SHA" --prepared-sha "$PREPARED_SHA" --candidate-version "$CANDIDATE_VERSION" --stable-version "$STABLE_VERSION" --descriptor-sha256 "$DESCRIPTOR_SHA256" --outcome "$outcome" --effects "$effects" --artifacts-json "$artifacts" --error-json "$error" --output release-result.json
       - if: always()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6

--- a/.github/workflows/release-candidate-smoke.yml
+++ b/.github/workflows/release-candidate-smoke.yml
@@ -62,6 +62,8 @@ jobs:
           python3 .github/scripts/release_control_contract.py validate-dispatch --operation-id "$OPERATION_ID" --step-id "$STEP_ID" --dispatch-nonce "$DISPATCH_NONCE" --descriptor-sha256 "$DESCRIPTOR_SHA256" --plan-hash "$PLAN_HASH" --source-sha "$SOURCE_SHA"
           python3 .github/scripts/release_control_contract.py authorize-dispatch --api-url "$RELEASE_CONTROL_API_URL" --repository '${{ github.repository }}' --operation-id "$OPERATION_ID" --step-id "$STEP_ID" --run-id '${{ github.run_id }}' --run-attempt '${{ github.run_attempt }}' --workflow 'release-candidate-smoke.yml' --event '${{ github.event_name }}' --sha '${{ github.sha }}' --release-intent-id "$RELEASE_INTENT_ID" --candidate-id "$CANDIDATE_ID" --attempt-id "$ATTEMPT_ID" --dispatch-nonce "$DISPATCH_NONCE" --plan-hash "$PLAN_HASH" --worker "$WORKER" --source-sha "$SOURCE_SHA" --descriptor-sha256 "$DESCRIPTOR_SHA256"
       - name: Install current iii CLI
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           curl -fsSL --retry 3 --retry-all-errors --retry-delay 5 \

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -271,6 +271,8 @@ jobs:
 
       - name: Install current iii runtime
         if: steps.interface.outputs.validation == 'required'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           curl -fsSL --retry 3 --retry-all-errors --retry-delay 5 \
@@ -349,7 +351,7 @@ jobs:
             container_name="release-interface-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
             image_name="$container_name:prepared"
             oci_archive=$(jq -er .oci_archive interface-work/stage.json)
-            skopeo copy "oci-archive:$oci_archive" "docker-daemon:$image_name"
+            sudo skopeo copy "oci-archive:$oci_archive" "docker-daemon:$image_name"
             docker_env=(--env "III_URL=$engine_url")
             while IFS= read -r encoded; do
               docker_env+=(--env "$(printf '%s' "$encoded" | base64 --decode)")


### PR DESCRIPTION
## Summary
- pass the workflow token to the iii installer in prepare adapter validation and candidate smoke
- import prepared OCI archives with the privileges required to preserve ownership metadata
- normalize probed effect states before writing candidate publication evidence
- enforce the release adapter requirements in workflow contract tests

## Validation
- TMPDIR=/dev/shm python3 -m pytest .github/scripts/tests/test_release_workflows.py .github/scripts/tests/test_release_control_contract.py -q
- git diff --check

Refs MOT-4614

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release workflow reliability when importing OCI images into Docker.
  - Added authenticated access for CLI installation during release preparation and smoke checks.
  - Normalized release effect states, treating invalid values as `unknown` for safer reporting.
  - Strengthened retry safety and validation across candidate publishing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->