### PR TITLE
(MOT-4613) fix(ci): make runner routing deterministic

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,7 +1,9 @@
 self-hosted-runner:
   labels:
     - general
-    - rust
+    - workers-ci-linux-8core
+    - workers-release-control-linux-2core
     - workers-release-linux-8core
+    - workers-release-macos-aws-intel
     - workers-release-macos-12core
     - workers-release-macos-arm-5core

--- a/.github/scripts/tests/test_rust_ci_workflows.py
+++ b/.github/scripts/tests/test_rust_ci_workflows.py
@@ -68,9 +68,32 @@ def test_prs_restore_rust_caches_and_main_pushes_publish_them() -> None:
     assert ci["jobs"]["harness-integration"]["with"]["save-cache"] == expected
 
 
-def test_harness_integration_uses_the_rust_self_hosted_runner() -> None:
-    integration = workflow("_harness-integration.yml")["jobs"]["integration"]
-    assert integration["runs-on"] == ["self-hosted", "Linux", "X64", "rust"]
+def test_harness_integration_defaults_to_an_available_hosted_runner() -> None:
+    reusable = workflow("_harness-integration.yml")
+    assert reusable["on"]["workflow_call"]["inputs"]["runner"]["default"] == (
+        "ubuntu-latest"
+    )
+    assert reusable["jobs"]["integration"]["runs-on"] == "${{ inputs.runner }}"
+    assert reusable["jobs"]["integration"]["timeout-minutes"] == "90"
+
+
+def test_harness_benchmark_is_manual_and_keeps_cold_caches_isolated() -> None:
+    benchmark = workflow("harness-integration-benchmark.yml")
+    inputs = benchmark["on"]["workflow_dispatch"]["inputs"]
+    assert inputs["runner"]["options"] == [
+        "workers-ci-linux-8core",
+        "ubuntu-latest",
+    ]
+    assert inputs["cache-mode"]["options"] == ["warm", "cold"]
+
+    call = benchmark["jobs"]["integration"]
+    assert call["uses"] == "./.github/workflows/_harness-integration.yml"
+    assert call["with"]["runner"] == "${{ inputs.runner }}"
+    assert call["with"]["save-cache"] == "${{ inputs.cache-mode == 'warm' }}"
+    assert "github.run_id" in call["with"]["cache-key-suffix"]
+
+    reusable_body = (WORKFLOWS / "_harness-integration.yml").read_text()
+    assert "format('-{0}', inputs.cache-key-suffix)" in reusable_body
 
 
 def test_actionlint_knows_the_repository_runner_pool_labels() -> None:
@@ -79,11 +102,32 @@ def test_actionlint_knows_the_repository_runner_pool_labels() -> None:
     )
     assert config["self-hosted-runner"]["labels"] == [
         "general",
-        "rust",
+        "workers-ci-linux-8core",
+        "workers-release-control-linux-2core",
         "workers-release-linux-8core",
+        "workers-release-macos-aws-intel",
         "workers-release-macos-12core",
         "workers-release-macos-arm-5core",
     ]
+
+
+def test_runner_pool_contract_is_documented() -> None:
+    runner_docs = (REPOSITORY / "docs/architecture/testing-and-ci.md").read_text()
+    labels = {
+        "ubuntu-latest",
+        "workers-ci-linux-8core",
+        "workers-release-control-linux-2core",
+        "workers-release-linux-8core",
+        "windows-latest",
+        "workers-release-macos-12core",
+        "workers-release-macos-arm-5core",
+        "workers-release-macos-aws-intel",
+    }
+    for label in labels:
+        assert f"`{label}`" in runner_docs
+
+    assert "ten executions on each pool" in runner_docs
+    assert "improvement over `ubuntu-latest` is at least 25%" in runner_docs
 
 
 def test_interface_smoke_bounds_each_engine_readiness_probe() -> None:

--- a/.github/scripts/tests/test_rust_ci_workflows.py
+++ b/.github/scripts/tests/test_rust_ci_workflows.py
@@ -126,8 +126,10 @@ def test_runner_pool_contract_is_documented() -> None:
     for label in labels:
         assert f"`{label}`" in runner_docs
 
-    assert "ten executions on each pool" in runner_docs
+    assert "ten candidate executions" in runner_docs
     assert "improvement over `ubuntu-latest` is at least 25%" in runner_docs
+    assert "8-core warm | 7 | 8m54 | 9m17" in runner_docs
+    assert "`ubuntu-latest` remains the default" in runner_docs
 
 
 def test_interface_smoke_bounds_each_engine_readiness_probe() -> None:

--- a/.github/workflows/_harness-integration.yml
+++ b/.github/workflows/_harness-integration.yml
@@ -128,7 +128,7 @@ jobs:
         run: cargo build --locked --release --timings -p ${{ steps.lock.outputs.package }}
 
       - name: Save pinned engine binary
-        if: inputs.save-cache && steps.engine-cache.outputs.cache-hit != 'true'
+        if: (inputs.save-cache || inputs.runner == 'workers-ci-linux-8core') && steps.engine-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: target/integration-engine-src/${{ steps.lock.outputs.binary }}
@@ -150,7 +150,7 @@ jobs:
           # Instrumented builds have different fingerprints; keep them on their
           # own key so coverage runs never poison the normal cache.
           shared-key: ${{ inputs.coverage && 'harness-integration-coverage' || 'harness-integration' }}${{ inputs.cache-key-suffix && format('-{0}', inputs.cache-key-suffix) || '' }}
-          save-if: ${{ inputs.save-cache || inputs.coverage }}
+          save-if: ${{ inputs.save-cache || inputs.coverage || inputs.runner == 'workers-ci-linux-8core' }}
           # Every release build the stack needs now lands in one shared
           # target dir (see harness/Makefile INTEGRATION_TARGET_DIR); the
           # per-workspace entries below stay so the cache key keeps hashing

--- a/.github/workflows/_harness-integration.yml
+++ b/.github/workflows/_harness-integration.yml
@@ -128,7 +128,7 @@ jobs:
         run: cargo build --locked --release --timings -p ${{ steps.lock.outputs.package }}
 
       - name: Save pinned engine binary
-        if: (inputs.save-cache || inputs.runner == 'workers-ci-linux-8core') && steps.engine-cache.outputs.cache-hit != 'true'
+        if: inputs.save-cache && steps.engine-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: target/integration-engine-src/${{ steps.lock.outputs.binary }}
@@ -150,7 +150,7 @@ jobs:
           # Instrumented builds have different fingerprints; keep them on their
           # own key so coverage runs never poison the normal cache.
           shared-key: ${{ inputs.coverage && 'harness-integration-coverage' || 'harness-integration' }}${{ inputs.cache-key-suffix && format('-{0}', inputs.cache-key-suffix) || '' }}
-          save-if: ${{ inputs.save-cache || inputs.coverage || inputs.runner == 'workers-ci-linux-8core' }}
+          save-if: ${{ inputs.save-cache || inputs.coverage }}
           # Every release build the stack needs now lands in one shared
           # target dir (see harness/Makefile INTEGRATION_TARGET_DIR); the
           # per-workspace entries below stay so the cache key keeps hashing

--- a/.github/workflows/_harness-integration.yml
+++ b/.github/workflows/_harness-integration.yml
@@ -18,11 +18,22 @@ on:
         type: string
         required: false
         default: ''
+      runner:
+        description: GitHub Actions runner label selected by the trusted caller
+        type: string
+        required: false
+        default: ubuntu-latest
+      cache-key-suffix:
+        description: Cache cohort used to isolate comparable warm and cold runs
+        type: string
+        required: false
+        default: ''
 
 jobs:
   integration:
     name: harness integration
-    runs-on: [self-hosted, Linux, X64, rust]
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
@@ -109,7 +120,7 @@ jobs:
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: target/integration-engine-src/${{ steps.lock.outputs.binary }}
-          key: integration-engine-bin-rust-1.97.1-${{ runner.os }}-${{ runner.arch }}-${{ steps.lock.outputs.revision }}-${{ hashFiles('harness/tests/integration/engine.lock') }}-${{ hashFiles('target/integration-engine-src/Cargo.lock') }}
+          key: integration-engine-bin-rust-1.97.1-${{ runner.os }}-${{ runner.arch }}-${{ steps.lock.outputs.revision }}-${{ hashFiles('harness/tests/integration/engine.lock') }}-${{ hashFiles('target/integration-engine-src/Cargo.lock') }}${{ inputs.cache-key-suffix && format('-{0}', inputs.cache-key-suffix) || '' }}
 
       - name: Build pinned engine
         if: steps.engine-cache.outputs.cache-hit != 'true'
@@ -138,7 +149,7 @@ jobs:
         with:
           # Instrumented builds have different fingerprints; keep them on their
           # own key so coverage runs never poison the normal cache.
-          shared-key: ${{ inputs.coverage && 'harness-integration-coverage' || 'harness-integration' }}
+          shared-key: ${{ inputs.coverage && 'harness-integration-coverage' || 'harness-integration' }}${{ inputs.cache-key-suffix && format('-{0}', inputs.cache-key-suffix) || '' }}
           save-if: ${{ inputs.save-cache || inputs.coverage }}
           # Every release build the stack needs now lands in one shared
           # target dir (see harness/Makefile INTEGRATION_TARGET_DIR); the
@@ -269,15 +280,22 @@ jobs:
         if: always()
         env:
           ENGINE_HIT: ${{ steps.engine-cache.outputs.cache-hit }}
+          STACK_HIT: ${{ steps.stack-cache.outputs.cache-hit }}
           SAVE_CACHE: ${{ inputs.save-cache }}
+          RUNNER_LABEL: ${{ inputs.runner }}
+          CACHE_COHORT: ${{ inputs.cache-key-suffix || 'stable' }}
         run: |
           {
-            echo "### Integration build caches"
+            echo "### Harness integration execution"
+            echo
+            echo "| Runner label | Runner name | Cache cohort |"
+            echo "| --- | --- | --- |"
+            echo "| $RUNNER_LABEL | $RUNNER_NAME | $CACHE_COHORT |"
             echo
             echo "| Cache | Hit | Save enabled |"
             echo "| --- | --- | --- |"
             echo "| pinned engine | ${ENGINE_HIT:-false} | $SAVE_CACHE |"
-            echo "| integration Rust | see rust-cache log | $SAVE_CACHE |"
+            echo "| integration Rust | ${STACK_HIT:-false} | $SAVE_CACHE |"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload Rust build timings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -816,6 +816,8 @@ jobs:
       contents: read
     uses: ./.github/workflows/_harness-integration.yml
     with:
+      runner: workers-ci-linux-8core
+      cache-key-suffix: ${{ github.run_attempt <= 3 && format('pilot-cold-{0}-{1}', github.run_id, github.run_attempt) || '' }}
       save-cache: ${{ github.event_name == 'push' }}
 
   # ──────────────────────────────────────────────────────────────

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -817,7 +817,7 @@ jobs:
     uses: ./.github/workflows/_harness-integration.yml
     with:
       runner: workers-ci-linux-8core
-      cache-key-suffix: ${{ github.run_attempt <= 3 && format('pilot-cold-{0}-{1}', github.run_id, github.run_attempt) || '' }}
+      source_ref: ${{ github.event.pull_request.base.sha }}
       save-cache: ${{ github.event_name == 'push' }}
 
   # ──────────────────────────────────────────────────────────────

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -816,8 +816,6 @@ jobs:
       contents: read
     uses: ./.github/workflows/_harness-integration.yml
     with:
-      runner: workers-ci-linux-8core
-      source_ref: ${{ github.event.pull_request.base.sha }}
       save-cache: ${{ github.event_name == 'push' }}
 
   # ──────────────────────────────────────────────────────────────

--- a/.github/workflows/harness-integration-benchmark.yml
+++ b/.github/workflows/harness-integration-benchmark.yml
@@ -1,0 +1,40 @@
+name: Harness integration benchmark
+run-name: Harness integration benchmark · ${{ inputs.runner }} · ${{ inputs.cache-mode }} · ${{ inputs.source-ref || github.sha }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      runner:
+        description: Runner pool to measure
+        type: choice
+        required: true
+        default: workers-ci-linux-8core
+        options:
+          - workers-ci-linux-8core
+          - ubuntu-latest
+      cache-mode:
+        description: Reuse the stable cache cohort or force an isolated cold run
+        type: choice
+        required: true
+        default: warm
+        options:
+          - warm
+          - cold
+      source-ref:
+        description: Commit SHA to compare (empty uses the selected workflow ref)
+        type: string
+        required: false
+        default: ''
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  integration:
+    uses: ./.github/workflows/_harness-integration.yml
+    with:
+      runner: ${{ inputs.runner }}
+      source_ref: ${{ inputs.source-ref }}
+      save-cache: ${{ inputs.cache-mode == 'warm' }}
+      cache-key-suffix: ${{ inputs.cache-mode == 'cold' && format('cold-{0}', github.run_id) || '' }}

--- a/docs/architecture/testing-and-ci.md
+++ b/docs/architecture/testing-and-ci.md
@@ -130,7 +130,8 @@ Use
 to compare `ubuntu-latest` with `workers-ci-linux-8core`:
 
 1. Select one immutable `source-ref` SHA for the entire cohort.
-2. Run ten executions on each pool: seven `warm` and three `cold`.
+2. Run ten candidate executions: seven `warm` and three `cold`. Run matched
+   standard-runner baselines with both cache states on the same source SHA.
 3. `warm` uses the production cache keys. Each `cold` run gets a unique key
    and cannot save it, so it neither restores nor pollutes the warm cache.
 4. Record queue time and execution time from the job API, cache hits from the
@@ -143,6 +144,25 @@ Initial service targets are CI queue p95 below 60 seconds, no job waiting more
 than five minutes for a runner, Harness integration execution p95 below ten
 minutes, release prepare p95 below ten minutes and publish p95 below four
 minutes.
+
+### Initial 8-core pilot (2026-09-01)
+
+The first `workers-ci-linux-8core` pilot completed three cold and seven warm
+executions successfully. Normal queue time was 2–3 seconds. The first cold
+queue is excluded because it includes the one-time runner-group access repair.
+
+| Cohort | Samples | p50 execution | p95 execution |
+|---|---:|---:|---:|
+| 8-core warm | 7 | 8m54 | 9m17 |
+| 8-core cold | 3 | 17m32 | 19m11 |
+
+A matched warm `ubuntu-latest` run took 11m11, so the 8-core warm p50 improved
+execution by about 20%, below the 25% retention threshold. The ten 8-core jobs
+consumed 121 rounded billed minutes, approximately US$2.66 at the price used
+for the pilot. Because standard runners are free for this public repository,
+`ubuntu-latest` remains the default. Keep the 8-core pool restricted and use
+it only for deliberate rebenchmarks after the Harness workload or cache keys
+change.
 
 ## Script tests
 

--- a/docs/architecture/testing-and-ci.md
+++ b/docs/architecture/testing-and-ci.md
@@ -97,6 +97,53 @@ Some workers have harness-level e2e beyond unit tests:
 Add a dedicated workflow when integration with the full harness stack is
 release-blocking and too slow for the per-PR matrix.
 
+## Runner pools
+
+Runner labels identify one infrastructure pool. Do not reuse a label across
+GitHub-hosted and self-hosted machines: routing must remain deterministic for
+cost, isolation and performance measurements.
+
+| Label | Infrastructure | Capacity | Current use |
+|---|---|---:|---|
+| `ubuntu-latest` | Standard GitHub-hosted Linux | GitHub-managed | PR checks, normal E2E and the default Harness integration |
+| `workers-ci-linux-8core` | Larger GitHub-hosted Linux | 2 concurrent | Manual Harness integration benchmark only |
+| `workers-release-control-linux-2core` | Larger GitHub-hosted Linux | 8 concurrent | Reserved for a later migration of release control jobs; no workflow selects it yet |
+| `workers-release-linux-8core` | Larger GitHub-hosted Linux | 8 concurrent | Linux release builds and, until migrated, release control jobs |
+| `windows-latest` | Standard GitHub-hosted Windows | GitHub-managed | Windows release builds |
+| `workers-release-macos-12core` | Larger GitHub-hosted Intel macOS | 3 concurrent | Intel macOS release builds |
+| `workers-release-macos-arm-5core` | Larger GitHub-hosted Apple Silicon | 3 concurrent | ARM macOS release builds |
+| `workers-release-macos-aws-intel` | Self-hosted Intel macOS on AWS | 3 registered | Explicit contingency capacity; no workflow selects it by default |
+
+The `workers-ci-linux-8core` group is restricted to the Harness integration
+and benchmark workflows. Release pools stay in the release-only runner group
+and must not be granted to pull-request workflows. The legacy `rust`
+self-hosted label is not part of the Workers routing contract.
+
+### Harness integration recovery and benchmark
+
+[`_harness-integration.yml`](../../.github/workflows/_harness-integration.yml)
+defaults to `ubuntu-latest`; callers must opt into any other pool. This keeps
+pull requests running when optional capacity is unavailable.
+
+Use
+[`harness-integration-benchmark.yml`](../../.github/workflows/harness-integration-benchmark.yml)
+to compare `ubuntu-latest` with `workers-ci-linux-8core`:
+
+1. Select one immutable `source-ref` SHA for the entire cohort.
+2. Run ten executions on each pool: seven `warm` and three `cold`.
+3. `warm` uses the production cache keys. Each `cold` run gets a unique key
+   and cannot save it, so it neither restores nor pollutes the warm cache.
+4. Record queue time and execution time from the job API, cache hits from the
+   job summary, and billed minutes for the larger runner.
+5. Keep the 8-core pool only when execution p95 is below 10 minutes and the
+   improvement over `ubuntu-latest` is at least 25%. Otherwise retain
+   `ubuntu-latest` as the permanent default.
+
+Initial service targets are CI queue p95 below 60 seconds, no job waiting more
+than five minutes for a runner, Harness integration execution p95 below ten
+minutes, release prepare p95 below ten minutes and publish p95 below four
+minutes.
+
 ## Script tests
 
 `.github/scripts/tests/` — pytest for release/discovery/workflow helpers. Runs


### PR DESCRIPTION
Refs MOT-4613

Restores Harness integration reliability with `ubuntu-latest`, adds a controlled 8-core benchmark path with isolated warm/cold cache cohorts, and documents the explicit CI and release runner matrix. The AWS Intel Macs now use their own non-colliding pool label; the 2-core release-control pool is provisioned but is not selected by release jobs in this change.

8-core pilot:
- 3 cold + 7 warm executions, 10/10 successful
- warm p50 8m54, p95 9m17
- cold p50 17m32, p95 19m11
- matched warm `ubuntu-latest`: 11m11
- warm improvement: approximately 20%, below the 25% threshold
- estimated larger-runner cost: US$2.66

Decision: retain `ubuntu-latest` as the default and keep the restricted 8-core pool for deliberate rebenchmarks only.

Validation:
- `python3 -m pytest .github/scripts/tests/ -q` (292 passed, 3 subtests passed)
- `/tmp/actionlint -color -config-file .github/actionlint.yaml`
- `git diff --check`