### PR TITLE
fix: keep worker configuration paths portable

### DIFF
--- a/crates/worker-paths/src/lib.rs
+++ b/crates/worker-paths/src/lib.rs
@@ -1,8 +1,9 @@
 //! Resolves worker-owned paths against the Compose project directory.
 //!
 //! Compose-managed workers receive `III_COMPOSE_DIR`. Standalone workers use
-//! their process working directory. Absolute paths and explicit home-relative
-//! paths keep their usual meaning.
+//! their process working directory. Configuration defaults stay relative so
+//! serialized worker configuration remains portable. Absolute paths and
+//! explicit home-relative paths keep their usual meaning.
 
 use std::ffi::OsStr;
 use std::path::{Component, Path, PathBuf};
@@ -10,12 +11,11 @@ use std::path::{Component, Path, PathBuf};
 /// Environment variable that contains the canonical Compose project directory.
 pub const COMPOSE_DIR_ENV: &str = "III_COMPOSE_DIR";
 
-/// Builds a Compose-absolute default while keeping standalone manifests portable.
+/// Builds a portable default for serialized worker configuration.
+///
+/// Resolve the returned value with [`resolve_path`] before filesystem access.
 pub fn default_path(relative: impl AsRef<Path>) -> String {
-    let compose_dir = std::env::var_os(COMPOSE_DIR_ENV);
-    default_path_with(relative.as_ref(), compose_dir.as_deref())
-        .to_string_lossy()
-        .into_owned()
+    clean_path(relative.as_ref()).to_string_lossy().into_owned()
 }
 
 /// Resolves a configured path while preserving explicit absolute and `~/` paths.
@@ -79,10 +79,7 @@ fn project_path_with(
     compose_dir: Option<&OsStr>,
     current_dir: Option<&Path>,
 ) -> PathBuf {
-    let relative: PathBuf = relative
-        .components()
-        .filter(|component| !matches!(component, Component::CurDir))
-        .collect();
+    let relative = clean_path(relative);
     let root = compose_dir
         .filter(|value| !value.is_empty())
         .map(PathBuf::from)
@@ -93,18 +90,10 @@ fn project_path_with(
     }
 }
 
-fn default_path_with(relative: &Path, compose_dir: Option<&OsStr>) -> PathBuf {
-    let relative: PathBuf = relative
-        .components()
+fn clean_path(path: &Path) -> PathBuf {
+    path.components()
         .filter(|component| !matches!(component, Component::CurDir))
-        .collect();
-    let root = compose_dir
-        .filter(|value| !value.is_empty())
-        .map(PathBuf::from);
-    match root {
-        Some(root) => root.join(relative),
-        None => relative,
-    }
+        .collect()
 }
 
 #[cfg(test)]
@@ -142,23 +131,17 @@ mod tests {
     }
 
     #[test]
-    fn default_path_is_absolute_inside_compose() {
-        let resolved = default_path_with(
-            Path::new("data/session-manager"),
-            Some(OsStr::new("/workspace/project")),
-        );
+    fn default_path_stays_portable() {
+        let default = default_path("data/session-manager");
 
-        assert_eq!(
-            resolved,
-            PathBuf::from("/workspace/project/data/session-manager")
-        );
+        assert_eq!(default, "data/session-manager");
     }
 
     #[test]
-    fn default_path_stays_portable_outside_compose() {
-        let resolved = default_path_with(Path::new("data/session-manager"), None);
+    fn default_path_removes_current_directory_components() {
+        let default = default_path("./data/session-manager");
 
-        assert_eq!(resolved, PathBuf::from("data/session-manager"));
+        assert_eq!(default, "data/session-manager");
     }
 
     #[test]

--- a/database/src/config.rs
+++ b/database/src/config.rs
@@ -19,10 +19,7 @@ pub const DEFAULT_DB_NAME: &str = "primary";
 pub const DEFAULT_SQLITE_URL: &str = "sqlite:./data/iii.db";
 
 fn default_sqlite_url() -> String {
-    format!(
-        "sqlite:{}",
-        iii_worker_paths::project_path("data/iii.db").display()
-    )
+    DEFAULT_SQLITE_URL.to_string()
 }
 
 /// Top-level worker config registered with the `configuration` worker.
@@ -101,6 +98,16 @@ pub struct DatabaseConfig {
     #[serde(skip)]
     #[schemars(skip)]
     pub driver: DriverKind,
+}
+
+impl DatabaseConfig {
+    /// Resolves file-backed SQLite URLs when the database is opened.
+    pub(crate) fn resolved_url(&self) -> String {
+        match self.driver {
+            DriverKind::Sqlite => resolve_sqlite_url(&self.url),
+            DriverKind::Postgres | DriverKind::Mysql => self.url.clone(),
+        }
+    }
 }
 
 /// TLS settings for a single database. Applies to postgres and mysql.
@@ -327,9 +334,6 @@ impl WorkerConfig {
                     redact_url(&db.url)
                 )
             })?;
-            if matches!(db.driver, DriverKind::Sqlite) {
-                db.url = resolve_sqlite_url(&db.url);
-            }
             if db.capture == CaptureMode::Native {
                 match db.driver {
                     // Postgres captures via LISTEN/NOTIFY; server-side
@@ -514,13 +518,7 @@ mod tests {
         });
         let c = WorkerConfig::from_json(&json).unwrap();
         assert!(matches!(c.databases["primary"].driver, DriverKind::Sqlite));
-        assert_eq!(
-            c.databases["primary"].url,
-            format!(
-                "sqlite:{}",
-                iii_worker_paths::project_path("data/iii.db").display()
-            )
-        );
+        assert_eq!(c.databases["primary"].url, DEFAULT_SQLITE_URL);
     }
 
     #[test]
@@ -698,14 +696,14 @@ databases:
     }
 
     #[test]
-    fn uppercase_sqlite_scheme_resolves_project_path() {
+    fn uppercase_sqlite_scheme_resolves_project_path_at_use() {
         let c = cfg("databases:\n  primary:\n    url: SQLiTE:FiLe:./data/case.db?mode=rwc\n");
         let expected = format!(
             "SQLiTE:FiLe:{}?mode=rwc",
             iii_worker_paths::project_path("data/case.db").display()
         );
 
-        assert_eq!(c.databases["primary"].url, expected);
+        assert_eq!(c.databases["primary"].resolved_url(), expected);
     }
 
     #[test]

--- a/database/src/pool/mod.rs
+++ b/database/src/pool/mod.rs
@@ -60,7 +60,8 @@ pub async fn build(db_name: &str, cfg: &crate::config::DatabaseConfig) -> Result
     match cfg.driver {
         DriverKind::Sqlite => {
             // Sqlite is local-file; the `tls` block has no meaning for it.
-            SqlitePool::new(&cfg.url, &cfg.pool).map(|p| Pool::Sqlite(p.with_db_name(db_name)))
+            let url = cfg.resolved_url();
+            SqlitePool::new(&url, &cfg.pool).map(|p| Pool::Sqlite(p.with_db_name(db_name)))
         }
         DriverKind::Postgres => PostgresPool::new(&cfg.url, &cfg.pool, &cfg.tls)
             .await

--- a/database/src/triggers/native.rs
+++ b/database/src/triggers/native.rs
@@ -227,7 +227,8 @@ impl NativeListeners {
                 ))))
             }
             crate::config::DriverKind::Sqlite => {
-                let Some(path) = super::sqlite_watch::sqlite_file_path(&db.url) else {
+                let url = db.resolved_url();
+                let Some(path) = super::sqlite_watch::sqlite_file_path(&url) else {
                     // Config validation rejects `:memory:`; reaching this
                     // means drift — fail visible, not silent.
                     tracing::warn!(db = %name, "native capture needs a file-backed sqlite url");

--- a/session-manager/src/config.rs
+++ b/session-manager/src/config.rs
@@ -12,7 +12,7 @@
 //! adapter:
 //!   name: fs
 //!   config:
-//!     data_dir: /project/data/session-manager
+//!     data_dir: data/session-manager
 //! ```
 //!
 //! or
@@ -267,7 +267,7 @@ mod tests {
         let StorageAdapter::Fs(fs) = cfg.resolve_adapter() else {
             panic!("expected fs adapter");
         };
-        assert_eq!(fs.data_dir, default_data_dir());
+        assert_eq!(fs.data_dir, "data/session-manager");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- keep project-owned worker path defaults relative when configuration is serialized
- resolve relative paths from `III_COMPOSE_DIR` only when workers access the filesystem
- keep SQLite file URLs portable and resolve them when pools and native watchers open the database

## Context

Worker configuration currently persists absolute paths derived from the local Compose directory. A configuration generated on one machine therefore cannot be shared safely with another machine.

This change keeps stored values relative while preserving the existing runtime path resolution behavior. Absolute and home-relative overrides continue to work.

## Validation

- worker-paths unit tests
- database unit and integration tests
- session-manager, context-manager, queue, iii-directory, memory, storage, worktree, shell, and state unit tests
- formatting checks for all changed crates
- Clippy with warnings denied for worker-paths, database, and session-manager
- direct manifest check with `III_COMPOSE_DIR` set; the session-manager default remains `data/session-manager`

## Related

- Follow-up to #936


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SQLite database paths are now resolved when the database opens, improving portability of serialized configurations.
  * SQLite changelog file paths now correctly use the resolved database location.
  * Default worker and session-manager paths remain relative and portable across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->