### PR TITLE
(MOT-4614) fix: recover partial deployment publication

### DIFF
--- a/.github/scripts/tests/test_deployment_workflows.py
+++ b/.github/scripts/tests/test_deployment_workflows.py
@@ -207,6 +207,8 @@ def test_publish_separates_immutable_version_from_explicit_channel_cas():
     assert 'has("package_descriptor") or has("descriptor_sha256") or has("channel")' in reusable
     assert "registry_publication.py publish-version" in reusable
     assert "build_publish_payload.py" in reusable
+    assert "jq 'has(\"tag\")' payload.json" in reusable
+    assert "has(\\\"tag\\\")" not in reusable
     assert '--registry-tag "$DEPLOYMENT_CHANNEL"' in reusable
     assert "Move requested channel with compare-and-swap" in reusable
     assert "Move the requested OCI channel to the immutable digest" in publish

--- a/.github/workflows/_deploy-registry.yml
+++ b/.github/workflows/_deploy-registry.yml
@@ -105,7 +105,7 @@ jobs:
             echo 'descriptor-native fields must never reach the current Registry' >&2
             exit 1
           fi
-          test "$(jq 'has(\"tag\")' payload.json)" = false
+          test "$(jq 'has("tag")' payload.json)" = false
 
       - name: Publish immutable version with readback
         env:


### PR DESCRIPTION
## Summary
- pass the Registry payload jq expression without literal shell escapes
- preserve the existing immutable GitHub release while allowing Registry publication to continue on retry

## Validation
- deployment workflow tests
- actionlint
- git diff --check

Refs MOT-4614