### PR TITLE
(MOT-3944) fix(queue): scope providers and deliveries by namespace

### DIFF
--- a/queue/Cargo.lock
+++ b/queue/Cargo.lock
@@ -1217,9 +1217,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.22.1-alpha.25"
+version = "0.23.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d24f39bff5a54a18ad0dbe92fff0311fe7d12445ec26da12b8d6b09056166bc"
+checksum = "048e37be8f4a9dddad14dbdffa37dce05bd3a5ae40b5497c80db333f911fabdc"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -1264,9 +1264,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.22.1-alpha.25"
+version = "0.23.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb1167081b82a1aa9f12b05ad9e093fdf1cd2a3ed282bb66451a26e37f4a459"
+checksum = "e44ba89dd7dedc26bf2f17dee1ec4e64b4544cc4fb2deea34e37112c759830cf"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/queue/Cargo.toml
+++ b/queue/Cargo.toml
@@ -27,9 +27,9 @@ rabbitmq = ["dep:lapin"]
 test-adapters = []
 
 [dependencies]
-iii-sdk = "=0.22.1-alpha.25"
+iii-sdk = "=0.23.0-rc.10"
 iii-worker-paths = { path = "../crates/worker-paths" }
-iii-helpers = "=0.22.1-alpha.25"
+iii-helpers = "=0.23.0-rc.10"
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time"] }
 serde = { version = "1", features = ["derive"] }

--- a/queue/src/adapter.rs
+++ b/queue/src/adapter.rs
@@ -208,6 +208,7 @@ pub trait QueueAdapter: Send + Sync + 'static {
         metadata: Option<Value>,
         condition_function_id: Option<String>,
         queue_config: Option<SubscriberQueueConfig>,
+        namespace: Option<String>,
     );
 
     /// Remove a previously registered subscriber.
@@ -399,6 +400,7 @@ impl QueueAdapter for SwappableAdapter {
         metadata: Option<Value>,
         condition_function_id: Option<String>,
         queue_config: Option<SubscriberQueueConfig>,
+        namespace: Option<String>,
     ) {
         self.current()
             .await
@@ -409,6 +411,7 @@ impl QueueAdapter for SwappableAdapter {
                 metadata,
                 condition_function_id,
                 queue_config,
+                namespace,
             )
             .await;
     }
@@ -574,6 +577,7 @@ mod tests {
             _metadata: Option<Value>,
             _condition_function_id: Option<String>,
             _queue_config: Option<SubscriberQueueConfig>,
+            _namespace: Option<String>,
         ) {
         }
 

--- a/queue/src/adapters/builtin.rs
+++ b/queue/src/adapters/builtin.rs
@@ -99,6 +99,7 @@ struct PollerConfig {
     /// The trigger's stored metadata, delivered with every message (the
     /// harness's `__binding` pointer — see `trigger.rs::RegisteredSubscriber`).
     metadata: Option<Value>,
+    namespace: Option<String>,
     condition_function_id: Option<String>,
     max_retries: u32,
     backoff_ms: u64,
@@ -237,6 +238,7 @@ impl QueueAdapter for BuiltinAdapter {
         metadata: Option<Value>,
         condition_function_id: Option<String>,
         queue_config: Option<SubscriberQueueConfig>,
+        namespace: Option<String>,
     ) {
         let key = (topic.to_string(), id.to_string());
         let mut subs = self.subscriptions.lock().await;
@@ -277,6 +279,7 @@ impl QueueAdapter for BuiltinAdapter {
             queue_name,
             function_id: function_id.to_string(),
             metadata,
+            namespace,
             condition_function_id,
             max_retries,
             backoff_ms,
@@ -968,6 +971,7 @@ async fn process_job(
         invoker.as_ref(),
         &cfg.function_id,
         cfg.metadata.clone(),
+        cfg.namespace.as_deref(),
         cfg.condition_function_id.as_deref(),
         job.payload.clone(),
     )
@@ -992,18 +996,22 @@ async fn invoke(
     invoker: &dyn Invoker,
     function_id: &str,
     metadata: Option<Value>,
+    namespace: Option<&str>,
     condition_function_id: Option<&str>,
     payload: Value,
 ) -> Result<(), String> {
     if let Some(condition_id) = condition_function_id {
-        match invoker.call(condition_id, payload.clone()).await {
+        match invoker
+            .call_in_namespace(condition_id, payload.clone(), namespace)
+            .await
+        {
             Ok(Some(Value::Bool(false))) => return Ok(()),
             Ok(_) => {}
             Err(err) => return Err(err),
         }
     }
     invoker
-        .call_delivery(function_id, payload, metadata)
+        .call_delivery(function_id, payload, metadata, namespace)
         .await
         .map(|_| ())
 }
@@ -1284,6 +1292,7 @@ mod tests {
     struct FakeInvoker {
         calls: Mutex<Vec<(String, Value)>>,
         delivery_metadata: Mutex<Vec<Option<Value>>>,
+        delivery_namespaces: Mutex<Vec<Option<String>>>,
         fail_backend: AtomicBool,
         condition_value: Mutex<Option<Value>>,
     }
@@ -1295,6 +1304,10 @@ mod tests {
 
         async fn delivery_metadata(&self) -> Vec<Option<Value>> {
             self.delivery_metadata.lock().await.clone()
+        }
+
+        async fn delivery_namespaces(&self) -> Vec<Option<String>> {
+            self.delivery_namespaces.lock().await.clone()
         }
     }
 
@@ -1320,8 +1333,13 @@ mod tests {
             function_id: &str,
             payload: Value,
             metadata: Option<Value>,
+            namespace: Option<&str>,
         ) -> Result<Option<Value>, String> {
             self.delivery_metadata.lock().await.push(metadata);
+            self.delivery_namespaces
+                .lock()
+                .await
+                .push(namespace.map(str::to_string));
             self.call(function_id, payload).await
         }
     }
@@ -1476,7 +1494,7 @@ mod tests {
         let adapter = BuiltinAdapter::with_poll_interval_ms(store.clone(), invoker.clone(), 5);
 
         adapter
-            .subscribe("demo", "sub1", "backend", None, None, None)
+            .subscribe("demo", "sub1", "backend", None, None, None, None)
             .await;
         adapter
             .enqueue("demo", json!({"hello": "world"}), None, None)
@@ -1501,10 +1519,10 @@ mod tests {
         let adapter = BuiltinAdapter::with_poll_interval_ms(store.clone(), invoker.clone(), 5);
 
         adapter
-            .subscribe("demo", "sub-a", "fn-a", None, None, None)
+            .subscribe("demo", "sub-a", "fn-a", None, None, None, None)
             .await;
         adapter
-            .subscribe("demo", "sub-b", "fn-b", None, None, None)
+            .subscribe("demo", "sub-b", "fn-b", None, None, None, None)
             .await;
 
         for i in 0..3 {
@@ -1526,7 +1544,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn same_function_subscriptions_each_receive_their_metadata() {
+    async fn same_function_subscriptions_receive_metadata_and_namespace() {
         let store: Arc<dyn QueueStore> = Arc::new(InMemoryStore::new());
         let invoker = Arc::new(FakeInvoker::default());
         let adapter = BuiltinAdapter::with_poll_interval_ms(store, invoker.clone(), 5);
@@ -1539,6 +1557,7 @@ mod tests {
                 Some(json!({"binding": "a"})),
                 None,
                 None,
+                Some("project-a".to_string()),
             )
             .await;
         adapter
@@ -1549,6 +1568,7 @@ mod tests {
                 Some(json!({"binding": "b"})),
                 None,
                 None,
+                Some("project-b".to_string()),
             )
             .await;
         adapter
@@ -1570,6 +1590,10 @@ mod tests {
         assert_eq!(metadata.len(), 2);
         assert!(metadata.contains(&Some(json!({"binding": "a"}))));
         assert!(metadata.contains(&Some(json!({"binding": "b"}))));
+        let namespaces = invoker.delivery_namespaces().await;
+        assert_eq!(namespaces.len(), 2);
+        assert!(namespaces.contains(&Some("project-a".to_string())));
+        assert!(namespaces.contains(&Some("project-b".to_string())));
         adapter.shutdown().await;
     }
 
@@ -1613,6 +1637,7 @@ mod tests {
                     concurrency: Some(0),
                     ..Default::default()
                 }),
+                None,
             )
             .await;
         adapter
@@ -1645,6 +1670,7 @@ mod tests {
                     concurrency: Some(3),
                     ..Default::default()
                 }),
+                None,
             )
             .await;
         for i in 0..12 {
@@ -1683,6 +1709,7 @@ mod tests {
                     concurrency: Some(5),
                     ..Default::default()
                 }),
+                None,
             )
             .await;
         for i in 0..20 {
@@ -1723,6 +1750,7 @@ mod tests {
                     backoff_delay_ms: Some(1),
                     ..Default::default()
                 }),
+                None,
             )
             .await;
         adapter.enqueue("demo", json!("job"), None, None).await;
@@ -1754,10 +1782,10 @@ mod tests {
             })
         };
         adapter
-            .subscribe("demo", "sub-a", "fn-a", None, None, retry_cfg())
+            .subscribe("demo", "sub-a", "fn-a", None, None, retry_cfg(), None)
             .await;
         adapter
-            .subscribe("demo", "sub-b", "fn-b", None, None, retry_cfg())
+            .subscribe("demo", "sub-b", "fn-b", None, None, retry_cfg(), None)
             .await;
 
         adapter.enqueue("demo", json!("job"), None, None).await;
@@ -1800,6 +1828,7 @@ mod tests {
                     concurrency: Some(0),
                     ..Default::default()
                 }),
+                None,
             )
             .await;
         adapter.enqueue("demo", json!("queued"), None, None).await;
@@ -1819,7 +1848,7 @@ mod tests {
 
         // Re-arming under the same id resumes exactly where it left off.
         adapter
-            .subscribe("demo", "sub1", "backend", None, None, None)
+            .subscribe("demo", "sub1", "backend", None, None, None, None)
             .await;
         wait_until(|| {
             let invoker = invoker.clone();
@@ -1845,7 +1874,7 @@ mod tests {
         ));
 
         adapter
-            .subscribe("demo", "sub1", "backend", None, None, None)
+            .subscribe("demo", "sub1", "backend", None, None, None, None)
             .await;
         adapter.enqueue("demo", json!("inflight"), None, None).await;
         tokio::time::timeout(Duration::from_secs(1), invoker.started.notified())
@@ -1895,10 +1924,10 @@ mod tests {
             ..Default::default()
         });
         adapter
-            .subscribe("demo", "sub1", "backend", None, None, paused.clone())
+            .subscribe("demo", "sub1", "backend", None, None, paused.clone(), None)
             .await;
         adapter
-            .subscribe("other", "sub2", "backend", None, None, paused)
+            .subscribe("other", "sub2", "backend", None, None, paused, None)
             .await;
 
         let entered = store.entered.notified();
@@ -1959,6 +1988,7 @@ mod tests {
                 None,
                 Some("condition".to_string()),
                 None,
+                None,
             )
             .await;
         adapter
@@ -1983,10 +2013,10 @@ mod tests {
         let adapter = BuiltinAdapter::with_poll_interval_ms(store.clone(), invoker.clone(), 3);
 
         adapter
-            .subscribe("demo", "sub1", "backend", None, None, None)
+            .subscribe("demo", "sub1", "backend", None, None, None, None)
             .await;
         adapter
-            .subscribe("demo", "sub1", "other-backend", None, None, None)
+            .subscribe("demo", "sub1", "other-backend", None, None, None, None)
             .await;
         assert_eq!(adapter.subscriptions.lock().await.len(), 1);
         adapter.shutdown().await;

--- a/queue/src/adapters/memory.rs
+++ b/queue/src/adapters/memory.rs
@@ -63,6 +63,7 @@ impl QueueAdapter for MemoryAdapter {
         metadata: Option<Value>,
         condition_function_id: Option<String>,
         queue_config: Option<SubscriberQueueConfig>,
+        namespace: Option<String>,
     ) {
         self.inner
             .subscribe(
@@ -72,6 +73,7 @@ impl QueueAdapter for MemoryAdapter {
                 metadata,
                 condition_function_id,
                 queue_config,
+                namespace,
             )
             .await;
     }
@@ -220,7 +222,7 @@ mod tests {
         let adapter = MemoryAdapter::new(invoker.clone());
 
         adapter
-            .subscribe("demo", "sub-1", "fn-1", None, None, None)
+            .subscribe("demo", "sub-1", "fn-1", None, None, None, None)
             .await;
         adapter
             .enqueue("demo", json!({"hello": "world"}), None, None)

--- a/queue/src/adapters/rabbitmq/adapter.rs
+++ b/queue/src/adapters/rabbitmq/adapter.rs
@@ -378,6 +378,7 @@ impl QueueAdapter for RabbitMQAdapter {
         metadata: Option<Value>,
         condition_function_id: Option<String>,
         queue_config: Option<SubscriberQueueConfig>,
+        namespace: Option<String>,
     ) {
         let topic = topic.to_string();
         let id = id.to_string();
@@ -458,6 +459,7 @@ impl QueueAdapter for RabbitMQAdapter {
                     id_clone,
                     function_id_clone,
                     metadata,
+                    namespace,
                     condition_function_id,
                     consumer_tag_clone,
                     queue_name_clone,

--- a/queue/src/adapters/rabbitmq/worker.rs
+++ b/queue/src/adapters/rabbitmq/worker.rs
@@ -42,8 +42,12 @@ async fn check_condition(
     invoker: &dyn Invoker,
     condition_function_id: &str,
     data: Value,
+    namespace: Option<&str>,
 ) -> Result<bool, String> {
-    match invoker.call(condition_function_id, data).await {
+    match invoker
+        .call_in_namespace(condition_function_id, data, namespace)
+        .await
+    {
         Ok(Some(result)) => Ok(result.as_bool() != Some(false)),
         Ok(None) => {
             tracing::warn!(
@@ -95,6 +99,7 @@ impl Worker {
         subscription_id: String,
         function_id: String,
         metadata: Option<Value>,
+        namespace: Option<String>,
         condition_function_id: Option<String>,
         consumer_tag: String,
         queue_name: String,
@@ -162,6 +167,7 @@ impl Worker {
                                     &subscription_id,
                                     &function_id,
                                     metadata.as_ref(),
+                                    namespace.as_deref(),
                                     condition_function_id.as_deref(),
                                 )
                                 .await
@@ -179,6 +185,7 @@ impl Worker {
                             let subscription_id_clone = subscription_id.clone();
                             let function_id_clone = function_id.clone();
                             let metadata_clone = metadata.clone();
+                            let namespace_clone = namespace.clone();
                             let condition_function_id_clone = condition_function_id.clone();
                             let semaphore = self.semaphore.as_ref().map(Arc::clone);
                             tasks.spawn(async move {
@@ -195,6 +202,7 @@ impl Worker {
                                         &subscription_id_clone,
                                         &function_id_clone,
                                         metadata_clone.as_ref(),
+                                        namespace_clone.as_deref(),
                                         condition_function_id_clone.as_deref(),
                                     )
                                     .await
@@ -232,6 +240,8 @@ impl Worker {
         }
     }
 
+    // Keep the delivery and subscriber routing fields explicit at this broker boundary.
+    #[expect(clippy::too_many_arguments)]
     async fn process_delivery(
         &self,
         delivery: Delivery,
@@ -239,12 +249,19 @@ impl Worker {
         subscription_id: &str,
         function_id: &str,
         metadata: Option<&Value>,
+        namespace: Option<&str>,
         condition_function_id: Option<&str>,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let mut job = JobParser::parse_from_delivery(&delivery)?;
 
         match self
-            .process_job(&job, function_id, metadata, condition_function_id)
+            .process_job(
+                &job,
+                function_id,
+                metadata,
+                namespace,
+                condition_function_id,
+            )
             .await
         {
             Ok(_) => {
@@ -282,6 +299,7 @@ impl Worker {
         job: &Job,
         function_id: &str,
         metadata: Option<&Value>,
+        namespace: Option<&str>,
         condition_function_id: Option<&str>,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let invoker = Arc::clone(&self.invoker);
@@ -292,7 +310,7 @@ impl Worker {
                 condition_function_id = %condition_path,
                 "Checking trigger conditions"
             );
-            match check_condition(invoker.as_ref(), condition_path, data.clone()).await {
+            match check_condition(invoker.as_ref(), condition_path, data.clone(), namespace).await {
                 Ok(true) => {}
                 Ok(false) => {
                     tracing::debug!(
@@ -313,7 +331,7 @@ impl Worker {
         }
 
         match invoker
-            .call_delivery(function_id, data, metadata.cloned())
+            .call_delivery(function_id, data, metadata.cloned(), namespace)
             .await
         {
             Ok(_) => {

--- a/queue/src/adapters/redis.rs
+++ b/queue/src/adapters/redis.rs
@@ -128,8 +128,12 @@ async fn check_condition(
     invoker: &dyn Invoker,
     condition_function_id: &str,
     data: Value,
+    namespace: Option<&str>,
 ) -> Result<bool, String> {
-    match invoker.call(condition_function_id, data).await {
+    match invoker
+        .call_in_namespace(condition_function_id, data, namespace)
+        .await
+    {
         Ok(Some(result)) => Ok(result.as_bool() != Some(false)),
         Ok(None) => {
             tracing::warn!(
@@ -192,6 +196,7 @@ impl QueueAdapter for RedisAdapter {
         metadata: Option<Value>,
         condition_function_id: Option<String>,
         _queue_config: Option<SubscriberQueueConfig>,
+        namespace: Option<String>,
     ) {
         let topic = topic.to_string();
         let id = id.to_string();
@@ -217,6 +222,7 @@ impl QueueAdapter for RedisAdapter {
         let id_for_task = id.clone();
         let function_id_for_task = function_id.clone();
         let metadata_for_task = metadata.clone();
+        let namespace_for_task = namespace.clone();
         let condition_function_id_for_task = condition_function_id.clone();
 
         tracing::debug!(topic = %topic_for_task, id = %id_for_task, function_id = %function_id_for_task, "Subscribing to Redis channel");
@@ -297,7 +303,14 @@ impl QueueAdapter for RedisAdapter {
                         condition_function_id = %condition_id,
                         "Checking trigger conditions"
                     );
-                    match check_condition(invoker.as_ref(), condition_id, data.clone()).await {
+                    match check_condition(
+                        invoker.as_ref(),
+                        condition_id,
+                        data.clone(),
+                        namespace_for_task.as_deref(),
+                    )
+                    .await
+                    {
                         Ok(true) => {}
                         Ok(false) => {
                             tracing::debug!(
@@ -320,10 +333,14 @@ impl QueueAdapter for RedisAdapter {
                 let invoker = Arc::clone(&invoker);
                 let function_id = function_id_for_task.clone();
                 let metadata = metadata_for_task.clone();
+                let namespace = namespace_for_task.clone();
                 let topic_for_call = topic_for_task.clone();
 
                 tokio::spawn(async move {
-                    if let Err(e) = invoker.call_delivery(&function_id, data, metadata).await {
+                    if let Err(e) = invoker
+                        .call_delivery(&function_id, data, metadata, namespace.as_deref())
+                        .await
+                    {
                         tracing::error!(
                             error = %e,
                             function_id = %function_id,

--- a/queue/src/boot.rs
+++ b/queue/src/boot.rs
@@ -39,11 +39,7 @@ impl BootHandle {
     }
 }
 
-pub async fn start(
-    project_iii: Arc<IIIClient>,
-    default_iii: Arc<IIIClient>,
-    config: QueueConfig,
-) -> anyhow::Result<BootHandle> {
+pub async fn start(project_iii: Arc<IIIClient>, config: QueueConfig) -> anyhow::Result<BootHandle> {
     guard_against_builtin_iii_queue(&project_iii).await?;
 
     let invoker: Arc<dyn Invoker> = Arc::new(IiiInvoker::new(project_iii.clone()));
@@ -70,7 +66,7 @@ pub async fn start(
     // target function to appear, so starting before dependent workers is safe.
     runtime.start().await?;
 
-    crate::functions::register_all(&project_iii, &default_iii, adapter.clone(), runtime.clone());
+    crate::functions::register_all(&project_iii, adapter.clone(), runtime.clone());
     let _ = project_iii.register_trigger_type(
         RegisterTriggerType::new(
             TRIGGER_TYPE,

--- a/queue/src/configuration.rs
+++ b/queue/src/configuration.rs
@@ -266,6 +266,7 @@ mod tests {
             _metadata: Option<serde_json::Value>,
             _condition_function_id: Option<String>,
             _queue_config: Option<crate::subscriber_config::SubscriberQueueConfig>,
+            _namespace: Option<String>,
         ) {
             self.subscribe_calls.fetch_add(1, Ordering::SeqCst);
         }
@@ -333,6 +334,7 @@ mod tests {
                 trigger_id: "t1".to_string(),
                 function_id: "backend".to_string(),
                 metadata: None,
+                namespace: None,
                 spec: SubscriberSpec {
                     queue: "demo".to_string(),
                     max_retries: None,
@@ -377,6 +379,7 @@ mod tests {
                 trigger_id: "t1".to_string(),
                 function_id: "backend".to_string(),
                 metadata: None,
+                namespace: None,
                 spec: SubscriberSpec {
                     queue: "demo".to_string(),
                     max_retries: None,

--- a/queue/src/functions.rs
+++ b/queue/src/functions.rs
@@ -139,7 +139,6 @@ enum AdapterDlqMessage {
 
 pub fn register_all(
     project_iii: &Arc<IIIClient>,
-    default_iii: &Arc<IIIClient>,
     adapter: Arc<SwappableAdapter>,
     runtime: FunctionQueueRuntime,
 ) {
@@ -153,7 +152,7 @@ pub fn register_all(
         .description("Define and start a durable named function queue"),
     );
 
-    default_iii.register_function(
+    project_iii.register_function(
         ENQUEUE_FUNCTION_FN_ID,
         RegisterFunction::new_async(move |input: EnqueueInput| {
             let runtime = runtime.clone();
@@ -203,7 +202,7 @@ pub fn register_all(
     );
 
     let list_adapter = adapter.clone();
-    default_iii.register_function(
+    project_iii.register_function(
         LIST_TOPICS_FN_ID,
         RegisterFunction::new_async(move |_input: ListTopicsInput| {
             let adapter = list_adapter.clone();
@@ -213,7 +212,7 @@ pub fn register_all(
     );
 
     let stats_adapter = adapter.clone();
-    default_iii.register_function(
+    project_iii.register_function(
         TOPIC_STATS_FN_ID,
         RegisterFunction::new_async(move |input: TopicStatsInput| {
             let adapter = stats_adapter.clone();
@@ -223,7 +222,7 @@ pub fn register_all(
     );
 
     let dlq_topics_adapter = adapter.clone();
-    default_iii.register_function(
+    project_iii.register_function(
         DLQ_TOPICS_FN_ID,
         RegisterFunction::new_async(move |_input: DlqTopicsInput| {
             let adapter = dlq_topics_adapter.clone();
@@ -233,7 +232,7 @@ pub fn register_all(
     );
 
     let dlq_messages_adapter = adapter;
-    default_iii.register_function(
+    project_iii.register_function(
         DLQ_MESSAGES_FN_ID,
         RegisterFunction::new_async(move |input: DlqMessagesInput| {
             let adapter = dlq_messages_adapter.clone();
@@ -484,6 +483,7 @@ mod tests {
             _metadata: Option<serde_json::Value>,
             _condition_function_id: Option<String>,
             _queue_config: Option<SubscriberQueueConfig>,
+            _namespace: Option<String>,
         ) {
         }
 

--- a/queue/src/main.rs
+++ b/queue/src/main.rs
@@ -1,13 +1,16 @@
 //! `queue` binary entry.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use clap::Parser;
 use iii_queue::config::QueueConfig;
 use iii_queue::configuration;
 use iii_sdk::runtime::WorkerMetadata;
-use iii_sdk::{register_worker, InitOptions};
+use iii_sdk::{register_worker, InitOptions, WorkerIdentityMode};
+
+const REGISTRATION_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Parser, Debug)]
 #[command(name = "queue", about = "Durable queue worker for iii.")]
@@ -32,13 +35,6 @@ fn worker_metadata() -> WorkerMetadata {
         pid: Some(std::process::id()),
         telemetry: None,
         ..WorkerMetadata::default()
-    }
-}
-
-fn engine_worker_metadata() -> WorkerMetadata {
-    WorkerMetadata {
-        name: "queue-engine".to_string(),
-        ..worker_metadata()
     }
 }
 
@@ -84,9 +80,14 @@ async fn main() -> Result<()> {
         &cli.url,
         InitOptions {
             metadata: Some(worker_metadata()),
+            identity: WorkerIdentityMode::Managed,
             ..InitOptions::default()
         },
     ));
+    project_iii
+        .wait_until_registered(REGISTRATION_TIMEOUT)
+        .await
+        .context("waiting for queue worker registration")?;
     configuration::register_config(&project_iii, seed.as_ref())
         .await
         .map_err(anyhow::Error::msg)
@@ -105,19 +106,7 @@ async fn main() -> Result<()> {
         }
     }
 
-    // Connect the project-scoped worker first. Compose observes that
-    // registration to verify III_NAMESPACE before this process opens the
-    // additional default-scoped connection for reserved engine::* providers.
-    let default_iii = Arc::new(register_worker(
-        &cli.url,
-        InitOptions {
-            metadata: Some(engine_worker_metadata()),
-            namespace: Some("default".to_string()),
-            ..InitOptions::default()
-        },
-    ));
-
-    let boot = iii_queue::boot::start(project_iii.clone(), default_iii.clone(), config).await?;
+    let boot = iii_queue::boot::start(project_iii.clone(), config).await?;
     configuration::register_config_trigger(
         &project_iii,
         boot.runtime.clone(),
@@ -139,6 +128,5 @@ async fn main() -> Result<()> {
     tracing::info!("queue worker shutting down");
     boot.shutdown().await;
     project_iii.shutdown_async().await;
-    default_iii.shutdown_async().await;
     Ok(())
 }

--- a/queue/src/runtime.rs
+++ b/queue/src/runtime.rs
@@ -1347,6 +1347,7 @@ mod tests {
             _metadata: Option<serde_json::Value>,
             _condition_function_id: Option<String>,
             _queue_config: Option<crate::subscriber_config::SubscriberQueueConfig>,
+            _namespace: Option<String>,
         ) {
         }
 

--- a/queue/src/trigger.rs
+++ b/queue/src/trigger.rs
@@ -34,6 +34,8 @@ const FUNCTION_QUEUE_INVOCATION_TIMEOUT_MS: u64 = 30 * 60 * 1_000;
 const ENGINE_EPOCH_PROBE_INTERVAL_MS: u64 = 1_000;
 const ENGINE_EPOCH_PROBE_TIMEOUT_MS: u64 = 3_000;
 const DEFAULT_NAMESPACE: &str = "default";
+const SUBSCRIPTION_NAMESPACE_SEPARATOR: char = '@';
+const SUBSCRIPTION_NAMESPACE_ESCAPE: char = '\\';
 
 /// The engine's boot identity: the earliest `connected_at_ms` among its
 /// in-process (`runtime == "engine"`) workers, which attach once at engine
@@ -314,19 +316,46 @@ impl RegisteredSubscriber {
     /// fresh empty queue and the old one sits bound to the exchange collecting
     /// a copy of every publish forever (the SDK mints a new trigger id per
     /// `register_trigger` call, so `trigger_id` itself cannot be the key).
-    /// A harness binding's `__binding` id is that identity; a plain SDK
-    /// subscriber falls back to its target function id — the pre-binding queue
-    /// naming, which also keeps existing deployments attached to their
-    /// backlogs across the upgrade. Distinct same-function subscribers without
-    /// a binding id therefore share one subscription (first registration's
-    /// config wins), exactly as they shared one function queue before.
-    fn subscription_key(&self) -> &str {
-        self.metadata
+    /// A harness binding's `__binding` id is the base identity; a plain SDK
+    /// subscriber falls back to its target function id. The effective
+    /// namespace is then folded into that base so equal bindings or functions
+    /// in different namespaces never share an adapter consumer or backlog.
+    /// `default` keeps the legacy suffix-less identity for ordinary keys, so
+    /// existing deployments stay attached to their durable queues.
+    fn subscription_key(&self) -> String {
+        let base = self
+            .metadata
             .as_ref()
             .and_then(|m| m.get("__binding"))
             .and_then(Value::as_str)
-            .unwrap_or(&self.function_id)
+            .unwrap_or(&self.function_id);
+        let escaped_base = escape_subscription_key_segment(base);
+        let namespace = self.namespace.as_deref().unwrap_or(DEFAULT_NAMESPACE);
+        if namespace == DEFAULT_NAMESPACE {
+            escaped_base
+        } else {
+            format!(
+                "{escaped_base}{SUBSCRIPTION_NAMESPACE_SEPARATOR}{}",
+                escape_subscription_key_segment(namespace)
+            )
+        }
     }
+}
+
+/// Escape the namespace separator and the escape character inside one
+/// subscription-key segment. This leaves the single unescaped `@` added by
+/// [`RegisteredSubscriber::subscription_key`] as an unambiguous namespace
+/// boundary.
+fn escape_subscription_key_segment(segment: &str) -> String {
+    segment
+        .replace(
+            SUBSCRIPTION_NAMESPACE_ESCAPE,
+            &format!("{SUBSCRIPTION_NAMESPACE_ESCAPE}{SUBSCRIPTION_NAMESPACE_ESCAPE}"),
+        )
+        .replace(
+            SUBSCRIPTION_NAMESPACE_SEPARATOR,
+            &format!("{SUBSCRIPTION_NAMESPACE_ESCAPE}{SUBSCRIPTION_NAMESPACE_SEPARATOR}"),
+        )
 }
 
 /// Merge the spec's legacy top-level `max_retries`/`backoff_ms` into its
@@ -383,7 +412,7 @@ impl QueueTriggerHandler {
     pub async fn resubscribe_all(&self) {
         let mut seen = HashSet::new();
         for registration in self.registrations().await {
-            let key = registration.subscription_key().to_string();
+            let key = registration.subscription_key();
             if !seen.insert((registration.spec.queue.clone(), key.clone())) {
                 continue; // registrations sharing a key share one subscription
             }
@@ -422,7 +451,7 @@ impl QueueTriggerHandler {
         // subscriber whose previous trigger was never unregistered) share the
         // one live subscription instead of stacking duplicate consumers that
         // would each deliver every message again.
-        let key = registration.subscription_key().to_string();
+        let key = registration.subscription_key();
         let already_live = registrations
             .values()
             .any(|r| r.spec.queue == registration.spec.queue && r.subscription_key() == key);
@@ -467,7 +496,7 @@ impl QueueTriggerHandler {
             .any(|r| r.spec.queue == registration.spec.queue && r.subscription_key() == key);
         if !still_shared {
             self.adapter
-                .unsubscribe(&registration.spec.queue, key)
+                .unsubscribe(&registration.spec.queue, &key)
                 .await;
         }
     }
@@ -686,9 +715,9 @@ mod tests {
         };
         assert_eq!(metadata, &Some(json!({ "__binding": "sub_abc" })));
         assert_eq!(namespace.as_deref(), Some("my-harness-ns"));
-        // The binding id is the durable subscription identity — it, not the
-        // ephemeral trigger id, keys the adapter's queue.
-        assert_eq!(id, "sub_abc");
+        // The binding id plus namespace is the durable subscription identity;
+        // the ephemeral trigger id does not key the adapter's queue.
+        assert_eq!(id, "sub_abc@my-harness-ns");
 
         // And a hot-swap resubscribe carries it to the NEW adapter too.
         let new_mock = Arc::new(MockAdapter::default());
@@ -706,7 +735,83 @@ mod tests {
         };
         assert_eq!(metadata, &Some(json!({ "__binding": "sub_abc" })));
         assert_eq!(namespace.as_deref(), Some("my-harness-ns"));
-        assert_eq!(id, "sub_abc");
+        assert_eq!(id, "sub_abc@my-harness-ns");
+    }
+
+    /// Equal queue/function pairs in different namespaces are independent
+    /// subscriptions. They must also remain independent after an adapter
+    /// hot-swap and when either trigger is removed.
+    #[tokio::test]
+    async fn namespaces_scope_subscription_identity_across_register_swap_and_unregister() {
+        let (handler, old_mock) = handler_with_mock();
+        let mut project_a = trigger_config("t-a", "backend", json!({"queue": "demo"}));
+        project_a.namespace = Some("project-a".to_string());
+        handler.register_trigger(project_a).await.unwrap();
+
+        let mut project_b = trigger_config("t-b", "backend", json!({"queue": "demo"}));
+        project_b.namespace = Some("project-b".to_string());
+        handler.register_trigger(project_b).await.unwrap();
+
+        let initial_calls = old_mock.calls();
+        assert_eq!(initial_calls.len(), 2);
+        assert!(initial_calls.iter().any(|call| matches!(
+            call,
+            Call::Subscribe { id, namespace, .. }
+                if id == "backend@project-a" && namespace.as_deref() == Some("project-a")
+        )));
+        assert!(initial_calls.iter().any(|call| matches!(
+            call,
+            Call::Subscribe { id, namespace, .. }
+                if id == "backend@project-b" && namespace.as_deref() == Some("project-b")
+        )));
+
+        let new_mock = Arc::new(MockAdapter::default());
+        let new_adapter: Arc<dyn QueueAdapter> = new_mock.clone();
+        handler.adapter.replace(new_adapter, "new-mock").await;
+        handler.resubscribe_all().await;
+
+        let swapped_calls = new_mock.calls();
+        assert_eq!(swapped_calls.len(), 2);
+        assert!(swapped_calls.iter().any(|call| matches!(
+            call,
+            Call::Subscribe { id, .. } if id == "backend@project-a"
+        )));
+        assert!(swapped_calls.iter().any(|call| matches!(
+            call,
+            Call::Subscribe { id, .. } if id == "backend@project-b"
+        )));
+
+        handler.unregister("t-a").await;
+        assert_eq!(
+            new_mock.calls().last().unwrap(),
+            &Call::Unsubscribe {
+                topic: "demo".to_string(),
+                id: "backend@project-a".to_string(),
+            }
+        );
+        assert_eq!(handler.registrations().await.len(), 1);
+    }
+
+    #[test]
+    fn subscription_identity_escapes_user_controlled_separator_characters() {
+        let registration = RegisteredSubscriber {
+            trigger_id: "t1".to_string(),
+            function_id: r"backend@v1\path".to_string(),
+            metadata: None,
+            namespace: Some(r"tenant@east\prod".to_string()),
+            spec: SubscriberSpec {
+                queue: "demo".to_string(),
+                max_retries: None,
+                backoff_ms: None,
+                condition_function_id: None,
+                queue_config: None,
+            },
+        };
+
+        assert_eq!(
+            registration.subscription_key(),
+            r"backend\@v1\\path@tenant\@east\\prod"
+        );
     }
 
     /// The SDK mints a fresh trigger id per registration, so a restarted

--- a/queue/src/trigger.rs
+++ b/queue/src/trigger.rs
@@ -33,6 +33,7 @@ const FUNCTION_QUEUE_INVOCATION_TIMEOUT_MS: u64 = 30 * 60 * 1_000;
 /// while an invocation is in flight, and how long one sample may take.
 const ENGINE_EPOCH_PROBE_INTERVAL_MS: u64 = 1_000;
 const ENGINE_EPOCH_PROBE_TIMEOUT_MS: u64 = 3_000;
+const DEFAULT_NAMESPACE: &str = "default";
 
 /// The engine's boot identity: the earliest `connected_at_ms` among its
 /// in-process (`runtime == "engine"`) workers, which attach once at engine
@@ -87,8 +88,21 @@ pub trait Invoker: Send + Sync + 'static {
         function_id: &str,
         payload: Value,
         metadata: Option<Value>,
+        namespace: Option<&str>,
     ) -> Result<Option<Value>, String> {
         let _ = metadata;
+        let _ = namespace;
+        self.call(function_id, payload).await
+    }
+
+    /// Invoke a condition or support function in the subscriber namespace.
+    async fn call_in_namespace(
+        &self,
+        function_id: &str,
+        payload: Value,
+        namespace: Option<&str>,
+    ) -> Result<Option<Value>, String> {
+        let _ = namespace;
         self.call(function_id, payload).await
     }
 
@@ -133,7 +147,30 @@ impl IiiInvoker {
 #[async_trait]
 impl Invoker for IiiInvoker {
     async fn call(&self, function_id: &str, payload: Value) -> Result<Option<Value>, String> {
-        self.call_delivery(function_id, payload, None).await
+        self.call_delivery(function_id, payload, None, None).await
+    }
+
+    async fn call_in_namespace(
+        &self,
+        function_id: &str,
+        payload: Value,
+        namespace: Option<&str>,
+    ) -> Result<Option<Value>, String> {
+        let request = TriggerRequest {
+            function_id: function_id.to_string(),
+            payload,
+            action: None,
+            timeout_ms: None,
+        };
+        let request = match namespace {
+            Some(namespace) => request.namespace(namespace),
+            None => request.into(),
+        };
+        self.iii
+            .trigger(request)
+            .await
+            .map(Some)
+            .map_err(|e| e.to_string())
     }
 
     async fn call_with_timeout(
@@ -163,6 +200,7 @@ impl Invoker for IiiInvoker {
         function_id: &str,
         payload: Value,
         metadata: Option<Value>,
+        namespace: Option<&str>,
     ) -> Result<Option<Value>, String> {
         let request = TriggerRequest {
             function_id: function_id.to_string(),
@@ -170,12 +208,18 @@ impl Invoker for IiiInvoker {
             action: None,
             timeout_ms: Some(FUNCTION_QUEUE_INVOCATION_TIMEOUT_MS),
         };
-        match metadata {
-            Some(m) => self.iii.trigger(request.metadata(m)).await,
-            None => self.iii.trigger(request).await,
+        let mut request = match metadata {
+            Some(metadata) => request.metadata(metadata),
+            None => request.into(),
+        };
+        if let Some(namespace) = namespace {
+            request = request.namespace(namespace);
         }
-        .map(Some)
-        .map_err(|e| e.to_string())
+        self.iii
+            .trigger(request)
+            .await
+            .map(Some)
+            .map_err(|e| e.to_string())
     }
 
     async fn function_available(&self, function_id: &str, namespace: &str) -> Result<bool, String> {
@@ -258,6 +302,8 @@ pub struct RegisteredSubscriber {
     /// pointer the delivery hop resolves; dropping it makes every delivery an
     /// unresolvable fire.
     pub metadata: Option<Value>,
+    /// Namespace where the subscriber function and its condition function live.
+    pub namespace: Option<String>,
     pub spec: SubscriberSpec,
 }
 
@@ -350,6 +396,7 @@ impl QueueTriggerHandler {
                     registration.metadata.clone(),
                     registration.spec.condition_function_id.clone(),
                     Some(queue_config),
+                    registration.namespace.clone(),
                 )
                 .await;
         }
@@ -389,6 +436,7 @@ impl QueueTriggerHandler {
                     registration.metadata.clone(),
                     registration.spec.condition_function_id.clone(),
                     Some(queue_config),
+                    registration.namespace.clone(),
                 )
                 .await;
         }
@@ -434,6 +482,14 @@ impl TriggerHandler for QueueTriggerHandler {
             trigger_id: config.id,
             function_id: config.function_id,
             metadata: config.metadata,
+            // Older engines do not send this field. Their only namespace was
+            // `default`, so preserve that behavior explicitly instead of
+            // inheriting the queue worker's own namespace by accident.
+            namespace: Some(
+                config
+                    .namespace
+                    .unwrap_or_else(|| DEFAULT_NAMESPACE.to_string()),
+            ),
             spec,
         })
         .await
@@ -455,6 +511,8 @@ mod tests {
     use std::sync::Mutex as StdMutex;
 
     #[derive(Debug, Clone, PartialEq)]
+    // This test record keeps the complete subscribe call visible to assertions.
+    #[expect(clippy::large_enum_variant)]
     enum Call {
         Subscribe {
             topic: String,
@@ -463,6 +521,7 @@ mod tests {
             metadata: Option<Value>,
             condition_function_id: Option<String>,
             queue_config: Option<SubscriberQueueConfig>,
+            namespace: Option<String>,
         },
         Unsubscribe {
             topic: String,
@@ -500,6 +559,7 @@ mod tests {
             metadata: Option<Value>,
             condition_function_id: Option<String>,
             queue_config: Option<SubscriberQueueConfig>,
+            namespace: Option<String>,
         ) {
             self.calls.lock().unwrap().push(Call::Subscribe {
                 topic: topic.to_string(),
@@ -508,6 +568,7 @@ mod tests {
                 metadata,
                 condition_function_id,
                 queue_config,
+                namespace,
             });
         }
 
@@ -598,6 +659,7 @@ mod tests {
                     backoff_delay_ms: Some(1),
                     ..Default::default()
                 }),
+                namespace: Some(DEFAULT_NAMESPACE.to_string()),
             }]
         );
     }
@@ -610,12 +672,20 @@ mod tests {
         let (handler, mock) = handler_with_mock();
         let mut config = trigger_config("t1", "harness::trigger::deliver", json!({"queue": "q"}));
         config.metadata = Some(json!({ "__binding": "sub_abc" }));
+        config.namespace = Some("my-harness-ns".to_string());
         handler.register_trigger(config).await.unwrap();
 
-        let Call::Subscribe { id, metadata, .. } = &mock.calls()[0] else {
+        let Call::Subscribe {
+            id,
+            metadata,
+            namespace,
+            ..
+        } = &mock.calls()[0]
+        else {
             panic!("expected a Subscribe call");
         };
         assert_eq!(metadata, &Some(json!({ "__binding": "sub_abc" })));
+        assert_eq!(namespace.as_deref(), Some("my-harness-ns"));
         // The binding id is the durable subscription identity — it, not the
         // ephemeral trigger id, keys the adapter's queue.
         assert_eq!(id, "sub_abc");
@@ -625,10 +695,17 @@ mod tests {
         let new_adapter: Arc<dyn QueueAdapter> = new_mock.clone();
         handler.adapter.replace(new_adapter, "new-mock").await;
         handler.resubscribe_all().await;
-        let Call::Subscribe { id, metadata, .. } = &new_mock.calls()[0] else {
+        let Call::Subscribe {
+            id,
+            metadata,
+            namespace,
+            ..
+        } = &new_mock.calls()[0]
+        else {
             panic!("expected a Subscribe call");
         };
         assert_eq!(metadata, &Some(json!({ "__binding": "sub_abc" })));
+        assert_eq!(namespace.as_deref(), Some("my-harness-ns"));
         assert_eq!(id, "sub_abc");
     }
 
@@ -864,6 +941,7 @@ mod tests {
                 max_retries: Some(2),
                 ..Default::default()
             }),
+            namespace: Some(DEFAULT_NAMESPACE.to_string()),
         }));
         assert!(new_calls.contains(&Call::Subscribe {
             topic: "demo-2".to_string(),
@@ -872,6 +950,7 @@ mod tests {
             metadata: None,
             condition_function_id: None,
             queue_config: Some(SubscriberQueueConfig::default()),
+            namespace: Some(DEFAULT_NAMESPACE.to_string()),
         }));
         // The registrations map itself is untouched by the swap.
         assert_eq!(handler.registrations().await.len(), 2);

--- a/queue/tests/common/engine.rs
+++ b/queue/tests/common/engine.rs
@@ -56,9 +56,9 @@ fn require_or_skip(connected: Option<Arc<IIIClient>>) -> Option<Arc<IIIClient>> 
     None
 }
 
-async fn try_connect_raw() -> Option<Arc<IIIClient>> {
+async fn try_connect_raw_with_options(options: InitOptions) -> Option<Arc<IIIClient>> {
     let url = ws_url();
-    let iii = Arc::new(register_worker(&url, InitOptions::default()));
+    let iii = Arc::new(register_worker(&url, options));
 
     for _ in 0..20 {
         tokio::time::sleep(Duration::from_millis(250)).await;
@@ -81,6 +81,10 @@ async fn try_connect_raw() -> Option<Arc<IIIClient>> {
     None
 }
 
+async fn try_connect_raw() -> Option<Arc<IIIClient>> {
+    try_connect_raw_with_options(InitOptions::default()).await
+}
+
 /// Open a fresh, dedicated engine connection (NOT the shared `OnceCell` one).
 ///
 /// Needed when a test registers a function id that another test in the same
@@ -91,6 +95,11 @@ async fn try_connect_raw() -> Option<Arc<IIIClient>> {
 /// The caller should `shutdown_async()` the returned client when done.
 pub async fn connect_fresh() -> Option<Arc<IIIClient>> {
     require_or_skip(try_connect_raw().await)
+}
+
+/// Open a fresh engine connection with caller-provided identity options.
+pub async fn connect_fresh_with_options(options: InitOptions) -> Option<Arc<IIIClient>> {
+    require_or_skip(try_connect_raw_with_options(options).await)
 }
 
 /// Get-or-init the shared engine handle for this test binary.

--- a/queue/tests/e2e_durability.rs
+++ b/queue/tests/e2e_durability.rs
@@ -6,15 +6,19 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use iii_queue::adapter::QueueAdapter;
+use iii_queue::adapter::SwappableAdapter;
 use iii_queue::adapters::builtin::BuiltinAdapter;
 use iii_queue::config::{AdapterEntry, QueueConfig};
-use iii_queue::functions::{DLQ_MESSAGES_FN_ID, PUBLISH_FN_ID, REDRIVE_FN_ID};
+use iii_queue::functions::{
+    DLQ_MESSAGES_FN_ID, ENQUEUE_FUNCTION_FN_ID, LIST_TOPICS_FN_ID, PUBLISH_FN_ID, REDRIVE_FN_ID,
+};
 use iii_queue::store::FileStore;
 use iii_queue::trigger::Invoker;
 use iii_queue::TRIGGER_TYPE;
 use iii_sdk::errors::Error;
 use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
-use iii_sdk::{IIIClient, RegisterFunction};
+use iii_sdk::runtime::WorkerMetadata;
+use iii_sdk::{IIIClient, InitOptions, RegisterFunction, TriggerAction, WorkerIdentityMode};
 use serde_json::{json, Value};
 use serial_test::serial;
 use tokio::sync::Notify;
@@ -101,6 +105,25 @@ async fn trigger(iii: &IIIClient, function_id: &str, payload: Value) -> Value {
     .expect("trigger should succeed")
 }
 
+async fn trigger_in_namespace(
+    iii: &IIIClient,
+    function_id: &str,
+    payload: Value,
+    namespace: &str,
+) -> Value {
+    iii.trigger(
+        TriggerRequest {
+            function_id: function_id.to_string(),
+            payload,
+            action: None,
+            timeout_ms: Some(5_000),
+        }
+        .namespace(namespace),
+    )
+    .await
+    .expect("namespaced trigger should succeed")
+}
+
 async fn wait_for_fires(fires: &AtomicUsize, expected: usize) {
     let deadline = Instant::now() + Duration::from_secs(3);
     while Instant::now() < deadline {
@@ -115,16 +138,106 @@ async fn wait_for_fires(fires: &AtomicUsize, expected: usize) {
     );
 }
 
-async fn wait_for_dlq(iii: &IIIClient, queue: &str) -> Vec<Value> {
+async fn wait_for_trigger_type(iii: &IIIClient, trigger_type: &str) {
     let deadline = Instant::now() + Duration::from_secs(3);
     while Instant::now() < deadline {
-        let value = trigger(
+        let listed = iii
+            .trigger(TriggerRequest {
+                function_id: "engine::triggers::list".to_string(),
+                payload: json!({ "prefix": trigger_type }),
+                action: None,
+                timeout_ms: Some(800),
+            })
+            .await;
+        if listed.is_ok_and(|value| {
+            value
+                .get("triggers")
+                .and_then(Value::as_array)
+                .is_some_and(|triggers| {
+                    triggers.iter().any(|trigger| {
+                        trigger.get("id").and_then(Value::as_str) == Some(trigger_type)
+                    })
+                })
+        }) {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    panic!("trigger type '{trigger_type}' was not registered");
+}
+
+async fn wait_for_function(iii: &IIIClient, function_id: &str, namespace: &str) {
+    let deadline = Instant::now() + Duration::from_secs(3);
+    while Instant::now() < deadline {
+        let found = iii
+            .trigger(TriggerRequest {
+                function_id: "engine::functions::info".to_string(),
+                payload: json!({
+                    "function_id": function_id,
+                    "namespace": namespace,
+                }),
+                action: None,
+                timeout_ms: Some(800),
+            })
+            .await;
+        if found.is_ok() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    panic!("function '{function_id}' was not registered");
+}
+
+async fn wait_for_registered_trigger(iii: &IIIClient, function_id: &str) {
+    let deadline = Instant::now() + Duration::from_secs(3);
+    while Instant::now() < deadline {
+        let listed = iii
+            .trigger(TriggerRequest {
+                function_id: "engine::registered-triggers::list".to_string(),
+                payload: json!({ "function_id": function_id }),
+                action: None,
+                timeout_ms: Some(800),
+            })
+            .await;
+        if listed.is_ok_and(|value| {
+            value
+                .get("registered_triggers")
+                .and_then(Value::as_array)
+                .is_some_and(|triggers| !triggers.is_empty())
+        }) {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    panic!("trigger for function '{function_id}' was not registered");
+}
+
+async fn wait_for_subscription(adapter: &SwappableAdapter, queue: &str) {
+    let deadline = Instant::now() + Duration::from_secs(3);
+    while Instant::now() < deadline {
+        if adapter
+            .list_topics()
+            .await
+            .is_ok_and(|topics| topics.iter().any(|topic| topic.name == queue))
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    panic!("queue '{queue}' was not subscribed");
+}
+
+async fn wait_for_dlq(iii: &IIIClient, queue: &str, namespace: &str) -> Vec<Value> {
+    let deadline = Instant::now() + Duration::from_secs(3);
+    while Instant::now() < deadline {
+        let value = trigger_in_namespace(
             iii,
             DLQ_MESSAGES_FN_ID,
             json!({
                 "queue": queue,
                 "limit": 50
             }),
+            namespace,
         )
         .await;
         let messages = serde_json::from_value::<Vec<Value>>(value).unwrap_or_default();
@@ -136,17 +249,41 @@ async fn wait_for_dlq(iii: &IIIClient, queue: &str) -> Vec<Value> {
     panic!("message did not reach DLQ");
 }
 
+async fn wait_for_adapter_dlq(adapter: &SwappableAdapter, queue: &str) {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        if adapter.dlq_count(queue).await.unwrap_or(0) > 0 {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    panic!("message did not reach adapter DLQ");
+}
+
 #[tokio::test]
 #[serial]
 async fn delivery_dlq_and_redrive_connect_or_skip() {
-    let Some(iii) = engine::connect_fresh().await else {
+    let suffix = Uuid::new_v4();
+    let namespace = format!("queue-e2e-{suffix}");
+    let Some(iii) = engine::connect_fresh_with_options(InitOptions {
+        metadata: Some(WorkerMetadata {
+            name: format!("queue-e2e-{suffix}"),
+            ..WorkerMetadata::default()
+        }),
+        namespace: Some(namespace.clone()),
+        identity: WorkerIdentityMode::Explicit,
+        ..InitOptions::default()
+    })
+    .await
+    else {
         return;
     };
 
     let dir = temp_store_dir();
-    let boot = iii_queue::boot::start(iii.clone(), iii.clone(), file_config(&dir))
+    let boot = iii_queue::boot::start(iii.clone(), file_config(&dir))
         .await
         .expect("queue worker should boot");
+    wait_for_trigger_type(&iii, TRIGGER_TYPE).await;
 
     let fires = Arc::new(AtomicUsize::new(0));
     let fail = Arc::new(AtomicBool::new(false));
@@ -156,7 +293,19 @@ async fn delivery_dlq_and_redrive_connect_or_skip() {
     // leftover consumers from earlier local runs.
     let queue_name = format!("e2e-demo-{}", Uuid::new_v4());
     register_counting_function(&iii, &function_id, fires.clone(), fail.clone());
+    wait_for_function(&iii, &function_id, &namespace).await;
+    trigger(&iii, &function_id, json!({"probe": true})).await;
+    wait_for_fires(&fires, 1).await;
+    fires.store(0, Ordering::SeqCst);
     register_subscriber(&iii, &function_id, &queue_name);
+    wait_for_registered_trigger(&iii, &function_id).await;
+    wait_for_subscription(&boot.adapter, &queue_name).await;
+    let registrations = boot.trigger_handler.registrations().await;
+    assert_eq!(registrations.len(), 1);
+    assert_eq!(
+        registrations[0].namespace.as_deref(),
+        Some(namespace.as_str())
+    );
 
     trigger(
         &iii,
@@ -173,7 +322,8 @@ async fn delivery_dlq_and_redrive_connect_or_skip() {
         json!({"queue": queue_name, "data": {"should": "dlq"}}),
     )
     .await;
-    let messages = wait_for_dlq(&iii, &queue_name).await;
+    wait_for_adapter_dlq(&boot.adapter, &queue_name).await;
+    let messages = wait_for_dlq(&iii, &queue_name, &namespace).await;
     assert_eq!(messages.len(), 1);
 
     fail.store(false, Ordering::SeqCst);
@@ -183,6 +333,68 @@ async fn delivery_dlq_and_redrive_connect_or_skip() {
     boot.shutdown().await;
     iii.shutdown_async().await;
     let _ = std::fs::remove_dir_all(dir);
+}
+
+#[tokio::test]
+#[serial]
+async fn provider_functions_and_enqueue_use_the_worker_namespace() {
+    let suffix = Uuid::new_v4();
+    let namespace = format!("queue-e2e-{suffix}");
+    let Some(iii) = engine::connect_fresh_with_options(InitOptions {
+        metadata: Some(WorkerMetadata {
+            name: format!("queue-e2e-{suffix}"),
+            ..WorkerMetadata::default()
+        }),
+        namespace: Some(namespace.clone()),
+        identity: WorkerIdentityMode::Explicit,
+        ..InitOptions::default()
+    })
+    .await
+    else {
+        return;
+    };
+
+    let queue_name = format!("function-queue-{suffix}");
+    let mut config = QueueConfig::packaged_default();
+    config
+        .queue_configs
+        .insert(queue_name.clone(), Default::default());
+    let boot = iii_queue::boot::start(iii.clone(), config)
+        .await
+        .expect("queue worker should boot in its configured namespace");
+
+    wait_for_function(&iii, LIST_TOPICS_FN_ID, &namespace).await;
+    let topics = trigger_in_namespace(&iii, LIST_TOPICS_FN_ID, json!({}), &namespace).await;
+    assert!(topics
+        .as_array()
+        .is_some_and(|topics| topics.iter().any(|topic| topic["name"] == queue_name)));
+
+    wait_for_function(&iii, ENQUEUE_FUNCTION_FN_ID, &namespace).await;
+    let fires = Arc::new(AtomicUsize::new(0));
+    let fail = Arc::new(AtomicBool::new(false));
+    let function_id = format!("queue::e2e::{}", suffix.simple());
+    register_counting_function(&iii, &function_id, fires.clone(), fail);
+    wait_for_function(&iii, &function_id, &namespace).await;
+
+    let receipt = iii
+        .trigger(
+            TriggerRequest {
+                function_id,
+                payload: json!({"from": "enqueue-action"}),
+                action: Some(TriggerAction::Enqueue {
+                    queue: queue_name.clone(),
+                }),
+                timeout_ms: Some(5_000),
+            }
+            .namespace(&namespace),
+        )
+        .await
+        .expect("namespaced enqueue action should use the queue provider");
+    assert!(receipt["messageReceiptId"].is_string());
+    wait_for_fires(&fires, 1).await;
+
+    boot.shutdown().await;
+    iii.shutdown_async().await;
 }
 
 struct RestartInvoker {
@@ -219,7 +431,15 @@ async fn file_based_pending_message_survives_binding_restart() {
     let store = Arc::new(FileStore::open(&dir, 5).await.unwrap());
     let adapter = BuiltinAdapter::new(store, invoker.clone());
     adapter
-        .subscribe(&queue_name, subscription_id, &function_id, None, None, None)
+        .subscribe(
+            &queue_name,
+            subscription_id,
+            &function_id,
+            None,
+            None,
+            None,
+            None,
+        )
         .await;
     adapter
         .enqueue(&queue_name, json!({"survives": true}), None, None)
@@ -234,7 +454,15 @@ async fn file_based_pending_message_survives_binding_restart() {
     let store = Arc::new(FileStore::open(&dir, 5).await.unwrap());
     let adapter = BuiltinAdapter::new(store, invoker.clone());
     adapter
-        .subscribe(&queue_name, subscription_id, &function_id, None, None, None)
+        .subscribe(
+            &queue_name,
+            subscription_id,
+            &function_id,
+            None,
+            None,
+            None,
+            None,
+        )
         .await;
     wait_for_fires(&invoker.fires, 1).await;
 

--- a/queue/tests/e2e_rabbitmq.rs
+++ b/queue/tests/e2e_rabbitmq.rs
@@ -150,6 +150,7 @@ impl Invoker for RecordingInvoker {
         _function_id: &str,
         payload: Value,
         _metadata: Option<Value>,
+        _namespace: Option<&str>,
     ) -> Result<Option<Value>, String> {
         self.deliveries.lock().await.push(payload);
         Ok(None)
@@ -192,7 +193,7 @@ async fn basic_delivery_connect_or_skip() {
 
     let topic = format!("e2e-rmq-basic-{}", Uuid::new_v4());
     adapter
-        .subscribe(&topic, "sub-1", &function_id, None, None, None)
+        .subscribe(&topic, "sub-1", &function_id, None, None, None, None)
         .await;
     // Give the consumer task a beat to actually attach before the first
     // publish.
@@ -447,6 +448,7 @@ async fn priority_ordering_connect_or_skip() {
                 concurrency: Some(1),
                 ..Default::default()
             }),
+            None,
         )
         .await;
 
@@ -494,7 +496,7 @@ async fn unsubscribe_keeps_backlog_for_same_id_resubscribe_connect_or_skip() {
     let topic = format!("e2e-rmq-rearm-{}", Uuid::new_v4());
     let sub_id = "sub-rearm-1";
     adapter
-        .subscribe(&topic, sub_id, "rearm-fn", None, None, None)
+        .subscribe(&topic, sub_id, "rearm-fn", None, None, None, None)
         .await;
     // Give the consumer task a beat to attach before the first publish --
     // same as basic_delivery.
@@ -523,7 +525,7 @@ async fn unsubscribe_keeps_backlog_for_same_id_resubscribe_connect_or_skip() {
     );
 
     adapter
-        .subscribe(&topic, sub_id, "rearm-fn", None, None, None)
+        .subscribe(&topic, sub_id, "rearm-fn", None, None, None, None)
         .await;
     wait_until(
         || {
@@ -596,6 +598,7 @@ async fn fifo_mode_preserves_order_connect_or_skip() {
                 concurrency: Some(1),
                 ..Default::default()
             }),
+            None,
         )
         .await;
     tokio::time::sleep(Duration::from_millis(300)).await;

--- a/queue/tests/e2e_redis.rs
+++ b/queue/tests/e2e_redis.rs
@@ -49,6 +49,7 @@ impl Invoker for RecordingInvoker {
         function_id: &str,
         payload: Value,
         metadata: Option<Value>,
+        _namespace: Option<&str>,
     ) -> Result<Option<Value>, String> {
         self.deliveries
             .lock()
@@ -103,7 +104,7 @@ async fn publish_delivers_unwrapped_payload_to_subscriber_connect_or_skip() {
 
     let topic = format!("e2e-redis-{}", Uuid::new_v4());
     adapter
-        .subscribe(&topic, "sub-1", &function_id, None, None, None)
+        .subscribe(&topic, "sub-1", &function_id, None, None, None, None)
         .await;
     // Give the subscription task a beat to actually SUBSCRIBE on the Redis
     // connection before the first publish — pub/sub has no buffering for a
@@ -157,6 +158,7 @@ async fn same_function_subscriptions_each_receive_their_metadata_connect_or_skip
             Some(json!({"binding": "a"})),
             None,
             None,
+            None,
         )
         .await;
     adapter
@@ -165,6 +167,7 @@ async fn same_function_subscriptions_each_receive_their_metadata_connect_or_skip
             "sub-b",
             "same-function",
             Some(json!({"binding": "b"})),
+            None,
             None,
             None,
         )


### PR DESCRIPTION
Refs MOT-3944

## Summary

- Replace the auxiliary `default` SDK connection with one project-scoped managed connection.
- Register queue provider functions in the worker namespace and preserve subscriber namespaces through builtin, Redis, and RabbitMQ delivery.
- Scope subscription deduplication and adapter identities by namespace, including adapter hot-swaps.
- Wait for worker registration before configuration RPCs and pin the Rust SDK packages to `0.23.0-rc.10`.
- Add custom-namespace coverage for topic delivery, provider functions, DLQ/redrive, and `TriggerAction::Enqueue`.

## Problem

The queue worker opened a project connection plus an auxiliary connection in `default`. Managed identity made those connections compete for the same worker lease. A custom namespace also routed provider functions and queued deliveries through `default`.

## Behavior

```text
queue worker (project namespace)
        |
        +-- queue/provider functions -> project-scoped connection
        |
        +-- subscriber namespace     -> preserved by every adapter
        |
        +-- target/condition call    -> subscriber namespace
```

A missing trigger namespace stays compatible with legacy traffic and resolves to `default`. The engine allowlist for scoped `engine::queue::*` providers is available in `iii/v0.23.0-rc.10`.

## Validation

- `cargo fmt --manifest-path queue/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path queue/Cargo.toml --all-targets --all-features --locked -- -D warnings`
- `cargo test --manifest-path queue/Cargo.toml --all-features --locked --lib` — 135 passed
- `cargo test --manifest-path queue/Cargo.toml --tests --no-run`
- Queue durability E2E against `iii/v0.23.0-rc.10` — 3 passed
- Harness compose startup in a custom namespace — 14 of 14 workers ready

## Related

- iii-hq/iii#2103
- iii-hq/iii#2112

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added namespace-aware queue subscriptions and function delivery across supported adapters.
  - Preserved namespaces through retries, redelivery, condition checks, and dead-letter workflows.
  - Queue workers now use a managed project identity and support namespace-specific triggers.

- **Bug Fixes**
  - Improved consistency of namespace propagation during registration and resubscription.

- **Tests**
  - Expanded end-to-end coverage for namespaced delivery, durability, retries, redrive, and dead-letter handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
