### PR TITLE
fix(mcp): remove stale dependency on the removed skills worker

### DIFF
--- a/mcp/iii.worker.yaml
+++ b/mcp/iii.worker.yaml
@@ -7,6 +7,3 @@ license: Apache-2.0
 bin: mcp
 tags: [mcp, model-context-protocol, bridge, http, agents]
 description: MCP 2025-06-18 Streamable HTTP bridge for the iii engine.
-
-dependencies:
-  skills: "0.x"


### PR DESCRIPTION
Fixes #1017

## What

Removes the `dependencies` block (a single stale entry, `skills: "0.x"`) from `mcp/iii.worker.yaml`.

## Why

The `skills` worker was removed from main and withdrawn from the registry when its functionality was folded into `iii-directory` (#124, 2026-05-12), but the mcp manifest kept referencing it. Every mcp release currently in the registry (0.5.7–0.5.9) therefore fails registry resolution — `iii compose build` and `iii worker add mcp` both end in `PACKAGE_NOT_RESOLVED: Worker 'skills' was not found in the registry` — and there is no older installable fallback, so the mcp worker is currently uninstallable for everyone.

With the dependency dropped, the worker resolves and installs again. Runtime behaviour is unchanged for tools; `resources/*` and `prompts/*` already degrade to empty lists when no delegate registers (`skills_bridge.rs` `delegate_or_empty`), since `iii-directory` exposes the `directory::skills::*` surface instead.

## Follow-up (not in this PR)

`skills_bridge.rs` still delegates to `skills::resources-*` function IDs that no worker registers. To make MCP resources/prompts populate again, either repoint the bridge at `directory::skills::*` or have `iii-directory` register `skills::*` aliases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the worker configuration by removing an outdated package dependency declaration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->