### PR TITLE
fix(quickstart): follow latest Console model picker

### DIFF
--- a/harness/tests/quickstart/console-first-capability.spec.ts
+++ b/harness/tests/quickstart/console-first-capability.spec.ts
@@ -23,14 +23,11 @@ async function selectSonnet(page: Page) {
   await expect(modelPicker).toBeEnabled()
   await modelPicker.click()
 
-  const anthropicGroup = page.getByRole('menuitem', { name: /^anthropic/i })
+  const modelMenu = page.getByRole('menu', { name: /^model:/i })
+  const anthropicGroup = modelMenu.getByRole('region', { name: /^anthropic$/i })
   await expect(anthropicGroup).toBeVisible()
-  if ((await anthropicGroup.getAttribute('aria-expanded')) !== 'true') {
-    await anthropicGroup.click()
-  }
-  await expect(anthropicGroup).toHaveAttribute('aria-expanded', 'true')
 
-  const sonnet = page.getByRole('menuitemradio', { name: MODEL_LABEL })
+  const sonnet = anthropicGroup.getByRole('button', { name: MODEL_LABEL })
   await expect(sonnet).toHaveCount(1)
   await sonnet.click()
 

--- a/harness/tests/quickstart/console-first-message.spec.ts
+++ b/harness/tests/quickstart/console-first-message.spec.ts
@@ -33,16 +33,13 @@ async function selectModel(
   await expect(modelPicker).toBeEnabled()
   await modelPicker.click()
 
-  const providerGroup = page.getByRole('menuitem', {
-    name: new RegExp(`^${provider}`, 'i'),
+  const modelMenu = page.getByRole('menu', { name: /^model:/i })
+  const providerGroup = modelMenu.getByRole('region', {
+    name: new RegExp(`^${provider}$`, 'i'),
   })
   await expect(providerGroup).toBeVisible()
-  if ((await providerGroup.getAttribute('aria-expanded')) !== 'true') {
-    await providerGroup.click()
-  }
-  await expect(providerGroup).toHaveAttribute('aria-expanded', 'true')
 
-  const model = page.getByRole('menuitemradio', { name: modelLabel })
+  const model = providerGroup.getByRole('button', { name: modelLabel })
   await expect(model).toHaveCount(1)
   await model.click()
 


### PR DESCRIPTION
## Summary

- select provider groups through the labelled regions exposed by the current Console
- select models through their current button roles in both quickstart browser scenarios

## Verification

- Playwright discovers and compiles both quickstart specs
- selectors match the current `ModelPicker` accessibility contract and the failed-run snapshot
- `git diff --check`