### PR TITLE
(MOT-4614) fix: preserve release effect state

### DIFF
--- a/.github/scripts/tests/test_deployment_workflows.py
+++ b/.github/scripts/tests/test_deployment_workflows.py
@@ -183,6 +183,8 @@ def test_publish_is_retry_safe_and_effect_states_are_probe_derived():
     assert "ref" not in checkout["with"]
     assert checkout["with"]["fetch-depth"] == 0
     assert "deployment_effects.py classify" in publish
+    assert "PUBLISH_GITHUB_STATE" in publish
+    assert "\n          GITHUB_STATE:" not in publish
     assert 'value=sys.argv[1].strip()' in publish
     assert 'all(.[]; .state == "absent" or .state == "present" or .state == "unknown")' in publish
     registry = body("_deploy-registry.yml")

--- a/.github/workflows/deploy-publish.yml
+++ b/.github/workflows/deploy-publish.yml
@@ -489,7 +489,7 @@ jobs:
           PUBLISH_RESULT: ${{ needs.publish.result }}
           REGISTRY_RESULT: ${{ needs.registry.result }}
           IMAGE_CHANNEL_RESULT: ${{ needs.image_channel.result }}
-          GITHUB_STATE: ${{ steps.effects.outputs.github_state }}
+          PUBLISH_GITHUB_STATE: ${{ steps.effects.outputs.github_state }}
           REGISTRY_STATE: ${{ steps.effects.outputs.registry_state }}
           NEXT_FLOOR_STATE: ${{ steps.effects.outputs.next_floor_state }}
           NEXT_FLOOR_VERSION: ${{ steps.effects.outputs.next_floor_version }}
@@ -511,7 +511,7 @@ jobs:
           normalize_state() {
             python3 -c 'import sys; value=sys.argv[1].strip(); print(value if value in {"absent", "present", "unknown"} else "unknown")' "$1"
           }
-          github_state=$(normalize_state "${GITHUB_STATE:-unknown}")
+          github_state=$(normalize_state "${PUBLISH_GITHUB_STATE:-unknown}")
           registry_state=$(normalize_state "${REGISTRY_STATE:-unknown}")
           effects=$(jq -nc --arg tag "$WORKER/v$TARGET_VERSION" --arg channel "$DEPLOYMENT_CHANNEL" --arg version "$TARGET_VERSION" --arg github_state "$github_state" --arg registry_state "$registry_state" '[{surface:"github-release",state:$github_state,immutable_id:$tag},{surface:("registry-"+$channel),state:$registry_state,after:$version}]')
           if [[ "$DEPLOYMENT_CHANNEL" == latest ]]; then


### PR DESCRIPTION
Avoid the reserved GitHub Actions `GITHUB_STATE` environment variable when carrying the authoritative release probe into `deployment-result.json`.

Adds a workflow regression and keeps effect classification byte-exact.

Refs MOT-4614

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment publishing reliability by ensuring GitHub release state is passed and interpreted correctly when generating deployment results.
  * Prevented workflow-level state configuration from interfering with publish status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->