### PR TITLE
(MOT-4634) fix(harness): stabilize database integration probes

### DIFF
--- a/harness/tests/integration/src/client.rs
+++ b/harness/tests/integration/src/client.rs
@@ -94,6 +94,20 @@ impl Client {
             .map_err(|error| error.to_string())?
     }
 
+    /// Call an engine function using all time left in the scenario.
+    ///
+    /// Scenario stimuli can legitimately be slower than routine control
+    /// calls. They still remain bounded by the shared scenario deadline.
+    pub async fn call_until_deadline(
+        &self,
+        function_id: &str,
+        payload: Value,
+        deadline: Deadline,
+    ) -> Result<Value, String> {
+        self.call_with_deadline(function_id, payload, deadline, u64::MAX)
+            .await
+    }
+
     pub async fn shutdown(&self) {
         self.iii.shutdown_async().await;
     }

--- a/harness/tests/integration/src/scenario/phases/completion.rs
+++ b/harness/tests/integration/src/scenario/phases/completion.rs
@@ -246,12 +246,7 @@ impl ScenarioRunner<'_> {
             })?;
         services
             .client()
-            .call_with_deadline(
-                &action.function_id,
-                payload,
-                deadline,
-                DEFAULT_CALL_TIMEOUT_MS,
-            )
+            .call_until_deadline(&action.function_id, payload, deadline)
             .await
             .map_err(|error| {
                 RunError::runner(RunPhase::Await, "fire probe action", anyhow::anyhow!(error))

--- a/harness/tests/integration/src/scenarios/condition_failure_notice.rs
+++ b/harness/tests/integration/src/scenarios/condition_failure_notice.rs
@@ -67,6 +67,9 @@ pub(super) fn scenario() -> ScenarioFixture {
             .allow_id(REGISTER)
             .allow_function(&checker),
     )
+    // This path serializes two turns around a durable SQLite transaction.
+    // Keep it bounded, but leave enough budget for a cold filesystem write.
+    .scenario_timeout_ms(60_000)
     .terminal_turn_statuses(["completed", "completed"])
     // One transaction: DDL + the INSERT. Only the INSERT emits a row event;
     // it reaches the binding, the condition call fails, and the notice — not
@@ -206,6 +209,7 @@ mod tests {
         let fixture = scenario();
         fixture.validate().unwrap();
         assert_eq!(fixture.expected_terminal_turns, 2);
+        assert_eq!(fixture.scenario.deadlines.scenario_ms, 60_000);
         assert_eq!(fixture.probe_actions.len(), 1);
         assert_eq!(fixture.probe_actions[0].after_turns, 1);
         assert_eq!(fixture.script.generations.len(), 3);

--- a/harness/tests/integration/src/scenarios/database_row_wake.rs
+++ b/harness/tests/integration/src/scenarios/database_row_wake.rs
@@ -59,6 +59,9 @@ pub(super) fn scenario() -> ScenarioFixture {
             .allow_id(REGISTER)
             .allow_function(&record),
     )
+    // This path serializes two turns around a durable SQLite transaction.
+    // Keep it bounded, but leave enough budget for a cold filesystem write.
+    .scenario_timeout_ms(60_000)
     .terminal_turn_statuses(["completed", "completed"])
     // One transaction: DDL + the INSERT. The row event flushes post-commit,
     // fires the binding, and wakes the idle session.
@@ -201,6 +204,7 @@ mod tests {
         let fixture = scenario();
         fixture.validate().unwrap();
         assert_eq!(fixture.expected_terminal_turns, 2);
+        assert_eq!(fixture.scenario.deadlines.scenario_ms, 60_000);
         assert_eq!(fixture.probe_actions.len(), 1);
         assert_eq!(fixture.probe_actions[0].after_turns, 1);
     }


### PR DESCRIPTION
Fixes MOT-4634
Refs MOT-4632

## Summary

- let completion probe actions use the time remaining in the scenario instead of the clients fixed 10-second call cap
- give the two SQLite-backed wake scenarios a 60-second end-to-end deadline
- keep routine control-plane calls on their existing short timeout

## Root cause

INT-014 and INT-019 dispatch `database::executeBatch` after the first turn. Their probe inherited `DEFAULT_CALL_TIMEOUT_MS` (10 seconds), so a loaded runner could cancel the database call while the scenario itself still had time remaining. That made healthy worker behavior appear as a scenario failure.

The probe is now bounded by the shared scenario deadline. This preserves a hard upper bound while removing the competing shorter timer that caused the flake.

This PR is stacked on #1033 so the integration-build speedup remains isolated and this diff contains only the flaky-test correction.

## Validation

- `cargo test --locked --manifest-path harness/Cargo.toml -p harness-integration` — passed (99 unit tests plus integration-contract suites)
- INT-014 against the pinned engine revision — passed 3/3
- INT-019 against the pinned engine revision — passed 3/3
- `cargo fmt --manifest-path harness/tests/integration/Cargo.toml -- --check`
- `git diff --check`
