### PR TITLE
fix(harness): seed the quickstart compose file only after the daemon boots

### DIFF
--- a/harness/tests/quickstart/run-ci.sh
+++ b/harness/tests/quickstart/run-ci.sh
@@ -659,9 +659,17 @@ ok "installed $cli_version"
 
 log "Step 2/9: Start an empty engine and the compose daemon"
 printf 'workers: []\n' >config.yaml
+start_engine
+wait_for_engine
+start_compose
+wait_for_compose
 # The seed only names the project: `compose::add` writes every container.
 # `namespace: default` is required — harness and Console must register beside
-# the engine builtins, exactly like the flow this validates.
+# the engine builtins, exactly like the flow this validates. Written only
+# AFTER the daemon is up: since 0.23.0-rc.8 the daemon validates the compose
+# file at startup and exits on empty containers (EMPTY_CONTAINERS), while
+# `compose::add` requires the file to exist — so the seed lands between the
+# daemon boot and the first add.
 cat >"$compose_file" <<'COMPOSE'
 namespace: default
 startup_timeout: 5m
@@ -669,10 +677,6 @@ stop_timeout: 10s
 
 containers:
 COMPOSE
-start_engine
-wait_for_engine
-start_compose
-wait_for_compose
 
 log "Step 3/9: Add harness and Console from worker tag $worker_tag via compose"
 run_compose_add "harness@$worker_tag" 2>&1 | tee "$log_dir/compose-add-harness.log"


### PR DESCRIPTION
The first scheduled quickstart smoke (2026-08-31 05:05 UTC, dispatched by release-control) died at 7s with `compose daemon exited before becoming ready`: **iii 0.23.0-rc.8** (published 2026-08-29) now validates the compose file at daemon startup and exits with `error[EMPTY_CONTAINERS]` on the quickstart's deliberately empty seed.

Empirically validated against the real rc.8 CLI (isolated HOME, engine + daemon + registry):

- any pre-existing file with empty containers (`containers:` null, key absent, `containers: {}`) → daemon exits with `EMPTY_CONTAINERS`;
- **no file at startup → daemon boots**, but `compose::add` then fails with `IO_ERROR` (it reads the file, it does not create it);
- **file written after daemon boot, before the first add → everything works**: `compose::add harness@next` returns `{"status":"ok"}` and writes the full resolved container graph (console, cron, iii-directory, …) into the seeded file.

So the fix is ordering only: move the seed heredoc from before `start_engine` to after `wait_for_compose`, with a comment pinning the why. No behavior change on `latest` CLIs (startup validation simply passes there in either order).

Verification: `bash -n` clean; the sequence above reproduced end-to-end locally with the published rc.8. The real E2E proof is the next scheduled smoke at 05:05 UTC.

https://claude.ai/code/session_01MKFaAGVqL8CcLKaBwL53L9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quickstart startup sequencing by waiting for the engine and compose daemon to become ready.
  * Preserved project namespace and timeout settings during worker setup.
  * Enhanced reliability when creating and launching the initial worker configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->