### PR TITLE
(MOT-4614) fix(release): resolve staged adapter paths

### DIFF
--- a/.github/scripts/release_interface.py
+++ b/.github/scripts/release_interface.py
@@ -137,7 +137,7 @@ def stage(args: argparse.Namespace) -> int:
             if len(units) != 1:
                 raise SystemExit(f"required interface needs exactly one {target} build unit")
             selected = _single_artifact(artifacts, "binary", unit=str(units[0]["id"]))
-            stage_dir = args.out.parent / "runtime"
+            stage_dir = (args.out.parent / "runtime").resolve()
             extract_regular_tar(args.prepared.parent / str(selected["name"]), stage_dir)
             command = runtime.get("exec")
             if not isinstance(command, list) or not command or not all(isinstance(part, str) for part in command):
@@ -149,7 +149,7 @@ def stage(args: argparse.Namespace) -> int:
             result.update(cwd=str(stage_dir), command=[str(executable), *command[1:]])
         elif kind in {"javascript-bundle", "python-bundle"}:
             selected = _single_artifact(artifacts, "bundle")
-            stage_dir = args.out.parent / "runtime"
+            stage_dir = (args.out.parent / "runtime").resolve()
             extract_regular_tar(args.prepared.parent / str(selected["name"]), stage_dir)
             start = runtime.get("start")
             install = runtime.get("install") or ""
@@ -174,7 +174,7 @@ def stage(args: argparse.Namespace) -> int:
             if len(units) != 1:
                 raise SystemExit("required OCI interface needs exactly one linux/amd64 build unit")
             selected = _single_artifact(artifacts, "oci-platform", unit=str(units[0]["id"]))
-            archive = args.out.parent / "image.oci.tar"
+            archive = (args.out.parent / "image.oci.tar").resolve()
             with gzip.open(args.prepared.parent / str(selected["name"]), "rb") as source:
                 with archive.open("wb") as destination:
                     shutil.copyfileobj(source, destination)

--- a/.github/scripts/tests/test_release_interface.py
+++ b/.github/scripts/tests/test_release_interface.py
@@ -77,6 +77,25 @@ def test_required_interface_stages_only_prepared_artifact_bytes(tmp_path: Path) 
     assert not (tmp_path / "source-must-not-be-read").exists()
 
 
+def test_stage_resolves_runtime_paths_before_adapter_changes_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    descriptor_path, prepared_path = write_prepared(tmp_path, descriptor())
+    monkeypatch.chdir(tmp_path)
+
+    release_interface.stage(argparse.Namespace(
+        descriptor=descriptor_path,
+        prepared=prepared_path,
+        out=Path("interface") / "stage.json",
+        github_output=None,
+    ))
+
+    stage = json.loads((tmp_path / "interface" / "stage.json").read_text())
+    assert Path(stage["cwd"]).is_absolute()
+    assert Path(stage["command"][0]).is_absolute()
+    assert Path(stage["command"][0]).is_relative_to(Path(stage["cwd"]))
+
+
 def test_skipped_interface_records_explicit_evidence_without_staging_runtime(tmp_path: Path) -> None:
     selected = descriptor("skipped")
     descriptor_path, prepared_path = write_prepared(tmp_path, selected)


### PR DESCRIPTION
## Summary
- resolve staged runtime directories before launching release adapters
- keep OCI archive paths absolute for the same cwd-independent contract
- cover relative stage output paths with a regression test

## Validation
- TMPDIR=/dev/shm python3 -m pytest .github/scripts/tests/test_release_interface.py .github/scripts/tests/test_release_workflows.py -q
- prepared console artifact booted locally and registered 10 functions plus 3 triggers
- git diff --check

Refs MOT-4614