### PR TITLE
(MOT-4614) fix: recover failed worker deployments

### DIFF
--- a/.deploy/workers.yaml
+++ b/.deploy/workers.yaml
@@ -184,7 +184,6 @@ workers:
       install_command:
       - pnpm
       - install
-      - --ignore-workspace
       - --frozen-lockfile
       build_command:
       - pnpm

--- a/.github/scripts/deployment_train.py
+++ b/.github/scripts/deployment_train.py
@@ -32,6 +32,27 @@ def sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
+def canonical_value(value: object) -> object:
+    """Normalize JSON numbers to the representation used by JSON.stringify."""
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    if isinstance(value, list):
+        return [canonical_value(item) for item in value]
+    if isinstance(value, dict):
+        return {key: canonical_value(item) for key, item in value.items()}
+    return value
+
+
+def canonical_bytes(value: object) -> bytes:
+    return json.dumps(
+        canonical_value(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
 def verify_descriptor(descriptor: object) -> dict[str, object]:
     if not isinstance(descriptor, dict):
         raise SystemExit("deployment descriptor must be an object")
@@ -49,9 +70,7 @@ def verify_descriptor(descriptor: object) -> dict[str, object]:
     if descriptor["contract"] != "deployment-descriptor":
         raise SystemExit("deployment descriptor contract mismatch")
     digest_subject = {key: value for key, value in descriptor.items() if key != "descriptor_sha256"}
-    digest = hashlib.sha256(
-        json.dumps(digest_subject, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
-    ).hexdigest()
+    digest = hashlib.sha256(canonical_bytes(digest_subject)).hexdigest()
     if descriptor["descriptor_sha256"] != digest:
         raise SystemExit("deployment descriptor digest is invalid")
     for field in ("source", "artifact", "runtime", "registry_projection"):

--- a/.github/scripts/tests/test_deployment_train.py
+++ b/.github/scripts/tests/test_deployment_train.py
@@ -28,9 +28,7 @@ from _test_helpers import GIT_HERMETIC_ENV
 
 def seal_descriptor(value: dict) -> dict:
     value.pop("descriptor_sha256", None)
-    value["descriptor_sha256"] = hashlib.sha256(
-        json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
-    ).hexdigest()
+    value["descriptor_sha256"] = hashlib.sha256(deployment_train.canonical_bytes(value)).hexdigest()
     return value
 
 
@@ -70,6 +68,17 @@ def descriptor(worker: str, source_sha: str, package_manifest_version: str) -> d
             "readme": "",
         },
     })
+
+
+def test_verify_descriptor_accepts_json_stringify_integral_float_digest() -> None:
+    selected = descriptor("security-scan", "a" * 40, "0.1.3")
+    selected["registry_projection"]["config"] = {
+        "defaults": {"max_cost_usd": 2.0, "ratio": 0.5},
+    }
+    selected = seal_descriptor(selected)
+
+    assert deployment_train.verify_descriptor(selected) == selected
+    assert b'"max_cost_usd":2' in deployment_train.canonical_bytes(selected)
 
 
 def rust_descriptor(worker: str, source_sha: str, targets: list[str]) -> dict:

--- a/.github/scripts/tests/test_deployment_workflows.py
+++ b/.github/scripts/tests/test_deployment_workflows.py
@@ -178,6 +178,21 @@ def test_release_build_validates_rust_targets_and_oci_platforms():
     assert '(.target // .platform // "none") == $target' in text
 
 
+def test_release_build_falls_back_when_optional_sccache_is_unavailable():
+    workflow = yaml.safe_load(body("_deploy-build.yml"))
+    steps = workflow["jobs"]["build"]["steps"]
+    by_name = {step.get("name"): step for step in steps}
+
+    assert by_name["Authorize cache access with GitHub OIDC"]["continue-on-error"] is True
+    assert by_name["Install sccache"]["continue-on-error"] is True
+    assert "sccache rustc -vV" in by_name["Probe optional sccache backend"]["run"]
+    assert "wrapper=" in by_name["Probe optional sccache backend"]["run"]
+    assert by_name["Build immutable artifact"]["env"]["RUSTC_WRAPPER"] == (
+        "${{ steps.sccache.outputs.wrapper }}"
+    )
+    assert "RUSTC_WRAPPER" not in workflow["env"]
+
+
 def test_prepare_uploads_inventory_without_booting_the_worker():
     text = body("deploy-prepare.yml")
     workflow = yaml.safe_load(text)

--- a/.github/scripts/tests/test_worker_compose.py
+++ b/.github/scripts/tests/test_worker_compose.py
@@ -104,6 +104,24 @@ def test_release_toolchains_and_bundle_locks_are_explicit():
     assert bundles == 15
 
 
+def test_claude_code_release_installs_its_shared_ui_workspace():
+    document = yaml.safe_load(CATALOG.read_text(encoding="utf-8"))
+    artifact = document["workers"]["claude-code"]["artifact"]
+    workspace = yaml.safe_load(
+        (ROOT / "claude-code" / "pnpm-workspace.yaml").read_text(encoding="utf-8")
+    )
+
+    assert artifact["workspace_root"] == "claude-code"
+    assert artifact["install_command"] == ["pnpm", "install", "--frozen-lockfile"]
+    assert set(workspace["packages"]) == {
+        ".",
+        "ui",
+        "../packages/agent-terminal-ui",
+        "../packages/console-ui",
+        "../packages/terminal-font",
+    }
+
+
 def test_scrapling_release_bundle_vendors_dependencies():
     document = yaml.safe_load(CATALOG.read_text(encoding="utf-8"))
     scrapling = document["workers"]["scrapling"]

--- a/.github/workflows/_deploy-build.yml
+++ b/.github/workflows/_deploy-build.yml
@@ -36,7 +36,6 @@ env:
   CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER: arm-linux-gnueabihf-gcc
   SCCACHE_BUCKET: ${{ vars.SCCACHE_BUCKET }}
   SCCACHE_REGION: ${{ vars.SCCACHE_REGION }}
-  RUSTC_WRAPPER: sccache
 
 jobs:
   build:
@@ -131,6 +130,7 @@ jobs:
 
       - name: Authorize cache access with GitHub OIDC
         if: inputs.kind == 'rust-binary'
+        continue-on-error: true
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
         with:
           role-to-assume: ${{ vars.SCCACHE_ROLE_ARN }}
@@ -138,6 +138,7 @@ jobs:
 
       - name: Install sccache
         if: inputs.kind == 'rust-binary'
+        continue-on-error: true
         uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
       - name: Cache Rust build
@@ -146,6 +147,20 @@ jobs:
         with:
           shared-key: release-${{ inputs.worker }}-${{ steps.metadata.outputs.toolchain_version }}-${{ inputs.target }}
           workspaces: ${{ inputs.worker }} -> target
+
+      - name: Probe optional sccache backend
+        if: inputs.kind == 'rust-binary'
+        id: sccache
+        env:
+          SCCACHE_S3_KEY_PREFIX: sccache/${{ steps.metadata.outputs.toolchain_version }}/${{ inputs.target }}
+        run: |
+          if sccache rustc -vV >/dev/null 2>&1; then
+            echo 'wrapper=sccache' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          sccache --stop-server >/dev/null 2>&1 || true
+          echo 'wrapper=' >> "$GITHUB_OUTPUT"
+          echo '::warning::sccache backend unavailable; compiling without the remote cache'
 
       - name: Install descriptor-pinned pnpm
         if: inputs.kind == 'javascript-bundle' && steps.metadata.outputs.package_manager_name == 'pnpm'
@@ -216,6 +231,7 @@ jobs:
       - name: Build immutable artifact
         env:
           BUILD_UNIT: ${{ inputs.unit }}
+          RUSTC_WRAPPER: ${{ steps.sccache.outputs.wrapper }}
           SOURCE_DATE_EPOCH: '0'
           SCCACHE_S3_KEY_PREFIX: sccache/${{ steps.metadata.outputs.toolchain_version }}/${{ inputs.target }}
         run: |
@@ -227,9 +243,15 @@ jobs:
 
       - name: Record sccache metrics
         if: always() && inputs.kind == 'rust-binary'
+        env:
+          SCCACHE_WRAPPER: ${{ steps.sccache.outputs.wrapper }}
         run: |
           mkdir -p release-output
-          sccache --show-stats | tee release-output/sccache-stats.txt
+          if [[ "$SCCACHE_WRAPPER" != sccache ]]; then
+            echo 'sccache disabled after backend probe failure' | tee release-output/sccache-stats.txt
+          elif ! sccache --show-stats | tee release-output/sccache-stats.txt; then
+            echo 'sccache metrics unavailable' > release-output/sccache-stats.txt
+          fi
 
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:

--- a/claude-code/pnpm-lock.yaml
+++ b/claude-code/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@anthropic-ai/claude-agent-sdk':
         specifier: ^0.3.173
         version: 0.3.173(@anthropic-ai/sdk@0.104.1(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
+      '@opentelemetry/api':
+        specifier: ^1.9.1
+        version: 1.9.1
       iii-sdk:
         specifier: 0.22.1-alpha.25
         version: 0.22.1-alpha.25
@@ -39,6 +42,77 @@ importers:
       vitest:
         specifier: ^3.0.0
         version: 3.2.6(@types/node@22.19.21)(tsx@4.22.4)(yaml@2.9.0)
+
+  ../packages/agent-terminal-ui:
+    dependencies:
+      '@iii-dev/console-ui':
+        specifier: workspace:*
+        version: link:../console-ui
+      '@iii-workers/terminal-font':
+        specifier: workspace:*
+        version: link:../terminal-font
+      '@xterm/addon-fit':
+        specifier: ^0.11.0
+        version: 0.11.0
+      '@xterm/xterm':
+        specifier: ^6.0.0
+        version: 6.0.0
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.18
+      react:
+        specifier: ^19.2.8
+        version: 19.2.8
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.3
+
+  ../packages/console-ui:
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.18
+
+  ../packages/terminal-font:
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.18
+      react:
+        specifier: ^19.2.8
+        version: 19.2.8
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.3
+
+  ui:
+    dependencies:
+      '@iii-dev/console-ui':
+        specifier: workspace:*
+        version: link:../../packages/console-ui
+      '@iii-workers/agent-terminal-ui':
+        specifier: workspace:*
+        version: link:../../packages/agent-terminal-ui
+      '@xterm/addon-fit':
+        specifier: ^0.11.0
+        version: 0.11.0
+      '@xterm/xterm':
+        specifier: ^6.0.0
+        version: 6.0.0
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.18
+      esbuild:
+        specifier: ^0.25.0
+        version: 0.25.12
+      react:
+        specifier: ^19.2.8
+        version: 19.2.8
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.3
 
 packages:
 
@@ -898,6 +972,9 @@ packages:
   '@types/node@22.19.21':
     resolution: {integrity: sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==}
 
+  '@types/react@19.2.18':
+    resolution: {integrity: sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==}
+
   '@types/shimmer@1.2.0':
     resolution: {integrity: sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==}
 
@@ -929,6 +1006,12 @@ packages:
 
   '@vitest/utils@3.2.6':
     resolution: {integrity: sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==}
+
+  '@xterm/addon-fit@0.11.0':
+    resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
+
+  '@xterm/xterm@6.0.0':
+    resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -1017,6 +1100,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1335,6 +1421,10 @@ packages:
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
+
+  react@19.2.8:
+    resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
+    engines: {node: '>=0.10.0'}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -2162,6 +2252,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/react@19.2.18':
+    dependencies:
+      csstype: 3.2.3
+
   '@types/shimmer@1.2.0': {}
 
   '@vitest/expect@3.2.6':
@@ -2205,6 +2299,10 @@ snapshots:
       '@vitest/pretty-format': 3.2.6
       loupe: 3.2.1
       tinyrainbow: 2.0.0
+
+  '@xterm/addon-fit@0.11.0': {}
+
+  '@xterm/xterm@6.0.0': {}
 
   accepts@2.0.0:
     dependencies:
@@ -2290,6 +2388,8 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  csstype@3.2.3: {}
 
   debug@4.4.3:
     dependencies:
@@ -2670,6 +2770,8 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       unpipe: 1.0.0
+
+  react@19.2.8: {}
 
   require-from-string@2.0.2: {}
 

--- a/claude-code/pnpm-workspace.yaml
+++ b/claude-code/pnpm-workspace.yaml
@@ -1,0 +1,9 @@
+packages:
+  - .
+  - ui
+  - ../packages/agent-terminal-ui
+  - ../packages/console-ui
+  - ../packages/terminal-font
+
+onlyBuiltDependencies:
+  - esbuild


### PR DESCRIPTION
## Summary

- reproduce descriptor digests with JSON Number semantics during deployment verification
- make the claude-code release build install its direct dependency and shared UI workspace from a frozen lockfile
- compile Rust artifacts without the optional remote cache when cache authentication or backend access fails

## Validation

- 284 deployment and repository tests, plus 3 subtests
- 108 claude-code tests
- claude-code build, typecheck, and descriptor-driven immutable bundle build
- frozen pnpm install
- git diff --check

Refs MOT-4614

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the Claude Code release package to include shared UI components and workspace packages.

- **Bug Fixes**
  - Improved deployment descriptor verification for consistent handling of equivalent numeric values.
  - Deployment builds now continue successfully when optional remote caching is unavailable, falling back to standard compilation with appropriate status reporting.

- **Chores**
  - Updated Claude Code installation to use frozen lockfiles for more reproducible releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->