### PR TITLE
chore(kanban): add the deploy build catalog entry

### DIFF
--- a/.deploy/workers.yaml
+++ b/.deploy/workers.yaml
@@ -854,6 +854,33 @@ workers:
       binary: image-resize
       targets: *id001
     publish: true
+  kanban:
+    source:
+      path: kanban
+      package_manifest: package.json
+    artifact:
+      kind: javascript-bundle
+      workspace_root: kanban
+      runtime:
+        name: node
+        version: 22.20.0
+      package_manager:
+        name: pnpm
+        version: 11.13.1
+      lockfile: pnpm-lock.yaml
+      install_command:
+      - pnpm
+      - install
+      - --ignore-workspace
+      - --frozen-lockfile
+      build_command:
+      - pnpm
+      - run
+      - build:bundle
+      include:
+      - dist/bundle/index.mjs
+      - iii.worker.yaml
+    publish: true
   llm-router:
     source:
       path: llm-router

--- a/.github/scripts/tests/test_worker_compose.py
+++ b/.github/scripts/tests/test_worker_compose.py
@@ -13,8 +13,8 @@ CATALOG = ROOT / ".deploy" / "workers.yaml"
 
 def test_private_catalog_has_exact_first_party_and_fixture_counts():
     workers = _lib.read_worker_catalog(CATALOG)
-    assert len(workers) == 75
-    assert sum(worker.publish for worker in workers.values()) == 69
+    assert len(workers) == 76
+    assert sum(worker.publish for worker in workers.values()) == 70
     assert sum(not worker.publish for worker in workers.values()) == 6
 
 
@@ -100,7 +100,7 @@ def test_release_toolchains_and_bundle_locks_are_explicit():
         else:
             assert artifact["runtime"] == {"name": "python", "version": "3.12.3"}
             assert artifact["package_manager"] == {"name": "uv", "version": "0.12.5"}
-    assert bundles == 15
+    assert bundles == 16
 
 
 def test_scrapling_release_bundle_vendors_dependencies():


### PR DESCRIPTION
## What

Adds the missing `.deploy/workers.yaml` entry for the kanban worker, mirroring the vscode javascript-bundle entry (node 22.20.0, pnpm 11.13.1 per the worker's packageManager pin, `pnpm run build:bundle`, ships `dist/bundle/index.mjs` + `iii.worker.yaml`).

Without a build-catalog entry Release Control cannot plan a release for the worker, so kanban (merged in #982) was absent from the operator picker. `docs/sops/new-worker.md` lists the catalog entry as part of a new worker; #982 missed it.

## Verification

- `test_deployment_compiler.py` and `test_deployment_targets.py` pass (6 tests).
- `deployment_compiler.py compile-index` at this commit emits 70 descriptors including a valid `descriptors/kanban.json` (kind javascript-bundle, correct build command).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deployment support for the Kanban worker.
  * Enabled publishing of the bundled Kanban worker artifact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->