### PR TITLE
fix(quickstart): pass provider credentials and require latest

### DIFF
--- a/.github/scripts/tests/test_quickstart_compose_environment.py
+++ b/.github/scripts/tests/test_quickstart_compose_environment.py
@@ -1,0 +1,78 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[3]
+HELPER = ROOT / "harness" / "tests" / "quickstart" / "configure_compose_environment.py"
+SPEC = importlib.util.spec_from_file_location("configure_compose_environment", HELPER)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+COMPOSE = """\
+namespace: default
+containers:
+  llm-router:
+    worker: package://llm-router
+    version: "1.4.14"
+    start_after:
+      - state
+  harness:
+    worker: package://harness
+    version: "0.8.1"
+"""
+
+
+def test_declares_literal_credentials_only_on_llm_router():
+    configured = MODULE.configure_compose_environment(COMPOSE)
+    document = yaml.safe_load(configured)
+
+    assert document["containers"]["llm-router"]["environment"] == {
+        "ANTHROPIC_API_KEY": "${ANTHROPIC_API_KEY}",
+        "OPENAI_API_KEY": "${OPENAI_API_KEY}",
+    }
+    assert "environment" not in document["containers"]["harness"]
+    assert configured.count("ANTHROPIC_API_KEY") == 2
+    assert configured.count("OPENAI_API_KEY") == 2
+
+
+def test_is_idempotent_and_preserves_other_router_environment():
+    original = COMPOSE.replace(
+        "    start_after:\n",
+        "    environment:\n"
+        "      ROUTER_LOG: info\n"
+        "      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}\n"
+        "      OPENAI_API_KEY: ${OPENAI_API_KEY}\n"
+        "    start_after:\n",
+    )
+
+    assert MODULE.configure_compose_environment(original) == original
+
+
+@pytest.mark.parametrize(
+    "compose, message",
+    [
+        (COMPOSE.replace("  llm-router:\n", ""), "exactly one llm-router"),
+        (
+            COMPOSE.replace(
+                "  harness:\n",
+                "  harness:\n    environment:\n      OPENAI_API_KEY: ${OPENAI_API_KEY}\n",
+            ),
+            "must only be declared on llm-router",
+        ),
+        (
+            COMPOSE.replace(
+                "    start_after:\n",
+                "    environment:\n      OPENAI_API_KEY: materialized-secret\n    start_after:\n",
+            ),
+            "literal placeholder",
+        ),
+    ],
+)
+def test_rejects_ambiguous_or_secret_materializing_compose(compose: str, message: str):
+    with pytest.raises(ValueError, match=message):
+        MODULE.configure_compose_environment(compose)

--- a/.github/scripts/tests/test_quickstart_workflow.py
+++ b/.github/scripts/tests/test_quickstart_workflow.py
@@ -22,7 +22,7 @@ def test_quickstart_workflow_exists_with_exact_dispatch_identity():
     assert set(inputs) == {"quickstart_id", "attempt", "cli_channel", "registry_tag"}
     assert all(inputs[name]["required"] for name in inputs)
     assert inputs["cli_channel"]["options"] == ["latest", "rc"]
-    assert inputs["registry_tag"]["options"] == ["latest", "next"]
+    assert inputs["registry_tag"]["options"] == ["latest"]
     # Release Control correlates runs by this exact title shape.
     assert (
         document["run-name"]
@@ -75,3 +75,13 @@ def test_quickstart_actions_are_sha_pinned_and_inputs_never_reach_shell_source()
         if run is None:
             continue
         assert "${{ inputs." not in run, "dispatch inputs must reach run: only through env:"
+
+
+def test_quickstart_enforces_latest_and_applies_provider_environment():
+    script = (ROOT / "harness" / "tests" / "quickstart" / "run-ci.sh").read_text(encoding="utf-8")
+    assert 'case "$worker_tag" in\n  latest)' in script
+    assert 'configure_compose_environment.py" "$compose_file"' in script
+    assert "run_compose_restart" in script
+    assert 'router::provider::list' in script
+    assert "unset ANTHROPIC_API_KEY OPENAI_API_KEY" in script
+    assert 'ANTHROPIC_API_KEY="$anthropic_api_key" OPENAI_API_KEY="$openai_api_key"' in script

--- a/.github/workflows/harness-quickstart.yml
+++ b/.github/workflows/harness-quickstart.yml
@@ -15,7 +15,9 @@ on:
       registry_tag:
         required: true
         type: choice
-        options: [latest, next]
+        # The quickstart follows the stable Registry graph. Release validation
+        # may still pin one exact candidate through the separate override.
+        options: [latest]
 
 permissions: {}
 

--- a/harness/tests/quickstart/README.md
+++ b/harness/tests/quickstart/README.md
@@ -52,10 +52,22 @@ The default engine and Console ports (`49134` and `3113`) must be available.
 The CLI installer and Registry worker selectors are independent:
 `III_CLI_CHANNEL` chooses `latest` or `rc` for `iii` (default `rc`; the CLI's
 `next` channel is dead, and `iii compose` needs 0.23.0-rc or newer — the
-validator refuses a CLI without the `compose` command), while `III_WORKER_TAG`
-chooses the Registry tag used by `harness` and `console`. The old combined
-`III_CHANNEL` variable is rejected to prevent a silent test against the wrong
-side of the split.
+validator refuses a CLI without the `compose` command). `III_WORKER_TAG` is
+restricted to `latest`, so `harness`, `console`, and their Registry dependency
+graph always resolve from the stable channel before the generated compose file
+pins exact versions. Release-triggered validation can still replace the one
+worker under test with an explicit immutable candidate version. The old
+combined `III_CHANNEL` variable is rejected to prevent a silent test against
+the wrong side of the split.
+
+After Registry resolution, the validator declares literal
+`${ANTHROPIC_API_KEY}` and `${OPENAI_API_KEY}` references only on `llm-router`
+and restarts the compose project. The provider values remain in the process
+environment of the compose daemon and the `llm-router` it starts; the installer,
+engine, CLI calls, other workers, and Playwright do not inherit them. They are
+never written to the compose file or artifacts. A `router::provider::list`
+preflight proves both providers received usable configuration before model
+discovery and browser validation begin.
 Set `HARNESS_QUICKSTART_TRACE=1` to print only the important external commands
 (`iii trigger compose::add`, `iii trigger`, installer, engine, and compose
 daemon) and save the list as `commands.log`. Polling attempts, assignments,

--- a/harness/tests/quickstart/configure_compose_environment.py
+++ b/harness/tests/quickstart/configure_compose_environment.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Declare provider credentials on llm-router without materializing secrets."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+ROUTER_HEADER = "  llm-router:"
+CREDENTIALS = ("ANTHROPIC_API_KEY", "OPENAI_API_KEY")
+CONTAINER_HEADER = re.compile(r"^  [^ #][^:]*:\s*(?:#.*)?$")
+
+
+def configure_compose_environment(text: str) -> str:
+    """Return compose YAML with literal provider placeholders on llm-router."""
+
+    trailing_newline = text.endswith("\n")
+    lines = text.splitlines()
+    router_headers = [index for index, line in enumerate(lines) if line == ROUTER_HEADER]
+    if len(router_headers) != 1:
+        raise ValueError(f"expected exactly one llm-router container, found {len(router_headers)}")
+
+    router_start = router_headers[0]
+    router_end = next(
+        (index for index in range(router_start + 1, len(lines)) if CONTAINER_HEADER.match(lines[index])),
+        len(lines),
+    )
+
+    for credential in CREDENTIALS:
+        declaration = re.compile(rf"^\s+{re.escape(credential)}\s*:")
+        for index, line in enumerate(lines):
+            if declaration.match(line) and not router_start < index < router_end:
+                raise ValueError(f"{credential} must only be declared on llm-router")
+
+    environment_headers = [
+        index
+        for index in range(router_start + 1, router_end)
+        if lines[index].startswith("    environment:")
+    ]
+    if len(environment_headers) > 1:
+        raise ValueError("llm-router has multiple environment sections")
+
+    expected = {credential: f"      {credential}: ${{{credential}}}" for credential in CREDENTIALS}
+    missing: list[str] = []
+    for credential in CREDENTIALS:
+        declarations = [
+            lines[index]
+            for index in range(router_start + 1, router_end)
+            if re.match(rf"^\s+{re.escape(credential)}\s*:", lines[index])
+        ]
+        if len(declarations) > 1:
+            raise ValueError(f"llm-router declares {credential} more than once")
+        if declarations and declarations[0] != expected[credential]:
+            raise ValueError(f"llm-router must reference {credential} through its literal placeholder")
+        if not declarations:
+            missing.append(credential)
+
+    if not missing:
+        return text
+
+    if environment_headers:
+        environment_index = environment_headers[0]
+        if lines[environment_index] != "    environment:":
+            raise ValueError("llm-router environment must use a YAML mapping")
+        insert_at = environment_index + 1
+    else:
+        insert_at = next(
+            (
+                index
+                for index in range(router_start + 1, router_end)
+                if lines[index].startswith("    start_after:")
+            ),
+            router_end,
+        )
+        lines.insert(insert_at, "    environment:")
+        insert_at += 1
+
+    lines[insert_at:insert_at] = [expected[credential] for credential in missing]
+    configured = "\n".join(lines)
+    return configured + ("\n" if trailing_newline else "")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("compose_file", type=Path)
+    args = parser.parse_args()
+
+    original = args.compose_file.read_text(encoding="utf-8")
+    configured = configure_compose_environment(original)
+    if configured != original:
+        args.compose_file.write_text(configured, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/harness/tests/quickstart/run-ci.sh
+++ b/harness/tests/quickstart/run-ci.sh
@@ -51,9 +51,9 @@ case "$cli_channel" in
 esac
 
 case "$worker_tag" in
-  latest | next) ;;
+  latest) ;;
   *)
-    echo "III_WORKER_TAG must be 'latest' or 'next' (got: $worker_tag)" >&2
+    echo "III_WORKER_TAG must be 'latest' (got: $worker_tag)" >&2
     exit 2
     ;;
 esac
@@ -65,16 +65,22 @@ if [[ -n "$release_worker" || -n "$release_version" ]]; then
   }
 fi
 
-[[ -n "${ANTHROPIC_API_KEY:-}" ]] || {
+anthropic_api_key=${ANTHROPIC_API_KEY:-}
+openai_api_key=${OPENAI_API_KEY:-}
+[[ -n "$anthropic_api_key" ]] || {
   echo "ANTHROPIC_API_KEY is required" >&2
   exit 2
 }
-[[ -n "${OPENAI_API_KEY:-}" ]] || {
+[[ -n "$openai_api_key" ]] || {
   echo "OPENAI_API_KEY is required" >&2
   exit 2
 }
+# Keep credentials out of installer, engine, CLI, Playwright, and other child
+# processes. Only the compose daemon needs them to resolve the placeholders
+# declared specifically on llm-router.
+unset ANTHROPIC_API_KEY OPENAI_API_KEY
 
-for command_name in curl jq ffmpeg; do
+for command_name in curl jq ffmpeg python3; do
   command -v "$command_name" >/dev/null 2>&1 || {
     echo "$command_name is required" >&2
     exit 2
@@ -121,6 +127,7 @@ rm -f \
   "$artifact_dir/model-anthropic.json" \
   "$artifact_dir/model-openai.json" \
   "$artifact_dir/model-catalog.json" \
+  "$artifact_dir/provider-status.json" \
   "$artifact_dir/browser-evidence.json" \
   "$artifact_dir/terminal-status.json" \
   "$artifact_dir/first-capability-browser-evidence.json" \
@@ -350,6 +357,7 @@ wait_for_functions() {
     "session::messages",
     "context::assemble",
     "router::models::get",
+    "router::provider::list",
     "shell::exec",
     "console::status"
   ]'
@@ -374,6 +382,34 @@ wait_for_functions() {
     sleep 1
   done
   die "required functions did not register: $missing"
+}
+
+wait_for_providers() {
+  local response attempt
+  log "Waiting for Anthropic and OpenAI provider configuration (up to ${wait_seconds}s)"
+  log_command "iii trigger router::provider::list --port $engine_port --json '{}'"
+  for ((attempt = 0; attempt < wait_seconds; attempt++)); do
+    response=$("$iii_bin" trigger router::provider::list --port "$engine_port" \
+      --json '{}' 2>>"$log_dir/provider-discovery.log" || true)
+    if jq -e '.providers | type == "array"' <<<"$response" >/dev/null 2>&1; then
+      printf '%s\n' "$response" >"$artifact_dir/provider-status.json"
+    fi
+    if jq -e '
+      [
+        .providers[]?
+        | select(.id == "anthropic" or .id == "openai")
+        | select(.configured == true and .available == true)
+      ] | length == 2
+    ' <<<"$response" >/dev/null 2>&1; then
+      ok "Anthropic and OpenAI providers configured after ${attempt}s"
+      return 0
+    fi
+    if ((attempt > 0 && attempt % 15 == 0)); then
+      log "Still waiting for configured Anthropic and OpenAI providers"
+    fi
+    sleep 1
+  done
+  die "llm-router did not report configured and available Anthropic and OpenAI providers"
 }
 
 wait_for_model() {
@@ -555,7 +591,7 @@ verify_first_capability() {
 
 artifacts_contain_secret() {
   local credential
-  for credential in "$ANTHROPIC_API_KEY" "$OPENAI_API_KEY"; do
+  for credential in "$anthropic_api_key" "$openai_api_key"; do
     if LC_ALL=C grep -R -a -F -l -- "$credential" "$artifact_dir" >/dev/null 2>&1; then
       return 0
     fi
@@ -598,6 +634,23 @@ run_compose_add() {
     || die "compose::add $spec did not report ok"
 }
 
+run_compose_restart() {
+  local payload response
+  payload=$(jq -cn --arg file "$compose_file" '{file: $file}')
+  log_command "iii trigger compose::restart --port $engine_port --timeout-ms $((add_timeout_seconds * 1000)) --json '$payload'"
+  if command -v timeout >/dev/null 2>&1; then
+    response=$(timeout --signal=TERM --kill-after=15s "$((add_timeout_seconds + 30))" \
+      "$iii_bin" trigger compose::restart --port "$engine_port" \
+      --timeout-ms "$((add_timeout_seconds * 1000))" --json "$payload")
+  else
+    response=$("$iii_bin" trigger compose::restart --port "$engine_port" \
+      --timeout-ms "$((add_timeout_seconds * 1000))" --json "$payload")
+  fi
+  printf '%s\n' "$response"
+  jq -e '.status == "ok"' <<<"$response" >/dev/null 2>&1 \
+    || die "compose::restart did not report ok"
+}
+
 start_engine() {
   local command=("$iii_bin" -c "$project_dir/config.yaml" --no-update-check)
   log_command "iii -c config.yaml --no-update-check"
@@ -616,9 +669,11 @@ start_compose() {
   local command=("$iii_bin" compose --engine "ws://127.0.0.1:$engine_port" --namespace default)
   log_command "iii compose --engine ws://127.0.0.1:$engine_port --namespace default"
   if command -v setsid >/dev/null 2>&1; then
-    setsid "${command[@]}" >"$log_dir/compose.log" 2>&1 &
+    ANTHROPIC_API_KEY="$anthropic_api_key" OPENAI_API_KEY="$openai_api_key" \
+      setsid "${command[@]}" >"$log_dir/compose.log" 2>&1 &
   else
-    "${command[@]}" >"$log_dir/compose.log" 2>&1 &
+    ANTHROPIC_API_KEY="$anthropic_api_key" OPENAI_API_KEY="$openai_api_key" \
+      "${command[@]}" >"$log_dir/compose.log" 2>&1 &
   fi
   compose_pid=$!
 }
@@ -687,7 +742,9 @@ COMPOSE
 log "Step 3/9: Add harness and Console from worker tag $worker_tag via compose"
 run_compose_add "harness@$worker_tag" 2>&1 | tee "$log_dir/compose-add-harness.log"
 run_compose_add "console@$worker_tag" 2>&1 | tee "$log_dir/compose-add-console.log"
-ok "compose declared and started harness + console"
+python3 "$script_dir/configure_compose_environment.py" "$compose_file"
+run_compose_restart 2>&1 | tee "$log_dir/compose-restart-provider-env.log"
+ok "compose declared harness + console from latest and applied provider credentials to llm-router"
 
 log "Step 4/9: Apply exact release candidate override"
 if [[ -n "$release_worker" ]]; then
@@ -700,6 +757,7 @@ fi
 
 log "Step 5/9: Verify registered functions"
 wait_for_functions
+wait_for_providers
 
 log "Step 6/9: Verify Sonnet 5 and Luna availability"
 wait_for_model anthropic claude-sonnet-5 "$artifact_dir/model-anthropic.json"
@@ -731,7 +789,11 @@ for required in harness console; do
 done
 grep -Eq '^[[:space:]]+version:' "$compose_file" \
   || die "worker-compose.yaml has no pinned versions"
-ok "worker-compose.yaml declares harness + console with pinned versions"
+grep -Fq 'ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}' "$compose_file" \
+  || die "worker-compose.yaml does not pass ANTHROPIC_API_KEY to llm-router"
+grep -Fq 'OPENAI_API_KEY: ${OPENAI_API_KEY}' "$compose_file" \
+  || die "worker-compose.yaml does not pass OPENAI_API_KEY to llm-router"
+ok "worker-compose.yaml declares latest-resolved pinned versions and secret-safe provider references"
 snapshot_project
 assert_secret_safe_artifacts
 


### PR DESCRIPTION
## Summary

- declare Anthropic and OpenAI credential references only on `llm-router`
- restart the compose project and verify provider readiness before model discovery
- constrain the scheduled worker graph to the stable `latest` tag
- keep provider values out of generated project files, artifacts, and unrelated child processes

## Validation

- `bash -n harness/tests/quickstart/run-ci.sh`
- `python3 -m pytest -q .github/scripts/tests` (287 passed, 3 subtests passed)
- `III_WORKER_TAG=next` is rejected before execution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quickstart validation now configures Anthropic and OpenAI provider credentials securely for `llm-router`.
  * Added provider readiness checks before model discovery and browser validation.
  * Added support for separate CLI and worker channel selection.

* **Bug Fixes**
  * Prevented credential values from being written to compose files or generated artifacts.
  * Improved validation for invalid, duplicate, misplaced, or secret-materializing credential settings.

* **Documentation**
  * Updated quickstart documentation with channel selection and provider configuration guidance.

* **Chores**
  * Restricted the worker channel to the stable `latest` release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->