### PR TITLE
fix(shell): keep engine internals and transient writes out of the change feed

### DIFF
--- a/shell/Cargo.lock
+++ b/shell/Cargo.lock
@@ -1970,6 +1970,7 @@ dependencies = [
  "clap",
  "cucumber",
  "globset",
+ "ignore",
  "iii-console-ui",
  "iii-helpers",
  "iii-sdk",

--- a/shell/Cargo.toml
+++ b/shell/Cargo.toml
@@ -37,6 +37,7 @@ url = "2"
 base64 = "0.22"
 walkdir = "2"
 globset = "0.4"
+ignore = "0.4"
 sha2 = "0.10"
 portable-pty = "0.9.0"
 

--- a/shell/src/events.rs
+++ b/shell/src/events.rs
@@ -160,6 +160,21 @@ pub(crate) fn merge_kinds(prev: &'static str, next: &'static str) -> &'static st
     }
 }
 
+/// What a coalesced change amounts to once the window closes. `born` says the
+/// path was created inside this window; a born path that is gone again never
+/// existed for an observer (atomic-write temps arrive as create+rename or
+/// create+delete), so it emits nothing regardless of the merged kind. A
+/// pre-existing path that vanished mid-window is a real deletion.
+pub(crate) fn resolve_kind(kind: &'static str, on_disk: bool, born: bool) -> Option<&'static str> {
+    match (kind, on_disk) {
+        (_, false) if born => None,
+        ("created", false) => None,
+        ("deleted", _) => Some("deleted"),
+        (_, false) => Some("deleted"),
+        (kind, true) => Some(kind),
+    }
+}
+
 /// The subset of root-relative `paths` the watch treats as ignored. Inside a
 /// git repository git itself decides. Outside one (compose template projects
 /// are plain directories), fall back to the root `.gitignore` plus a small
@@ -169,7 +184,10 @@ pub(crate) async fn ignored_under<'a>(
     root: &Path,
     paths: impl Iterator<Item = &'a String> + Clone,
 ) -> HashSet<String> {
-    if root.join(".git").exists() {
+    // A watch root inside a repository (any ancestor owns a `.git`) is git's
+    // domain too: `git -C root check-ignore` resolves the containing
+    // repository and its parent .gitignore rules from a subdirectory.
+    if root.ancestors().any(|dir| dir.join(".git").exists()) {
         return git_ignored(root, paths).await;
     }
     let mut builder = ignore::gitignore::GitignoreBuilder::new(root);
@@ -268,6 +286,7 @@ async fn pump(
         // Coalesce the storm: kinds for one path merge across the window
         // (macOS reports a create and the write that fills it separately).
         let mut batch: HashMap<String, &'static str> = HashMap::new();
+        let mut born: HashSet<String> = HashSet::new();
         let mut fold = |event: notify::Event| {
             if is_noise_kind(&event.kind) {
                 return;
@@ -278,6 +297,9 @@ async fn pump(
                     continue;
                 }
                 if let Some(rel) = rel_to(&root, p) {
+                    if kind == "created" {
+                        born.insert(rel.clone());
+                    }
                     batch
                         .entry(rel)
                         .and_modify(|prev| *prev = merge_kinds(prev, kind))
@@ -300,14 +322,8 @@ async fn pump(
         let ignored_paths = ignored_under(&root, batch.keys()).await;
         for (path, kind) in batch.drain() {
             let on_disk = root.join(&path).exists();
-            // An atomic-write temp (created and renamed away inside one
-            // coalesce window) never existed for an observer: skip it.
-            // A tracked file that vanished mid-window is a real deletion.
-            let kind = match (kind, on_disk) {
-                ("created", false) => continue,
-                ("deleted", _) => "deleted",
-                (_, false) => "deleted",
-                (kind, true) => kind,
+            let Some(kind) = resolve_kind(kind, on_disk, born.contains(&path)) else {
+                continue;
             };
             let dir = kind != "deleted" && root.join(&path).is_dir();
             let ignored = ignored_paths.contains(&path);
@@ -427,6 +443,50 @@ pub fn register_changed_trigger(iii: &IIIClient, resolver: ResolverCell) {
 
 #[cfg(test)]
 mod tests {
+    #[tokio::test]
+    async fn fallback_defers_to_git_from_a_subdirectory_watch() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let status = std::process::Command::new("git")
+            .arg("-C")
+            .arg(root)
+            .args(["init", "-q"])
+            .status()
+            .unwrap();
+        assert!(status.success());
+        std::fs::write(root.join(".gitignore"), "*.log\n").unwrap();
+        std::fs::create_dir_all(root.join("sub")).unwrap();
+        let paths = [
+            "build.log".to_string(),
+            "data/keep.txt".to_string(),
+            "src/main.rs".to_string(),
+        ];
+        let ignored = super::ignored_under(&root.join("sub"), paths.iter()).await;
+        assert!(ignored.contains("build.log"));
+        assert!(!ignored.contains("data/keep.txt"));
+        assert!(!ignored.contains("src/main.rs"));
+    }
+
+    #[test]
+    fn resolve_kind_folds_transient_writes_and_real_deletions() {
+        assert_eq!(super::resolve_kind("created", false, true), None);
+        assert_eq!(super::resolve_kind("deleted", false, true), None);
+        assert_eq!(super::resolve_kind("created", false, false), None);
+        assert_eq!(
+            super::resolve_kind("deleted", false, false),
+            Some("deleted")
+        );
+        assert_eq!(
+            super::resolve_kind("modified", false, false),
+            Some("deleted")
+        );
+        assert_eq!(
+            super::resolve_kind("modified", true, false),
+            Some("modified")
+        );
+        assert_eq!(super::resolve_kind("created", true, true), Some("created"));
+    }
+
     #[tokio::test]
     async fn fallback_ignores_engine_dirs_and_root_gitignore_outside_a_repository() {
         let dir = tempfile::tempdir().unwrap();

--- a/shell/src/events.rs
+++ b/shell/src/events.rs
@@ -160,6 +160,40 @@ pub(crate) fn merge_kinds(prev: &'static str, next: &'static str) -> &'static st
     }
 }
 
+/// The subset of root-relative `paths` the watch treats as ignored. Inside a
+/// git repository git itself decides. Outside one (compose template projects
+/// are plain directories), fall back to the root `.gitignore` plus a small
+/// built-in set for engine-owned directories — otherwise every internal
+/// state/queue write floods the change feed as reviewable work.
+pub(crate) async fn ignored_under<'a>(
+    root: &Path,
+    paths: impl Iterator<Item = &'a String> + Clone,
+) -> HashSet<String> {
+    if root.join(".git").exists() {
+        return git_ignored(root, paths).await;
+    }
+    let mut builder = ignore::gitignore::GitignoreBuilder::new(root);
+    for line in ["data/", "config/", ".iii/", "node_modules/", ".git/"] {
+        let _ = builder.add_line(None, line);
+    }
+    let gitignore = root.join(".gitignore");
+    if gitignore.is_file() {
+        let _ = builder.add(&gitignore);
+    }
+    let Ok(matcher) = builder.build() else {
+        return HashSet::new();
+    };
+    paths
+        .filter(|rel| {
+            let is_dir = root.join(rel.as_str()).is_dir();
+            matcher
+                .matched_path_or_any_parents(rel.as_str(), is_dir)
+                .is_ignore()
+        })
+        .cloned()
+        .collect()
+}
+
 /// The subset of root-relative `paths` git ignores under `root`. A root
 /// that is not a repository, or a host without git, ignores nothing.
 pub(crate) async fn git_ignored<'a>(
@@ -263,8 +297,18 @@ async fn pump(
                 () = &mut window => break,
             }
         }
-        let ignored_paths = git_ignored(&root, batch.keys()).await;
+        let ignored_paths = ignored_under(&root, batch.keys()).await;
         for (path, kind) in batch.drain() {
+            let on_disk = root.join(&path).exists();
+            // An atomic-write temp (created and renamed away inside one
+            // coalesce window) never existed for an observer: skip it.
+            // A tracked file that vanished mid-window is a real deletion.
+            let kind = match (kind, on_disk) {
+                ("created", false) => continue,
+                ("deleted", _) => "deleted",
+                (_, false) => "deleted",
+                (kind, true) => kind,
+            };
             let dir = kind != "deleted" && root.join(&path).is_dir();
             let ignored = ignored_paths.contains(&path);
             let event = ChangedEvent {
@@ -383,6 +427,42 @@ pub fn register_changed_trigger(iii: &IIIClient, resolver: ResolverCell) {
 
 #[cfg(test)]
 mod tests {
+    #[tokio::test]
+    async fn fallback_ignores_engine_dirs_and_root_gitignore_outside_a_repository() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(root.join(".gitignore"), "*.log\n").unwrap();
+        let paths = [
+            "data/state/a.bin.tmp".to_string(),
+            "config/shell-ui.yaml.tmp".to_string(),
+            "todo/node_modules/x/index.js".to_string(),
+            "build.log".to_string(),
+            "src/main.rs".to_string(),
+        ];
+        let ignored = super::ignored_under(root, paths.iter()).await;
+        assert!(ignored.contains("data/state/a.bin.tmp"));
+        assert!(ignored.contains("config/shell-ui.yaml.tmp"));
+        assert!(ignored.contains("todo/node_modules/x/index.js"));
+        assert!(ignored.contains("build.log"));
+        assert!(!ignored.contains("src/main.rs"));
+    }
+
+    #[tokio::test]
+    async fn fallback_defers_to_git_inside_a_repository() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let status = std::process::Command::new("git")
+            .arg("-C")
+            .arg(root)
+            .args(["init", "-q"])
+            .status()
+            .unwrap();
+        assert!(status.success());
+        let paths = ["data/a.jsonl".to_string()];
+        let ignored = super::ignored_under(root, paths.iter()).await;
+        assert!(ignored.is_empty());
+    }
+
     #[tokio::test]
     async fn git_ignored_reports_only_the_ignored_paths() {
         let dir = tempfile::tempdir().unwrap();

--- a/shell/src/turn_observe.rs
+++ b/shell/src/turn_observe.rs
@@ -23,7 +23,7 @@ use std::time::Duration;
 use notify::{RecursiveMode, Watcher};
 
 use crate::events::{
-    git_ignored, is_git_internal, is_noise_kind, is_own_temp, kind_of, merge_kinds,
+    ignored_under, is_git_internal, is_noise_kind, is_own_temp, kind_of, merge_kinds,
 };
 use crate::turns::TurnLog;
 
@@ -214,6 +214,15 @@ async fn pump(
         let changes: Vec<(String, &'static str)> = batch
             .drain()
             .filter(|(path, _)| !ignored.contains(path))
+            .filter_map(|(path, kind)| {
+                let on_disk = Path::new(&path).exists();
+                match (kind, on_disk) {
+                    ("created", false) => None,
+                    ("deleted", _) => Some((path, "deleted")),
+                    (_, false) => Some((path, "deleted")),
+                    (kind, true) => Some((path, kind)),
+                }
+            })
             .collect();
         if changes.is_empty() {
             continue;
@@ -237,7 +246,7 @@ async fn ignored_set<'a>(root: &Path, paths: impl Iterator<Item = &'a String>) -
                 .map(|rel| (rel.to_string_lossy().into_owned(), abs))
         })
         .collect();
-    let ignored = git_ignored(root, rels.iter().map(|(rel, _)| rel)).await;
+    let ignored = ignored_under(root, rels.iter().map(|(rel, _)| rel)).await;
     rels.into_iter()
         .filter(|(rel, _)| ignored.contains(rel))
         .map(|(_, abs)| abs.clone())

--- a/shell/src/turn_observe.rs
+++ b/shell/src/turn_observe.rs
@@ -23,7 +23,7 @@ use std::time::Duration;
 use notify::{RecursiveMode, Watcher};
 
 use crate::events::{
-    ignored_under, is_git_internal, is_noise_kind, is_own_temp, kind_of, merge_kinds,
+    ignored_under, is_git_internal, is_noise_kind, is_own_temp, kind_of, merge_kinds, resolve_kind,
 };
 use crate::turns::TurnLog;
 
@@ -171,6 +171,7 @@ async fn pump(
             return;
         };
         let mut batch: HashMap<String, &'static str> = HashMap::new();
+        let mut born: HashSet<String> = HashSet::new();
         let mut fold = |event: notify::Event| {
             if is_noise_kind(&event.kind) {
                 return;
@@ -186,8 +187,12 @@ async fn pump(
                 if kind != "deleted" && p.is_dir() {
                     continue;
                 }
+                let key = p.to_string_lossy().into_owned();
+                if kind == "created" {
+                    born.insert(key.clone());
+                }
                 batch
-                    .entry(p.to_string_lossy().into_owned())
+                    .entry(key)
                     .and_modify(|prev| *prev = merge_kinds(prev, kind))
                     .or_insert(kind);
             }
@@ -216,12 +221,8 @@ async fn pump(
             .filter(|(path, _)| !ignored.contains(path))
             .filter_map(|(path, kind)| {
                 let on_disk = Path::new(&path).exists();
-                match (kind, on_disk) {
-                    ("created", false) => None,
-                    ("deleted", _) => Some((path, "deleted")),
-                    (_, false) => Some((path, "deleted")),
-                    (kind, true) => Some((path, kind)),
-                }
+                let kind = resolve_kind(kind, on_disk, born.contains(&path))?;
+                Some((path, kind))
             })
             .collect();
         if changes.is_empty() {

--- a/shell/ui/src/page/ReviewPane.tsx
+++ b/shell/ui/src/page/ReviewPane.tsx
@@ -597,10 +597,15 @@ export function ReviewPane({
       }
       void loadReviewContents(descriptor.host, descriptor.root, descriptor.entry)
         .then<FileState>((contents) => ({ phase: 'ready', ...contents }))
-        .catch<FileState>((error: unknown) => ({
-          phase: 'error',
-          message: errorMessage(error),
-        }))
+        .catch<FileState>((error: unknown) => {
+          const message = errorMessage(error)
+          return {
+            phase: 'error',
+            message: message.includes('"C211"')
+              ? 'file is no longer on disk — a transient write (created and removed within the change window)'
+              : message,
+          }
+        })
         .then((state) => {
           const latest = availableLoadsRef.current.get(path)
           if (latest !== undefined && sameLoadDescriptor(latest, descriptor)) {


### PR DESCRIPTION
## What

Three related fixes that keep engine internals and transient writes out of the shell change feed and turn records, plus one review-pane message fix.

1. **Ignore fallback outside a git repository** (`src/events.rs`). `git_ignored` returns nothing when the watch root is not a repository, which is exactly what `iii project init` templates produce. Every internal write under `data/` and `config/` then lands in Session Changes as reviewable work, and an agent turn that runs `npm install` floods the pane with hundreds of `node_modules` files. New `ignored_under()` defers to git inside a repository and otherwise builds a matcher (via the `ignore` crate) from the root `.gitignore` plus a small builtin set (`data/`, `config/`, `.iii/`, `node_modules/`, `.git/`).
2. **Turn capture uses the same rule** (`src/turn_observe.rs`). The turn observer imported `git_ignored` directly, so Last Turn and Session Changes kept showing the noise even with the feed fixed.
3. **Transient atomic writes are folded away** (`src/events.rs`, `src/turn_observe.rs`). Compose rewrites `worker-compose.yaml` through `worker-compose.compose-edit-<uuid>.tmp`; the temp appeared in turn records as the only change while the real file edit was obscured. At emit time, a path that was created and no longer exists is dropped, and a tracked path that vanished mid-window is reported as deleted.
4. **Review pane message for vanished files** (`ui/src/page/ReviewPane.tsx`). Fetching content for a file that disappeared surfaced the raw handler error (`{"code":"C211", ...}`). It now reads: `file is no longer on disk - a transient write (created and removed within the change window)`.

## Verification

- New unit tests for the fallback (engine dirs, root `.gitignore` patterns, node_modules, and the inside-a-repository path deferring to git); full shell suite passes (1395 tests), `cargo fmt` and `cargo clippy -- -D warnings` clean, ui typecheck/build and vitest suite pass.
- Live-verified on a compose rig (engine 0.23.0-rc.8, template project without git): before, a single agent turn showed 399 files including `node_modules` and `data/*.tmp` rows with raw C211 errors; after, the same class of turn shows only the files the agent actually touched, with proper diffs.
- Repository behavior unchanged inside a git repo: git remains the only authority there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file-change tracking when files are created and removed quickly.
  - Correctly reports missing paths as deleted and ignores stale creation events.
  - Expanded ignore handling for Git repositories and standard engine-managed directories.
  - Review errors for transiently missing files now display a clearer explanation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->