### PR TITLE
(MOT-4614) fix(ci): the deploy catalog now carries 70 workers

### DIFF
--- a/.github/workflows/deploy-descriptor-index.yml
+++ b/.github/workflows/deploy-descriptor-index.yml
@@ -87,7 +87,7 @@ jobs:
           assert index["source_sha"] == os.environ["SOURCE_SHA"]
           assert index["compiler"]["repository"] == os.environ["GITHUB_REPOSITORY"]
           assert index["compiler"]["commit"] == os.environ["SOURCE_SHA"]
-          assert len(index["workers"]) == 69
+          assert len(index["workers"]) == 70
           assert all(entry["publish"] is True for entry in index["workers"].values())
           validator = Draft202012Validator(schema)
           for worker, entry in index["workers"].items():


### PR DESCRIPTION
Refs MOT-4614

The kanban deploy catalog entry (#1025) grew the fleet to 70 workers, but the descriptor-index guard still asserts 69 — every index build since 13:36 UTC failed, leaving no compiled descriptor checkpoint for main and Release Control's /api/workers returning 500 (`compiled descriptor checkpoint is unavailable for 93034570…`). One-character bump to match the catalog.

https://claude.ai/code/session_01HJ71LMZyUZte6UhZ5fgqaQ