### PR TITLE
feat: rc-first executor with candidate/stable target profiles and deploy-finalize

### DIFF
--- a/.deploy/workers.yaml
+++ b/.deploy/workers.yaml
@@ -9,13 +9,15 @@ workers:
         name: rust
         version: 1.97.1
       binary: a2ui
-      targets: &id001
+      candidate_targets: &id001
       - x86_64-apple-darwin
       - aarch64-apple-darwin
       - x86_64-unknown-linux-gnu
       - x86_64-unknown-linux-musl
       - aarch64-unknown-linux-gnu
       - armv7-unknown-linux-gnueabihf
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: a2ui/ui
@@ -47,7 +49,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: iii-acp
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
     publish: true
   approval-gate:
     source:
@@ -59,7 +63,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: approval-gate
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: harness/ui
@@ -91,7 +97,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: bridge
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
     publish: true
   browser:
     source:
@@ -103,7 +111,15 @@ workers:
         name: rust
         version: 1.97.1
       binary: browser
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets:
+      - x86_64-apple-darwin
+      - aarch64-apple-darwin
+      - x86_64-unknown-linux-gnu
+      - x86_64-unknown-linux-musl
+      - aarch64-unknown-linux-gnu
+      - armv7-unknown-linux-gnueabihf
+      - x86_64-pc-windows-msvc
       frontends:
       - workspace_root: .
         source_path: browser/ui
@@ -135,7 +151,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: canvas
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: canvas/ui
@@ -194,12 +212,19 @@ workers:
         name: rust
         version: 1.97.1
       binary: code-runner
-      targets:
+      candidate_targets:
       - x86_64-apple-darwin
       - aarch64-apple-darwin
       - x86_64-unknown-linux-gnu
       - x86_64-unknown-linux-musl
       - aarch64-unknown-linux-gnu
+      stable_targets:
+      - x86_64-apple-darwin
+      - aarch64-apple-darwin
+      - x86_64-unknown-linux-gnu
+      - x86_64-unknown-linux-musl
+      - aarch64-unknown-linux-gnu
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: code-runner/ui
@@ -267,7 +292,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: codex
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
     publish: true
   compose-ui:
     source:
@@ -306,7 +333,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: computer
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: computer/ui
@@ -338,7 +367,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: console
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: console/ui
@@ -389,7 +420,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: context-manager
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: context-manager/ui
@@ -421,7 +454,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: cron
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: cron/ui
@@ -480,7 +515,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: database
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: database/ui
@@ -558,7 +595,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: devin
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
     publish: true
   document:
     source:
@@ -570,7 +609,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: document
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
     publish: true
   editor:
     source:
@@ -582,7 +623,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: editor
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: editor/ui
@@ -614,7 +657,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: email
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
     publish: true
   eval:
     source:
@@ -626,7 +671,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: eval
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: eval/ui
@@ -677,7 +724,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: fp
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
     publish: true
   github:
     source:
@@ -689,7 +738,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: github
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: github/ui
@@ -721,7 +772,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: grok
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
     publish: true
   harness:
     source:
@@ -733,7 +786,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: harness
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: harness/ui
@@ -777,7 +832,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: http
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
     publish: true
   iii-directory:
     source:
@@ -789,7 +846,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: iii-directory
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: iii-directory/ui
@@ -852,7 +911,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: image-resize
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
     publish: true
   kanban:
     source:
@@ -891,7 +952,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: llm-router
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: llm-router/ui
@@ -923,7 +986,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: lsp
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
     publish: true
   mcp:
     source:
@@ -935,7 +1000,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: mcp
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
     publish: true
   memory:
     source:
@@ -947,7 +1014,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: memory
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: memory/ui
@@ -979,7 +1048,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: memory-consolidate
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
     publish: true
   opencode:
     source:
@@ -1072,7 +1143,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: pdf
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: pdf/ui
@@ -1131,7 +1204,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: provider-anthropic
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: llm-router/ui
@@ -1163,7 +1238,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: provider-claude-code
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: llm-router/ui
@@ -1195,7 +1272,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: provider-command-code
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: llm-router/ui
@@ -1227,7 +1306,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: provider-deepseek
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: llm-router/ui
@@ -1259,7 +1340,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: provider-github-copilot
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: llm-router/ui
@@ -1291,7 +1374,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: provider-kimi
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: llm-router/ui
@@ -1323,7 +1408,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: provider-llamacpp
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: llm-router/ui
@@ -1355,7 +1442,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: provider-openai
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: llm-router/ui
@@ -1387,7 +1476,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: provider-openai-codex
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: llm-router/ui
@@ -1438,7 +1529,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: provider-opencode-go
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: llm-router/ui
@@ -1470,7 +1563,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: provider-openrouter
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: llm-router/ui
@@ -1502,7 +1597,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: provider-xai
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: llm-router/ui
@@ -1534,7 +1631,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: provider-zai
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: llm-router/ui
@@ -1566,7 +1665,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: pubsub
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
     publish: true
   queue:
     source:
@@ -1578,7 +1679,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: queue
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
     publish: true
   rbac-proxy:
     source:
@@ -1590,7 +1693,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: rbac-proxy
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
     publish: true
   fixture-rbac-proxy-harness:
     source:
@@ -1635,7 +1740,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: sandbox-code-runner
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: sandbox-code-runner/ui
@@ -1707,7 +1814,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: security-scan
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: security-scan/ui
@@ -1739,7 +1848,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: session-manager
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
     publish: true
   shell:
     source:
@@ -1751,13 +1862,21 @@ workers:
         name: rust
         version: 1.97.1
       binary: shell
-      targets:
+      candidate_targets:
       - x86_64-apple-darwin
       - aarch64-apple-darwin
       - x86_64-unknown-linux-gnu
       - x86_64-unknown-linux-musl
       - aarch64-unknown-linux-gnu
       - armv7-unknown-linux-gnueabihf
+      stable_targets:
+      - x86_64-apple-darwin
+      - aarch64-apple-darwin
+      - x86_64-unknown-linux-gnu
+      - x86_64-unknown-linux-musl
+      - aarch64-unknown-linux-gnu
+      - armv7-unknown-linux-gnueabihf
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: shell/ui
@@ -1840,7 +1959,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: slack
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
     publish: true
   state:
     source:
@@ -1852,7 +1973,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: state
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: state/ui
@@ -1884,7 +2007,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: storage
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: storage/ui
@@ -1952,7 +2077,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: tailscale
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: tailscale/ui
@@ -1984,7 +2111,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: telegram-bot
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
     publish: true
   vscode:
     source:
@@ -2023,7 +2152,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: web
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: web/ui
@@ -2055,7 +2186,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: workflow
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
     publish: true
   worktree:
     source:
@@ -2067,7 +2200,9 @@ workers:
         name: rust
         version: 1.97.1
       binary: worktree
-      targets: *id001
+      candidate_targets: *id001
+      stable_targets: *id001
+      windows_exception: Windows support has not been validated for this worker
       frontends:
       - workspace_root: .
         source_path: worktree/ui

--- a/.github/contracts/deployment-descriptor.schema.json
+++ b/.github/contracts/deployment-descriptor.schema.json
@@ -123,12 +123,14 @@
     "rustArtifact": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["kind", "toolchain", "binary", "targets"],
+      "required": ["kind", "toolchain", "binary", "candidate_targets", "stable_targets"],
       "properties": {
         "kind": {"const": "rust-binary"},
         "toolchain": {"$ref": "#/$defs/identityVersion"},
         "binary": {"type": "string", "minLength": 1},
-        "targets": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+        "candidate_targets": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+        "stable_targets": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+        "windows_exception": {"type": "string", "minLength": 1},
         "frontends": {"type": "array", "items": {"$ref": "#/$defs/frontend"}}
       }
     },

--- a/.github/contracts/deployment-execution.schema.json
+++ b/.github/contracts/deployment-execution.schema.json
@@ -15,13 +15,21 @@
       "required": ["worker", "phase", "source_sha", "prepared_sha", "target_version", "channel", "descriptor_sha256"],
       "properties": {
         "worker": { "$ref": "#/$defs/worker" },
-        "phase": { "enum": ["prepare", "publish", "verify"] },
+        "phase": { "enum": ["prepare", "publish", "finalize", "verify"] },
         "source_sha": { "$ref": "#/$defs/sha" },
         "prepared_sha": { "oneOf": [{ "$ref": "#/$defs/sha" }, { "type": "null" }] },
         "target_version": { "$ref": "#/$defs/deploymentVersion" },
         "channel": { "enum": ["next", "latest"] },
-        "descriptor_sha256": { "$ref": "#/$defs/sha256" }
-      }
+        "descriptor_sha256": { "$ref": "#/$defs/sha256" },
+        "candidate_version": { "$ref": "#/$defs/candidateVersion" }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "phase": { "const": "finalize" } }, "required": ["phase"] },
+          "then": { "required": ["candidate_version"] },
+          "else": { "not": { "required": ["candidate_version"] } }
+        }
+      ]
     },
     "outcome": { "enum": ["succeeded", "failed", "canceled"] },
     "effects": {
@@ -79,7 +87,8 @@
     "uuid": { "type": "string", "format": "uuid" },
     "sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
     "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
-    "deploymentVersion": { "type": "string", "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-(?:experimental|alpha|beta))?$" },
+    "deploymentVersion": { "type": "string", "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-(?:experimental|alpha|beta|rc\\.[1-9][0-9]*))?$" },
+    "candidateVersion": { "type": "string", "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)-rc\\.[1-9][0-9]*$" },
     "worker": { "type": "string", "pattern": "^[a-z0-9][a-z0-9_-]*$" },
     "identity": {
       "type": "object",

--- a/.github/deployment-control-contract.json
+++ b/.github/deployment-control-contract.json
@@ -1,6 +1,6 @@
 {
   "repository": "iii-hq/release-control",
-  "commit": "cb940c0036192b68ce1deb9c70cdc0ffa0c438ed",
+  "commit": "d9cf220cd843bde4ea03dc122bcd3a8d495aef26",
   "path": "api/contracts/deployment-execution.schema.json",
-  "sha256": "dc51f42d89626f0d554b94965b49aace257726a0b77010c4be05e22c6eb44196"
+  "sha256": "c9cd573a793ef8287e6d75814f4c7d474449e10dcec2238ff0d85648c6fb6784"
 }

--- a/.github/scripts/_lib.py
+++ b/.github/scripts/_lib.py
@@ -22,7 +22,7 @@ DEPLOYMENT_TARGET_VERSION_RE = re.compile(
     r"^(?:0|[1-9][0-9]*)\."
     r"(?:0|[1-9][0-9]*)\."
     r"(?:0|[1-9][0-9]*)"
-    r"(?:-(?:experimental|alpha|beta))?$"
+    r"(?:-(?:experimental|alpha|beta|rc\.[1-9][0-9]*))?$"
 )
 RELEASE_MATURITIES = ("experimental", "alpha", "beta", "rc", "stable")
 RELEASE_SUFFIXES = ("none", "experimental", "alpha", "beta")
@@ -72,13 +72,43 @@ def parse_release_version(version: str) -> ReleaseVersion:
 
 
 def validate_deployment_target_version(version: str) -> str:
-    """Validate a new deployment target without accepting legacy numbered RCs."""
+    """Validate a new deployment target against the release version grammar."""
     if not DEPLOYMENT_TARGET_VERSION_RE.fullmatch(version):
         raise ValueError(
             "deployment target version must be MAJOR.MINOR.PATCH with an optional "
-            "-experimental, -alpha, or -beta suffix"
+            "-experimental, -alpha, -beta, or -rc.N suffix"
         )
     return version
+
+
+def validate_channel_target_version(channel: str, version: str) -> str:
+    """Enforce the channel/version-form contract of the rc-first flow.
+
+    `latest` only ever receives pure MAJOR.MINOR.PATCH versions minted by
+    release finalization. `next` accepts any in-grammar version today; the
+    suffixed-only invariant for `next` lands after the rc flip is live, so the
+    nightly window never gets stuck between executor and orchestrator deploys.
+    """
+    if channel not in {"next", "latest"}:
+        raise ValueError("deployment channel must be next or latest")
+    validate_deployment_target_version(version)
+    if channel == "latest" and "-" in version:
+        raise ValueError(f"latest deployments require a pure MAJOR.MINOR.PATCH version, got {version}")
+    return version
+
+
+def validate_finalization(candidate: str, stable: str) -> None:
+    """Require a numbered rc candidate and the pure stable of the same core."""
+    parsed_candidate = parse_release_version(candidate)
+    if parsed_candidate.maturity != "rc":
+        raise ValueError(f"finalization candidate must be an X.Y.Z-rc.N version, got {candidate}")
+    parsed_stable = parse_release_version(stable)
+    if parsed_stable.maturity != "stable":
+        raise ValueError(f"finalization stable must be a pure MAJOR.MINOR.PATCH version, got {stable}")
+    if parsed_candidate.core != parsed_stable.core:
+        raise ValueError(
+            f"finalization stable {stable} must share the candidate core {parsed_candidate.core_text}"
+        )
 
 
 def release_maturity(version: str) -> str:
@@ -500,9 +530,10 @@ def read_worker_catalog(path: Path | None = None) -> dict[str, WorkerSpec]:
         if not isinstance(manifest, str) or not manifest:
             raise ValueError(f"{catalog_path}: workers.{catalog_id}.source.package_manifest is required")
         if artifact_kind == "rust-binary":
-            targets = artifact.get("targets")
-            if not isinstance(targets, list) or not targets or not all(isinstance(target, str) for target in targets):
-                raise ValueError(f"{catalog_path}: workers.{catalog_id}.artifact.targets must be non-empty")
+            for field in ("candidate_targets", "stable_targets"):
+                targets = artifact.get(field)
+                if not isinstance(targets, list) or not targets or not all(isinstance(target, str) for target in targets):
+                    raise ValueError(f"{catalog_path}: workers.{catalog_id}.artifact.{field} must be non-empty")
             if not isinstance(binary, str) or not binary:
                 raise ValueError(f"{catalog_path}: workers.{catalog_id}.artifact.binary is required")
         public = read_iii_worker_yaml(worker_path)

--- a/.github/scripts/deployment_compiler.py
+++ b/.github/scripts/deployment_compiler.py
@@ -237,7 +237,10 @@ def validate_artifact(
     if kind not in ARTIFACT_KINDS:
         fail(f"workers.{worker}.artifact.kind is unsupported")
     allowed_fields = {
-        "rust-binary": {"kind", "toolchain", "binary", "targets", "frontends"},
+        "rust-binary": {
+            "kind", "toolchain", "binary", "candidate_targets", "stable_targets",
+            "windows_exception", "frontends",
+        },
         "javascript-bundle": {
             "kind", "workspace_root", "runtime", "package_manager", "lockfile",
             "install_command", "build_command", "include",
@@ -258,16 +261,41 @@ def validate_artifact(
         fail(f"{worker}: iii.worker.yaml deploy={deploy!r} conflicts with artifact.kind={kind!r}")
     if kind == "rust-binary":
         binary = artifact.get("binary")
-        targets = artifact.get("targets")
         if not isinstance(binary, str) or not binary:
             fail(f"workers.{worker}.artifact.binary is required")
         if binary != str(manifest.get("bin") or worker):
             fail(f"{worker}: public bin and private artifact.binary differ")
-        if not isinstance(targets, list) or not targets or any(not isinstance(target, str) for target in targets):
-            fail(f"workers.{worker}.artifact.targets must be a non-empty string array")
+        for field in ("candidate_targets", "stable_targets"):
+            targets = artifact.get(field)
+            if not isinstance(targets, list) or not targets or any(
+                not isinstance(target, str) or not target for target in targets
+            ):
+                fail(f"workers.{worker}.artifact.{field} must be a non-empty string array")
+            if len(set(targets)) != len(targets):
+                fail(f"workers.{worker}.artifact.{field} contains duplicate targets")
+        candidate_targets = artifact["candidate_targets"]
+        stable_targets = artifact["stable_targets"]
+        # Candidates are the nightly rc surface: Windows bytes only ever exist
+        # for finalized stable versions, built as the stable-delta profile.
+        windows_targets = [target for target in candidate_targets if "windows" in target]
+        if windows_targets:
+            fail(f"workers.{worker}.artifact.candidate_targets cannot include Windows targets: {windows_targets}")
+        missing = [target for target in candidate_targets if target not in stable_targets]
+        if missing:
+            fail(f"workers.{worker}: candidate_targets must be a subset of stable_targets, missing {missing}")
+        # Windows absence must be a justified decision, never a silent omission.
+        windows_declared = "x86_64-pc-windows-msvc" in stable_targets
+        windows_exception = artifact.get("windows_exception")
+        if windows_declared and windows_exception is not None:
+            fail(f"workers.{worker}: declares both Windows support and a windows_exception")
+        if not windows_declared and (not isinstance(windows_exception, str) or not windows_exception.strip()):
+            fail(
+                f"workers.{worker}: must either include x86_64-pc-windows-msvc in stable_targets "
+                "or justify its absence with windows_exception"
+            )
         public_targets = manifest.get("targets")
-        if public_targets is not None and public_targets != targets:
-            fail(f"{worker}: public targets and private artifact.targets differ")
+        if public_targets is not None and public_targets != stable_targets:
+            fail(f"{worker}: public targets and private artifact.stable_targets differ")
         toolchain = artifact.get("toolchain")
         if not isinstance(toolchain, dict) or set(toolchain) != {"name", "version"}:
             fail(f"workers.{worker}.artifact.toolchain must contain only name and version")
@@ -365,9 +393,12 @@ def validate_artifact(
 def build_units(worker: str, artifact: dict[str, Any]) -> list[dict[str, Any]]:
     kind = str(artifact["kind"])
     if kind == "rust-binary":
+        # Build units describe the candidate profile: release candidates only
+        # ever build these. Stable-delta units (Windows) are derived at
+        # finalization from stable_targets - candidate_targets.
         return [
             {"id": f"{worker}-{target}", "kind": kind, "target": target}
-            for target in artifact["targets"]
+            for target in artifact["candidate_targets"]
         ]
     if kind == "oci-image":
         return [

--- a/.github/scripts/deployment_control_contract.py
+++ b/.github/scripts/deployment_control_contract.py
@@ -21,6 +21,7 @@ import _lib
 PHASES = {
     "prepare",
     "publish",
+    "finalize",
     "verify",
 }
 PHASE_WORKFLOWS = {phase: f"deploy-{phase.replace('_', '-')}.yml" for phase in PHASES}
@@ -80,6 +81,19 @@ def deployment_channel(value: str) -> str:
 
 def target_version(value: str) -> str:
     return _lib.validate_deployment_target_version(value)
+
+
+def channel_target_version(channel: str, version: str) -> str:
+    """The channel/version-form gate: latest only ever receives pure versions."""
+    return _lib.validate_channel_target_version(channel, version)
+
+
+def candidate_version(value: str | None, stable: str) -> str | None:
+    """Validate the finalize-phase rc candidate against its stable version."""
+    if value is None:
+        return None
+    _lib.validate_finalization(value, stable)
+    return value
 
 
 def validate_executor(args: argparse.Namespace) -> None:
@@ -198,6 +212,19 @@ def write_result(args: argparse.Namespace) -> int:
     if args.workflow != PHASE_WORKFLOWS[args.phase]:
         raise ValueError(f"phase {args.phase} requires workflow {PHASE_WORKFLOWS[args.phase]}")
     prepared_sha = nullable(args.prepared_sha)
+    candidate = nullable(args.candidate_version)
+    if args.phase == "finalize":
+        # A finalize subject binds the rc candidate to its stable version: the
+        # bytes are the rc's, the channel move is latest, and no new source
+        # revision exists (prepared_sha is the rc's source_sha).
+        if candidate is None:
+            raise ValueError("finalize results require --candidate-version")
+        if args.channel != "latest":
+            raise ValueError("finalize results require channel=latest")
+        if prepared_sha != args.source_sha:
+            raise ValueError("finalize results require prepared_sha equal to source_sha")
+    elif candidate is not None:
+        raise ValueError(f"phase {args.phase} does not accept --candidate-version")
     payload = {
         "contract": "deployment-execution",
         "identity": {
@@ -221,9 +248,14 @@ def write_result(args: argparse.Namespace) -> int:
             "phase": args.phase,
             "source_sha": commit_sha(args.source_sha, "source_sha"),
             "prepared_sha": commit_sha(prepared_sha, "prepared_sha") if prepared_sha else None,
-            "target_version": target_version(args.target_version),
-            "channel": deployment_channel(args.channel),
+            "target_version": channel_target_version(deployment_channel(args.channel), args.target_version),
+            "channel": args.channel,
             "descriptor_sha256": sha256_hex(args.descriptor_sha256, "descriptor_sha256"),
+            **(
+                {"candidate_version": candidate_version(candidate, args.target_version)}
+                if args.phase == "finalize"
+                else {}
+            ),
         },
         "outcome": args.outcome,
         "effects": validate_effects(args.effects),
@@ -305,8 +337,8 @@ def authorize_dispatch(args: argparse.Namespace) -> int:
         "subject": {
             "worker": validate_worker(args.worker),
             "source_sha": commit_sha(args.source_sha, "source_sha"),
-            "target_version": target_version(args.target_version),
-            "channel": deployment_channel(args.channel),
+            "target_version": channel_target_version(deployment_channel(args.channel), args.target_version),
+            "channel": args.channel,
             "descriptor_sha256": sha256_hex(args.descriptor_sha256, "descriptor_sha256"),
         },
     }
@@ -391,6 +423,7 @@ def parser() -> argparse.ArgumentParser:
     write.add_argument("--phase", choices=sorted(PHASES), required=True)
     write.add_argument("--source-sha", required=True)
     write.add_argument("--prepared-sha", default="none")
+    write.add_argument("--candidate-version", default="none")
     write.add_argument("--target-version", required=True)
     write.add_argument("--channel", choices=["next", "latest"], required=True)
     write.add_argument("--descriptor-sha256", required=True)

--- a/.github/scripts/deployment_targets.py
+++ b/.github/scripts/deployment_targets.py
@@ -14,6 +14,17 @@ DEFAULT_TARGETS = [
     "armv7-unknown-linux-gnueabihf",
 ]
 
+# Windows targets are stable-profile only: they are never built for release
+# candidates and only ever enter a worker's `stable_targets` by explicit
+# opt-in. x86_64 is the only supported triple today; i686/aarch64 msvc extend
+# this map without redesign when product support lands.
+WINDOWS_TARGETS = [
+    "x86_64-pc-windows-msvc",
+]
+
+# Canonical ordering for every declarable target across both profiles.
+ALL_TARGETS = [*DEFAULT_TARGETS, *WINDOWS_TARGETS]
+
 TARGET_RUNNERS = {
     "x86_64-apple-darwin": "macos-latest",
     "aarch64-apple-darwin": "macos-latest",
@@ -21,6 +32,7 @@ TARGET_RUNNERS = {
     "x86_64-unknown-linux-musl": "ubuntu-latest",
     "aarch64-unknown-linux-gnu": "ubuntu-22.04",
     "armv7-unknown-linux-gnueabihf": "ubuntu-22.04",
+    "x86_64-pc-windows-msvc": "windows-latest",
 }
 
 # The release runner group is restricted to the release workflows on main.
@@ -35,16 +47,19 @@ TARGET_LARGER_RUNNERS = {
     "x86_64-unknown-linux-musl": "workers-release-linux-8core",
     "aarch64-unknown-linux-gnu": "workers-release-linux-8core",
     "armv7-unknown-linux-gnueabihf": "workers-release-linux-8core",
+    # Windows builds only run at finalization (stable-delta) and use
+    # GitHub-hosted capacity until a dedicated pool proves necessary.
+    "x86_64-pc-windows-msvc": "windows-latest",
 }
 
 
-def normalize_targets(raw: object, *, deploy: str | None = "binary") -> list[str]:
-    """Return canonical targets, rejecting Windows and unknown triples.
+def normalize_targets(raw: object, *, deploy: str | None = "binary", allow_windows: bool = False) -> list[str]:
+    """Return canonical targets, rejecting unknown triples.
 
-    An omitted target list means every supported Unix target for binaries. A
-    non-binary worker has no executable target matrix, but an explicit Windows
-    entry is still rejected so manifests cannot silently advertise unsupported
-    artifacts.
+    An omitted target list means every supported Unix target for binaries.
+    Windows triples are accepted only when `allow_windows` is set — the
+    stable profile of an explicitly opted-in worker — so candidate manifests
+    can never silently advertise unsupported artifacts.
     """
     if raw is None or raw == "":
         return list(DEFAULT_TARGETS) if deploy == "binary" else []
@@ -64,10 +79,12 @@ def normalize_targets(raw: object, *, deploy: str | None = "binary") -> list[str
             if "windows" in target:
                 raise ValueError(f"Windows release target is not supported: {target}")
             raise ValueError(f"unknown release target: {target}")
+        if target in WINDOWS_TARGETS and not allow_windows:
+            raise ValueError(f"Windows release target is stable-profile only: {target}")
         if target in requested:
             raise ValueError(f"duplicate release target: {target}")
         requested.append(target)
 
     if deploy == "binary" and not requested:
         raise ValueError("binary workers must declare at least one Unix release target")
-    return [target for target in DEFAULT_TARGETS if target in requested]
+    return [target for target in ALL_TARGETS if target in requested]

--- a/.github/scripts/deployment_train.py
+++ b/.github/scripts/deployment_train.py
@@ -273,7 +273,9 @@ def build_frontends(args: argparse.Namespace) -> int:
 
 def build_metadata(args: argparse.Namespace) -> int:
     descriptor = verify_descriptor(json.loads(args.descriptor.read_bytes()))
-    units = [unit for unit in descriptor["build_units"] if isinstance(unit, dict) and unit.get("id") == args.unit]
+    # The stable profile is the full unit universe: candidate units plus the
+    # supplemental (Windows) units built only at finalization.
+    units = [unit for unit in profile_units(descriptor, "stable") if unit.get("id") == args.unit]
     if len(units) != 1:
         raise SystemExit(f"build unit {args.unit!r} is not declared exactly once")
     artifact = descriptor["artifact"]
@@ -428,9 +430,10 @@ def prepare(args: argparse.Namespace) -> int:
     actual = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
     if actual != args.source_sha:
         raise SystemExit(f"source SHA mismatch: checkout={actual}, requested={args.source_sha}")
-    _lib.validate_deployment_target_version(args.target_version)
-    if args.channel not in {"next", "latest"}:
-        raise SystemExit("deployment channel must be next or latest")
+    try:
+        _lib.validate_channel_target_version(args.channel, args.target_version)
+    except ValueError as error:
+        raise SystemExit(str(error)) from error
 
     descriptor = verify_descriptor(json.loads(args.descriptor.read_bytes()))
     expected = {
@@ -444,10 +447,75 @@ def prepare(args: argparse.Namespace) -> int:
     return 0
 
 
+def finalize(args: argparse.Namespace) -> int:
+    """Validate a finalize_release intent against the immutable rc origin.
+
+    The stable version reuses the rc bytes, so the descriptor identity, the
+    annotated rc tag, and the release history must all prove the candidate
+    before any supplemental build or channel move happens.
+    """
+    actual = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+    if actual != args.source_sha:
+        raise SystemExit(f"source SHA mismatch: checkout={actual}, requested={args.source_sha}")
+    try:
+        _lib.validate_finalization(args.candidate_version, args.stable_version)
+        _lib.validate_channel_target_version("latest", args.stable_version)
+    except ValueError as error:
+        raise SystemExit(str(error)) from error
+
+    descriptor = verify_descriptor(json.loads(args.descriptor.read_bytes()))
+    expected = {
+        "worker": args.worker,
+        "source_sha": args.source_sha,
+        "descriptor_sha256": args.descriptor_sha256,
+    }
+    if any(descriptor[field] != value for field, value in expected.items()):
+        raise SystemExit("selected descriptor identity differs from finalization intent")
+
+    # Requires a full clone (fetch-depth 0): the rc tag proves the candidate
+    # was published from this exact source, and the history gate proves the
+    # stable core is not moving backwards.
+    versions = _lib.list_tagged_versions(args.worker)
+    if args.candidate_version not in versions:
+        raise SystemExit(f"candidate tag {args.worker}/v{args.candidate_version} is not in the git history")
+    try:
+        _lib.validate_release_history(args.stable_version, versions)
+    except ValueError as error:
+        raise SystemExit(str(error)) from error
+    print(json.dumps(descriptor, sort_keys=True))
+    return 0
+
+
+def profile_units(descriptor: dict, profile: str) -> list[dict]:
+    """Resolve build units for a target profile.
+
+    `candidate` is the descriptor's embedded build_units. For rust binaries,
+    `stable` adds the supplemental targets declared only in stable_targets and
+    `stable-delta` is just that supplement; other artifact kinds have an empty
+    delta and identical candidate/stable profiles.
+    """
+    units = [unit for unit in descriptor["build_units"] if isinstance(unit, dict)]
+    if profile == "candidate":
+        return units
+    artifact = descriptor["artifact"]
+    kind = str(artifact.get("kind"))
+    if kind != "rust-binary":
+        return units if profile == "stable" else []
+    candidate_targets = set(artifact["candidate_targets"])
+    delta_units = [
+        {"id": f"{descriptor['worker']}-{target}", "kind": kind, "target": target}
+        for target in artifact["stable_targets"]
+        if target not in candidate_targets
+    ]
+    if profile == "stable-delta":
+        return delta_units
+    return units + delta_units
+
+
 def matrix(args: argparse.Namespace) -> int:
     descriptor = verify_descriptor(json.loads(args.descriptor.read_text(encoding="utf-8")))
     include: list[dict[str, str]] = []
-    for unit in descriptor["build_units"]:
+    for unit in profile_units(descriptor, args.profile):
         if not isinstance(unit, dict):
             raise SystemExit("build unit must be an object")
         kind = str(unit.get("kind"))
@@ -468,7 +536,7 @@ def build(args: argparse.Namespace) -> int:
     actual = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
     if actual != descriptor["source_sha"]:
         raise SystemExit(f"prepared SHA mismatch: checkout={actual}, descriptor={descriptor['source_sha']}")
-    units = [unit for unit in descriptor["build_units"] if isinstance(unit, dict) and unit.get("id") == args.unit]
+    units = [unit for unit in profile_units(descriptor, "stable") if unit.get("id") == args.unit]
     if len(units) != 1:
         raise SystemExit(f"build unit {args.unit!r} is not declared exactly once")
     unit = units[0]
@@ -589,10 +657,9 @@ def assemble(args: argparse.Namespace) -> int:
     return 0
 
 
-def verify_prepared(args: argparse.Namespace) -> int:
-    """Verify the immutable prepare inventory without executing the worker."""
-    descriptor = verify_descriptor(json.loads(args.descriptor.read_bytes()))
-    prepared = json.loads(args.prepared.read_text(encoding="utf-8"))
+def _verify_prepared_inventory(descriptor: dict, descriptor_path: Path, prepared_path: Path) -> dict:
+    """Validate a prepared inventory and its directory byte-for-byte."""
+    prepared = json.loads(prepared_path.read_text(encoding="utf-8"))
     expected = {
         "contract": "prepared-artifacts",
         "worker": descriptor["worker"],
@@ -614,22 +681,76 @@ def verify_prepared(args: argparse.Namespace) -> int:
         if not isinstance(name, str) or not name or Path(name).name != name or name in names:
             raise SystemExit(f"prepared artifact name is invalid or duplicated: {name!r}")
         names.add(name)
-        path = args.prepared.parent / name
+        path = prepared_path.parent / name
         if not path.is_file() or path.is_symlink():
             raise SystemExit(f"prepared artifact is not a regular file: {path}")
         if path.stat().st_size != artifact.get("size") or sha256(path) != artifact.get("sha256"):
             raise SystemExit(f"prepared artifact bytes differ from inventory: {path}")
     actual = {
-        path.name for path in args.prepared.parent.iterdir()
+        path.name for path in prepared_path.parent.iterdir()
         if path.is_file() and not path.is_symlink()
     }
-    expected_files = names | {args.descriptor.name, args.prepared.name}
+    expected_files = names | {descriptor_path.name, prepared_path.name}
     if actual != expected_files:
         raise SystemExit(
             f"prepared directory differs from inventory: missing={sorted(expected_files - actual)} "
             f"unknown={sorted(actual - expected_files)}"
         )
+    return prepared
+
+
+def verify_prepared(args: argparse.Namespace) -> int:
+    """Verify the immutable prepare inventory without executing the worker."""
+    descriptor = verify_descriptor(json.loads(args.descriptor.read_bytes()))
+    prepared = _verify_prepared_inventory(descriptor, args.descriptor, args.prepared)
     print(json.dumps(prepared, sort_keys=True))
+    return 0
+
+
+def assemble_stable(args: argparse.Namespace) -> int:
+    """Union verified rc bytes with supplemental builds into a stable inventory.
+
+    Nothing already proved for the candidate is rebuilt: the rc files are
+    copied byte-for-byte, the supplemental (stable-delta) build results are
+    validated exactly like `assemble` validates candidate builds, and the
+    result must cover the stable profile exactly.
+    """
+    descriptor_bytes = args.descriptor.read_bytes()
+    descriptor = verify_descriptor(json.loads(descriptor_bytes))
+    prepared = _verify_prepared_inventory(descriptor, args.descriptor, args.prepared)
+    args.out.mkdir(parents=True, exist_ok=True)
+    entries: list[dict[str, object]] = []
+    for artifact in prepared["artifacts"]:
+        source = args.prepared.parent / str(artifact["name"])
+        destination = args.out / source.name
+        if destination.exists():
+            raise SystemExit(f"duplicate artifact name {destination.name}")
+        shutil.copy2(source, destination)
+        entries.append(dict(artifact))
+    for result_path in sorted(args.supplemental_dir.rglob("build-result.json")) if args.supplemental_dir.is_dir() else []:
+        result = json.loads(result_path.read_text(encoding="utf-8"))
+        if result.get("descriptor_sha256") != descriptor["descriptor_sha256"]:
+            raise SystemExit(f"{result_path}: descriptor digest mismatch")
+        unit = result.get("unit")
+        for artifact in result.get("artifacts", []):
+            source = result_path.parent / artifact["name"]
+            if not source.is_file() or sha256(source) != artifact["sha256"] or source.stat().st_size != artifact["size"]:
+                raise SystemExit(f"{source}: artifact bytes differ from build result")
+            destination = args.out / source.name
+            if destination.exists():
+                raise SystemExit(f"duplicate artifact name {destination.name}")
+            shutil.copy2(source, destination)
+            entries.append({"unit": unit, **artifact})
+    expected_units = {unit["id"] for unit in profile_units(descriptor, "stable")}
+    actual_units = {entry["unit"] for entry in entries if entry["role"] != "checksum"}
+    if expected_units != actual_units:
+        raise SystemExit(f"stable units differ: expected={sorted(expected_units)} actual={sorted(actual_units)}")
+    (args.out / "deployment-descriptor.json").write_bytes(descriptor_bytes)
+    stable = {"contract": "prepared-artifacts", "worker": descriptor["worker"],
+              "source_sha": descriptor["source_sha"], "descriptor_sha256": descriptor["descriptor_sha256"],
+              "artifacts": sorted(entries, key=lambda entry: (str(entry["unit"]), str(entry["name"])))}
+    (args.out / "prepared-artifacts.json").write_text(json.dumps(stable, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(stable, sort_keys=True))
     return 0
 
 
@@ -665,9 +786,18 @@ def make_parser() -> argparse.ArgumentParser:
     prepare_parser.add_argument("--channel", choices=["next", "latest"], required=True)
     prepare_parser.add_argument("--descriptor-sha256", required=True)
     prepare_parser.add_argument("--descriptor", type=Path, required=True)
+    finalize_parser = sub.add_parser("finalize")
+    finalize_parser.set_defaults(handler=finalize)
+    finalize_parser.add_argument("--worker", required=True)
+    finalize_parser.add_argument("--source-sha", required=True)
+    finalize_parser.add_argument("--candidate-version", required=True)
+    finalize_parser.add_argument("--stable-version", required=True)
+    finalize_parser.add_argument("--descriptor-sha256", required=True)
+    finalize_parser.add_argument("--descriptor", type=Path, required=True)
     matrix_parser = sub.add_parser("matrix")
     matrix_parser.set_defaults(handler=matrix)
     matrix_parser.add_argument("--descriptor", type=Path, required=True)
+    matrix_parser.add_argument("--profile", choices=["candidate", "stable", "stable-delta"], default="candidate")
     build_parser = sub.add_parser("build")
     build_parser.set_defaults(handler=build)
     build_parser.add_argument("--descriptor", type=Path, required=True)
@@ -678,6 +808,12 @@ def make_parser() -> argparse.ArgumentParser:
     assemble_parser.add_argument("--descriptor", type=Path, required=True)
     assemble_parser.add_argument("--artifacts-dir", type=Path, required=True)
     assemble_parser.add_argument("--out", type=Path, required=True)
+    assemble_stable_parser = sub.add_parser("assemble-stable")
+    assemble_stable_parser.set_defaults(handler=assemble_stable)
+    assemble_stable_parser.add_argument("--descriptor", type=Path, required=True)
+    assemble_stable_parser.add_argument("--prepared", type=Path, required=True)
+    assemble_stable_parser.add_argument("--supplemental-dir", type=Path, required=True)
+    assemble_stable_parser.add_argument("--out", type=Path, required=True)
     verify_parser = sub.add_parser("verify-prepared")
     verify_parser.set_defaults(handler=verify_prepared)
     verify_parser.add_argument("--descriptor", type=Path, required=True)

--- a/.github/scripts/registry_publication.py
+++ b/.github/scripts/registry_publication.py
@@ -648,6 +648,105 @@ def advance_next_floor(
     return {**result, "next": version}
 
 
+def finalize_release(
+    api_url: str,
+    api_key: str,
+    worker: str,
+    candidate_version: str,
+    stable_version: str,
+    expected_latest_version: str,
+) -> dict[str, Any]:
+    """Atomically point next and latest at the published stable version.
+
+    Uses the Registry's transactional finalize primitive: every precondition
+    is checked under the worker lock server-side, so a rejected call leaves
+    both channel pointers untouched. Readback after every attempt proves the
+    multi-tag move on the raw pointer surface, never trusting the response.
+    """
+    try:
+        _lib.validate_finalization(candidate_version, stable_version)
+    except ValueError as error:
+        raise RegistryPublicationError(str(error)) from error
+    if not expected_latest_version:
+        raise RegistryPublicationError("expected_latest_version is required for release finalization")
+
+    payload: dict[str, Any] = {
+        "candidate_version": candidate_version,
+        "stable_version": stable_version,
+        "expected_latest_version": None if expected_latest_version == "none" else expected_latest_version,
+    }
+    encoded_worker = urllib.parse.quote(worker, safe="")
+
+    def both_channels_settled() -> Readback:
+        next_pointer = read_channel(api_url, worker, "next")
+        latest_pointer = read_channel(api_url, worker, "latest")
+        for tag, pointer in (("next", next_pointer), ("latest", latest_pointer)):
+            if pointer.state in {"divergent", "unavailable"}:
+                return Readback(pointer.state, f"channel {tag}: {pointer.detail}")
+        if (
+            next_pointer.state == "equivalent"
+            and latest_pointer.state == "equivalent"
+            and next_pointer.detail == latest_pointer.detail == stable_version
+        ):
+            return Readback("equivalent", f"raw next and latest pointers equal {stable_version}")
+        return Readback(
+            "absent",
+            f"next points to {next_pointer.detail}, latest points to {latest_pointer.detail}",
+        )
+
+    last = "release finalization did not run"
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        transport_error: str | None = None
+        try:
+            status, body = request_json(
+                "POST",
+                f"{api_url.rstrip('/')}/w/{encoded_worker}/releases/finalize",
+                payload,
+                api_key=api_key,
+            )
+        except TransportError as error:
+            status, body = 0, {}
+            transport_error = str(error)
+        if status == 200:
+            finalize = body.get("finalize")
+            if not isinstance(finalize, dict) or finalize.get("stable_version") != stable_version:
+                raise RegistryPublicationError("finalize response returned a different stable version")
+        elif status == 409:
+            current = both_channels_settled()
+            if current.state == "equivalent":
+                return {
+                    "state": "unchanged",
+                    "attempt": attempt,
+                    "proof": current.detail,
+                    "candidate": candidate_version,
+                    "expected_latest": expected_latest_version,
+                }
+            raise RegistryPublicationError(
+                f"finalize CAS conflict: {json.dumps(body, sort_keys=True)}; {current.detail}"
+            )
+        elif status != 0 and not 500 <= status <= 599:
+            raise RegistryPublicationError(
+                f"release finalization failed with HTTP {status}: {json.dumps(body, sort_keys=True)}"
+            )
+
+        current = both_channels_settled()
+        if current.state == "equivalent":
+            changed = body.get("changed") if status == 200 else None
+            return {
+                "state": "unchanged" if changed is False else ("changed" if status == 200 else "recovered"),
+                "attempt": attempt,
+                "proof": current.detail,
+                "candidate": candidate_version,
+                "expected_latest": expected_latest_version,
+            }
+        if current.state in {"divergent", "unavailable"}:
+            raise RegistryPublicationError(f"finalized channels cannot be proved: {current.detail}")
+        last = current.detail if transport_error is None else f"{transport_error}; {current.detail}"
+        if attempt < MAX_ATTEMPTS:
+            _retry_delay(attempt)
+    raise RegistryPublicationError(f"finalization was not verified after {MAX_ATTEMPTS} attempts: {last}")
+
+
 def _api_key() -> str:
     value = os.environ.get("WORKERS_REGISTRY_API_KEY", "")
     if not value:
@@ -676,6 +775,13 @@ def main() -> int:
     channel_parser.add_argument("--expected-current-version", required=True)
     next_floor_parser = common("advance-next-floor")
     next_floor_parser.add_argument("--expected-next-version", required=True)
+    finalize_parser = subparsers.add_parser("finalize-release")
+    finalize_parser.add_argument("--api-url", required=True)
+    finalize_parser.add_argument("--worker", required=True)
+    finalize_parser.add_argument("--candidate-version", required=True)
+    finalize_parser.add_argument("--stable-version", required=True)
+    finalize_parser.add_argument("--expected-latest-version", required=True)
+    finalize_parser.add_argument("--out", type=pathlib.Path, required=True)
     args = parser.parse_args()
 
     try:
@@ -692,13 +798,22 @@ def main() -> int:
                 args.registry_tag,
                 args.expected_current_version,
             )
-        else:
+        elif args.command == "advance-next-floor":
             result = advance_next_floor(
                 args.api_url,
                 _api_key(),
                 args.worker,
                 args.version,
                 args.expected_next_version,
+            )
+        else:
+            result = finalize_release(
+                args.api_url,
+                _api_key(),
+                args.worker,
+                args.candidate_version,
+                args.stable_version,
+                args.expected_latest_version,
             )
         _write_receipt(args.out, result)
         print(json.dumps(result, sort_keys=True))

--- a/.github/scripts/tests/test_build_publish_payload.py
+++ b/.github/scripts/tests/test_build_publish_payload.py
@@ -56,27 +56,23 @@ def test_target_version_is_independent_from_manifest_metadata_and_has_no_implici
     assert "tag" not in target
 
 
-def test_new_publish_target_rejects_legacy_numbered_rc() -> None:
+def test_publish_target_accepts_numbered_rc() -> None:
     projection = {
         "worker_name": "smoke", "type": "binary", "description": "smoke",
         "license": "Apache-2.0", "tags": [], "dependencies": [], "config": {},
         "experimental": False, "readme": "# Smoke\n",
     }
-    try:
-        build_payload(
-            registry_projection=projection,
-            published_version="2.0.0-rc.4",
-            repo_url="https://github.com/iii-hq/workers",
-            interface={"functions": [], "triggers": []},
-            artifacts={
-                "kind": "rust-binary",
-                "binaries": {"x86_64-unknown-linux-gnu": {"url": "https://example.test/smoke.tgz", "sha256": "b" * 64}},
-            },
-        )
-    except ValueError as error:
-        assert "deployment target version" in str(error)
-    else:
-        raise AssertionError("legacy numbered rc target was accepted")
+    payload = build_payload(
+        registry_projection=projection,
+        published_version="2.0.0-rc.4",
+        repo_url="https://github.com/iii-hq/workers",
+        interface={"functions": [], "triggers": []},
+        artifacts={
+            "kind": "rust-binary",
+            "binaries": {"x86_64-unknown-linux-gnu": {"url": "https://example.test/smoke.tgz", "sha256": "b" * 64}},
+        },
+    )
+    assert payload["version"] == "2.0.0-rc.4"
 
 
 def test_engine_builtins_are_not_deployment_targets() -> None:

--- a/.github/scripts/tests/test_deployment_control_contract.py
+++ b/.github/scripts/tests/test_deployment_control_contract.py
@@ -22,7 +22,7 @@ def run(*args: str) -> subprocess.CompletedProcess[str]:
 
 
 def test_contract_schema_is_byte_identical_to_release_control():
-    assert hashlib.sha256(SCHEMA.read_bytes()).hexdigest() == "dc51f42d89626f0d554b94965b49aace257726a0b77010c4be05e22c6eb44196"
+    assert hashlib.sha256(SCHEMA.read_bytes()).hexdigest() == "c9cd573a793ef8287e6d75814f4c7d474449e10dcec2238ff0d85648c6fb6784"
 
 
 def test_compact_identity_input_requires_exact_canonical_fields():
@@ -143,7 +143,8 @@ def test_authorize_posts_nested_canonical_body_and_its_digest(monkeypatch):
     assert request.get_header("Authorization") == "Bearer oidc:release-control-workers"
 
 
-def test_new_deployment_target_rejects_legacy_numbered_rc(tmp_path: pathlib.Path):
+def test_new_deployment_target_accepts_numbered_rc_on_next(tmp_path: pathlib.Path):
+    output = tmp_path / "deployment-result.json"
     result = run(
         "write-result", "--repository", "iii-hq/workers", "--step-id", STEP_ID,
         "--run-id", "123", "--run-attempt", "1", "--workflow", "deploy-prepare.yml",
@@ -155,10 +156,11 @@ def test_new_deployment_target_rejects_legacy_numbered_rc(tmp_path: pathlib.Path
         "--target-version", "1.2.3-rc.1", "--channel", "next",
         "--descriptor-sha256", "d" * 64, "--outcome", "succeeded", "--effects", "[]",
         "--artifacts-json", "[]", "--error-json", "null",
-        "--output", str(tmp_path / "deployment-result.json"),
+        "--output", str(output),
     )
-    assert result.returncode == 2
-    assert "deployment target version" in result.stderr
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(output.read_text())
+    assert payload["subject"]["target_version"] == "1.2.3-rc.1"
 
 
 def test_post_result_sends_the_file_bytes_without_reserializing(tmp_path, monkeypatch):
@@ -197,3 +199,96 @@ def test_phase_and_workflow_must_match(tmp_path: pathlib.Path):
     )
     assert result.returncode == 2
     assert "requires workflow deploy-prepare.yml" in result.stderr
+
+
+def run_finalize_write_result(output: pathlib.Path, **overrides: str) -> subprocess.CompletedProcess[str]:
+    values = {
+        "repository": "iii-hq/workers",
+        "step-id": STEP_ID,
+        "run-id": "123",
+        "run-attempt": "1",
+        "workflow": "deploy-finalize.yml",
+        "event": "workflow_dispatch",
+        "sha": "a" * 40,
+        "deployment-batch-id": DEPLOYMENT_BATCH_ID,
+        "deployment-target-id": DEPLOYMENT_TARGET_ID,
+        "attempt-id": ATTEMPT_ID,
+        "dispatch-nonce": NONCE,
+        "plan-hash": "b" * 64,
+        "worker": "eval",
+        "phase": "finalize",
+        "source-sha": "a" * 40,
+        "prepared-sha": "a" * 40,
+        "candidate-version": "1.7.0-rc.2",
+        "target-version": "1.7.0",
+        "channel": "latest",
+        "descriptor-sha256": "d" * 64,
+        "outcome": "succeeded",
+        "effects": "[]",
+        "artifacts-json": "[]",
+        "error-json": "null",
+        "output": str(output),
+    }
+    values.update({key.replace("_", "-"): value for key, value in overrides.items()})
+    return run("write-result", *[part for key, value in values.items() for part in (f"--{key}", value)])
+
+
+def test_finalize_result_binds_candidate_to_its_stable_version(tmp_path: pathlib.Path):
+    output = tmp_path / "deployment-result.json"
+    result = run_finalize_write_result(output)
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(output.read_text())
+    assert set(payload) == {"contract", "identity", "executor", "subject", "outcome", "effects", "artifacts", "error", "completed_at"}
+    assert set(payload["subject"]) == {
+        "worker", "phase", "source_sha", "prepared_sha", "target_version",
+        "channel", "descriptor_sha256", "candidate_version",
+    }
+    assert payload["subject"]["phase"] == "finalize"
+    assert payload["subject"]["channel"] == "latest"
+    assert payload["subject"]["target_version"] == "1.7.0"
+    assert payload["subject"]["candidate_version"] == "1.7.0-rc.2"
+    assert payload["subject"]["prepared_sha"] == payload["subject"]["source_sha"]
+
+
+def test_finalize_requires_a_candidate_version(tmp_path: pathlib.Path):
+    result = run_finalize_write_result(tmp_path / "deployment-result.json", candidate_version="none")
+    assert result.returncode == 2
+    assert "require --candidate-version" in result.stderr
+
+
+def test_finalize_requires_channel_latest(tmp_path: pathlib.Path):
+    result = run_finalize_write_result(tmp_path / "deployment-result.json", channel="next")
+    assert result.returncode == 2
+    assert "require channel=latest" in result.stderr
+
+
+def test_finalize_requires_prepared_sha_equal_to_source_sha(tmp_path: pathlib.Path):
+    result = run_finalize_write_result(tmp_path / "deployment-result.json", prepared_sha="c" * 40)
+    assert result.returncode == 2
+    assert "prepared_sha equal to source_sha" in result.stderr
+
+
+def test_non_finalize_phases_reject_a_candidate_version(tmp_path: pathlib.Path):
+    result = run_finalize_write_result(
+        tmp_path / "deployment-result.json",
+        workflow="deploy-prepare.yml", phase="prepare", channel="next",
+        target_version="1.7.0-rc.2",
+    )
+    assert result.returncode == 2
+    assert "does not accept" in result.stderr
+
+
+def test_latest_channel_rejects_rc_target_versions(tmp_path: pathlib.Path):
+    result = run_finalize_write_result(
+        tmp_path / "deployment-result.json",
+        workflow="deploy-publish.yml", phase="publish",
+        candidate_version="none", target_version="1.2.3-rc.1",
+    )
+    assert result.returncode == 2
+    assert "pure MAJOR.MINOR.PATCH" in result.stderr
+
+
+def test_finalize_phase_requires_the_finalize_workflow(tmp_path: pathlib.Path):
+    result = run_finalize_write_result(tmp_path / "deployment-result.json", workflow="deploy-verify.yml")
+    assert result.returncode == 2
+    assert "requires workflow deploy-finalize.yml" in result.stderr

--- a/.github/scripts/tests/test_deployment_targets.py
+++ b/.github/scripts/tests/test_deployment_targets.py
@@ -17,10 +17,22 @@ def test_binary_default_is_the_complete_unix_matrix() -> None:
 
 
 def test_windows_and_unknown_targets_are_rejected() -> None:
-    with pytest.raises(ValueError, match="Windows release target"):
+    with pytest.raises(ValueError, match="stable-profile only"):
         deployment_targets.normalize_targets("x86_64-pc-windows-msvc")
     with pytest.raises(ValueError, match="unknown release target"):
         deployment_targets.normalize_targets("sparc64-unknown-linux-gnu")
+
+
+def test_allow_windows_accepts_the_supported_triple_and_orders_it_last() -> None:
+    assert deployment_targets.normalize_targets(
+        ["x86_64-pc-windows-msvc", "x86_64-unknown-linux-gnu", "x86_64-apple-darwin"],
+        allow_windows=True,
+    ) == ["x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+
+
+def test_unsupported_windows_triples_stay_rejected_even_with_allow_windows() -> None:
+    with pytest.raises(ValueError, match="Windows release target is not supported"):
+        deployment_targets.normalize_targets("i686-pc-windows-msvc", allow_windows=True)
 
 
 def test_explicit_subsets_are_canonicalized_and_non_binary_has_one_build() -> None:

--- a/.github/scripts/tests/test_deployment_train.py
+++ b/.github/scripts/tests/test_deployment_train.py
@@ -1,24 +1,31 @@
 import argparse
 import hashlib
 import json
+import subprocess
 import tarfile
 import zipfile
 from pathlib import Path
 
 import pytest
 
+import deployment_targets
 import deployment_train
 from deployment_train import (
+    assemble_stable,
     build,
     build_frontends,
     build_oci_layout,
+    finalize,
     frontend_metadata,
+    matrix,
     normalized_tar,
     normalized_zip,
     prepare,
     select_descriptor,
     verify_prepared,
 )
+
+from _test_helpers import GIT_HERMETIC_ENV
 
 
 def seal_descriptor(value: dict) -> dict:
@@ -67,6 +74,27 @@ def descriptor(worker: str, source_sha: str, package_manifest_version: str) -> d
     })
 
 
+def rust_descriptor(
+    worker: str, source_sha: str, candidate_targets: list[str], stable_targets: list[str]
+) -> dict:
+    selected = descriptor(worker, source_sha, "1.0.0-rc.1")
+    selected["source"] = {"path": worker, "package_manifest": "Cargo.toml"}
+    selected["artifact"] = {
+        "kind": "rust-binary",
+        "binary": worker,
+        "candidate_targets": candidate_targets,
+        "stable_targets": stable_targets,
+        "toolchain": {"name": "rust", "version": "1.97.1"},
+    }
+    selected["runtime"] = {"environment": {}, "resources": {}, "exec": [worker]}
+    selected["registry_projection"]["type"] = "binary"
+    selected["build_units"] = [
+        {"id": f"{worker}-{target}", "kind": "rust-binary", "target": target}
+        for target in candidate_targets
+    ]
+    return seal_descriptor(selected)
+
+
 def test_prepare_accepts_exact_target_independent_of_manifest_metadata(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -88,6 +116,53 @@ def test_prepare_accepts_exact_target_independent_of_manifest_metadata(
         descriptor_sha256=selected["descriptor_sha256"],
         descriptor=descriptor_path,
     )) == 0
+
+
+def test_prepare_accepts_numbered_rc_target_on_next(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source_sha = "a" * 40
+    selected = descriptor("smoke", source_sha, "0.1.0")
+    descriptor_path = tmp_path / "deployment-descriptor.json"
+    descriptor_path.write_text(json.dumps(selected), encoding="utf-8")
+    monkeypatch.setattr(
+        deployment_train.subprocess,
+        "check_output",
+        lambda *_args, **_kwargs: source_sha + "\n",
+    )
+
+    assert prepare(argparse.Namespace(
+        worker="smoke",
+        source_sha=source_sha,
+        target_version="2.0.0-rc.1",
+        channel="next",
+        descriptor_sha256=selected["descriptor_sha256"],
+        descriptor=descriptor_path,
+    )) == 0
+
+
+def test_prepare_rejects_suffixed_target_on_latest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source_sha = "a" * 40
+    selected = descriptor("smoke", source_sha, "0.1.0")
+    descriptor_path = tmp_path / "deployment-descriptor.json"
+    descriptor_path.write_text(json.dumps(selected), encoding="utf-8")
+    monkeypatch.setattr(
+        deployment_train.subprocess,
+        "check_output",
+        lambda *_args, **_kwargs: source_sha + "\n",
+    )
+
+    with pytest.raises(SystemExit, match="pure MAJOR.MINOR.PATCH"):
+        prepare(argparse.Namespace(
+            worker="smoke",
+            source_sha=source_sha,
+            target_version="1.2.3-beta",
+            channel="latest",
+            descriptor_sha256=selected["descriptor_sha256"],
+            descriptor=descriptor_path,
+        ))
 
 
 def test_verify_prepared_checks_inventory_without_executing_worker(tmp_path: Path) -> None:
@@ -218,18 +293,11 @@ def test_rust_build_uses_deterministic_target_native_archive(
     binary.parent.mkdir(parents=True)
     binary.write_bytes(b"immutable executable\n")
     binary.chmod(0o755)
-    selected = descriptor("smoke", source_sha, "1.0.0-rc.1")
-    selected["source"] = {"path": "smoke", "package_manifest": "Cargo.toml"}
-    selected["artifact"] = {
-        "kind": "rust-binary",
-        "binary": "smoke",
-        "targets": [target],
-        "toolchain": {"name": "rust", "version": "1.97.1"},
-    }
-    selected["runtime"] = {"environment": {}, "resources": {}, "exec": ["smoke"]}
-    selected["registry_projection"]["type"] = "binary"
-    selected["build_units"] = [{"id": f"rust-{target}", "kind": "rust-binary", "target": target}]
-    seal_descriptor(selected)
+    # build_units always describe the candidate profile; the Windows unit is
+    # resolved from the stable superset the way finalization builds it.
+    candidate_targets = ["x86_64-unknown-linux-gnu"] if target in deployment_targets.WINDOWS_TARGETS else [target]
+    stable_targets = candidate_targets + ([target] if target in deployment_targets.WINDOWS_TARGETS else [])
+    selected = rust_descriptor("smoke", source_sha, candidate_targets, stable_targets)
     descriptor_path = tmp_path / "deployment-descriptor.json"
     descriptor_path.write_text(json.dumps(selected), encoding="utf-8")
     monkeypatch.chdir(tmp_path)
@@ -240,7 +308,7 @@ def test_rust_build_uses_deterministic_target_native_archive(
     outputs = []
     for output_name in ("first", "second"):
         output = tmp_path / output_name
-        build(argparse.Namespace(descriptor=descriptor_path, unit=f"rust-{target}", out=output))
+        build(argparse.Namespace(descriptor=descriptor_path, unit=f"smoke-{target}", out=output))
         outputs.append(output)
 
     first_archive = outputs[0] / archive_name
@@ -395,3 +463,234 @@ def test_descriptor_frontends_install_once_and_build_each_explicit_output(tmp_pa
     assert [command for command, _cwd in calls].count(("pnpm", "run", "build")) == 2
     assert (output_dir / "one/ui/dist/index.js").is_file()
     assert (output_dir / "two/ui/dist/index.js").is_file()
+
+
+def test_matrix_candidate_profile_is_exactly_the_descriptor_build_units(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    selected = rust_descriptor(
+        "smoke", "a" * 40,
+        ["x86_64-unknown-linux-gnu"],
+        ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"],
+    )
+    descriptor_path = tmp_path / "deployment-descriptor.json"
+    descriptor_path.write_text(json.dumps(selected), encoding="utf-8")
+
+    assert matrix(argparse.Namespace(descriptor=descriptor_path, profile="candidate")) == 0
+
+    assert json.loads(capsys.readouterr().out) == {"include": [{
+        "unit": "smoke-x86_64-unknown-linux-gnu",
+        "kind": "rust-binary",
+        "target": "x86_64-unknown-linux-gnu",
+        "runner": "workers-release-linux-8core",
+    }]}
+
+
+def test_matrix_stable_delta_is_only_the_supplemental_windows_unit(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    selected = rust_descriptor(
+        "smoke", "a" * 40,
+        ["x86_64-unknown-linux-gnu"],
+        ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"],
+    )
+    descriptor_path = tmp_path / "deployment-descriptor.json"
+    descriptor_path.write_text(json.dumps(selected), encoding="utf-8")
+
+    assert matrix(argparse.Namespace(descriptor=descriptor_path, profile="stable-delta")) == 0
+
+    assert json.loads(capsys.readouterr().out) == {"include": [{
+        "unit": "smoke-x86_64-pc-windows-msvc",
+        "kind": "rust-binary",
+        "target": "x86_64-pc-windows-msvc",
+        "runner": "windows-latest",
+    }]}
+
+
+def test_matrix_stable_delta_is_empty_for_bundles(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    selected = descriptor("smoke", "a" * 40, "0.1.0")
+    descriptor_path = tmp_path / "deployment-descriptor.json"
+    descriptor_path.write_text(json.dumps(selected), encoding="utf-8")
+
+    assert matrix(argparse.Namespace(descriptor=descriptor_path, profile="stable-delta")) == 0
+
+    assert json.loads(capsys.readouterr().out) == {"include": []}
+
+
+def _init_release_repo(tmp_path: Path, tags: list[str]) -> str:
+    """Initialises a tmp git repo with one commit plus annotated release tags
+    and returns the HEAD SHA, following the conftest tmp_git_repo_with_tag
+    pattern (the worker/tag names differ per finalize scenario)."""
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=tmp_path, check=True, env=GIT_HERMETIC_ENV)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path, check=True, env=GIT_HERMETIC_ENV)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, check=True, env=GIT_HERMETIC_ENV)
+    (tmp_path / "README.md").write_text("hello\n")
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, env=GIT_HERMETIC_ENV)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=tmp_path, check=True, env=GIT_HERMETIC_ENV)
+    for tag in tags:
+        subprocess.run(
+            ["git", "tag", "-a", tag, "-m", f"Release {tag}"],
+            cwd=tmp_path, check=True, env=GIT_HERMETIC_ENV,
+        )
+    return subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=tmp_path, text=True, env=GIT_HERMETIC_ENV
+    ).strip()
+
+
+def test_finalize_accepts_tagged_candidate_with_matching_stable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source_sha = _init_release_repo(tmp_path, ["smoke/v1.7.0-rc.2"])
+    selected = rust_descriptor(
+        "smoke", source_sha,
+        ["x86_64-unknown-linux-gnu"],
+        ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"],
+    )
+    descriptor_path = tmp_path / "deployment-descriptor.json"
+    descriptor_path.write_text(json.dumps(selected), encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    assert finalize(argparse.Namespace(
+        worker="smoke",
+        source_sha=source_sha,
+        candidate_version="1.7.0-rc.2",
+        stable_version="1.7.0",
+        descriptor_sha256=selected["descriptor_sha256"],
+        descriptor=descriptor_path,
+    )) == 0
+
+
+def test_finalize_rejects_candidate_without_rc_tag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source_sha = _init_release_repo(tmp_path, [])
+    selected = rust_descriptor(
+        "smoke", source_sha,
+        ["x86_64-unknown-linux-gnu"],
+        ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"],
+    )
+    descriptor_path = tmp_path / "deployment-descriptor.json"
+    descriptor_path.write_text(json.dumps(selected), encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(SystemExit, match="is not in the git history"):
+        finalize(argparse.Namespace(
+            worker="smoke",
+            source_sha=source_sha,
+            candidate_version="1.7.0-rc.2",
+            stable_version="1.7.0",
+            descriptor_sha256=selected["descriptor_sha256"],
+            descriptor=descriptor_path,
+        ))
+
+
+def test_finalize_rejects_stable_behind_existing_tagged_core(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source_sha = _init_release_repo(tmp_path, ["smoke/v1.7.0-rc.2", "smoke/v2.0.0"])
+    selected = rust_descriptor(
+        "smoke", source_sha,
+        ["x86_64-unknown-linux-gnu"],
+        ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"],
+    )
+    descriptor_path = tmp_path / "deployment-descriptor.json"
+    descriptor_path.write_text(json.dumps(selected), encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(SystemExit, match="is behind existing"):
+        finalize(argparse.Namespace(
+            worker="smoke",
+            source_sha=source_sha,
+            candidate_version="1.7.0-rc.2",
+            stable_version="1.7.0",
+            descriptor_sha256=selected["descriptor_sha256"],
+            descriptor=descriptor_path,
+        ))
+
+
+def _prepared_entry(path: Path, unit: str, role: str) -> dict:
+    return {
+        "unit": unit,
+        "name": path.name,
+        "role": role,
+        "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+        "size": path.stat().st_size,
+    }
+
+
+def _write_rc_prepared(prepared_dir: Path) -> tuple[dict, Path, Path]:
+    """Writes a verified rc prepared directory (descriptor + inventory +
+    artifact bytes) for a worker whose stable profile adds one Windows unit."""
+    prepared_dir.mkdir()
+    selected = rust_descriptor(
+        "smoke", "a" * 40,
+        ["x86_64-unknown-linux-gnu"],
+        ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"],
+    )
+    descriptor_path = prepared_dir / "deployment-descriptor.json"
+    descriptor_path.write_text(json.dumps(selected), encoding="utf-8")
+    rc_artifact = prepared_dir / "smoke-x86_64-unknown-linux-gnu.tar.gz"
+    rc_artifact.write_bytes(b"candidate bytes")
+    prepared_path = prepared_dir / "prepared-artifacts.json"
+    prepared_path.write_text(json.dumps({
+        "contract": "prepared-artifacts",
+        "worker": "smoke",
+        "source_sha": "a" * 40,
+        "descriptor_sha256": selected["descriptor_sha256"],
+        "artifacts": [_prepared_entry(rc_artifact, "smoke-x86_64-unknown-linux-gnu", "binary")],
+    }), encoding="utf-8")
+    return selected, descriptor_path, prepared_path
+
+
+def test_assemble_stable_unions_rc_bytes_with_supplemental_builds(tmp_path: Path) -> None:
+    selected, descriptor_path, prepared_path = _write_rc_prepared(tmp_path / "prepared")
+    delta_dir = tmp_path / "supplemental" / "smoke-x86_64-pc-windows-msvc"
+    delta_dir.mkdir(parents=True)
+    delta_artifact = delta_dir / "smoke-x86_64-pc-windows-msvc.zip"
+    delta_artifact.write_bytes(b"windows bytes")
+    (delta_dir / "build-result.json").write_text(json.dumps({
+        "contract": "release-build-result",
+        "worker": "smoke",
+        "source_sha": "a" * 40,
+        "descriptor_sha256": selected["descriptor_sha256"],
+        "unit": "smoke-x86_64-pc-windows-msvc",
+        "artifacts": [{
+            "name": delta_artifact.name,
+            "role": "binary",
+            "sha256": hashlib.sha256(delta_artifact.read_bytes()).hexdigest(),
+            "size": delta_artifact.stat().st_size,
+        }],
+    }), encoding="utf-8")
+
+    out = tmp_path / "stable"
+    assert assemble_stable(argparse.Namespace(
+        descriptor=descriptor_path,
+        prepared=prepared_path,
+        supplemental_dir=tmp_path / "supplemental",
+        out=out,
+    )) == 0
+
+    stable = json.loads((out / "prepared-artifacts.json").read_text(encoding="utf-8"))
+    assert {entry["unit"] for entry in stable["artifacts"]} == {
+        "smoke-x86_64-unknown-linux-gnu", "smoke-x86_64-pc-windows-msvc",
+    }
+    rc_artifact = prepared_path.parent / "smoke-x86_64-unknown-linux-gnu.tar.gz"
+    assert deployment_train.sha256(out / rc_artifact.name) == deployment_train.sha256(rc_artifact)
+    assert (out / delta_artifact.name).read_bytes() == delta_artifact.read_bytes()
+    assert (out / "deployment-descriptor.json").read_bytes() == descriptor_path.read_bytes()
+
+
+def test_assemble_stable_rejects_missing_supplemental_build(tmp_path: Path) -> None:
+    _selected, descriptor_path, prepared_path = _write_rc_prepared(tmp_path / "prepared")
+    supplemental_dir = tmp_path / "supplemental"
+    supplemental_dir.mkdir()
+
+    with pytest.raises(SystemExit, match="stable units differ"):
+        assemble_stable(argparse.Namespace(
+            descriptor=descriptor_path,
+            prepared=prepared_path,
+            supplemental_dir=supplemental_dir,
+            out=tmp_path / "stable",
+        ))

--- a/.github/scripts/tests/test_deployment_workflows.py
+++ b/.github/scripts/tests/test_deployment_workflows.py
@@ -10,8 +10,14 @@ ENTRYPOINTS = {
     "deploy-prepare.yml": "prepare",
     "deploy-publish.yml": "publish",
     "deploy-verify.yml": "verify",
+    "deploy-finalize.yml": "finalize",
 }
-REUSABLE = {"_deploy-build.yml", "_deploy-registry.yml", "_worker-e2e.yml"}
+REUSABLE = {
+    "_deploy-build.yml",
+    "_deploy-registry.yml",
+    "_deploy-registry-finalize.yml",
+    "_worker-e2e.yml",
+}
 
 
 def body(name: str) -> str:
@@ -69,9 +75,24 @@ def test_dispatch_inputs_use_one_identity_object_and_fit_github_limit():
         assert inputs["identity"] == {"required": True, "type": "string"}
         assert identity_components.isdisjoint(inputs), name
         assert "target_version" in inputs, name
-        assert "channel" in inputs, name
+        if name == "deploy-finalize.yml":
+            # Finalization is latest-only by construction: the channel is a
+            # fixed workflow constant, never a dispatch degree of freedom.
+            assert "channel" not in inputs, name
+        else:
+            assert "channel" in inputs, name
         assert "stable_version" not in inputs, name
         assert "prepared_artifact" not in inputs, name
+
+
+def test_finalize_dispatch_carries_the_full_rc_promotion_context():
+    workflow = yaml.safe_load(body("deploy-finalize.yml"))
+    assert set(workflow[True]["workflow_dispatch"]["inputs"]) == {
+        "identity", "worker", "source_sha", "source_rc_version",
+        "target_version", "expected_current_version", "expected_next_version",
+        "descriptor_sha256", "prepared_run_id", "source_target_id",
+    }
+    assert "DEPLOYMENT_CHANNEL: latest" in body("deploy-finalize.yml")
 
 
 def test_dispatch_values_are_never_rendered_into_shell_source():
@@ -117,7 +138,7 @@ def test_descriptor_index_independently_verifies_approved_compiler_bytes():
     assert "Verify approved compiler bytes" in text
     assert (
         "APPROVED_COMPILER_DIGEST: "
-        "5f720e57d1987b9016a0c2c9b7eaff25a696509506809734d28a88ecc208c364"
+        "2b471d87f21887e4dbac0e8b8c70f91ea7297cddada8538523ac74414cc0f236"
     ) in text
     assert 'digest.update(b"iii-workers-deployment-compiler\\0")' in text
     assert 'Path(".github/scripts/deployment_compiler.py").read_bytes()' in text
@@ -220,6 +241,62 @@ def test_publish_separates_immutable_version_from_explicit_channel_cas():
     assert "Move the requested OCI channel to the immutable digest" in publish
     assert '"$DEPLOYMENT_CHANNEL" == next || "$TARGET_VERSION" == *-*' in publish
     assert '"$RELEASE_CHANNEL" == next || "$TARGET_VERSION" == *-*' in body("deploy-verify.yml")
+
+
+def test_finalize_serializes_with_publish_per_worker():
+    # Serialization is load-bearing: a finalize racing a publish for the same
+    # worker would interleave the channel compare-and-swap moves.
+    finalize = yaml.safe_load(body("deploy-finalize.yml"))
+    publish = yaml.safe_load(body("deploy-publish.yml"))
+    assert finalize["concurrency"]["group"] == "deployment-${{ inputs.worker }}"
+    assert finalize["concurrency"] == publish["concurrency"]
+
+
+def test_prepared_artifacts_outlive_the_soak_window():
+    # Verified rc bytes are the finalization fast path: both the prepare
+    # assemble and the finalize assemble must keep them for 90 days.
+    for name in ("deploy-prepare.yml", "deploy-finalize.yml"):
+        workflow = yaml.safe_load(body(name))
+        uploads = [
+            step for step in workflow["jobs"]["assemble"]["steps"]
+            if str(step.get("uses", "")).startswith("actions/upload-artifact@")
+            and str(step.get("with", {}).get("name", "")).startswith("deployment-prepared-")
+        ]
+        assert len(uploads) == 1, name
+        assert uploads[0]["with"]["retention-days"] == 90, name
+
+
+def test_finalize_promotes_rc_bytes_through_the_train_contracts():
+    text = body("deploy-finalize.yml")
+    assert "deployment_train.py finalize" in text
+    assert "deployment_train.py matrix" in text
+    assert "--profile stable-delta" in text
+    assert "deployment_train.py assemble-stable" in text
+
+
+def test_registry_finalize_is_atomic_and_never_moves_channels_piecewise():
+    text = body("_deploy-registry-finalize.yml")
+    assert "registry_publication.py finalize-release" in text
+    assert "registry_publication.py publish-version" in text
+    assert "deployment_train.py verify-prepared" in text
+    assert "advance-next-floor" not in text
+    assert "assign-channel" not in text
+
+
+def test_repo_latest_is_granted_only_after_the_registry_receipt():
+    workflow = yaml.safe_load(body("deploy-finalize.yml"))
+    assert "registry" in workflow["jobs"]["promote"]["needs"]
+    assert "--latest=false" in body("deploy-finalize.yml")
+
+
+def test_release_build_restores_frontends_with_a_portable_copy():
+    text = body("_deploy-build.yml")
+    assert "shutil.copytree('.release-frontend', '.', dirs_exist_ok=True)" in text
+    # rsync is not guaranteed on the Windows and macOS release runners: it may
+    # be named only in comments, never invoked.
+    for line in text.splitlines():
+        if "rsync" in line:
+            assert line.lstrip().startswith("#"), line
 
 
 def test_bundle_caches_are_scoped_by_descriptor_lock_runtime_and_architecture():

--- a/.github/scripts/tests/test_lib.py
+++ b/.github/scripts/tests/test_lib.py
@@ -42,6 +42,61 @@ class TestParseSemver:
         assert _lib.parse_semver("1.2.3-rc.9") < _lib.parse_semver("1.2.3")
 
 
+class TestValidateDeploymentTargetVersion:
+    def test_accepts_numbered_rc(self):
+        assert _lib.validate_deployment_target_version("1.2.3-rc.1") == "1.2.3-rc.1"
+
+    def test_rejects_rc_zero(self):
+        with pytest.raises(ValueError, match="deployment target version"):
+            _lib.validate_deployment_target_version("1.2.3-rc.0")
+
+    def test_rejects_bare_rc_suffix(self):
+        with pytest.raises(ValueError, match="deployment target version"):
+            _lib.validate_deployment_target_version("1.2.3-rc")
+
+
+class TestValidateChannelTargetVersion:
+    def test_next_accepts_numbered_rc(self):
+        assert _lib.validate_channel_target_version("next", "1.2.3-rc.1") == "1.2.3-rc.1"
+
+    def test_next_accepts_pure_version_until_the_rc_flip_lands(self):
+        # Fase 1C tightens `next` to suffixed-only; until then any in-grammar
+        # version keeps the nightly window deployable.
+        assert _lib.validate_channel_target_version("next", "1.2.3") == "1.2.3"
+
+    def test_latest_accepts_pure_version(self):
+        assert _lib.validate_channel_target_version("latest", "1.2.3") == "1.2.3"
+
+    def test_latest_rejects_numbered_rc(self):
+        with pytest.raises(ValueError, match="pure MAJOR.MINOR.PATCH"):
+            _lib.validate_channel_target_version("latest", "1.2.3-rc.1")
+
+    def test_latest_rejects_maturity_suffix(self):
+        with pytest.raises(ValueError, match="pure MAJOR.MINOR.PATCH"):
+            _lib.validate_channel_target_version("latest", "1.2.3-beta")
+
+    def test_unknown_channel_raises(self):
+        with pytest.raises(ValueError, match="next or latest"):
+            _lib.validate_channel_target_version("stable", "1.2.3")
+
+
+class TestValidateFinalization:
+    def test_rc_candidate_and_same_core_stable_pass(self):
+        _lib.validate_finalization("1.7.0-rc.2", "1.7.0")
+
+    def test_pure_candidate_raises(self):
+        with pytest.raises(ValueError, match="X.Y.Z-rc.N"):
+            _lib.validate_finalization("1.7.0", "1.7.0")
+
+    def test_rc_stable_raises(self):
+        with pytest.raises(ValueError, match="pure MAJOR.MINOR.PATCH"):
+            _lib.validate_finalization("1.7.0-rc.2", "1.7.0-rc.3")
+
+    def test_different_core_raises(self):
+        with pytest.raises(ValueError, match="share the candidate core"):
+            _lib.validate_finalization("1.7.0-rc.2", "1.7.1")
+
+
 class TestBump:
     def test_patch(self):
         assert _lib.bump("1.2.3", "patch") == "1.2.4"

--- a/.github/scripts/tests/test_registry_publication.py
+++ b/.github/scripts/tests/test_registry_publication.py
@@ -503,3 +503,102 @@ def test_channel_409_fails_even_when_a_readback_is_available(monkeypatch) -> Non
     monkeypatch.setattr(registry_publication, "request_json", request)
     with pytest.raises(RegistryPublicationError, match="CAS conflict"):
         registry_publication.assign_channel(API, KEY, WORKER, VERSION, "next", "1.2.2")
+
+
+CANDIDATE = "1.7.0-rc.2"
+STABLE = "1.7.0"
+
+
+def channels_response(next_version: str, latest_version: str) -> dict[str, object]:
+    if next_version == latest_version:
+        return {"versions": [
+            {"version": next_version, "tag": "latest", "tags": ["next", "latest"], "dependencies": []},
+        ]}
+    return {"versions": [
+        {"version": next_version, "tag": "next", "tags": ["next"], "dependencies": []},
+        {"version": latest_version, "tag": "latest", "tags": ["latest"], "dependencies": []},
+    ]}
+
+
+def test_finalize_posts_candidate_pair_and_reads_back_both_pointers(monkeypatch) -> None:
+    calls: list[tuple[str, str]] = []
+
+    def request(method, url, body=None, **kwargs):
+        calls.append((method, url))
+        if url.endswith("/releases/finalize"):
+            assert body == {
+                "candidate_version": CANDIDATE,
+                "stable_version": STABLE,
+                "expected_latest_version": None,
+            }
+            assert kwargs["api_key"] == KEY
+            return 200, {"finalize": {"stable_version": STABLE}, "changed": True}
+        return 200, channels_response(STABLE, STABLE)
+
+    monkeypatch.setattr(registry_publication, "request_json", request)
+    result = registry_publication.finalize_release(API, KEY, WORKER, CANDIDATE, STABLE, "none")
+    assert result["state"] == "changed"
+    assert [method for method, _url in calls] == ["POST", "GET", "GET"]
+
+
+def test_finalize_200_changed_false_is_idempotent(monkeypatch) -> None:
+    def request(_method, url, _body=None, **_kwargs):
+        if url.endswith("/releases/finalize"):
+            return 200, {"finalize": {"stable_version": STABLE}, "changed": False}
+        return 200, channels_response(STABLE, STABLE)
+
+    monkeypatch.setattr(registry_publication, "request_json", request)
+    result = registry_publication.finalize_release(API, KEY, WORKER, CANDIDATE, STABLE, "1.6.0")
+    assert result["state"] == "unchanged"
+
+
+def test_finalize_409_is_idempotent_when_both_pointers_already_match(monkeypatch) -> None:
+    def request(_method, url, _body=None, **_kwargs):
+        if url.endswith("/releases/finalize"):
+            return 409, {"error": "stale"}
+        return 200, channels_response(STABLE, STABLE)
+
+    monkeypatch.setattr(registry_publication, "request_json", request)
+    result = registry_publication.finalize_release(API, KEY, WORKER, CANDIDATE, STABLE, "1.6.0")
+    assert result["state"] == "unchanged"
+
+
+def test_finalize_409_fails_when_latest_points_elsewhere(monkeypatch) -> None:
+    def request(_method, url, _body=None, **_kwargs):
+        if url.endswith("/releases/finalize"):
+            return 409, {"error": "stale"}
+        return 200, channels_response(STABLE, "1.6.0")
+
+    monkeypatch.setattr(registry_publication, "request_json", request)
+    with pytest.raises(RegistryPublicationError, match="finalize CAS conflict"):
+        registry_publication.finalize_release(API, KEY, WORKER, CANDIDATE, STABLE, "1.6.0")
+
+
+def test_finalize_timeout_is_recovered_when_both_pointers_match(monkeypatch) -> None:
+    def request(_method, url, _body=None, **_kwargs):
+        if url.endswith("/releases/finalize"):
+            raise TransportError("timeout")
+        return 200, channels_response(STABLE, STABLE)
+
+    monkeypatch.setattr(registry_publication, "request_json", request)
+    result = registry_publication.finalize_release(API, KEY, WORKER, CANDIDATE, STABLE, "1.6.0")
+    assert result["state"] == "recovered"
+    assert result["attempt"] == 1
+
+
+def test_finalize_rejects_a_pure_candidate_before_any_request(monkeypatch) -> None:
+    def request(*_args, **_kwargs):
+        raise AssertionError("must not reach the registry")
+
+    monkeypatch.setattr(registry_publication, "request_json", request)
+    with pytest.raises(RegistryPublicationError, match="finalization candidate must be an X.Y.Z-rc.N version"):
+        registry_publication.finalize_release(API, KEY, WORKER, STABLE, STABLE, "none")
+
+
+def test_finalize_blank_latest_precondition_is_rejected(monkeypatch) -> None:
+    def request(*_args, **_kwargs):
+        raise AssertionError("must not reach the registry")
+
+    monkeypatch.setattr(registry_publication, "request_json", request)
+    with pytest.raises(RegistryPublicationError, match="expected_latest_version is required"):
+        registry_publication.finalize_release(API, KEY, WORKER, CANDIDATE, STABLE, "")

--- a/.github/scripts/tests/test_registry_worker_smoke.py
+++ b/.github/scripts/tests/test_registry_worker_smoke.py
@@ -21,7 +21,13 @@ def add_catalog_worker(root: Path, worker: str) -> None:
     catalog = yaml.safe_load(path.read_text()) if path.exists() else {"workers": {}}
     catalog["workers"][worker] = {
         "source": {"path": worker, "package_manifest": "Cargo.toml"},
-        "artifact": {"kind": "rust-binary", "binary": worker, "targets": ["x86_64-unknown-linux-gnu"]},
+        "artifact": {
+            "kind": "rust-binary",
+            "binary": worker,
+            "candidate_targets": ["x86_64-unknown-linux-gnu"],
+            "stable_targets": ["x86_64-unknown-linux-gnu"],
+            "windows_exception": "Windows support has not been validated for this worker",
+        },
         "publish": True,
     }
     path.write_text(yaml.safe_dump(catalog, sort_keys=False))

--- a/.github/workflows/_deploy-build.yml
+++ b/.github/workflows/_deploy-build.yml
@@ -42,6 +42,11 @@ jobs:
   build:
     name: ${{ inputs.worker }} / ${{ inputs.unit }}
     runs-on: ${{ inputs.runner }}
+    defaults:
+      run:
+        # Windows runners default to pwsh; every run step here is written for
+        # bash, which the hosted Windows images ship too.
+        shell: bash
     permissions:
       actions: read
       contents: read
@@ -75,7 +80,8 @@ jobs:
 
       - name: Restore embedded frontend outputs
         if: inputs.kind == 'rust-binary'
-        run: rsync -a .release-frontend/ ./
+        # shutil, not rsync: Windows and macOS runners do not guarantee rsync.
+        run: python3 -c "import shutil; shutil.copytree('.release-frontend', '.', dirs_exist_ok=True)"
 
       - name: Validate immutable descriptor
         env:
@@ -90,9 +96,15 @@ jobs:
           # build unit before any assertion runs.
           test "$(jq -r .worker deployment-input/deployment-descriptor.json)" = "$WORKER"
           test "$(jq -r .source_sha deployment-input/deployment-descriptor.json)" = "$PREPARED_SHA"
-          jq -e --arg unit "$UNIT" --arg target "$TARGET" \
-            '.build_units | any(.id == $unit and ((.target // .platform // "none") == $target))' \
-            deployment-input/deployment-descriptor.json >/dev/null
+          # A supplemental stable-delta unit (a stable-only rust target such as
+          # Windows) is not in build_units — accept it when the descriptor
+          # declares the target in stable_targets beyond candidate_targets.
+          jq -e --arg unit "$UNIT" --arg target "$TARGET" '
+            (.build_units | any(.id == $unit and ((.target // .platform // "none") == $target)))
+            or (.artifact.kind == "rust-binary"
+              and ((.artifact.stable_targets - .artifact.candidate_targets) | any(. == $target))
+              and $unit == (.worker + "-" + $target))
+          ' deployment-input/deployment-descriptor.json >/dev/null
 
       - name: Rewrite SSH to HTTPS for public dependencies
         run: git config --local url."https://github.com/".insteadOf "ssh://git@github.com/"

--- a/.github/workflows/_deploy-registry-finalize.yml
+++ b/.github/workflows/_deploy-registry-finalize.yml
@@ -1,0 +1,158 @@
+name: Deployment Registry Finalize
+
+on:
+  workflow_call:
+    inputs:
+      worker: {required: true, type: string}
+      candidate_version: {required: true, type: string}
+      stable_version: {required: true, type: string}
+      github_tag: {required: true, type: string}
+      prepared_artifact: {required: true, type: string}
+      image_tag: {required: false, default: '', type: string}
+      expected_latest_version: {required: true, type: string}
+      expected_next_version: {required: true, type: string}
+    secrets:
+      WORKERS_REGISTRY_API_KEY: {required: true}
+
+permissions: {}
+
+jobs:
+  publish:
+    runs-on: workers-release-linux-8core
+    environment: workers-registry-release
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/scripts
+
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: ${{ inputs.prepared_artifact }}
+          path: deploy-prepared
+
+      - name: Build the current Registry payload from prepared stable bytes
+        env:
+          WORKER: ${{ inputs.worker }}
+          STABLE_VERSION: ${{ inputs.stable_version }}
+          GITHUB_TAG: ${{ inputs.github_tag }}
+          IMAGE_TAG: ${{ inputs.image_tag }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/deployment_train.py verify-prepared \
+            --descriptor deploy-prepared/deployment-descriptor.json \
+            --prepared deploy-prepared/prepared-artifacts.json
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+          from pathlib import Path
+
+          sys.path.insert(0, ".github/scripts")
+          import deployment_train
+
+          descriptor = json.loads(Path("deploy-prepared/deployment-descriptor.json").read_text())
+          prepared = json.loads(Path("deploy-prepared/prepared-artifacts.json").read_text())
+          if descriptor["worker"] != os.environ["WORKER"]:
+              raise SystemExit("prepared descriptor identity mismatch")
+          if prepared["descriptor_sha256"] != descriptor["descriptor_sha256"]:
+              raise SystemExit("prepared artifact descriptor mismatch")
+          kind = descriptor["artifact"]["kind"]
+          base = f"https://github.com/{os.environ['GITHUB_REPOSITORY']}/releases/download/{os.environ['GITHUB_TAG']}"
+          artifacts = [entry for entry in prepared["artifacts"] if entry["role"] != "checksum"]
+          if kind == "rust-binary":
+              # The stable inventory covers the full stable profile, so the
+              # unit-to-target map must too: candidate units plus the
+              # supplemental stable-delta units built at finalization.
+              targets = {
+                  unit["id"]: unit["target"]
+                  for unit in deployment_train.profile_units(descriptor, "stable")
+              }
+              artifact_payload = {
+                  "kind": kind,
+                  "binaries": {
+                      targets[entry["unit"]]: {
+                          "url": f"{base}/{entry['name']}",
+                          "sha256": entry["sha256"],
+                      }
+                      for entry in artifacts
+                  },
+              }
+          elif kind in {"javascript-bundle", "python-bundle"}:
+              if len(artifacts) != 1:
+                  raise SystemExit("bundle release requires exactly one prepared archive")
+              entry = artifacts[0]
+              artifact_payload = {
+                  "kind": kind,
+                  "archive_url": f"{base}/{entry['name']}",
+                  "sha256": entry["sha256"],
+              }
+          elif kind == "oci-image":
+              image_tag = os.environ["IMAGE_TAG"]
+              if not image_tag or "@sha256:" not in image_tag:
+                  raise SystemExit("image release requires a digest-pinned image tag")
+              artifact_payload = {"kind": kind, "image_tag": image_tag}
+          else:
+              raise SystemExit(f"unsupported artifact kind {kind}")
+          Path("interface.json").write_text(json.dumps({"functions": [], "triggers": []}, sort_keys=True) + "\n")
+          Path("registry-artifacts.json").write_text(json.dumps(artifact_payload, sort_keys=True) + "\n")
+          PY
+          python3 .github/scripts/build_publish_payload.py \
+            --descriptor deploy-prepared/deployment-descriptor.json \
+            --published-version "$STABLE_VERSION" \
+            --repo-url "https://github.com/$GITHUB_REPOSITORY" \
+            --interface-json interface.json \
+            --artifacts-json registry-artifacts.json \
+            --out payload.json
+          if jq -e 'has("package_descriptor") or has("descriptor_sha256") or has("channel")' payload.json >/dev/null; then
+            echo 'descriptor-native fields must never reach the current Registry' >&2
+            exit 1
+          fi
+          test "$(jq 'has("tag")' payload.json)" = false
+
+      - name: Publish immutable stable version with readback
+        env:
+          WORKERS_REGISTRY_API_KEY: ${{ secrets.WORKERS_REGISTRY_API_KEY }}
+          WORKER: ${{ inputs.worker }}
+          STABLE_VERSION: ${{ inputs.stable_version }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/registry_publication.py publish-version \
+            --api-url https://api.workers.iii.dev \
+            --worker "$WORKER" --version "$STABLE_VERSION" \
+            --payload payload.json --out registry-version-receipt.json
+
+      # The atomic finalize primitive validates next == candidate server-side
+      # under the worker lock; expected_next_version is carried here for the
+      # receipt and audit trail only.
+      - name: Atomically move next and latest to the stable version
+        env:
+          WORKERS_REGISTRY_API_KEY: ${{ secrets.WORKERS_REGISTRY_API_KEY }}
+          WORKER: ${{ inputs.worker }}
+          CANDIDATE_VERSION: ${{ inputs.candidate_version }}
+          STABLE_VERSION: ${{ inputs.stable_version }}
+          EXPECTED_LATEST_VERSION: ${{ inputs.expected_latest_version }}
+          EXPECTED_NEXT_VERSION: ${{ inputs.expected_next_version }}
+        run: |
+          set -euo pipefail
+          echo "expected next pointer before finalization: $EXPECTED_NEXT_VERSION"
+          python3 .github/scripts/registry_publication.py finalize-release \
+            --api-url https://api.workers.iii.dev \
+            --worker "$WORKER" \
+            --candidate-version "$CANDIDATE_VERSION" \
+            --stable-version "$STABLE_VERSION" \
+            --expected-latest-version "$EXPECTED_LATEST_VERSION" \
+            --out registry-finalize-receipt.json
+
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: registry-finalization-${{ inputs.worker }}-${{ inputs.stable_version }}
+          path: |
+            payload.json
+            registry-version-receipt.json
+            registry-finalize-receipt.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/deploy-descriptor-index.yml
+++ b/.github/workflows/deploy-descriptor-index.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Verify approved compiler bytes
         env:
-          APPROVED_COMPILER_DIGEST: 5f720e57d1987b9016a0c2c9b7eaff25a696509506809734d28a88ecc208c364
+          APPROVED_COMPILER_DIGEST: 2b471d87f21887e4dbac0e8b8c70f91ea7297cddada8538523ac74414cc0f236
         run: |
           set -euo pipefail
           python3 - <<'PY'

--- a/.github/workflows/deploy-finalize.yml
+++ b/.github/workflows/deploy-finalize.yml
@@ -1,0 +1,823 @@
+name: Deployment Finalize
+run-name: Deployment finalize · ${{ inputs.worker }} · ${{ fromJSON(inputs.identity).deployment_batch_id }} · ${{ fromJSON(inputs.identity).deployment_target_id }} · ${{ fromJSON(inputs.identity).step_id }} · ${{ fromJSON(inputs.identity).dispatch_nonce }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      identity: {required: true, type: string}
+      worker: {required: true, type: string}
+      source_sha: {required: true, type: string}
+      source_rc_version: {required: true, type: string}
+      target_version: {required: true, type: string}
+      expected_current_version: {required: true, type: string}
+      expected_next_version: {required: true, type: string}
+      descriptor_sha256: {required: true, type: string}
+      prepared_run_id: {required: true, type: string}
+      source_target_id: {required: true, type: string}
+
+env:
+  DEPLOYMENT_IDENTITY: ${{ inputs.identity }}
+  DEPLOYMENT_BATCH_ID: ${{ fromJSON(inputs.identity).deployment_batch_id }}
+  DEPLOYMENT_TARGET_ID: ${{ fromJSON(inputs.identity).deployment_target_id }}
+  STEP_ID: ${{ fromJSON(inputs.identity).step_id }}
+  ATTEMPT_ID: ${{ fromJSON(inputs.identity).attempt_id }}
+  DISPATCH_NONCE: ${{ fromJSON(inputs.identity).dispatch_nonce }}
+  PLAN_HASH: ${{ fromJSON(inputs.identity).plan_hash }}
+  WORKER: ${{ inputs.worker }}
+  SOURCE_SHA: ${{ inputs.source_sha }}
+  SOURCE_RC_VERSION: ${{ inputs.source_rc_version }}
+  TARGET_VERSION: ${{ inputs.target_version }}
+  DEPLOYMENT_CHANNEL: latest
+  EXPECTED_CURRENT_VERSION: ${{ inputs.expected_current_version }}
+  EXPECTED_NEXT_VERSION: ${{ inputs.expected_next_version }}
+  DESCRIPTOR_SHA256: ${{ inputs.descriptor_sha256 }}
+  PREPARED_RUN_ID: ${{ inputs.prepared_run_id }}
+  SOURCE_TARGET_ID: ${{ inputs.source_target_id }}
+
+permissions: {}
+
+concurrency:
+  group: deployment-${{ inputs.worker }}
+  cancel-in-progress: false
+
+jobs:
+  guard:
+    runs-on: workers-release-linux-8core
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+      has_supplemental: ${{ steps.matrix.outputs.has_supplemental }}
+      descriptor_artifact: ${{ steps.matrix.outputs.descriptor_artifact }}
+      frontend_artifact: ${{ steps.matrix.outputs.frontend_artifact }}
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.source_sha }}
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        id: prepared
+        continue-on-error: true
+        with:
+          name: deployment-prepared-${{ env.SOURCE_TARGET_ID }}
+          path: deploy-prepared
+          run-id: ${{ inputs.prepared_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Verify prepared rc bytes byte-exactly
+        if: steps.prepared.outcome == 'success'
+        run: |
+          set -euo pipefail
+          test "$(jq -r .worker deploy-prepared/deployment-descriptor.json)" = "$WORKER"
+          test "$(jq -r .source_sha deploy-prepared/deployment-descriptor.json)" = "$SOURCE_SHA"
+          test "$(jq -r .descriptor_sha256 deploy-prepared/deployment-descriptor.json)" = "$DESCRIPTOR_SHA256"
+          test "$(jq -r .worker deploy-prepared/prepared-artifacts.json)" = "$WORKER"
+          test "$(jq -r .source_sha deploy-prepared/prepared-artifacts.json)" = "$SOURCE_SHA"
+          test "$(jq -r .descriptor_sha256 deploy-prepared/prepared-artifacts.json)" = "$DESCRIPTOR_SHA256"
+          python3 .github/scripts/deployment_train.py verify-prepared \
+            --descriptor deploy-prepared/deployment-descriptor.json \
+            --prepared deploy-prepared/prepared-artifacts.json
+
+      - name: Reconstruct prepared rc bytes from immutable surfaces
+        if: steps.prepared.outcome != 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # The prepared artifact's Actions retention expired. A valid rc must
+          # never be non-finalizable because of that, so rebuild the inventory
+          # from surfaces that cannot expire: the descriptor from the rc's own
+          # compiler bytes in this checkout, the artifact bytes from the
+          # immutable GitHub release, and the digests from the Registry record.
+          # The release runners are not guaranteed to have pip on PATH, so the
+          # compiler's PyYAML comes from the distribution package.
+          sudo apt-get update
+          sudo apt-get install -y python3-yaml
+          python3 .github/scripts/deployment_compiler.py compile-index \
+            --root . \
+            --deployment-spec .deploy/workers.yaml \
+            --source-sha "$SOURCE_SHA" \
+            --compiler-repository iii-hq/workers \
+            --compiler-commit "$SOURCE_SHA" \
+            --schema .github/contracts/deployment-descriptor.schema.json \
+            --output-dir descriptor-recompiled
+          recompiled_digest=$(jq -r .descriptor_sha256 "descriptor-recompiled/descriptors/$WORKER.json")
+          if [[ "$recompiled_digest" != "$DESCRIPTOR_SHA256" ]]; then
+            echo "the rc's compiler must reproduce the descriptor byte-exactly: recompiled=$recompiled_digest expected=$DESCRIPTOR_SHA256" >&2
+            exit 1
+          fi
+          rm -rf deploy-prepared
+          mkdir -p deploy-prepared
+          cp "descriptor-recompiled/descriptors/$WORKER.json" deploy-prepared/deployment-descriptor.json
+          gh release download "$WORKER/v$SOURCE_RC_VERSION" --dir deploy-prepared
+          body=$(jq -nc --arg worker "$WORKER" --arg version "$SOURCE_RC_VERSION" '{worker:$worker,version:$version}')
+          curl -fsS -H 'Content-Type: application/json' -X POST \
+            'https://api.workers.iii.dev/resolve' --data "$body" > rc-resolve.json
+          python3 - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          worker = os.environ["WORKER"]
+          prepared_dir = Path("deploy-prepared")
+          descriptor = json.loads((prepared_dir / "deployment-descriptor.json").read_text())
+          artifact = descriptor["artifact"]
+          kind = artifact["kind"]
+
+          def digest(path):
+              value = hashlib.sha256()
+              with path.open("rb") as handle:
+                  for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                      value.update(chunk)
+              return value.hexdigest()
+
+          def sidecar_name(name):
+              for suffix in (".tar.gz", ".zip"):
+                  if name.endswith(suffix):
+                      return name[: -len(suffix)] + ".sha256"
+              return name + ".sha256"
+
+          entries = []
+          for unit in descriptor["build_units"]:
+              if kind == "rust-binary":
+                  target = unit["target"]
+                  suffix = ".zip" if target.endswith("-pc-windows-msvc") else ".tar.gz"
+                  name = f"{artifact['binary']}-{target}{suffix}"
+                  role = "binary"
+              elif kind in {"javascript-bundle", "python-bundle"}:
+                  name = f"{worker}.tar.gz"
+                  role = "bundle"
+              elif kind == "oci-image":
+                  platform_slug = unit["platform"].replace("/", "-")
+                  name = f"{worker}-image-{platform_slug}.oci.tar.gz"
+                  role = "oci-platform"
+              else:
+                  raise SystemExit(f"unsupported artifact kind {kind!r}")
+              for entry_name, entry_role in ((name, role), (sidecar_name(name), "checksum")):
+                  path = prepared_dir / entry_name
+                  if not path.is_file():
+                      raise SystemExit(f"rc release asset is missing: {entry_name}")
+                  entries.append({
+                      "unit": unit["id"], "name": entry_name, "role": entry_role,
+                      "sha256": digest(path), "size": path.stat().st_size,
+                  })
+
+          names = {entry["name"] for entry in entries}
+          downloaded = {
+              path.name for path in prepared_dir.iterdir()
+              if path.is_file() and path.name != "deployment-descriptor.json"
+          }
+          if downloaded != names:
+              raise SystemExit(
+                  f"rc release assets differ from the descriptor: missing={sorted(names - downloaded)} "
+                  f"unknown={sorted(downloaded - names)}"
+              )
+
+          resolved = json.loads(Path("rc-resolve.json").read_text())
+          matches = [node for node in resolved["graph"] if node.get("name") == worker]
+          if len(matches) != 1 or matches[0].get("version") != os.environ["SOURCE_RC_VERSION"]:
+              raise SystemExit("registry resolve did not return the exact rc version")
+          node = matches[0]
+          for entry in entries:
+              if entry["role"] == "binary":
+                  target = entry["unit"].removeprefix(f"{worker}-")
+                  published = node["binaries"][target]["sha256"]
+              elif entry["role"] == "bundle":
+                  published = node["sha256"]
+              else:
+                  # Checksum sidecars are covered by their archives; OCI archives
+                  # are proved by the immutable image digest, which the Registry
+                  # records as a pinned image tag rather than per-asset bytes.
+                  continue
+              if entry["sha256"] != published:
+                  raise SystemExit(f"{entry['name']}: bytes differ from the published Registry record")
+
+          prepared = {"contract": "prepared-artifacts", "worker": worker,
+                      "source_sha": descriptor["source_sha"], "descriptor_sha256": descriptor["descriptor_sha256"],
+                      "artifacts": sorted(entries, key=lambda entry: (str(entry["unit"]), str(entry["name"])))}
+          (prepared_dir / "prepared-artifacts.json").write_text(json.dumps(prepared, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+          PY
+          python3 .github/scripts/deployment_train.py verify-prepared \
+            --descriptor deploy-prepared/deployment-descriptor.json \
+            --prepared deploy-prepared/prepared-artifacts.json
+
+      - name: Authorize exact finalization dispatch
+        env:
+          RELEASE_CONTROL_API_URL: ${{ vars.RELEASE_CONTROL_API_URL }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/deployment_control_contract.py validate-identity --identity "$DEPLOYMENT_IDENTITY"
+          python3 .github/scripts/deployment_control_contract.py validate-dispatch --step-id "$STEP_ID" --dispatch-nonce "$DISPATCH_NONCE" --descriptor-sha256 "$DESCRIPTOR_SHA256" --plan-hash "$PLAN_HASH" --source-sha "$SOURCE_SHA" --prepared-sha "$SOURCE_SHA" --mutating
+          python3 .github/scripts/deployment_control_contract.py authorize-dispatch --api-url "$RELEASE_CONTROL_API_URL" --repository '${{ github.repository }}' --step-id "$STEP_ID" --run-id '${{ github.run_id }}' --run-attempt '${{ github.run_attempt }}' --workflow 'deploy-finalize.yml' --event '${{ github.event_name }}' --sha '${{ github.sha }}' --deployment-batch-id "$DEPLOYMENT_BATCH_ID" --deployment-target-id "$DEPLOYMENT_TARGET_ID" --attempt-id "$ATTEMPT_ID" --dispatch-nonce "$DISPATCH_NONCE" --plan-hash "$PLAN_HASH" --worker "$WORKER" --source-sha "$SOURCE_SHA" --target-version "$TARGET_VERSION" --channel "$DEPLOYMENT_CHANNEL" --descriptor-sha256 "$DESCRIPTOR_SHA256"
+          python3 .github/scripts/deployment_train.py finalize --worker "$WORKER" --source-sha "$SOURCE_SHA" --candidate-version "$SOURCE_RC_VERSION" --stable-version "$TARGET_VERSION" --descriptor-sha256 "$DESCRIPTOR_SHA256" --descriptor deploy-prepared/deployment-descriptor.json
+
+      - name: Resolve descriptor-owned frontend metadata
+        id: frontend
+        run: >-
+          python3 .github/scripts/deployment_train.py frontend-metadata
+          --descriptor deploy-prepared/deployment-descriptor.json
+          --github-output "$GITHUB_OUTPUT"
+
+      - name: Install descriptor-pinned pnpm
+        if: steps.frontend.outputs.count != '0'
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+        with:
+          version: ${{ steps.frontend.outputs.package_manager_version }}
+
+      - name: Install descriptor-pinned Node.js
+        if: steps.frontend.outputs.count != '0'
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: ${{ steps.frontend.outputs.runtime_version }}
+
+      - name: Resolve frontend pnpm store
+        if: steps.frontend.outputs.count != '0'
+        id: frontend-pnpm
+        run: echo "store_path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache descriptor-pinned frontend dependencies
+        if: steps.frontend.outputs.count != '0'
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ steps.frontend-pnpm.outputs.store_path }}
+          key: deployment-frontend-${{ steps.frontend.outputs.package_manager_version }}-node${{ steps.frontend.outputs.runtime_version }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.frontend.outputs.lock_sha256 }}
+
+      - name: Build embedded frontends once
+        run: >-
+          python3 .github/scripts/deployment_train.py build-frontends
+          --descriptor deploy-prepared/deployment-descriptor.json
+          --out .release-frontend
+
+      - name: Export supplemental build matrix
+        id: matrix
+        run: |
+          set -euo pipefail
+          matrix=$(python3 .github/scripts/deployment_train.py matrix \
+            --descriptor deploy-prepared/deployment-descriptor.json \
+            --profile stable-delta)
+          has_supplemental=false
+          if [[ "$(jq '.include | length' <<<"$matrix")" != 0 ]]; then has_supplemental=true; fi
+          {
+            echo "matrix=$matrix"
+            echo "has_supplemental=$has_supplemental"
+            echo "descriptor_artifact=deployment-descriptor-$DEPLOYMENT_TARGET_ID-$STEP_ID"
+            echo "frontend_artifact=deployment-frontend-$DEPLOYMENT_TARGET_ID-$STEP_ID"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: deployment-source-prepared-${{ env.DEPLOYMENT_TARGET_ID }}
+          path: deploy-prepared/
+          if-no-files-found: error
+          retention-days: 7
+
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: deployment-descriptor-${{ env.DEPLOYMENT_TARGET_ID }}-${{ env.STEP_ID }}
+          path: deploy-prepared/deployment-descriptor.json
+          if-no-files-found: error
+          retention-days: 7
+
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: deployment-frontend-${{ env.DEPLOYMENT_TARGET_ID }}-${{ env.STEP_ID }}
+          path: .release-frontend/
+          if-no-files-found: error
+          include-hidden-files: true
+          retention-days: 7
+
+  build_supplemental:
+    needs: guard
+    if: needs.guard.outputs.has_supplemental == 'true'
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.guard.outputs.matrix) }}
+    uses: ./.github/workflows/_deploy-build.yml
+    with:
+      worker: ${{ inputs.worker }}
+      prepared_sha: ${{ inputs.source_sha }}
+      descriptor_artifact: ${{ needs.guard.outputs.descriptor_artifact }}
+      frontend_artifact: ${{ needs.guard.outputs.frontend_artifact }}
+      target: ${{ matrix.target }}
+      unit: ${{ matrix.unit }}
+      kind: ${{ matrix.kind }}
+      runner: ${{ matrix.runner }}
+
+  assemble:
+    needs: [guard, build_supplemental]
+    if: always() && needs.guard.result == 'success' && (needs.build_supplemental.result == 'success' || needs.build_supplemental.result == 'skipped')
+    runs-on: workers-release-linux-8core
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/scripts
+
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: deployment-source-prepared-${{ env.DEPLOYMENT_TARGET_ID }}
+          path: deploy-prepared
+
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        continue-on-error: true
+        with:
+          pattern: release-build-${{ inputs.worker }}-*
+          path: release-builds
+
+      - name: Assemble the stable release from rc bytes and supplements
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/deployment_train.py assemble-stable \
+            --descriptor deploy-prepared/deployment-descriptor.json \
+            --prepared deploy-prepared/prepared-artifacts.json \
+            --supplemental-dir release-builds \
+            --out deploy-prepared-stable
+
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: deployment-prepared-${{ env.DEPLOYMENT_TARGET_ID }}
+          path: deploy-prepared-stable/
+          if-no-files-found: error
+          retention-days: 90
+
+  publish:
+    needs: assemble
+    runs-on: workers-release-linux-8core
+    permissions:
+      actions: read
+      contents: write
+      packages: write
+    outputs:
+      tag: ${{ steps.identity.outputs.tag }}
+      image_tag: ${{ steps.image.outputs.image_tag }}
+      image_digest: ${{ steps.image.outputs.image_digest }}
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          sparse-checkout: .github/scripts
+
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: deployment-prepared-${{ env.DEPLOYMENT_TARGET_ID }}
+          path: deploy-prepared
+
+      - name: Verify assembled stable bytes
+        run: |
+          set -euo pipefail
+          test "$(jq -r .worker deploy-prepared/deployment-descriptor.json)" = "$WORKER"
+          test "$(jq -r .source_sha deploy-prepared/deployment-descriptor.json)" = "$SOURCE_SHA"
+          test "$(jq -r .descriptor_sha256 deploy-prepared/deployment-descriptor.json)" = "$DESCRIPTOR_SHA256"
+          test "$(jq -r .descriptor_sha256 deploy-prepared/prepared-artifacts.json)" = "$DESCRIPTOR_SHA256"
+          python3 .github/scripts/deployment_train.py verify-prepared \
+            --descriptor deploy-prepared/deployment-descriptor.json \
+            --prepared deploy-prepared/prepared-artifacts.json
+
+      - name: Resolve immutable tag
+        id: identity
+        run: echo "tag=$WORKER/v$TARGET_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Publish immutable assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.identity.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null; then
+            git fetch --no-tags origin "refs/tags/$TAG:refs/tags/$TAG"
+            test "$(git cat-file -t "refs/tags/$TAG")" = tag
+            test "$(git rev-list -n1 "$TAG")" = "$SOURCE_SHA"
+            tag_message=$(git for-each-ref "refs/tags/$TAG" --format='%(contents)')
+            grep -Fx "worker: $WORKER" <<<"$tag_message"
+            grep -Fx "version: $TARGET_VERSION" <<<"$tag_message"
+            grep -Fx "descriptor-sha256: $DESCRIPTOR_SHA256" <<<"$tag_message"
+          else
+            tag_message=$(printf 'worker: %s\n\nversion: %s\n\ndescriptor-sha256: %s\n' \
+              "$WORKER" "$TARGET_VERSION" "$DESCRIPTOR_SHA256")
+            tag_object=$(gh api --method POST "/repos/${GITHUB_REPOSITORY}/git/tags" \
+              -f tag="$TAG" -f message="$tag_message" -f object="$SOURCE_SHA" -f type=commit \
+              --jq .sha)
+            [[ "$tag_object" =~ ^[0-9a-f]{40}$ ]]
+            gh api --method POST "/repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f ref="refs/tags/$TAG" -f sha="$tag_object" >/dev/null
+          fi
+          mapfile -t assets < <(find deploy-prepared -maxdepth 1 -type f ! -name '*.json' | sort)
+          ((${#assets[@]} > 0))
+
+          verify_release_assets() {
+            local release_json=$1 allow_missing=$2 asset name size id remote_sha local_sha
+            find deploy-prepared -maxdepth 1 -type f ! -name '*.json' -printf '%f\n' | sort > expected-assets.txt
+            jq -r '.assets[].name' "$release_json" | sort > remote-assets.txt
+            extra=$(comm -13 expected-assets.txt remote-assets.txt)
+            [[ -z "$extra" ]] || { echo "unexpected immutable release assets: $extra"; return 1; }
+            mkdir -p remote-assets
+            for asset in "${assets[@]}"; do
+              name=$(basename "$asset")
+              if ! jq -e --arg name "$name" '[.assets[] | select(.name == $name)] | length == 1' "$release_json" >/dev/null; then
+                [[ "$allow_missing" == true ]] || { echo "release asset missing after upload: $name"; return 1; }
+                continue
+              fi
+              size=$(jq -er --arg name "$name" '.assets[] | select(.name == $name) | .size' "$release_json")
+              test "$size" = "$(stat -c %s "$asset")"
+              id=$(jq -er --arg name "$name" '.assets[] | select(.name == $name) | .id' "$release_json")
+              gh api -H 'Accept: application/octet-stream' \
+                "/repos/${GITHUB_REPOSITORY}/releases/assets/$id" > "remote-assets/$name"
+              remote_sha=$(sha256sum "remote-assets/$name" | cut -d' ' -f1)
+              local_sha=$(sha256sum "$asset" | cut -d' ' -f1)
+              test "$remote_sha" = "$local_sha"
+            done
+          }
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh api "/repos/${GITHUB_REPOSITORY}/releases/tags/$TAG" > release.json
+            test "$(jq -r .draft release.json)" = false
+            test "$(jq -r .prerelease release.json)" = false
+            verify_release_assets release.json true
+            mapfile -t missing < <(
+              for asset in "${assets[@]}"; do
+                name=$(basename "$asset")
+                jq -e --arg name "$name" '.assets[] | select(.name == $name)' release.json >/dev/null || printf '%s\n' "$asset"
+              done
+            )
+            ((${#missing[@]} == 0)) || gh release upload "$TAG" "${missing[@]}"
+          else
+            # A pure stable version is never a prerelease, and repo-latest is
+            # granted only by the promote job after the atomic Registry receipt.
+            gh release create "$TAG" "${assets[@]}" --verify-tag --latest=false \
+              --title "$WORKER $TARGET_VERSION"
+          fi
+          gh api "/repos/${GITHUB_REPOSITORY}/releases/tags/$TAG" > release-final.json
+          test "$(jq -r .prerelease release-final.json)" = false
+          verify_release_assets release-final.json false
+
+      - name: Classify prepared artifact
+        id: artifact
+        run: |
+          if [[ "$(jq -r .artifact.kind deploy-prepared/deployment-descriptor.json)" == oci-image ]]; then
+            echo 'is_oci=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'is_oci=false' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up deterministic OCI index tooling
+        if: steps.artifact.outputs.is_oci == 'true'
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
+        with:
+          version: v0.36.1
+
+      - name: Authenticate OCI publication
+        if: steps.artifact.outputs.is_oci == 'true'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Publish immutable OCI image when declared
+        id: image
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [[ "$(jq -r .artifact.kind deploy-prepared/deployment-descriptor.json)" == oci-image ]]; then
+            sudo apt-get update
+            sudo apt-get install -y skopeo
+            base="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/$WORKER"
+            skopeo login ghcr.io --username "$GITHUB_ACTOR" --password "$GH_TOKEN"
+            : >expected-image-digests.txt
+            refs=()
+            while IFS=$'\t' read -r unit archive; do
+              platform=$(jq -er --arg unit "$unit" '.build_units[] | select(.id == $unit) | .platform' \
+                deploy-prepared/deployment-descriptor.json)
+              platform_slug=${platform//\//-}
+              test -f "deploy-prepared/$archive"
+              gzip -dc "deploy-prepared/$archive" >"image-$platform_slug.oci.tar"
+              source_digest=$(skopeo inspect --format '{{.Digest}}' "oci-archive:image-$platform_slug.oci.tar")
+              [[ "$source_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+              staging_tag="$TARGET_VERSION-$platform_slug"
+              if remote_digest=$(skopeo inspect --format '{{.Digest}}' "docker://$base:$staging_tag" 2>/dev/null); then
+                test "$remote_digest" = "$source_digest"
+              else
+                skopeo copy "oci-archive:image-$platform_slug.oci.tar" "docker://$base:$staging_tag"
+              fi
+              docker buildx imagetools inspect "$base:$staging_tag" --raw >"staging-$platform_slug.json"
+              if jq -e '.manifests | type == "array"' "staging-$platform_slug.json" >/dev/null; then
+                jq -r '.manifests[].digest' "staging-$platform_slug.json" >>expected-image-digests.txt
+              else
+                printf 'sha256:%s\n' "$(sha256sum "staging-$platform_slug.json" | cut -d' ' -f1)" \
+                  >>expected-image-digests.txt
+              fi
+              refs+=("$base:$staging_tag")
+            done < <(jq -r '.artifacts[] | select(.role == "oci-platform") | [.unit,.name] | @tsv' \
+              deploy-prepared/prepared-artifacts.json)
+            test "${#refs[@]}" = "$(jq '.build_units | length' deploy-prepared/deployment-descriptor.json)"
+            if ! docker buildx imagetools inspect "$base:$TARGET_VERSION" --raw >published-index.json 2>/dev/null; then
+              docker buildx imagetools create --tag "$base:$TARGET_VERSION" "${refs[@]}"
+              docker buildx imagetools inspect "$base:$TARGET_VERSION" --raw >published-index.json
+            fi
+            sort -u expected-image-digests.txt -o expected-image-digests.txt
+            jq -r '.manifests[].digest' published-index.json | sort -u >published-image-digests.txt
+            cmp expected-image-digests.txt published-image-digests.txt
+            digest="sha256:$(sha256sum published-index.json | cut -d' ' -f1)"
+            [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+            echo "image_digest=$digest" >> "$GITHUB_OUTPUT"
+            echo "image_tag=$base:$TARGET_VERSION@$digest" >> "$GITHUB_OUTPUT"
+          else
+            echo 'image_digest=' >> "$GITHUB_OUTPUT"
+            echo 'image_tag=' >> "$GITHUB_OUTPUT"
+          fi
+
+  registry:
+    needs: publish
+    permissions:
+      actions: read
+      contents: read
+    uses: ./.github/workflows/_deploy-registry-finalize.yml
+    with:
+      worker: ${{ inputs.worker }}
+      candidate_version: ${{ inputs.source_rc_version }}
+      stable_version: ${{ inputs.target_version }}
+      github_tag: ${{ needs.publish.outputs.tag }}
+      prepared_artifact: deployment-prepared-${{ fromJSON(inputs.identity).deployment_target_id }}
+      image_tag: ${{ needs.publish.outputs.image_tag }}
+      expected_latest_version: ${{ inputs.expected_current_version }}
+      expected_next_version: ${{ inputs.expected_next_version }}
+    secrets:
+      WORKERS_REGISTRY_API_KEY: ${{ secrets.WORKERS_REGISTRY_API_KEY }}
+
+  promote:
+    needs: [publish, registry]
+    runs-on: workers-release-linux-8core
+    permissions:
+      contents: write
+    steps:
+      - name: Mark the finalized release repo-latest
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.publish.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # Only after the atomic Registry receipt: repo-latest is the last
+          # cosmetic surface, so a failure here never rolls anything back.
+          gh release edit "$TAG" --latest
+
+  image_channel:
+    needs: [publish, registry]
+    if: needs.publish.outputs.image_digest != ''
+    runs-on: workers-release-linux-8core
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
+        with:
+          version: v0.36.1
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+      - name: Move the requested OCI channel to the immutable digest
+        env:
+          IMAGE_DIGEST: ${{ needs.publish.outputs.image_digest }}
+        run: |
+          set -euo pipefail
+          [[ "$IMAGE_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]
+          base="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/$WORKER"
+          docker buildx imagetools inspect "$base@$IMAGE_DIGEST" --raw >immutable-image.json
+          test "sha256:$(sha256sum immutable-image.json | cut -d' ' -f1)" = "$IMAGE_DIGEST"
+          if docker buildx imagetools inspect "$base:$DEPLOYMENT_CHANNEL" --raw >channel-before.json 2>/dev/null \
+            && cmp immutable-image.json channel-before.json; then
+            exit 0
+          fi
+          docker buildx imagetools create --tag "$base:$DEPLOYMENT_CHANNEL" "$base@$IMAGE_DIGEST"
+          docker buildx imagetools inspect "$base:$DEPLOYMENT_CHANNEL" --raw >channel-after.json
+          cmp immutable-image.json channel-after.json
+
+  report:
+    if: always()
+    needs: [guard, build_supplemental, assemble, publish, registry, promote, image_channel]
+    runs-on: workers-release-linux-8core
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/scripts
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        continue-on-error: true
+        with:
+          name: deployment-prepared-${{ env.DEPLOYMENT_TARGET_ID }}
+          path: deploy-prepared
+      - name: Probe finalization effects from authoritative surfaces
+        if: always()
+        id: effects
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PUBLISHED_IMAGE_DIGEST: ${{ needs.publish.outputs.image_digest }}
+        run: |
+          set -euo pipefail
+          github_state=unknown
+          registry_latest_state=unknown
+          registry_next_state=unknown
+          image_state=unknown
+          image_channel_state=unknown
+          image_digest=
+
+          if [[ -f deploy-prepared/deployment-descriptor.json && -f deploy-prepared/prepared-artifacts.json ]]; then
+            python3 .github/scripts/deployment_train.py verify-prepared \
+              --descriptor deploy-prepared/deployment-descriptor.json \
+              --prepared deploy-prepared/prepared-artifacts.json
+            tag="$WORKER/v$TARGET_VERSION"
+            if gh api "/repos/${GITHUB_REPOSITORY}/releases/tags/$tag" \
+              >release-probe.json 2>release-probe.err; then
+              github_state=present
+              if gh api "/repos/${GITHUB_REPOSITORY}/git/ref/tags/$tag" >tag-ref-probe.json; then
+                tag_type=$(jq -er .object.type tag-ref-probe.json)
+                tag_sha=$(jq -er .object.sha tag-ref-probe.json)
+                if [[ "$tag_type" == tag ]]; then
+                  tag_sha=$(gh api "/repos/${GITHUB_REPOSITORY}/git/tags/$tag_sha" --jq .object.sha)
+                fi
+                [[ "$tag_type" == tag && "$tag_sha" == "$SOURCE_SHA" ]] || github_state=absent
+              else
+                github_state=unknown
+              fi
+              [[ "$(jq -r .draft release-probe.json)" == false ]] || github_state=absent
+              # A finalized stable is never a prerelease.
+              [[ "$(jq -r .prerelease release-probe.json)" == false ]] || github_state=absent
+              find deploy-prepared -maxdepth 1 -type f ! -name '*.json' -printf '%f\n' \
+                | sort >expected-assets.txt
+              jq -r '.assets[].name' release-probe.json | sort >remote-assets.txt
+              if ! cmp expected-assets.txt remote-assets.txt; then
+                github_state=absent
+              else
+                mkdir -p remote-probe-assets
+                while IFS= read -r name; do
+                  id=$(jq -er --arg name "$name" '.assets[] | select(.name == $name) | .id' release-probe.json) || {
+                    github_state=absent
+                    break
+                  }
+                  if ! gh api -H 'Accept: application/octet-stream' \
+                    "/repos/${GITHUB_REPOSITORY}/releases/assets/$id" \
+                    >"remote-probe-assets/$name"; then
+                    github_state=unknown
+                    break
+                  fi
+                  if ! cmp "deploy-prepared/$name" "remote-probe-assets/$name"; then
+                    github_state=absent
+                    break
+                  fi
+                done <expected-assets.txt
+              fi
+            elif grep -Eq 'HTTP 404|Not Found' release-probe.err; then
+              github_state=absent
+            fi
+
+            body=$(jq -nc --arg worker "$WORKER" '{worker:$worker,version:"latest"}')
+            status=$(curl -sS -o latest-probe.json -w '%{http_code}' \
+              -H 'Content-Type: application/json' -X POST \
+              'https://api.workers.iii.dev/resolve' --data "$body" || true)
+            if [[ "$status" == 200 ]]; then
+              if jq -e --slurpfile descriptor deploy-prepared/deployment-descriptor.json \
+                --arg worker "$WORKER" --arg version "$TARGET_VERSION" '
+                  .root.version == $version
+                  and ([.graph[] | select(.name == $worker)] | length) == 1
+                  and ([.graph[] | select(.name == $worker)][0].version == $version)
+                  and ([.graph[] | select(.name == $worker)][0].type == $descriptor[0].registry_projection.type)
+                  and ([.graph[] | select(.name == $worker)][0].dependencies == ($descriptor[0].registry_projection.dependencies | map({key:.name,value:.version}) | from_entries))
+                ' latest-probe.json >/dev/null; then
+                registry_latest_state=present
+              else
+                registry_latest_state=absent
+              fi
+            elif [[ "$status" == 404 ]]; then
+              registry_latest_state=absent
+            fi
+
+            # The atomic finalize points next and latest at the same stable, so
+            # both raw pointers must resolve to exactly the target version.
+            next_body=$(jq -nc --arg worker "$WORKER" '{worker:$worker,version:"next"}')
+            next_status=$(curl -sS -o next-probe.json -w '%{http_code}' \
+              -H 'Content-Type: application/json' -X POST \
+              'https://api.workers.iii.dev/resolve' --data "$next_body" || true)
+            if [[ "$next_status" == 200 ]]; then
+              if [[ "$(jq -er .root.version next-probe.json)" == "$TARGET_VERSION" ]]; then
+                registry_next_state=present
+              else
+                registry_next_state=absent
+              fi
+            elif [[ "$next_status" == 404 ]]; then
+              registry_next_state=absent
+            fi
+
+            kind=$(jq -r .artifact.kind deploy-prepared/deployment-descriptor.json)
+            if [[ "$kind" == oci-image ]]; then
+              image_digest=${PUBLISHED_IMAGE_DIGEST:-}
+              [[ "$image_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+              base="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/$WORKER"
+              if docker buildx imagetools inspect "$base:$TARGET_VERSION" --raw \
+                >target-image-probe.json 2>target-image-probe.err; then
+                actual_digest="sha256:$(sha256sum target-image-probe.json | cut -d' ' -f1)"
+                image_state=absent
+                [[ "$actual_digest" == "$image_digest" ]] && image_state=present
+              elif grep -Eiq 'manifest unknown|not found' target-image-probe.err; then
+                image_state=absent
+              fi
+              if docker buildx imagetools inspect "$base:$DEPLOYMENT_CHANNEL" --raw \
+                >channel-image-probe.json 2>channel-image-probe.err; then
+                actual_channel_digest="sha256:$(sha256sum channel-image-probe.json | cut -d' ' -f1)"
+                image_channel_state=absent
+                [[ "$actual_channel_digest" == "$image_digest" ]] && image_channel_state=present
+              elif grep -Eiq 'manifest unknown|not found' channel-image-probe.err; then
+                image_channel_state=absent
+              fi
+            fi
+          fi
+
+          # The probes above already hold the effect state verbatim: with no
+          # pre-mutation probe (before=unknown), classification is the
+          # identity function, so the states pass through unchanged.
+          {
+            echo "github_state=$github_state"
+            echo "registry_latest_state=$registry_latest_state"
+            echo "registry_next_state=$registry_next_state"
+            echo "image_state=$image_state"
+            echo "image_channel_state=$image_channel_state"
+            echo "image_digest=$image_digest"
+          } >>"$GITHUB_OUTPUT"
+      - name: Write byte-exact result
+        if: always()
+        env:
+          GUARD_RESULT: ${{ needs.guard.result }}
+          BUILD_SUPPLEMENTAL_RESULT: ${{ needs.build_supplemental.result }}
+          ASSEMBLE_RESULT: ${{ needs.assemble.result }}
+          PUBLISH_RESULT: ${{ needs.publish.result }}
+          REGISTRY_RESULT: ${{ needs.registry.result }}
+          PROMOTE_RESULT: ${{ needs.promote.result }}
+          IMAGE_CHANNEL_RESULT: ${{ needs.image_channel.result }}
+          PUBLISH_GITHUB_STATE: ${{ steps.effects.outputs.github_state }}
+          REGISTRY_LATEST_STATE: ${{ steps.effects.outputs.registry_latest_state }}
+          REGISTRY_NEXT_STATE: ${{ steps.effects.outputs.registry_next_state }}
+          IMAGE_STATE: ${{ steps.effects.outputs.image_state }}
+          IMAGE_CHANNEL_STATE: ${{ steps.effects.outputs.image_channel_state }}
+          IMAGE_DIGEST: ${{ steps.effects.outputs.image_digest }}
+        run: |
+          set -euo pipefail
+          outcome=succeeded; error=null
+          if [[ "$GUARD_RESULT" == cancelled || "$BUILD_SUPPLEMENTAL_RESULT" == cancelled || "$ASSEMBLE_RESULT" == cancelled || "$PUBLISH_RESULT" == cancelled || "$REGISTRY_RESULT" == cancelled || "$PROMOTE_RESULT" == cancelled || "$IMAGE_CHANNEL_RESULT" == cancelled ]]; then
+            outcome=canceled; error='{"code":"finalize_canceled","category":"release","retryable":true,"message":"release finalization was canceled"}'
+          elif [[ "$GUARD_RESULT" != success || "$ASSEMBLE_RESULT" != success || "$PUBLISH_RESULT" != success || "$REGISTRY_RESULT" != success || ( "$BUILD_SUPPLEMENTAL_RESULT" != success && "$BUILD_SUPPLEMENTAL_RESULT" != skipped ) || ( "$IMAGE_CHANNEL_RESULT" != success && "$IMAGE_CHANNEL_RESULT" != skipped ) ]]; then
+            outcome=failed; error='{"code":"finalize_failed","category":"release","retryable":true,"message":"release finalization did not complete"}'
+          elif [[ "$PROMOTE_RESULT" != success ]]; then
+            outcome=failed; error='{"code":"finalize_promote_failed","category":"release","retryable":true,"message":"the Registry finalized but the GitHub release was not marked repo-latest"}'
+          fi
+          artifacts='[]'
+          kind=unknown
+          if [[ -f deploy-prepared/prepared-artifacts.json ]]; then artifacts=$(jq -c '[.artifacts[] | del(.unit)]' deploy-prepared/prepared-artifacts.json); fi
+          if [[ -f deploy-prepared/deployment-descriptor.json ]]; then kind=$(jq -r .artifact.kind deploy-prepared/deployment-descriptor.json); fi
+          normalize_state() {
+            python3 -c 'import sys; value=sys.argv[1].strip(); print(value if value in {"absent", "present", "unknown"} else "unknown")' "$1"
+          }
+          github_state=$(normalize_state "${PUBLISH_GITHUB_STATE:-unknown}")
+          registry_latest_state=$(normalize_state "${REGISTRY_LATEST_STATE:-unknown}")
+          registry_next_state=$(normalize_state "${REGISTRY_NEXT_STATE:-unknown}")
+          effects=$(jq -nc --arg tag "$WORKER/v$TARGET_VERSION" --arg version "$TARGET_VERSION" --arg github_state "$github_state" --arg latest_state "$registry_latest_state" --arg next_state "$registry_next_state" '[{surface:"github-release",state:$github_state,immutable_id:$tag},{surface:"registry-latest",state:$latest_state,after:$version},{surface:"registry-next",state:$next_state,after:$version}]')
+          if [[ "$kind" == oci-image ]]; then
+            image_state=$(normalize_state "${IMAGE_STATE:-unknown}")
+            image_effect=$(jq -nc --arg state "$image_state" --arg digest "$IMAGE_DIGEST" 'if $digest == "" then {surface:"registry-image",state:$state} else {surface:"registry-image",state:$state,immutable_id:$digest} end')
+            image_channel_state=$(normalize_state "${IMAGE_CHANNEL_STATE:-unknown}")
+            channel_effect=$(jq -nc --arg channel "$DEPLOYMENT_CHANNEL" --arg state "$image_channel_state" --arg digest "$IMAGE_DIGEST" '{surface:("image-"+$channel),state:$state,immutable_id:$digest}')
+            effects=$(jq -cn --argjson effects "$effects" --argjson image "$image_effect" --argjson channel "$channel_effect" '$effects + [$image,$channel]')
+          fi
+          jq -e 'all(.[]; .state == "absent" or .state == "present" or .state == "unknown")' <<<"$effects" >/dev/null
+          python3 .github/scripts/deployment_control_contract.py write-result --repository '${{ github.repository }}' --step-id "$STEP_ID" --run-id '${{ github.run_id }}' --run-attempt '${{ github.run_attempt }}' --workflow 'deploy-finalize.yml' --event '${{ github.event_name }}' --sha '${{ github.sha }}' --deployment-batch-id "$DEPLOYMENT_BATCH_ID" --deployment-target-id "$DEPLOYMENT_TARGET_ID" --attempt-id "$ATTEMPT_ID" --dispatch-nonce "$DISPATCH_NONCE" --plan-hash "$PLAN_HASH" --worker "$WORKER" --phase finalize --source-sha "$SOURCE_SHA" --prepared-sha "$SOURCE_SHA" --candidate-version "$SOURCE_RC_VERSION" --target-version "$TARGET_VERSION" --channel "$DEPLOYMENT_CHANNEL" --descriptor-sha256 "$DESCRIPTOR_SHA256" --outcome "$outcome" --effects "$effects" --artifacts-json "$artifacts" --error-json "$error" --output deployment-result.json
+      - if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: deployment-result-${{ env.DEPLOYMENT_TARGET_ID }}-${{ env.STEP_ID }}-attempt-${{ github.run_attempt }}
+          path: deployment-result.json
+          retention-days: 30
+          if-no-files-found: error
+      - name: Report to Release Control
+        if: always()
+        env:
+          RELEASE_CONTROL_API_URL: ${{ vars.RELEASE_CONTROL_API_URL }}
+        run: python3 .github/scripts/deployment_control_contract.py post-result --api-url "$RELEASE_CONTROL_API_URL" --result deployment-result.json

--- a/.github/workflows/deploy-prepare.yml
+++ b/.github/workflows/deploy-prepare.yml
@@ -162,7 +162,7 @@ jobs:
           set -euo pipefail
           {
             echo "prepared_sha=$(jq -r .source_sha deployment-input/deployment-descriptor.json)"
-            echo "matrix=$(python3 .github/scripts/deployment_train.py matrix --descriptor deployment-input/deployment-descriptor.json)"
+            echo "matrix=$(python3 .github/scripts/deployment_train.py matrix --descriptor deployment-input/deployment-descriptor.json --profile candidate)"
             echo "artifact=deployment-descriptor-$DEPLOYMENT_TARGET_ID-$STEP_ID"
             echo "frontend_artifact=deployment-frontend-$DEPLOYMENT_TARGET_ID-$STEP_ID"
           } >> "$GITHUB_OUTPUT"
@@ -237,7 +237,10 @@ jobs:
           name: deployment-prepared-${{ env.DEPLOYMENT_TARGET_ID }}
           path: deploy-prepared/
           if-no-files-found: error
-          retention-days: 7
+          # Fast path for release finalization: verified rc bytes must outlive
+          # the soak window, so keep them long enough to promote without a
+          # rebuild.
+          retention-days: 90
 
   report:
     if: always()

--- a/docs/architecture/deploy-modes.md
+++ b/docs/architecture/deploy-modes.md
@@ -6,15 +6,25 @@ The release train consumes only that descriptor after prepare.
 
 | `artifact.kind` | Prepared artifact | Publication |
 |---|---|---|
-| `rust-binary` | one deterministic `tar.gz` and checksum per target | GitHub Release URLs and digests keyed by Rust target |
+| `rust-binary` | one deterministic `tar.gz` (`zip` on Windows) and checksum per target | GitHub Release URLs and digests keyed by Rust target |
 | `javascript-bundle` | one deterministic archive from explicit files | GitHub Release archive URL and digest |
 | `python-bundle` | one deterministic archive from explicit files | GitHub Release archive URL and digest |
 | `oci-image` | deterministic OCI-layout archive | digest-pinned GHCR image |
 
+Rust workers declare two target profiles: `candidate_targets` (the Unix
+matrix built for every release candidate) and `stable_targets` (the full set a
+finalized stable version ships, optionally adding `x86_64-pc-windows-msvc` for
+workers that opt in — absence must be justified with `windows_exception`).
+`candidate_targets` must be a subset of `stable_targets`; the stable-delta is
+built only at finalization by
+[`deploy-finalize.yml`](../../.github/workflows/deploy-finalize.yml), which
+reuses the rc bytes for everything else and assembles a stable inventory.
+
 [`deploy-prepare.yml`](../../.github/workflows/deploy-prepare.yml) builds one
-matrix job per descriptor build unit. Embedded frontends are built once before
-the Rust target fan-out. Rust units share remote sccache objects by toolchain
-and target, but artifact bytes remain target-specific.
+matrix job per descriptor build unit (the candidate profile). Embedded
+frontends are built once before the Rust target fan-out. Rust units share
+remote sccache objects by toolchain and target, but artifact bytes remain
+target-specific.
 
 [`deploy-publish.yml`](../../.github/workflows/deploy-publish.yml) publishes one
 exact immutable target version and assigns Registry `next` or `latest` with an

--- a/docs/sops/release.md
+++ b/docs/sops/release.md
@@ -20,16 +20,28 @@ planning.
 
 ## Sequence
 
+Releases are rc-first: `next` only ever receives `X.Y.Z-rc.N` candidates
+(minted by the nightly window or an operator deploy), and `latest` only ever
+receives the pure `X.Y.Z` minted by a `finalize_release` operation from a
+tested candidate.
+
 1. `deploy-prepare.yml` authorizes the dispatch, verifies descriptor identity,
-   builds one job per target, and uploads the byte-unchanged descriptor,
-   prepared inventory, and artifacts with their SHA-256 and size.
+   builds one job per **candidate-profile** target, and uploads the
+   byte-unchanged descriptor, prepared inventory, and artifacts with their
+   SHA-256 and size (retained 90 days as the finalization fast path).
 2. `deploy-publish.yml` publishes or proves GitHub assets, the exact Registry
    version and a digest-pinned OCI image when applicable, then CASes the
-   requested `next` or `latest` channel from the value captured in the plan.
-   For `latest`, it first advances `next` only when the target is ahead and
-   never moves `next` backwards. The OCI channel alias is updated by digest in
-   this same workflow.
-3. `deploy-verify.yml` verifies GitHub, Registry and optional GHCR surfaces.
+   requested channel from the value captured in the plan.
+3. `deploy-finalize.yml` executes `finalize_release` operations exclusively:
+   it re-verifies the rc bytes (from the retained artifact, or from the rc's
+   immutable GitHub Release checked against Registry hashes when the artifact
+   expired), builds only the supplemental **stable-profile** targets (Windows
+   `x86_64-pc-windows-msvc` for opted-in workers), assembles the stable
+   inventory without rebuilding anything already proved, publishes the pure
+   version to the Registry **without a channel**, and then moves `next` and
+   `latest` together through the Registry's transactional finalize primitive.
+   It shares the `deployment-<worker>` concurrency group with publish.
+4. `deploy-verify.yml` verifies GitHub, Registry and optional GHCR surfaces.
 
 Every entrypoint authorizes with GitHub OIDC audience
 `release-control-workers`. It uploads


### PR DESCRIPTION
## What

The executor side of the rc-first release flow: `@next` only ever receives `X.Y.Z-rc.N` candidates, and `@latest` only ever receives the pure `X.Y.Z` minted by a `finalize_release` operation that **reuses the tested rc bytes** and builds only the supplemental stable-profile targets.

### Scripts
- `_lib.py`: the deployment target grammar accepts `-rc.N`; new `validate_channel_target_version` (latest ⇒ pure version only; next stays permissive until the RC flip is live) and `validate_finalization` (rc candidate + pure stable, same core).
- `.deploy/workers.yaml` + compiler + descriptor schema: rust workers now declare `candidate_targets`/`stable_targets` (candidate ⊆ stable, Windows never in candidate). `browser` opts into `x86_64-pc-windows-msvc`; every other rust worker justifies its absence with an explicit `windows_exception`. Build units remain the candidate profile; compiler digest re-pinned.
- `deployment_train.py`: `matrix --profile candidate|stable|stable-delta`, a `finalize` intent gate (annotated rc tag + release history), and `assemble-stable` unioning verified rc bytes with supplemental build results into the exact stable inventory.
- `deployment_control_contract.py`: `finalize` phase; the subject binds `candidate_version` (rc, same core, channel latest, `prepared_sha == source_sha`); channel/version-form enforced on authorize and write-result.
- `registry_publication.py`: `finalize-release` client for the Registry's transactional dual-pointer move, with next+latest readback after every attempt.

### Workflows
- **`deploy-finalize.yml` (new)**: exclusive `finalize_release` executor. Guard re-proves the rc bytes (retained artifact fast path, or reconstruction from the immutable GitHub Release cross-checked against the Registry record when retention expired — an expired artifact never makes a valid rc non-finalizable), builds the Windows delta on `windows-latest`, assembles the stable inventory, publishes the pure version **without a channel**, executes the atomic finalize, and only then grants repo-latest / moves the OCI channel. Shares the `deployment-<worker>` concurrency group with publish.
- **`_deploy-registry-finalize.yml` (new)**: channelless stable publication + atomic `finalize-release`; never uses `advance-next-floor`/`assign-channel`.
- `_deploy-build.yml` is Windows-capable (bash defaults, portable frontend copy, stable-delta units accepted by the jq gate); `deploy-prepare.yml` retains prepared artifacts for 90 days and pins `--profile candidate`.

## Tests

Full suite 284 passed (from 240): grammar/channel/finalization units, profile matrices, finalize/assemble-stable train coverage, contract-phase coverage, atomic finalize client coverage (happy/idempotent/CAS-conflict/transport-recovery), and workflow-contract pins for both new files (shared concurrency, retention 90, no piecewise channel moves, repo-latest only after the receipt). Cross-repo check: a generated finalize result validates against both this repo's execution schema and Release Control's ingest schema, and the dispatch input set matches Release Control's executor byte-for-byte.

## Rollout

Deploy order: Registry finalize primitive is already live (iii-hq/registry#91). This PR lands before the Release Control orchestrator (rc-first flow) — `next` still accepts pure versions here so the nightly window never wedges between the two deploys; the `next ⇒ suffixed` invariant tightens in a follow-up after the RC flip is live.

Fixes MOT-4614

https://claude.ai/code/session_01MKFaAGVqL8CcLKaBwL53L9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a release-candidate workflow that promotes validated candidates to stable releases.
  * Added atomic promotion of `next` and `latest` release channels.
  * Added stable-profile support for validated Windows builds.
  * Added release finalization controls, version validation, and artifact integrity checks.
  * Improved cross-platform build compatibility and extended prepared-artifact retention.

* **Documentation**
  * Updated release and deployment guidance for the candidate-to-stable workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->