### PR TITLE
(MOT-4630) fix(queue): recover evicted configuration schema

### DIFF
--- a/queue/src/configuration.rs
+++ b/queue/src/configuration.rs
@@ -85,14 +85,47 @@ pub async fn fetch_config(iii: &IIIClient) -> Result<QueueConfig, String> {
 /// snapshot before invoking this helper.
 pub async fn persist_config(iii: &IIIClient, config: &QueueConfig) -> Result<(), String> {
     config.validate()?;
-    trigger_configuration_with_retry(
+    let payload = json!({ "id": config_id(), "value": config.to_json() });
+    let result = trigger_configuration_with_retry(
         iii,
         "configuration::set",
-        json!({ "id": config_id(), "value": config.to_json() }),
+        payload.clone(),
         CONFIG_BUS_TIMEOUT_MS,
     )
-    .await?;
-    Ok(())
+    .await;
+
+    match result {
+        Ok(_) => Ok(()),
+        Err(error) if schema_unavailable(&error) => {
+            // The configuration fs adapter can briefly remove and recreate a
+            // persisted entry while the engine rewrites seeded configuration.
+            // Re-attach the worker-owned schema before retrying the write so a
+            // queue definition cannot remain permanently unwritable after that
+            // startup race.
+            tracing::warn!(
+                config_id = config_id(),
+                "queue configuration schema disappeared; registering it again"
+            );
+            register_config(iii, Some(config))
+                .await
+                .map_err(|register_error| {
+                    format!("{error}; configuration schema recovery failed: {register_error}")
+                })?;
+            trigger_configuration_with_retry(
+                iii,
+                "configuration::set",
+                payload,
+                CONFIG_BUS_TIMEOUT_MS,
+            )
+            .await?;
+            Ok(())
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn schema_unavailable(error: &str) -> bool {
+    error.contains("SCHEMA_UNAVAILABLE")
 }
 
 pub fn register_config_trigger(
@@ -447,5 +480,15 @@ mod tests {
             ..QueueConfig::default()
         };
         assert!(swap_needed(&old, &new));
+    }
+
+    #[test]
+    fn schema_recovery_only_matches_the_missing_schema_error() {
+        assert!(schema_unavailable(
+            "remote error (SCHEMA_UNAVAILABLE): configuration 'queue' has no schema"
+        ));
+        assert!(!schema_unavailable(
+            "remote error (VALIDATION_FAILED): configuration does not match its schema"
+        ));
     }
 }


### PR DESCRIPTION
## Summary

- recover queue configuration writes when the filesystem watcher temporarily evicts the registered schema
- re-register the existing queue schema and retry the interrupted write without replacing a stored value
- limit recovery to the engine's explicit `SCHEMA_UNAVAILABLE` response

## Testing

- `cargo fmt --manifest-path queue/Cargo.toml -- --check`
- `cargo clippy --locked --manifest-path queue/Cargo.toml --all-targets -- -D warnings`
- `cargo test --locked --manifest-path queue/Cargo.toml`
- repeated isolated harness stack startups against the pinned optimized engine

Refs MOT-4630

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Queue configuration updates now recover automatically when the configuration schema is unavailable.
  - Validation errors and other configuration failures continue to be reported normally.
  - Improved reliability when saving queue settings after schema interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->