### PR TITLE
feat: require a prerelease version on the next channel

### DIFF
--- a/.github/scripts/_lib.py
+++ b/.github/scripts/_lib.py
@@ -84,16 +84,17 @@ def validate_deployment_target_version(version: str) -> str:
 def validate_channel_target_version(channel: str, version: str) -> str:
     """Enforce the channel/version-form contract of the rc-first flow.
 
-    `latest` only ever receives pure MAJOR.MINOR.PATCH versions minted by
-    release finalization. `next` accepts any in-grammar version today; the
-    suffixed-only invariant for `next` lands after the rc flip is live, so the
-    nightly window never gets stuck between executor and orchestrator deploys.
+    The two channels carry disjoint version forms: `next` only ever serves a
+    prerelease under test, and `latest` only ever serves the pure
+    MAJOR.MINOR.PATCH minted from one by release finalization.
     """
     if channel not in {"next", "latest"}:
         raise ValueError("deployment channel must be next or latest")
     validate_deployment_target_version(version)
     if channel == "latest" and "-" in version:
         raise ValueError(f"latest deployments require a pure MAJOR.MINOR.PATCH version, got {version}")
+    if channel == "next" and "-" not in version:
+        raise ValueError(f"next deployments require a prerelease version, got {version}")
     return version
 
 

--- a/.github/scripts/tests/test_lib.py
+++ b/.github/scripts/tests/test_lib.py
@@ -59,10 +59,14 @@ class TestValidateChannelTargetVersion:
     def test_next_accepts_numbered_rc(self):
         assert _lib.validate_channel_target_version("next", "1.2.3-rc.1") == "1.2.3-rc.1"
 
-    def test_next_accepts_pure_version_until_the_rc_flip_lands(self):
-        # Fase 1C tightens `next` to suffixed-only; until then any in-grammar
-        # version keeps the nightly window deployable.
-        assert _lib.validate_channel_target_version("next", "1.2.3") == "1.2.3"
+    def test_next_accepts_maturity_suffix(self):
+        assert _lib.validate_channel_target_version("next", "1.2.3-beta") == "1.2.3-beta"
+
+    def test_next_rejects_pure_version(self):
+        # A pure version is what finalization mints for `latest`; publishing one
+        # to `next` would make the two channels indistinguishable.
+        with pytest.raises(ValueError, match="prerelease version"):
+            _lib.validate_channel_target_version("next", "1.2.3")
 
     def test_latest_accepts_pure_version(self):
         assert _lib.validate_channel_target_version("latest", "1.2.3") == "1.2.3"


### PR DESCRIPTION
**Draft on purpose — do not merge until the first rc window has succeeded.**

## What

Completes the rc-first invariant in `validate_channel_target_version`: `next` now rejects pure `X.Y.Z` versions, the mirror of the existing rule that `latest` rejects suffixed ones. The two channels end up carrying disjoint version forms — `next` serves a prerelease under test, `latest` serves the pure version that finalization mints from it.

## Why it is held back

Until the orchestrator flip (iii-hq/release-control#113) was deployed, the nightly window still published **pure** versions to `next`; tightening this earlier would have wedged that window. The flip is now live and verified in production (a preview at workers `f631866c` resolves `cron` to `0.21.13-rc.1` on `next`), but no worker has an rc on `@next` yet — the first window that mints them runs at 03:05 UTC.

Landing this before that window would also remove the escape hatch of publishing a pure version to `next` if the window needs manual intervention. Merge once a real rc window has succeeded.

## Tests

`.github/scripts` suite: 285 passed. The former "next accepts a pure version until the rc flip lands" case is replaced by a rejection test plus coverage that `next` still accepts maturity suffixes.

https://claude.ai/code/session_01MKFaAGVqL8CcLKaBwL53L9