### PR TITLE
fix(provider-openai-codex): read function-call arguments from done events

### DIFF
--- a/provider-openai-codex/src/sse.rs
+++ b/provider-openai-codex/src/sse.rs
@@ -372,6 +372,40 @@ pub fn handle_chunk(
                 arguments_preview: None,
             });
         }
+        n if n.contains("function_call_arguments.done") => {
+            let full = chunk.get("arguments").and_then(Value::as_str).unwrap_or("");
+            if !full.is_empty() {
+                if let Some(last) = state.tool_calls.last_mut() {
+                    last.args_json = full.to_string();
+                }
+            }
+        }
+        n if n.contains("output_item.done") => {
+            let item = chunk.get("item").or_else(|| chunk.get("output_item"));
+            if let Some(item) = item
+                .filter(|item| item.get("type").and_then(Value::as_str) == Some("function_call"))
+            {
+                let full = item.get("arguments").and_then(Value::as_str).unwrap_or("");
+                if !full.is_empty() {
+                    let id = item
+                        .get("call_id")
+                        .or_else(|| item.get("id"))
+                        .and_then(Value::as_str)
+                        .unwrap_or("");
+                    let idx = state
+                        .tool_calls
+                        .iter()
+                        .position(|tc| !id.is_empty() && tc.id == id);
+                    let call = match idx {
+                        Some(i) => state.tool_calls.get_mut(i),
+                        None => state.tool_calls.last_mut(),
+                    };
+                    if let Some(call) = call {
+                        call.args_json = full.to_string();
+                    }
+                }
+            }
+        }
         n if n.contains("completed") => {
             state.terminated = true;
             merge_usage(chunk, &mut state.usage);
@@ -518,6 +552,43 @@ mod tests {
                 assert_eq!(usage.input, Some(6));
                 assert_eq!(usage.cache_read, Some(4));
             }
+            other => panic!("want done, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tool_call_takes_arguments_from_arguments_done() {
+        let (_, events) = run(&[
+            json!({ "type": "response.output_item.added", "item": { "type": "function_call", "call_id": "c1", "name": "shell__exec" } }),
+            json!({ "type": "response.function_call_arguments.done", "arguments": "{\"cmd\":\"ls\"}" }),
+            json!({ "type": "response.completed" }),
+        ]);
+        match events.last().unwrap() {
+            AssistantMessageEvent::Done { message } => match &message.content[0] {
+                ContentBlock::FunctionCall { arguments, .. } => {
+                    assert_eq!(arguments["cmd"], "ls");
+                }
+                other => panic!("want function_call, got {other:?}"),
+            },
+            other => panic!("want done, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tool_call_takes_arguments_from_output_item_done() {
+        let (_, events) = run(&[
+            json!({ "type": "response.output_item.added", "item": { "type": "function_call", "call_id": "c2", "name": "shell__exec" } }),
+            json!({ "type": "response.output_item.done", "item": { "type": "function_call", "call_id": "c2", "arguments": "{\"cmd\":\"pwd\"}" } }),
+            json!({ "type": "response.completed" }),
+        ]);
+        match events.last().unwrap() {
+            AssistantMessageEvent::Done { message } => match &message.content[0] {
+                ContentBlock::FunctionCall { id, arguments, .. } => {
+                    assert_eq!(id, "c2");
+                    assert_eq!(arguments["cmd"], "pwd");
+                }
+                other => panic!("want function_call, got {other:?}"),
+            },
             other => panic!("want done, got {other:?}"),
         }
     }


### PR DESCRIPTION
## What

The codex SSE parser only accumulates function-call arguments from `response.function_call_arguments.delta` events. Newer codex backends can deliver the complete arguments in `response.function_call_arguments.done` and `response.output_item.done` instead, and `build_content` silently turns an empty `args_json` into `{}`. The result on a live harness session: every model call arrives as `agent_trigger` with empty arguments, the harness answers `agent_trigger_no_target`, and the model loops failed calls until the turn dies with no output.

This adds the two `done` arms, mirroring what `provider-openai/src/sse.rs` already does for the Responses API: `function_call_arguments.done` overwrites the accumulated arguments with the authoritative full string, and `output_item.done` recovers arguments from the completed item, matching by `call_id` with a last-call fallback.

## Why it matters

Observed on a compose rig (engine 0.23.0-rc.8, provider-openai-codex 0.4.6-rc.4): agent turns on `codex/gpt-5.3-codex-spark` and `codex/gpt-5.6-sol` failed 40 to 120 consecutive `agent_trigger` calls with `REQUEST empty`. The failure is intermittent across sessions, which fits an upstream event-shape difference rather than a constant regression; the `done` arms make the parser robust to both shapes.

## Verification

- Two new unit tests: arguments delivered only via `function_call_arguments.done`, and only via `output_item.done` (85 tests pass).
- `cargo fmt`, `cargo clippy -- -D warnings`, `cargo test` clean.
- Live-verified on the rig: with this build swapped in, the same agent prompt that previously looped empty calls created files and completed normally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of streamed OpenAI responses so completed tool and function calls consistently include their complete, authoritative arguments.
  * Fixed cases where final response messages could contain incomplete or outdated function-call details.
  * Enhanced reliability when processing function-call completion events during streaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->