### PR TITLE
fix(harness): give compose::add the script's own timeout instead of the CLI's 30s default

### DIFF
--- a/harness/tests/quickstart/run-ci.sh
+++ b/harness/tests/quickstart/run-ci.sh
@@ -578,12 +578,18 @@ run_compose_add() {
   local spec=$1 payload response
   payload=$(jq -cn --arg file "$compose_file" --arg worker "$spec" \
     '{file: $file, worker: $worker}')
-  log_command "iii trigger compose::add --port $engine_port --json '$payload'"
+  # `iii trigger` waits only 30s for the invocation result by default, far
+  # less than a cold registry install of the full graph on a CI runner —
+  # the CLI must wait as long as the add itself is allowed to run; the
+  # external `timeout` stays as the hard stop against a hung CLI.
+  log_command "iii trigger compose::add --port $engine_port --timeout-ms $((add_timeout_seconds * 1000)) --json '$payload'"
   if command -v timeout >/dev/null 2>&1; then
-    response=$(timeout --signal=TERM --kill-after=15s "$add_timeout_seconds" \
-      "$iii_bin" trigger compose::add --port "$engine_port" --json "$payload")
+    response=$(timeout --signal=TERM --kill-after=15s "$((add_timeout_seconds + 30))" \
+      "$iii_bin" trigger compose::add --port "$engine_port" \
+      --timeout-ms "$((add_timeout_seconds * 1000))" --json "$payload")
   else
-    response=$("$iii_bin" trigger compose::add --port "$engine_port" --json "$payload")
+    response=$("$iii_bin" trigger compose::add --port "$engine_port" \
+      --timeout-ms "$((add_timeout_seconds * 1000))" --json "$payload")
   fi
   printf '%s\n' "$response"
   # A container that failed to start comes back as JSON with status "failed",


### PR DESCRIPTION
Second quickstart attempt (run 33385144395, post-#1023) got past the daemon boot and died 62s in at the first `compose::add`: `Timed out waiting for the engine (no response within the timeout)`. Root cause: `iii trigger` defaults `--timeout-ms` to **30000**, while `compose::add` is synchronous through a cold registry install of the 13-container graph — measured **27.6s** on a warm dev machine, comfortably past 30s on a GitHub runner.

Fix: pass `--timeout-ms $((add_timeout_seconds * 1000))` (default 600s, same knob the script already owns) and keep the external `timeout` wrapper — now with +30s headroom — as the hard stop against a hung CLI.

Validated locally against the real rc.8: engine + daemon + post-boot seed + `compose::add harness@next --timeout-ms 600000` → `{"status":"ok"}`. `bash -n` clean.

https://claude.ai/code/session_01MKFaAGVqL8CcLKaBwL53L9