### PR TITLE
(MOT-4389) fix(console): install harness through Compose

### DIFF
--- a/console/web/src/components/chat/EmptyState.tsx
+++ b/console/web/src/components/chat/EmptyState.tsx
@@ -35,7 +35,7 @@ import './EmptyState.css'
  *   - `ready`          — harness present + a model available (the hero copy)
  *   - `no-provider`    — harness present, no model configured -> configure CTA
  *   - `no-harness`     — harness worker missing -> install CTA + cli hint
- *   - `installing`     — `worker::add` in flight -> live console
+ *   - `installing`     — `compose::add` in flight -> live console
  *   - `install-failed` — add failed -> console + retry
  *
  * `MessageList` derives the variant from `ConversationsContext` (harness

--- a/console/web/src/hooks/use-harness-status.test.ts
+++ b/console/web/src/hooks/use-harness-status.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { IiiClient } from '@/lib/iii-client'
+import { addHarnessToCompose } from './use-harness-status'
+
+describe('addHarnessToCompose', () => {
+  it('adds harness through the Compose control plane', async () => {
+    const trigger = vi.fn().mockResolvedValue({ status: 'started' })
+    const client = { trigger } as unknown as Pick<IiiClient, 'trigger'>
+
+    await addHarnessToCompose(client)
+
+    expect(trigger).toHaveBeenCalledOnce()
+    expect(trigger).toHaveBeenCalledWith('compose::add', {
+      workers: ['harness'],
+    })
+  })
+})

--- a/console/web/src/hooks/use-harness-status.ts
+++ b/console/web/src/hooks/use-harness-status.ts
@@ -6,7 +6,7 @@ import { useWorkerLifecycle } from './use-worker-lifecycle'
 
 /**
  * Watches the engine for the `harness` worker and drives an in-app install of
- * it via `worker::add`, surfacing live progress.
+ * it via `compose::add`, surfacing live progress.
  *
  * Two signals feed `present`:
  *   1. An initial `engine::workers::list` read on mount.
@@ -15,12 +15,12 @@ import { useWorkerLifecycle } from './use-worker-lifecycle'
  *      `iii trigger compose::add worker=harness` run in the operator's own terminal (this is the
  *      educational, "you can do this in the CLI too" angle).
  *
- * `install()` triggers `worker::add` for the registry `harness` source. It
+ * `install()` triggers `compose::add` for the registry `harness` worker. It
  * resolves with a terminal outcome, but the per-stage progress
  * (started -> downloading -> downloaded -> done) only arrives through the
  * `worker` trigger, so we render that as a small console. When the trigger type
  * isn't published (or no events arrive) we still resolve cleanly off the
- * `worker::add` result and a presence re-check — a graceful, progress-less
+ * `compose::add` result and a presence re-check — a graceful, progress-less
  * fallback.
  */
 
@@ -54,7 +54,7 @@ export interface HarnessStatus {
   stages: InstallStage[]
   /** Last install error message, or null. */
   error: string | null
-  /** Kick off `worker::add` for the harness registry source. */
+  /** Add the harness registry worker to the active Compose project. */
   install: () => void
   /** Clear the error and retry the add. */
   retry: () => void
@@ -124,6 +124,15 @@ async function checkHarnessPresent(client: IiiClient): Promise<boolean> {
   )
   const workers = Array.isArray(res?.workers) ? res.workers : []
   return workers.some((w) => w?.name === HARNESS_WORKER_NAME)
+}
+
+/** Add harness to the active Compose project and wait for reconciliation. */
+export async function addHarnessToCompose(
+  client: Pick<IiiClient, 'trigger'>,
+): Promise<void> {
+  await client.trigger('compose::add', {
+    workers: [HARNESS_WORKER_NAME],
+  })
 }
 
 /**
@@ -209,10 +218,7 @@ export function useHarnessStatus(enabled: boolean): HarnessStatus {
     void (async () => {
       const client = await getIiiClient()
       try {
-        await client.trigger('worker::add', {
-          source: { kind: 'registry', name: HARNESS_WORKER_NAME },
-          wait: true,
-        })
+        await addHarnessToCompose(client)
         // Terminal success. Trigger events may have already flipped these, but
         // setting them again is harmless and covers the no-events fallback.
         setPresent(true)


### PR DESCRIPTION
## Summary

- route the Console harness install action through `compose::add`
- send the canonical Compose worker list payload
- add regression coverage for the function id and payload

## Why

iii 0.23 removed `worker::add`. The Console still called that function when the user clicked **add harness**, so installation failed with `function_not_found`.

## Validation

- `pnpm --dir console/web exec vitest run src/hooks/use-harness-status.test.ts src/components/chat/EmptyState.test.tsx`
- `pnpm --dir console/web exec biome check src/hooks/use-harness-status.ts src/hooks/use-harness-status.test.ts src/components/chat/EmptyState.tsx`
- `pnpm --dir console/web typecheck`
- `pnpm --dir console/web build`

Refs MOT-4389

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved harness installation by using the correct Compose operation, helping ensure installations complete successfully.

* **Tests**
  * Added coverage to verify that harness installation triggers the expected Compose operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->