### PR TITLE
fix(deploy): drop unused pyyaml install from descriptor validation

### DIFF
--- a/.github/workflows/_deploy-build.yml
+++ b/.github/workflows/_deploy-build.yml
@@ -85,7 +85,9 @@ jobs:
           UNIT: ${{ inputs.unit }}
         run: |
           set -euo pipefail
-          pip install --quiet pyyaml
+          # jq-only validation: no pyyaml needed, and the x86_64 macOS release
+          # runner has no `pip` on PATH — an install line here fails the whole
+          # build unit before any assertion runs.
           test "$(jq -r .worker deployment-input/deployment-descriptor.json)" = "$WORKER"
           test "$(jq -r .source_sha deployment-input/deployment-descriptor.json)" = "$PREPARED_SHA"
           jq -e --arg unit "$UNIT" --arg target "$TARGET" \


### PR DESCRIPTION
All 10 worker failures in the first nightly auto-deploy batch (2026-08-31, release-control batch `e13976be`) were one cause: the `build <worker>-x86_64-apple-darwin` job on `workers-release-macos-12core` dies at the **Validate immutable descriptor** step with

```
…/_temp/….sh: line 2: pip: command not found
##[error]Process completed with exit code 127.
```

The step is jq-only — `pyyaml` is never used — but it opens with `pip install --quiet pyyaml` under `set -euo pipefail`, and that runner has no `pip` on PATH (it also lacks `sccache`, though the sccache-action installs its own binary for builds). The identical step passed on every other build unit (Linux gnu/musl x86_64/aarch64, armv7, aarch64-apple-darwin).

This drops the unused install. The two `pip install` lines in `deploy-prepare.yml` stay: those steps genuinely run python scripts (`deployment_control_contract.py`, `deployment_train.py`) and execute on ubuntu runners where `pip` exists.

Note for the runner owner: the `workers-release-macos-12core` image should still be reprovisioned (pip + sccache on PATH) — this PR only removes the spurious dependency.

Verification: `pytest .github/scripts/tests/` green; actionlint runs in CI.

https://claude.ai/code/session_01MKFaAGVqL8CcLKaBwL53L9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined deployment validation by removing an unnecessary package installation step.
  * Improved compatibility with macOS release runners that do not include `pip` on the system PATH.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->