### PR TITLE
fix(console): enforce browser worker namespace

### DIFF
--- a/console/Cargo.lock
+++ b/console/Cargo.lock
@@ -779,9 +779,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0342a8980e12e9bb994d9221637914a719a156cee73705b595d6588e45c9cfca"
+checksum = "e654538584cf6feec82f4f9e773d4b9f8c84bba5085e49a585aebe7227f8af8c"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -800,9 +800,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.22.1-alpha.25"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb1167081b82a1aa9f12b05ad9e093fdf1cd2a3ed282bb66451a26e37f4a459"
+checksum = "3952d1ac84c88304fa27fef8ce0a9350585abe9e9b9f7513730497e72918186f"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.22.1-alpha.25"
+iii-sdk = "=0.23.0"
 # Worker-side injectable console UI (content function + console:script/style
 # triggers + hot-reload watcher) — the console dogfoods its own protocol to
 # ship the injectable-UI toggle form. Direct link, never published.

--- a/console/src/proxy.rs
+++ b/console/src/proxy.rs
@@ -6,15 +6,19 @@
 //! between [`axum::extract::ws::Message`] and
 //! [`tokio_tungstenite::tungstenite::Message`].
 //!
-//! The proxy is intentionally dumb — no buffering, no auth — with TWO
+//! The proxy is intentionally dumb — no buffering, no auth — with THREE
 //! exceptions on the browser→engine leg:
 //!
-//! 1. `registerfunction` messages get `metadata.internal = true` stamped
+//! 1. The browser worker registration gets the Console worker's namespace
+//!    stamped on (see [`enforce_worker_namespace`]). This is authoritative at
+//!    the proxy boundary, so stale/cached bundles cannot reconnect in
+//!    `default` while the Console worker runs in a project namespace.
+//! 2. `registerfunction` messages get `metadata.internal = true` stamped
 //!    on (see [`stamp_internal_registration`]). Everything a console page
 //!    registers is a live-update delivery target for that page, never a
 //!    discoverable API, and stamping here (not just in the SPA) means
 //!    stale/cached bundles can't pollute `engine::functions::list` either.
-//! 2. `registertriggertype` frames are dropped (see
+//! 3. `registertriggertype` frames are dropped (see
 //!    [`is_trigger_type_registration`]). Trigger-type ownership is
 //!    last-writer-wins engine-wide — a hostile page could re-register
 //!    `console:script` and intercept every UI-asset registration. The SPA
@@ -31,6 +35,13 @@ use futures_util::stream::StreamExt;
 use tokio_tungstenite::tungstenite::protocol::{CloseFrame as TungCloseFrame, WebSocketConfig};
 use tokio_tungstenite::tungstenite::Message as TungMessage;
 
+/// Connection settings required by the `/ws` proxy.
+#[derive(Clone)]
+pub struct ProxyConfig {
+    pub engine_url: Arc<String>,
+    pub namespace: Option<String>,
+}
+
 /// Axum handler. Splits the upgraded socket into a sender + receiver
 /// and spawns a single `handle_ws` future for the lifetime of the
 /// connection.
@@ -44,7 +55,7 @@ use tokio_tungstenite::tungstenite::Message as TungMessage;
 pub async fn ws_proxy(
     headers: HeaderMap,
     ws: WebSocketUpgrade,
-    State(engine_url): State<Arc<String>>,
+    State(config): State<ProxyConfig>,
 ) -> Response {
     if !browser_origin_allowed(&headers) {
         tracing::warn!("rejected cross-origin browser WebSocket upgrade");
@@ -52,7 +63,7 @@ pub async fn ws_proxy(
     }
     ws.max_message_size(usize::MAX)
         .max_frame_size(usize::MAX)
-        .on_upgrade(move |socket| handle_ws(socket, engine_url))
+        .on_upgrade(move |socket| handle_ws(socket, config))
 }
 
 /// Browsers always send `Origin` on a WebSocket handshake. Require its
@@ -96,14 +107,14 @@ fn origin_matches_host(origin: &str, host: &str) -> bool {
     origin_host.eq_ignore_ascii_case(request_host) && origin_port == request_port
 }
 
-async fn handle_ws(client: WebSocket, engine_url: Arc<String>) {
+async fn handle_ws(client: WebSocket, config: ProxyConfig) {
     let engine_ws_config = WebSocketConfig {
         max_message_size: None,
         max_frame_size: None,
         ..Default::default()
     };
     let (engine, _resp) = match tokio_tungstenite::connect_async_with_config(
-        engine_url.as_str(),
+        config.engine_url.as_str(),
         Some(engine_ws_config),
         false,
     )
@@ -113,7 +124,7 @@ async fn handle_ws(client: WebSocket, engine_url: Arc<String>) {
         Err(e) => {
             tracing::warn!(
                 error = %e,
-                engine_url = %engine_url,
+                engine_url = %config.engine_url,
                 "failed to dial iii engine WebSocket; closing browser WS"
             );
             // Best-effort close; ignore the result. axum will drop the
@@ -151,6 +162,7 @@ async fn handle_ws(client: WebSocket, engine_url: Arc<String>) {
                         );
                         continue;
                     }
+                    let t = enforce_worker_namespace(&t, config.namespace.as_deref()).unwrap_or(t);
                     match stamp_internal_registration(&t) {
                         Some(stamped) => AxumMessage::Text(stamped),
                         None => AxumMessage::Text(t),
@@ -198,6 +210,40 @@ async fn handle_ws(client: WebSocket, engine_url: Arc<String>) {
         _ = client_to_engine => {}
         _ = engine_to_client => {}
     }
+}
+
+/// If `text` is the browser SDK's `engine::workers::register` invocation,
+/// return a copy whose `data.namespace` matches this Console worker.
+///
+/// `None` as the configured namespace means the engine's `default` namespace,
+/// so an explicit namespace from a stale bundle is removed. A `None` return
+/// means the original frame should pass through unchanged.
+pub(crate) fn enforce_worker_namespace(text: &str, namespace: Option<&str>) -> Option<String> {
+    const REGISTER_WORKER: &str = "engine::workers::register";
+
+    // Fast path: only the SDK's worker-registration invocation needs a parse.
+    if !text.contains(REGISTER_WORKER) {
+        return None;
+    }
+    let mut msg: serde_json::Value = serde_json::from_str(text).ok()?;
+    if msg.get("type").and_then(|value| value.as_str()) != Some("invokefunction")
+        || msg.get("function_id").and_then(|value| value.as_str()) != Some(REGISTER_WORKER)
+    {
+        return None;
+    }
+    let data = msg.get_mut("data")?.as_object_mut()?;
+    match namespace {
+        Some(namespace) => {
+            data.insert(
+                "namespace".into(),
+                serde_json::Value::String(namespace.to_owned()),
+            );
+        }
+        None => {
+            data.remove("namespace");
+        }
+    }
+    serde_json::to_string(&msg).ok()
 }
 
 /// `true` if `text` is a wire `registertriggertype` message — the one
@@ -371,6 +417,51 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(v["metadata"]["internal"], serde_json::json!(true));
         assert_eq!(v["id"], "console::harness-watch::r0::console-abc");
+    }
+
+    #[test]
+    fn worker_registration_gets_the_console_namespace() {
+        let wire = r#"{"type":"invokefunction","function_id":"engine::workers::register","data":{"runtime":"browser","name":"console-old"},"action":{"type":"void"}}"#;
+        let out = enforce_worker_namespace(wire, Some("project-a")).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&out).unwrap();
+
+        assert_eq!(value["data"]["namespace"], "project-a");
+        assert_eq!(value["data"]["runtime"], "browser");
+    }
+
+    #[test]
+    fn worker_registration_cannot_override_the_console_namespace() {
+        let wire = r#"{"type":"invokefunction","function_id":"engine::workers::register","data":{"runtime":"browser","namespace":"default"}}"#;
+        let out = enforce_worker_namespace(wire, Some("project-a")).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&out).unwrap();
+
+        assert_eq!(value["data"]["namespace"], "project-a");
+    }
+
+    #[test]
+    fn default_console_removes_a_stale_explicit_namespace() {
+        let wire = r#"{"type":"invokefunction","function_id":"engine::workers::register","data":{"runtime":"browser","namespace":"project-a"}}"#;
+        let out = enforce_worker_namespace(wire, None).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&out).unwrap();
+
+        assert!(value["data"].get("namespace").is_none());
+    }
+
+    #[test]
+    fn namespace_enforcement_ignores_other_messages_and_bad_input() {
+        assert!(enforce_worker_namespace(
+            r#"{"type":"invokefunction","function_id":"session::messages","data":{"text":"engine::workers::register"}}"#,
+            Some("project-a")
+        )
+        .is_none());
+        assert!(
+            enforce_worker_namespace("engine::workers::register{", Some("project-a")).is_none()
+        );
+        assert!(enforce_worker_namespace(
+            r#"{"type":"invokefunction","function_id":"engine::workers::register","data":"weird"}"#,
+            Some("project-a")
+        )
+        .is_none());
     }
 
     #[test]

--- a/console/src/server.rs
+++ b/console/src/server.rs
@@ -86,10 +86,13 @@ impl AppState {
     }
 }
 
-/// The `/ws` proxy only needs the engine URL.
-impl FromRef<AppState> for Arc<String> {
+/// Connection settings extracted by the `/ws` proxy.
+impl FromRef<AppState> for proxy::ProxyConfig {
     fn from_ref(state: &AppState) -> Self {
-        state.engine_url.clone()
+        Self {
+            engine_url: state.engine_url.clone(),
+            namespace: state.namespace.clone(),
+        }
     }
 }
 

--- a/console/web/package.json
+++ b/console/web/package.json
@@ -38,7 +38,7 @@
     "@tanstack/react-virtual": "^3.13.24",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "iii-browser-sdk": "0.22.1-alpha.25",
+    "iii-browser-sdk": "0.23.0",
     "lexical": "^0.44.0",
     "lucide-react": "^1.16.0",
     "monaco-editor": "^0.56.0",

--- a/console/web/src/lib/iii-client.test.ts
+++ b/console/web/src/lib/iii-client.test.ts
@@ -202,4 +202,29 @@ describe('namespaced browser connection', () => {
 
     expect(calls).toEqual([])
   })
+
+  it('retries bootstrap after runtime namespace discovery recovers', async () => {
+    const { sdk } = fakeSdk()
+    const calls: Array<{ options?: InitOptions }> = []
+    let namespaceAttempts = 0
+    __setIiiClientDepsForTests({
+      resolveWsUrl: () => 'ws://console.test/ws',
+      resolveNamespace: async () => {
+        namespaceAttempts += 1
+        if (namespaceAttempts === 1) throw new Error('runtime unavailable')
+        return 'project-a'
+      },
+      makeBrowserId: () => BROWSER_ID,
+      registerWorker: (_url, options) => {
+        calls.push({ options })
+        return sdk
+      },
+    })
+
+    await expect(getIiiClient()).rejects.toThrow('runtime unavailable')
+    await getIiiClient()
+
+    expect(namespaceAttempts).toBe(2)
+    expect(calls).toEqual([{ options: { namespace: 'project-a' } }])
+  })
 })

--- a/console/web/src/lib/iii-client.test.ts
+++ b/console/web/src/lib/iii-client.test.ts
@@ -135,6 +135,33 @@ describe('namespaced browser connection', () => {
     ])
   })
 
+  it('uses the namespace returned by the runtime endpoint', async () => {
+    const { sdk } = fakeSdk()
+    const calls: Array<{ options?: InitOptions }> = []
+    vi.stubGlobal('window', {
+      location: { href: 'http://console.test/#/chat' },
+    })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ namespace: 'project-a' }),
+      })),
+    )
+    __setIiiClientDepsForTests({
+      resolveWsUrl: () => 'ws://console.test/ws',
+      makeBrowserId: () => BROWSER_ID,
+      registerWorker: (_url, options) => {
+        calls.push({ options })
+        return sdk
+      },
+    })
+
+    await getIiiClient()
+
+    expect(calls).toEqual([{ options: { namespace: 'project-a' } }])
+  })
+
   it('inherits project calls and routes engine control-plane calls to default', async () => {
     const { sdk, triggers } = fakeSdk()
     const client = wrapSdk(sdk, BROWSER_ID)
@@ -152,10 +179,9 @@ describe('namespaced browser connection', () => {
     ])
   })
 
-  it('warns when runtime namespace discovery falls back to default', async () => {
+  it('refuses to connect when runtime namespace discovery fails', async () => {
     const { sdk } = fakeSdk()
     const calls: Array<{ options?: InitOptions }> = []
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     vi.stubGlobal('window', { location: { href: 'http://console.test/' } })
     vi.stubGlobal(
       'fetch',
@@ -170,11 +196,10 @@ describe('namespaced browser connection', () => {
       },
     })
 
-    await getIiiClient()
-
-    expect(calls).toEqual([{ options: undefined }])
-    expect(warn).toHaveBeenCalledWith(
-      'Runtime namespace request failed with HTTP 503; connecting to default',
+    await expect(getIiiClient()).rejects.toThrow(
+      'Runtime namespace request failed with HTTP 503; refusing to connect to default',
     )
+
+    expect(calls).toEqual([])
   })
 })

--- a/console/web/src/lib/iii-client.ts
+++ b/console/web/src/lib/iii-client.ts
@@ -94,7 +94,10 @@ function defaultDeps(): Deps {
  */
 export function getIiiClient(): Promise<IiiClient> {
   if (!_clientPromise) {
-    _clientPromise = bootstrap(_deps)
+    _clientPromise = bootstrap(_deps).catch((error: unknown) => {
+      _clientPromise = null
+      throw error
+    })
   }
   return _clientPromise
 }

--- a/console/web/src/lib/iii-client.ts
+++ b/console/web/src/lib/iii-client.ts
@@ -298,26 +298,30 @@ function resolveWsUrl(): string {
  */
 async function resolveNamespace(): Promise<string | undefined> {
   if (typeof window === 'undefined' || !window.location) return undefined
+  const url = new URL('./runtime', window.location.href)
+  let response: Response
   try {
-    const url = new URL('./runtime', window.location.href)
-    const response = await fetch(url, { cache: 'no-store' })
-    if (!response.ok) {
-      console.warn(
-        `Runtime namespace request failed with HTTP ${response.status}; connecting to default`,
-      )
-      return undefined
-    }
-    const value = (await response.json()) as { namespace?: unknown }
-    return typeof value.namespace === 'string' && value.namespace.length > 0
-      ? value.namespace
-      : undefined
-  } catch (error) {
-    console.warn(
-      'Runtime namespace request failed; connecting to default',
-      error,
+    response = await fetch(url, { cache: 'no-store' })
+  } catch (cause) {
+    throw new Error(
+      'Runtime namespace request failed; refusing to connect to default',
+      { cause },
     )
-    return undefined
   }
+  if (!response.ok) {
+    throw new Error(
+      `Runtime namespace request failed with HTTP ${response.status}; refusing to connect to default`,
+    )
+  }
+  const value = (await response.json()) as { namespace?: unknown }
+  if (value.namespace === null || value.namespace === undefined)
+    return undefined
+  if (typeof value.namespace === 'string' && value.namespace.length > 0) {
+    return value.namespace
+  }
+  throw new Error(
+    'Runtime namespace response is invalid; refusing to connect to default',
+  )
 }
 
 /** Engine control-plane functions are registered only in `default`. */

--- a/crates/console-ui/Cargo.lock
+++ b/crates/console-ui/Cargo.lock
@@ -515,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0342a8980e12e9bb994d9221637914a719a156cee73705b595d6588e45c9cfca"
+checksum = "e654538584cf6feec82f4f9e773d4b9f8c84bba5085e49a585aebe7227f8af8c"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -536,9 +536,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.22.1-alpha.25"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb1167081b82a1aa9f12b05ad9e093fdf1cd2a3ed282bb66451a26e37f4a459"
+checksum = "3952d1ac84c88304fa27fef8ce0a9350585abe9e9b9f7513730497e72918186f"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/crates/console-ui/Cargo.toml
+++ b/crates/console-ui/Cargo.toml
@@ -13,11 +13,11 @@ repository = "https://github.com/iii-hq/workers"
 publish = false
 
 [dependencies]
-# Range, not an exact pin: workers on this repo's SDK line carry their own
-# exact pins (alpha.2 for the harness, alpha.3 for most workers) and cargo must be able
-# to unify them with this crate. Path-linking this crate must never be what
-# drags a worker onto a different SDK build, nor what blocks one.
-iii-sdk = "=0.22.1-alpha.25"
+# Range, not an exact pin: workers carry their own exact SDK pins and Cargo
+# must be able to unify them with this crate during the 0.23 migration.
+# Path-linking this crate must never drag a worker onto a different SDK build
+# or block one that has not migrated yet.
+iii-sdk = ">=0.22.1-alpha.25, <=0.23.0"
 tokio = { version = "1", features = ["rt", "sync", "time", "fs"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,8 +268,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       iii-browser-sdk:
-        specifier: 0.22.1-alpha.25
-        version: 0.22.1-alpha.25
+        specifier: 0.23.0
+        version: 0.23.0
       lexical:
         specifier: ^0.44.0
         version: 0.44.0
@@ -3948,8 +3948,8 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
-  iii-browser-sdk@0.22.1-alpha.25:
-    resolution: {integrity: sha512-SH35BJofl4GsAEIU2DRWbvmlSVnDSGRCm83GXZVxYmh6yx0XsTEe5MUZibLoD8bD3t8wuO0E3HxWM5W2ayN+Wg==}
+  iii-browser-sdk@0.23.0:
+    resolution: {integrity: sha512-tnTi6Szu5NwtCJNpA9hcbfIJ0Kb9BjXbRdA4gwswRKiSyduhoVNUoHaK8XTMCgQs/6vWRqwhGn1CHeVYeJB2cg==}
 
   iii-sdk@0.22.1-alpha.25:
     resolution: {integrity: sha512-WUDzAydJacutn5IQz3Tcx296fAn88UnUt8S5/2slRsZK7WCadMS9o3qXmkgKAUAmPHsdCOAwVolBWNnAz4imqQ==}
@@ -8139,7 +8139,7 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  iii-browser-sdk@0.22.1-alpha.25: {}
+  iii-browser-sdk@0.23.0: {}
 
   iii-sdk@0.22.1-alpha.25:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -50,6 +50,6 @@ allowBuilds:
 
 minimumReleaseAgeExclude:
   - '@pierre/trees@1.0.0-beta.6'
-  - '@iii-dev/helpers@0.22.1-alpha.25'
-  - 'iii-browser-sdk@0.22.1-alpha.25'
-  - 'iii-sdk@0.22.1-alpha.25'
+  - '@iii-dev/helpers@0.23.0'
+  - 'iii-browser-sdk@0.23.0'
+  - 'iii-sdk@0.23.0'

--- a/shell/Cargo.lock
+++ b/shell/Cargo.lock
@@ -943,9 +943,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.22.1-alpha.25"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d24f39bff5a54a18ad0dbe92fff0311fe7d12445ec26da12b8d6b09056166bc"
+checksum = "e654538584cf6feec82f4f9e773d4b9f8c84bba5085e49a585aebe7227f8af8c"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -964,9 +964,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.22.1-alpha.25"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb1167081b82a1aa9f12b05ad9e093fdf1cd2a3ed282bb66451a26e37f4a459"
+checksum = "3952d1ac84c88304fa27fef8ce0a9350585abe9e9b9f7513730497e72918186f"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/shell/Cargo.toml
+++ b/shell/Cargo.toml
@@ -11,9 +11,9 @@ name = "shell"
 path = "src/main.rs"
 
 [dependencies]
-iii-sdk = "=0.22.1-alpha.25"
+iii-sdk = "=0.23.0"
 iii-worker-paths = { path = "../crates/worker-paths" }
-iii-helpers = "=0.22.1-alpha.25"
+iii-helpers = "=0.23.0"
 iii-console-ui = { path = "../crates/console-ui" }
 # Filesystem watch behind the shell::changed trigger type (FSEvents/inotify).
 notify = "8"


### PR DESCRIPTION
## Summary

- update Shell, Console, and browser dependencies to the stable iii SDK 0.23.0 namespace contract
- resolve the browser namespace from the Console runtime endpoint and refuse unsafe fallback to default
- enforce the Console worker namespace at the WebSocket proxy boundary so stale browser bundles reconnect in the correct namespace
- keep the shared Console UI crate compatible with workers that have not migrated from the 0.22 SDK yet

## Validation

- `cargo test --locked --manifest-path console/Cargo.toml`
- `cargo clippy --locked --manifest-path console/Cargo.toml --all-targets --all-features -- -D warnings`
- `pnpm --dir console/web exec vitest run src/lib/iii-client.test.ts`
- `pnpm --dir console/web typecheck`
- `pnpm --dir console/web build`
- compose runtime check: stale Console browser clients re-registered functions in `my-project`; repeated default-namespace Shell and Session errors stopped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Console connections now consistently enforce the configured worker namespace.
  * Worker registrations automatically remove stale namespace assignments when using the default namespace.
  * Updated Console and Shell components to SDK version 0.23.0.

* **Bug Fixes**
  * Runtime namespace discovery now validates responses and reports connection errors instead of silently falling back to the default namespace.
  * Failed runtime requests no longer attempt worker registration.
  * Namespace discovery can now retry successfully after an initial bootstrap failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->