### PR TITLE
feat: mirror next and latest after deployments

### DIFF
--- a/.github/scripts/tests/test_deployment_workflows.py
+++ b/.github/scripts/tests/test_deployment_workflows.py
@@ -215,10 +215,9 @@ def test_publish_is_retry_safe_and_effect_states_are_probe_derived():
     assert 'value=sys.argv[1].strip()' in publish
     assert 'all(.[]; .state == "absent" or .state == "present" or .state == "unknown")' in publish
     registry = body("_deploy-registry.yml")
-    assert "registry_publication.py assign-channel" in registry
-    assert "registry_publication.py advance-next-floor" in registry
+    assert registry.count("registry_publication.py assign-channel") == 2
     assert "expected-current-version" in registry
-    assert "expected-next-version" in registry
+    assert "EXPECTED_MIRROR_VERSION" in registry
     assert "--clobber" not in publish
 
 
@@ -238,8 +237,11 @@ def test_publish_separates_immutable_version_from_explicit_channel_cas():
     assert "build_publish_payload.py" in reusable
     assert "jq 'has(\"tag\")' payload.json" in reusable
     assert "has(\\\"tag\\\")" not in reusable
+    assert "MIRROR_CHANNEL: ${{ inputs.channel == 'latest' && 'next' || 'latest' }}" in reusable
     assert '--registry-tag "$DEPLOYMENT_CHANNEL"' in reusable
+    assert '--registry-tag "$MIRROR_CHANNEL"' in reusable
     assert "Move requested channel with compare-and-swap" in reusable
+    assert "Mirror the other channel with compare-and-swap" in reusable
     assert "Move the requested OCI channel to the immutable digest" in publish
     assert '"$DEPLOYMENT_CHANNEL" == next || "$TARGET_VERSION" == *-*' in publish
     assert '"$RELEASE_CHANNEL" == next || "$TARGET_VERSION" == *-*' in body("deploy-verify.yml")

--- a/.github/workflows/_deploy-registry.yml
+++ b/.github/workflows/_deploy-registry.yml
@@ -119,21 +119,6 @@ jobs:
             --worker "$WORKER" --version "$TARGET_VERSION" \
             --payload payload.json --out registry-version-receipt.json
 
-      - name: Preserve next at or ahead of latest
-        if: inputs.channel == 'latest'
-        env:
-          WORKERS_REGISTRY_API_KEY: ${{ secrets.WORKERS_REGISTRY_API_KEY }}
-          WORKER: ${{ inputs.worker }}
-          TARGET_VERSION: ${{ inputs.target_version }}
-          EXPECTED_NEXT_VERSION: ${{ inputs.expected_next_version }}
-        run: |
-          set -euo pipefail
-          python3 .github/scripts/registry_publication.py advance-next-floor \
-            --api-url https://api.workers.iii.dev \
-            --worker "$WORKER" --version "$TARGET_VERSION" \
-            --expected-next-version "$EXPECTED_NEXT_VERSION" \
-            --out registry-next-receipt.json
-
       - name: Move requested channel with compare-and-swap
         env:
           WORKERS_REGISTRY_API_KEY: ${{ secrets.WORKERS_REGISTRY_API_KEY }}
@@ -150,13 +135,29 @@ jobs:
             --expected-current-version "$EXPECTED_CURRENT_VERSION" \
             --out registry-channel-receipt.json
 
+      - name: Mirror the other channel with compare-and-swap
+        env:
+          WORKERS_REGISTRY_API_KEY: ${{ secrets.WORKERS_REGISTRY_API_KEY }}
+          WORKER: ${{ inputs.worker }}
+          TARGET_VERSION: ${{ inputs.target_version }}
+          MIRROR_CHANNEL: ${{ inputs.channel == 'latest' && 'next' || 'latest' }}
+          EXPECTED_MIRROR_VERSION: ${{ inputs.expected_next_version }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/registry_publication.py assign-channel \
+            --api-url https://api.workers.iii.dev \
+            --worker "$WORKER" --version "$TARGET_VERSION" \
+            --registry-tag "$MIRROR_CHANNEL" \
+            --expected-current-version "$EXPECTED_MIRROR_VERSION" \
+            --out registry-mirror-channel-receipt.json
+
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: registry-publication-${{ inputs.worker }}-${{ inputs.target_version }}-${{ inputs.channel }}
           path: |
             payload.json
             registry-version-receipt.json
-            registry-next-receipt.json
             registry-channel-receipt.json
+            registry-mirror-channel-receipt.json
           if-no-files-found: warn
           retention-days: 30

--- a/.github/workflows/deploy-publish.yml
+++ b/.github/workflows/deploy-publish.yml
@@ -32,7 +32,7 @@ env:
   TARGET_VERSION: ${{ inputs.target_version }}
   DEPLOYMENT_CHANNEL: ${{ inputs.channel }}
   EXPECTED_CURRENT_VERSION: ${{ inputs.expected_current_version }}
-  EXPECTED_NEXT_VERSION: ${{ inputs.expected_next_version }}
+  EXPECTED_MIRROR_VERSION: ${{ inputs.expected_next_version }}
   DESCRIPTOR_SHA256: ${{ inputs.descriptor_sha256 }}
   PREPARED_RUN_ID: ${{ inputs.prepared_run_id }}
 
@@ -81,9 +81,7 @@ jobs:
           python3 .github/scripts/deployment_train.py verify-prepared \
             --descriptor deploy-prepared/deployment-descriptor.json \
             --prepared deploy-prepared/prepared-artifacts.json
-          if [[ "$DEPLOYMENT_CHANNEL" == latest ]]; then
-            [[ -n "$EXPECTED_NEXT_VERSION" ]]
-          fi
+          [[ -n "$EXPECTED_MIRROR_VERSION" ]]
           python3 .github/scripts/deployment_control_contract.py validate-identity --identity "$DEPLOYMENT_IDENTITY"
           python3 .github/scripts/deployment_control_contract.py validate-dispatch --step-id "$STEP_ID" --dispatch-nonce "$DISPATCH_NONCE" --descriptor-sha256 "$DESCRIPTOR_SHA256" --plan-hash "$PLAN_HASH" --source-sha "$SOURCE_SHA" --prepared-sha "$PREPARED_SHA" --mutating
           python3 .github/scripts/deployment_control_contract.py authorize-dispatch --api-url "$RELEASE_CONTROL_API_URL" --repository '${{ github.repository }}' --step-id "$STEP_ID" --run-id '${{ github.run_id }}' --run-attempt '${{ github.run_attempt }}' --workflow 'deploy-publish.yml' --event '${{ github.event_name }}' --sha '${{ github.sha }}' --deployment-batch-id "$DEPLOYMENT_BATCH_ID" --deployment-target-id "$DEPLOYMENT_TARGET_ID" --attempt-id "$ATTEMPT_ID" --dispatch-nonce "$DISPATCH_NONCE" --plan-hash "$PLAN_HASH" --worker "$WORKER" --source-sha "$SOURCE_SHA" --target-version "$TARGET_VERSION" --channel "$DEPLOYMENT_CHANNEL" --descriptor-sha256 "$DESCRIPTOR_SHA256"


### PR DESCRIPTION
## Summary

- replace the latest-only next-floor step with a symmetric channel mirror
- update the requested channel first, then move the other channel to the same immutable version
- keep both mutations protected by the existing compare-and-swap and readback behavior
- preserve the current dispatch input shape for a staged cross-repository rollout

## Rollout dependency

Keep this PR in draft until iii-hq/release-control#118 is deployed. Release Control must begin sending the non-selected channel snapshot before this workflow handles next-to-latest mirroring.

## Validation

- pytest .github/scripts/tests/
- actionlint