### PR TITLE
feat(harness): notify sessions when Compose operations finish

### DIFF
--- a/harness/src/clients/engine.rs
+++ b/harness/src/clients/engine.rs
@@ -68,8 +68,32 @@ impl EngineClient {
         function_id: &str,
         payload: Value,
     ) -> Result<Value, DispatchError> {
+        let (payload, target_namespace) = self.prepare_dispatch(function_id, payload);
+        self.dispatch_prepared(function_id, payload, target_namespace)
+            .await
+    }
+
+    /// Apply the harness-owned scope and routing policy before authorization
+    /// or dispatch. Deferred call bindings use this same boundary so they
+    /// cannot bypass Compose's file, namespace, or asynchronous mode.
+    pub(crate) fn prepare_dispatch<'a>(
+        &'a self,
+        function_id: &str,
+        payload: Value,
+    ) -> (Value, Option<&'a str>) {
         let (payload, prepared_namespace) = self.compose.prepare(function_id, payload);
-        let target_namespace = dispatch_namespace(function_id, prepared_namespace);
+        (payload, dispatch_namespace(function_id, prepared_namespace))
+    }
+
+    /// Dispatch a payload that already passed [`Self::prepare_dispatch`].
+    /// This keeps argument approval and the actual invocation on the same
+    /// normalized value.
+    pub(crate) async fn dispatch_prepared(
+        &self,
+        function_id: &str,
+        payload: Value,
+        target_namespace: Option<&str>,
+    ) -> Result<Value, DispatchError> {
         // Capture the epoch immediately before the invocation instead of
         // comparing against process-global state. A global baseline becomes
         // stale when the engine restarts while this worker is idle and would
@@ -207,9 +231,24 @@ impl ComposeScope {
             if let Some(namespace) = &self.namespace {
                 arguments.insert("namespace".to_string(), Value::String(namespace.clone()));
             }
+            if is_compose_mutation(function_id) {
+                arguments.insert("wait".to_string(), Value::Bool(false));
+            }
         }
         (payload, self.namespace.as_deref())
     }
+}
+
+pub(crate) fn is_compose_mutation(function_id: &str) -> bool {
+    matches!(
+        function_id,
+        "compose::up"
+            | "compose::down"
+            | "compose::add"
+            | "compose::remove"
+            | "compose::restart"
+            | "compose::update"
+    )
 }
 
 fn dispatch_namespace<'a>(
@@ -447,6 +486,30 @@ mod tests {
         assert_eq!(payload["worker"], "database");
         assert_eq!(payload["file"], "/srv/app/worker-compose.yaml");
         assert_eq!(payload["namespace"], "compose-daemon");
+        assert_eq!(payload["wait"], false);
+    }
+
+    #[test]
+    fn compose_mutation_overrides_an_explicit_blocking_wait() {
+        let scope = ComposeScope {
+            namespace: Some("compose-daemon".to_string()),
+            file: Some("/srv/app/worker-compose.yaml".to_string()),
+        };
+        let (payload, _) = scope.prepare("compose::restart", json!({ "wait": true }));
+
+        assert_eq!(payload["wait"], false);
+    }
+
+    #[test]
+    fn compose_reads_do_not_receive_wait() {
+        let scope = ComposeScope {
+            namespace: Some("compose-daemon".to_string()),
+            file: Some("/srv/app/worker-compose.yaml".to_string()),
+        };
+        for function_id in ["compose::status", "compose::operations::get"] {
+            let (payload, _) = scope.prepare(function_id, json!({}));
+            assert!(payload.get("wait").is_none(), "{function_id}");
+        }
     }
 
     #[test]

--- a/harness/src/functions/subscribe.rs
+++ b/harness/src/functions/subscribe.rs
@@ -31,6 +31,7 @@ use serde_json::{json, Value};
 use crate::bindings::{
     Binding, BindingTarget, Causation, ConditionSpec, Lifecycle, OwnerScope, ReserveOutcome,
 };
+use crate::clients::engine::is_compose_mutation;
 use crate::clients::EngineClient;
 use crate::deps::Deps;
 use crate::error::HarnessError;
@@ -53,6 +54,9 @@ const APPROVAL_EVALUATE_ID: &str = "approval::evaluate";
 /// so it resolves the caller's subscription, enforces ownership, and unregisters
 /// the underlying engine trigger.
 pub const UNREGISTER_TRIGGER_ID: &str = "engine::unregister_trigger";
+
+const COMPOSE_OPERATION_TRIGGER: &str = "compose::operation";
+const COMPOSE_NAMESPACE_ENV: &str = "III_COMPOSE_NAMESPACE";
 
 /// Agent-facing subscription contract.
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
@@ -280,8 +284,112 @@ pub async fn invoke(
         // (the `harness::state::*` accessors are denied above), so the risk
         // is denial of service, not exfiltration; deny it anyway.
         crate::state::CLAIM_NAMESPACE_ID => trigger::denied_result(function_id),
-        _ => trigger::invoke_target(engine, policy, function_id, arguments).await,
+        _ => {
+            let result = trigger::invoke_target(engine, policy, function_id, arguments).await;
+            arm_compose_operation_wake(deps, result, function_id, session_id, caller, policy).await
+        }
     }
+}
+
+async fn arm_compose_operation_wake(
+    deps: &Deps,
+    result: ResultData,
+    function_id: &str,
+    session_id: &str,
+    caller: Option<CallerModel<'_>>,
+    policy: &CompiledPolicy,
+) -> ResultData {
+    if result.is_error {
+        return result;
+    }
+    let Some(operation_id) =
+        accepted_compose_operation_id(function_id, &result.details).map(str::to_string)
+    else {
+        return result;
+    };
+
+    let mut details = result.details;
+    let response = register_compose_operation_wake(
+        deps,
+        function_id,
+        &operation_id,
+        session_id,
+        caller,
+        policy,
+    )
+    .await;
+    if let Some(object) = details.as_object_mut() {
+        match response {
+            Ok(response) => {
+                object.insert(
+                    "subscription_id".to_string(),
+                    Value::String(response.subscription_id),
+                );
+                object.insert(
+                    "notification".to_string(),
+                    Value::String("armed".to_string()),
+                );
+                if let Some(note) = response.note {
+                    object.insert("notification_note".to_string(), Value::String(note));
+                }
+            }
+            Err(error) => {
+                // The mutation is already accepted. Preserve that success so
+                // the caller can fall back to compose::operations::get.
+                object.insert(
+                    "notification_error".to_string(),
+                    Value::String(error.to_string()),
+                );
+            }
+        }
+    }
+    trigger::normalized_result(details)
+}
+
+pub(crate) async fn register_compose_operation_wake(
+    deps: &Deps,
+    function_id: &str,
+    operation_id: &str,
+    session_id: &str,
+    caller: Option<CallerModel<'_>>,
+    policy: &CompiledPolicy,
+) -> Result<SubscribeResponse, HarnessError> {
+    handle(
+        deps,
+        compose_operation_subscription(function_id, operation_id),
+        session_id,
+        caller,
+        policy,
+    )
+    .await
+}
+
+fn compose_operation_subscription(function_id: &str, operation_id: &str) -> SubscribeRequest {
+    SubscribeRequest {
+        trigger_type: COMPOSE_OPERATION_TRIGGER.to_string(),
+        config: json!({ "operation_id": operation_id }),
+        label: Some(format!("{function_id} {operation_id}")),
+        once: Some(true),
+        function_id: None,
+        metadata: Some(json!({
+            "action": format!("compose operation {operation_id} finished")
+        })),
+        target: None,
+        conditions: Vec::new(),
+        lifecycle: None,
+    }
+}
+
+pub(crate) fn accepted_compose_operation_id<'a>(
+    function_id: &str,
+    result: &'a Value,
+) -> Option<&'a str> {
+    if !is_compose_mutation(function_id) {
+        return None;
+    }
+    (result.get("state").and_then(Value::as_str) == Some("accepted"))
+        .then(|| result.get("operation_id").and_then(Value::as_str))
+        .flatten()
 }
 
 fn send_invocation_context(
@@ -699,7 +807,16 @@ async fn handle(
         standing_binding_advisory(&req, once),
         state_catchall_advisory(&req),
         armed_wake_advisory(&req, once),
-        (binding.target.function_id != crate::functions::SEND_ID).then(|| {
+        is_compose_mutation(&binding.target.function_id).then(|| {
+            format!(
+                "note: this binding dispatches `{}` asynchronously; the harness will wake this \
+                 session when its Compose operation reaches a terminal state.",
+                binding.target.function_id
+            )
+        }),
+        (binding.target.function_id != crate::functions::SEND_ID
+            && !is_compose_mutation(&binding.target.function_id))
+        .then(|| {
             format!(
                 "note: this binding dispatches `{}` — its result reaches nobody and cannot wake \
                  you. Anything that must reach this chat writes state you watch with a plain \
@@ -813,7 +930,7 @@ async fn resolve_target(
         Some(id) => {
             let id = id.to_string();
             validate_call_target(&id, policy).map_err(HarnessError::InvalidRequest)?;
-            let (payload, event_into) = match req.target.as_ref() {
+            let (mut payload, event_into) = match req.target.as_ref() {
                 Some(t) => {
                     validate_event_into(t.event_into.as_deref())?;
                     (t.payload.clone(), t.event_into.clone())
@@ -829,6 +946,11 @@ async fn resolve_target(
                     )
                 }
             };
+            if id.starts_with("compose::") {
+                let engine = deps.engine().await;
+                let (prepared, _) = engine.prepare_dispatch(&id, payload.unwrap_or(Value::Null));
+                payload = Some(prepared);
+            }
             let target = BindingTarget {
                 function_id: id,
                 payload,
@@ -1199,24 +1321,50 @@ fn is_function_absent(error: &str) -> bool {
 /// unregister closure is held in [`crate::bindings::TriggerHandles`].
 pub const SDK_TRIGGER_ID_PREFIX: &str = "sdk:";
 
-/// The channel registration for a binding's delivery trigger. `namespace` and
-/// `trigger_namespace` are deliberately left unset: the SDK stamps this
-/// worker's namespace on the target (so the fire resolves
+/// The channel registration for a binding's delivery trigger. `namespace` is
+/// left unset, so the SDK stamps this worker's namespace on the target and
+/// the fire resolves
 /// `harness::trigger::deliver` where THIS harness registered it, `default`
-/// included when un-namespaced), and an unset provider namespace resolves
-/// home-first with the engine's `default` as fallback. Hardcoding either here
-/// would break one of the two deployment shapes.
+/// included when un-namespaced. The provider also resolves home-first with
+/// `default` as fallback, except `compose::operation`: that provider lives in
+/// the supervisor-owned `III_COMPOSE_NAMESPACE`.
 fn delivery_registration_input(
     trigger_type: &str,
     config: &Value,
     binding_id: &str,
 ) -> iii_sdk::protocol::RegisterTriggerInput {
-    iii_sdk::protocol::RegisterTriggerInput::new(
+    delivery_registration_input_for_namespace(
+        trigger_type,
+        config,
+        binding_id,
+        compose_provider_namespace(trigger_type).as_deref(),
+    )
+}
+
+fn delivery_registration_input_for_namespace(
+    trigger_type: &str,
+    config: &Value,
+    binding_id: &str,
+    provider_namespace: Option<&str>,
+) -> iii_sdk::protocol::RegisterTriggerInput {
+    let input = iii_sdk::protocol::RegisterTriggerInput::new(
         trigger_type,
         crate::functions::trigger_deliver::DELIVER_ID,
         config.clone(),
     )
-    .with_metadata(json!({ "__binding": binding_id }))
+    .with_metadata(json!({ "__binding": binding_id }));
+    match provider_namespace {
+        Some(namespace) => input.in_trigger_namespace(namespace),
+        None => input,
+    }
+}
+
+fn compose_provider_namespace(trigger_type: &str) -> Option<String> {
+    (trigger_type == COMPOSE_OPERATION_TRIGGER)
+        .then(|| std::env::var(COMPOSE_NAMESPACE_ENV).ok())
+        .flatten()
+        .map(|namespace| namespace.trim().to_string())
+        .filter(|namespace| !namespace.is_empty())
 }
 
 /// Register a binding's engine trigger over the worker channel and record its
@@ -1248,8 +1396,13 @@ pub fn register_delivery_trigger(
 /// checked namespace warns.
 async fn provider_presence_note(deps: &Deps, trigger_type: &str) -> Option<String> {
     let mut namespaces: Vec<String> = Vec::new();
+    if let Some(namespace) = compose_provider_namespace(trigger_type) {
+        namespaces.push(namespace);
+    }
     if let Some(own) = deps.iii.namespace() {
-        namespaces.push(own);
+        if !namespaces.contains(&own) {
+            namespaces.push(own);
+        }
     }
     if !namespaces.iter().any(|ns| ns == "default") {
         namespaces.push("default".to_string());
@@ -1362,6 +1515,68 @@ mod tests {
         );
         assert!(input.namespace.is_none());
         assert!(input.trigger_namespace.is_none());
+    }
+
+    #[test]
+    fn compose_completion_uses_the_daemon_as_trigger_provider() {
+        let input = delivery_registration_input_for_namespace(
+            COMPOSE_OPERATION_TRIGGER,
+            &json!({ "operation_id": "op-1" }),
+            "sub_compose",
+            Some("compose-daemon"),
+        );
+
+        assert_eq!(input.namespace, None);
+        assert_eq!(input.trigger_namespace.as_deref(), Some("compose-daemon"));
+    }
+
+    #[test]
+    fn accepted_compose_mutation_exposes_its_operation_id() {
+        let result = json!({
+            "operation_id": "op-1",
+            "state": "accepted"
+        });
+
+        assert_eq!(
+            accepted_compose_operation_id("compose::add", &result),
+            Some("op-1")
+        );
+    }
+
+    #[test]
+    fn completed_compose_mutation_does_not_arm_a_wake() {
+        let result = json!({
+            "operation_id": "op-2",
+            "status": "completed"
+        });
+
+        assert_eq!(accepted_compose_operation_id("compose::add", &result), None);
+    }
+
+    #[test]
+    fn compose_read_does_not_arm_a_wake() {
+        let result = json!({
+            "operation_id": "op-3",
+            "state": "accepted"
+        });
+
+        assert_eq!(
+            accepted_compose_operation_id("compose::status", &result),
+            None
+        );
+    }
+
+    #[test]
+    fn compose_completion_subscription_is_a_one_shot_wake() {
+        let request = compose_operation_subscription("compose::add", "op-1");
+
+        assert_eq!(request.trigger_type, COMPOSE_OPERATION_TRIGGER);
+        assert_eq!(request.config, json!({ "operation_id": "op-1" }));
+        assert_eq!(request.once, Some(true));
+        assert!(
+            request.function_id.is_none(),
+            "completion must wake its owner"
+        );
     }
 
     /// `sdk:` ids belong to the handle map; with the handle gone (a record

--- a/harness/src/functions/trigger_deliver.rs
+++ b/harness/src/functions/trigger_deliver.rs
@@ -475,6 +475,15 @@ async fn call_target(
         &grants,
         deps.hooks.filesystem_boundary(target),
     );
+    let compose_dispatch = if target.starts_with("compose::") {
+        let engine = deps.engine().await;
+        let (prepared, target_namespace) = engine.prepare_dispatch(target, payload);
+        payload = prepared;
+        let target_namespace = target_namespace.map(str::to_string);
+        Some((engine, target_namespace))
+    } else {
+        None
+    };
     // Argument-constrained approval rules must see the payload that will
     // actually run, after event projection and trusted filesystem stamping.
     if let Err(e) = crate::functions::subscribe::approval_allows_unattended(
@@ -492,19 +501,105 @@ async fn call_target(
     // rejected payload — is recorded as delivered and "why did nothing
     // happen?" becomes unanswerable from the timeline. The dispatch timeout
     // bounds the wait.
-    let timeout_ms = deps.cfg().await.dispatch_timeout_ms;
-    let outcome = deps
-        .iii
-        .trigger(TriggerRequest {
-            function_id: target.to_string(),
-            payload: payload.clone(),
-            action: None,
-            timeout_ms: Some(timeout_ms),
-        })
-        .await
-        .map(|_| ())
-        .map_err(|e| e.to_string());
-    (payload, outcome)
+    let outcome = match compose_dispatch {
+        Some((engine, target_namespace)) => engine
+            .dispatch_prepared(target, payload.clone(), target_namespace.as_deref())
+            .await
+            .map_err(|error| error.to_string()),
+        None => {
+            let timeout_ms = deps.cfg().await.dispatch_timeout_ms;
+            deps.iii
+                .trigger(TriggerRequest {
+                    function_id: target.to_string(),
+                    payload: payload.clone(),
+                    action: None,
+                    timeout_ms: Some(timeout_ms),
+                })
+                .await
+                .map_err(|error| error.to_string())
+        }
+    };
+    match outcome {
+        Ok(result) => {
+            arm_deferred_compose_operation_wake(deps, binding, target, &result).await;
+            (payload, Ok(()))
+        }
+        Err(error) => (payload, Err(error)),
+    }
+}
+
+async fn arm_deferred_compose_operation_wake(
+    deps: &Deps,
+    binding: &Binding,
+    function_id: &str,
+    result: &Value,
+) {
+    let Some(operation_id) =
+        crate::functions::subscribe::accepted_compose_operation_id(function_id, result)
+            .map(str::to_string)
+    else {
+        return;
+    };
+    let policy = CompiledPolicy::from(binding.capability.as_ref());
+    if let Err(error) = crate::functions::subscribe::register_compose_operation_wake(
+        deps,
+        function_id,
+        &operation_id,
+        &binding.owner.session_id,
+        None,
+        &policy,
+    )
+    .await
+    {
+        tracing::warn!(
+            binding = %binding.id,
+            operation_id,
+            error = %error,
+            "Compose operation accepted without a completion wake"
+        );
+        notify_compose_wake_failure(
+            deps,
+            binding,
+            function_id,
+            &operation_id,
+            &error.to_string(),
+        )
+        .await;
+    }
+}
+
+async fn notify_compose_wake_failure(
+    deps: &Deps,
+    binding: &Binding,
+    function_id: &str,
+    operation_id: &str,
+    error: &str,
+) {
+    let message = AgentMessage::user_text(format!(
+        "[notification] {function_id} was accepted as {operation_id}, but its completion watcher \
+         could not be registered: {error}. Check it with compose::operations::get."
+    ));
+    let entry_id = format!("e_compose_watch_{}_{}", binding.id, binding.fires);
+    if let Err(inject_error) = crate::functions::send::inject(
+        deps,
+        &binding.owner.session_id,
+        message,
+        Some(&entry_id),
+        Some(&json!({
+            "notification": true,
+            "binding": binding.id,
+            "operation_id": operation_id,
+        })),
+    )
+    .await
+    {
+        tracing::warn!(
+            binding = %binding.id,
+            operation_id,
+            error = %inject_error,
+            "Compose completion-wake failure notice could not be delivered"
+        );
+    }
 }
 
 fn notification_text(binding: &Binding, event: &Value) -> String {


### PR DESCRIPTION
## Summary

- force harness-dispatched Compose mutations to use asynchronous execution
- register one-shot compose::operation wakes for direct calls and deferred trigger targets
- route completion subscriptions through the supervisor Compose namespace
- notify the owning session when a completion watcher cannot be registered

## Motivation

Compose mutations can take longer than one agent turn. The harness now keeps the originating session connected to the accepted operation ID and wakes that session when the operation reaches a terminal state. Deferred trigger targets use the same Compose scoping and asynchronous dispatch rules as direct calls.

## Dependency

This requires the companion iii Compose operation-completion trigger change at runtime.

## Testing

- cargo fmt --all -- --check
- cargo test
- cargo clippy --all-targets --all-features --locked -- -D warnings