### PR TITLE
feat: revive harness-quickstart.yml for the Release Control smoke schedule

### DIFF
--- a/.github/scripts/tests/test_quickstart_workflow.py
+++ b/.github/scripts/tests/test_quickstart_workflow.py
@@ -1,0 +1,77 @@
+import re
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW = ROOT / ".github" / "workflows" / "harness-quickstart.yml"
+
+
+def body() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def workflow() -> dict:
+    return yaml.safe_load(body())
+
+
+def test_quickstart_workflow_exists_with_exact_dispatch_identity():
+    document = workflow()
+    inputs = document[True]["workflow_dispatch"]["inputs"]
+    assert set(inputs) == {"quickstart_id", "attempt", "cli_channel", "registry_tag"}
+    assert all(inputs[name]["required"] for name in inputs)
+    assert inputs["cli_channel"]["options"] == ["latest", "rc"]
+    assert inputs["registry_tag"]["options"] == ["latest", "next"]
+    # Release Control correlates runs by this exact title shape.
+    assert (
+        document["run-name"]
+        == "RC · quickstart · ${{ inputs.quickstart_id }} · ${{ inputs.attempt }}"
+    )
+
+
+def test_quickstart_job_runs_the_validator_within_its_timeout():
+    document = workflow()
+    jobs = document["jobs"]
+    assert set(jobs) == {"quickstart"}
+    job = jobs["quickstart"]
+    assert job["timeout-minutes"] == 20
+    validator_steps = [
+        step for step in job["steps"] if step.get("run") == "harness/tests/quickstart/run-ci.sh"
+    ]
+    assert len(validator_steps) == 1
+    assert validator_steps[0]["env"]["III_CLI_CHANNEL"] == "${{ inputs.cli_channel }}"
+    assert validator_steps[0]["env"]["III_WORKER_TAG"] == "${{ inputs.registry_tag }}"
+
+
+def test_quickstart_validates_the_dispatching_actor_before_any_checkout():
+    steps = workflow()["jobs"]["quickstart"]["steps"]
+    guard = steps[0]
+    assert "RELEASE_CONTROL_BOT_LOGIN" in str(guard.get("env", {}))
+    assert 'test "$ACTOR" = "$BOT_LOGIN"' in guard["run"]
+    assert all("checkout" not in str(step.get("uses", "")) for step in [guard])
+
+
+def test_quickstart_result_artifact_always_uploads_the_identity_named_bundle():
+    steps = workflow()["jobs"]["quickstart"]["steps"]
+    uploads = [step for step in steps if str(step.get("uses", "")).startswith("actions/upload-artifact@")]
+    assert len(uploads) == 1
+    upload = uploads[0]
+    assert upload["if"] == "always()"
+    assert (
+        upload["with"]["name"]
+        == "quickstart-result-${{ inputs.quickstart_id }}-${{ inputs.attempt }}"
+    )
+    assert upload["with"]["path"] == "target/harness-quickstart/"
+    assert upload["with"]["if-no-files-found"] == "warn"
+
+
+def test_quickstart_actions_are_sha_pinned_and_inputs_never_reach_shell_source():
+    for match in re.finditer(r"uses:\s*(\S+)", body()):
+        reference = match.group(1)
+        assert re.search(r"@[0-9a-f]{40}$", reference), reference
+    for step in workflow()["jobs"]["quickstart"]["steps"]:
+        run = step.get("run")
+        if run is None:
+            continue
+        assert "${{ inputs." not in run, "dispatch inputs must reach run: only through env:"

--- a/.github/workflows/harness-quickstart.yml
+++ b/.github/workflows/harness-quickstart.yml
@@ -1,0 +1,107 @@
+name: Harness quickstart smoke test
+run-name: RC · quickstart · ${{ inputs.quickstart_id }} · ${{ inputs.attempt }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      quickstart_id: {required: true, type: string}
+      attempt: {required: true, type: string}
+      cli_channel:
+        required: true
+        type: choice
+        # `rc` replaced the CLI's dead `next` prerelease channel; the compose
+        # flow the validator drives needs a 0.23.0-rc or newer CLI.
+        options: [latest, rc]
+      registry_tag:
+        required: true
+        type: choice
+        options: [latest, next]
+
+permissions: {}
+
+concurrency:
+  group: harness-quickstart
+  cancel-in-progress: false
+
+jobs:
+  quickstart:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.cache/ms-playwright
+    steps:
+      - name: Validate Release Control dispatch
+        env:
+          BOT_LOGIN: ${{ vars.RELEASE_CONTROL_BOT_LOGIN }}
+          ACTOR: ${{ github.actor }}
+          QUICKSTART_ID: ${{ inputs.quickstart_id }}
+          ATTEMPT: ${{ inputs.attempt }}
+        run: |
+          set -euo pipefail
+          test -n "$BOT_LOGIN"
+          test "$ACTOR" = "$BOT_LOGIN"
+          python3 - "$QUICKSTART_ID" "$ATTEMPT" <<'EOF'
+          import sys
+          import uuid
+
+          quickstart_id, attempt = sys.argv[1], sys.argv[2]
+          assert str(uuid.UUID(quickstart_id)) == quickstart_id.lower(), "quickstart_id must be a UUID"
+          assert attempt.isdigit() and int(attempt) >= 1, "attempt must be a positive integer"
+          EOF
+
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+        with:
+          version: 11.13.1
+
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 22
+          package-manager-cache: false
+
+      - name: Install Console Playwright dependencies
+        working-directory: console/web
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Chromium and video tooling
+        working-directory: console/web
+        run: |
+          pnpm exec playwright install --with-deps chromium
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg
+
+      - name: Run quickstart validator
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          HARNESS_QUICKSTART_ARTIFACTS_DIR: ${{ github.workspace }}/target/harness-quickstart
+          HARNESS_QUICKSTART_TRACE: '1'
+          III_CLI_CHANNEL: ${{ inputs.cli_channel }}
+          III_WORKER_TAG: ${{ inputs.registry_tag }}
+        run: harness/tests/quickstart/run-ci.sh
+
+      - name: Show quickstart logs
+        if: always()
+        run: |
+          shopt -s nullglob
+          for log in target/harness-quickstart/logs/*.log; do
+            echo "::group::$(basename "$log")"
+            cat "$log"
+            echo "::endgroup::"
+          done
+
+      # Release Control reads result.json and the slack-evidence video from
+      # this artifact; a runner-level catastrophe still settles from the run
+      # conclusion, hence warn instead of error.
+      - if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: quickstart-result-${{ inputs.quickstart_id }}-${{ inputs.attempt }}
+          path: target/harness-quickstart/
+          retention-days: 14
+          if-no-files-found: warn


### PR DESCRIPTION
Companion to iii-hq/release-control#99 (daily quickstart smoke schedule).

The quickstart validator (`harness/tests/quickstart/`) survived the MOT-4614 cutover, but its workflow wrapper spoke the retired release-control contract (`operation_id`/`step_id`, `release_control_contract.py`) and was deleted in #1011. This re-adds a thin wrapper on current conventions:

- Identity is `quickstart_id` + `attempt`, mirrored in `run-name` (`RC · quickstart · <id> · <attempt>`) — Release Control correlates runs by that exact title plus the bot actor.
- Dispatch guard: `github.actor` must equal `vars.RELEASE_CONTROL_BOT_LOGIN` and `quickstart_id` must be a UUID; inputs reach shell only through `env:`. No deployment-contract identity — this run is advisory and authorizes nothing.
- Runs `harness/tests/quickstart/run-ci.sh` against the dispatched `cli_channel`/`registry_tag` pair (`rc`/`next` on the schedule), 20-min timeout, actions pinned to the repo's existing SHAs.
- Uploads `target/harness-quickstart/` (result.json, slack-evidence MP4, logs) as `quickstart-result-<id>-<attempt>` with `if: always()` and `if-no-files-found: warn`, so Release Control can settle from the artifact or fall back to the run conclusion.

Verification: `pytest .github/scripts/tests/` — 250 passed, including the new `test_quickstart_workflow.py` (inputs/run-name contract, actor guard before checkout, always-uploaded identity-named artifact, SHA-pinned actions, no inputs in shell source).

The workflow is inert until dispatched; a manual human dispatch fails the actor guard by design.

https://claude.ai/code/session_01MKFaAGVqL8CcLKaBwL53L9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authorized workflow for running Harness quickstart smoke tests.
  * Supports selecting CLI and registry channels, quickstart IDs, and attempt numbers.
  * Displays test logs and always uploads identity-named artifacts for troubleshooting.

* **Tests**
  * Added automated coverage validating workflow inputs, authorization checks, execution settings, artifact uploads, and secure action usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->