### PR TITLE
fix(ci): install rc engine for harness integration

### DIFF
--- a/.github/scripts/tests/test_rust_ci_workflows.py
+++ b/.github/scripts/tests/test_rust_ci_workflows.py
@@ -144,21 +144,19 @@ def test_interface_smoke_bounds_each_engine_readiness_probe() -> None:
     ) in run
 
 
-def test_harness_integration_caches_the_final_engine_and_skips_rebuilds() -> None:
+def test_harness_integration_downloads_latest_rc_engine_without_building_it() -> None:
     integration = workflow("_harness-integration.yml")
     steps = integration["jobs"]["integration"]["steps"]
-    restore = named_step(steps, "Restore pinned engine binary")
-    build = named_step(steps, "Build pinned engine")
-    save = named_step(steps, "Save pinned engine binary")
+    install = named_step(steps, "Install latest iii @rc")
     stack_cache = named_step(steps, "Restore integration Rust cache")
 
-    expected_path = "target/integration-engine-src/${{ steps.lock.outputs.binary }}"
-    assert restore["with"]["path"] == expected_path
-    assert "integration-engine-bin-rust-1.97.1" in restore["with"]["key"]
-    assert "hashFiles('harness/tests/integration/engine.lock')" in restore["with"]["key"]
-    assert build["if"] == "steps.engine-cache.outputs.cache-hit != 'true'"
-    assert "--locked --release --timings" in build["run"]
-    assert save["with"]["path"] == expected_path
+    assert "https://install.iii.dev/iii/main/install.sh" in install["run"]
+    assert 'sh "$installer" --rc' in install["run"]
+    assert "command -v iii" in install["run"]
+    assert "III_ENGINE_VERSION" in install["run"]
+    assert "Build pinned engine" not in {step.get("name") for step in steps}
+    assert "integration-engine-src" not in (WORKFLOWS / "_harness-integration.yml").read_text()
+    assert "cron -> target" in stack_cache["with"]["workspaces"]
     assert "database -> target" in stack_cache["with"]["workspaces"]
 
 

--- a/.github/workflows/_harness-integration.yml
+++ b/.github/workflows/_harness-integration.yml
@@ -40,62 +40,6 @@ jobs:
           persist-credentials: false
           ref: ${{ inputs.source_ref }}
 
-      - name: Read and validate engine.lock
-        id: lock
-        run: |
-          set -euo pipefail
-          lock=harness/tests/integration/engine.lock
-          read_field() {
-            local field=$1 values
-            values=$(sed -n "s/^${field} = \"\\([^\"]*\\)\"$/\\1/p" "$lock")
-            [[ $(printf '%s\n' "$values" | sed '/^$/d' | wc -l) -eq 1 ]] || {
-              echo "engine.lock: $field must appear exactly once"
-              exit 3
-            }
-            printf '%s' "$values"
-          }
-          invalid=$(sed \
-            -e '/^[[:space:]]*$/d' \
-            -e '/^[[:space:]]*#/d' \
-            -e '/^\(repository\|revision\|package\|binary\) = "[^"]*"$/d' \
-            "$lock")
-          [[ -z "$invalid" ]] || {
-            echo "engine.lock: unsupported or malformed entry"
-            printf '%s\n' "$invalid"
-            exit 3
-          }
-          repository=$(read_field repository)
-          revision=$(read_field revision)
-          package=$(read_field package)
-          binary=$(read_field binary)
-          [[ "$repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || {
-            echo "engine.lock: repository must be an owner/name slug"
-            exit 3
-          }
-          [[ "$revision" =~ ^[0-9a-f]{40}$ ]] || { echo "engine.lock: revision must be 40-hex"; exit 3; }
-          [[ "$package" =~ ^[A-Za-z0-9_-]+$ ]] || {
-            echo "engine.lock: package contains unsupported characters"
-            exit 3
-          }
-          [[ "$binary" =~ ^target/(debug|release)/[A-Za-z0-9_.-]+$ ]] || {
-            echo "engine.lock: binary must be a target profile path"
-            exit 3
-          }
-          {
-            echo "repository=$repository"
-            echo "revision=$revision"
-            echo "package=$package"
-            echo "binary=$binary"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Checkout pinned engine source
-        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
-        with:
-          persist-credentials: false
-          repository: ${{ steps.lock.outputs.repository }}
-          ref: ${{ steps.lock.outputs.revision }}
-          path: target/integration-engine-src
-
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # 1.97.1
         with:
           toolchain: 1.97.1
@@ -111,36 +55,27 @@ jobs:
           # This step never cached; the repository is already over its cache budget.
           node-version: 22
 
-      # The engine source is immutable at the locked revision. Cache the final
-      # executable, not its multi-gigabyte target directory, so a hit can skip
-      # Cargo entirely instead of merely making the unconditional rebuild less
-      # cold.
-      - name: Restore pinned engine binary
-        id: engine-cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: target/integration-engine-src/${{ steps.lock.outputs.binary }}
-          key: integration-engine-bin-rust-1.97.1-${{ runner.os }}-${{ runner.arch }}-${{ steps.lock.outputs.revision }}-${{ hashFiles('harness/tests/integration/engine.lock') }}-${{ hashFiles('target/integration-engine-src/Cargo.lock') }}${{ inputs.cache-key-suffix && format('-{0}', inputs.cache-key-suffix) || '' }}
-
-      - name: Build pinned engine
-        if: steps.engine-cache.outputs.cache-hit != 'true'
-        working-directory: target/integration-engine-src
-        run: cargo build --locked --release --timings -p ${{ steps.lock.outputs.package }}
-
-      - name: Save pinned engine binary
-        if: inputs.save-cache && steps.engine-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: target/integration-engine-src/${{ steps.lock.outputs.binary }}
-          key: ${{ steps.engine-cache.outputs.cache-primary-key }}
-
-      - name: Record engine digest
+      - name: Install latest iii @rc
         id: engine
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          bin="$GITHUB_WORKSPACE/target/integration-engine-src/${{ steps.lock.outputs.binary }}"
-          [[ -x "$bin" ]] || { echo "engine binary missing at $bin"; exit 3; }
+          installer="$RUNNER_TEMP/install-iii.sh"
+          curl -fsSL --retry 3 --retry-all-errors --retry-delay 5 \
+            https://install.iii.dev/iii/main/install.sh -o "$installer"
+          sh "$installer" --rc
+          {
+            echo "$HOME/.local/bin"
+            echo "$HOME/.iii/bin"
+          } >> "$GITHUB_PATH"
+          export PATH="$HOME/.local/bin:$HOME/.iii/bin:$PATH"
+          bin=$(command -v iii)
+          [[ -x "$bin" ]] || { echo "iii @rc binary is missing or not executable"; exit 3; }
+          version=$("$bin" --version)
+          printf '%s\n' "$version"
           sha256sum "$bin"
+          echo "III_ENGINE_VERSION=$version" >> "$GITHUB_ENV"
           echo "bin=$bin" >> "$GITHUB_OUTPUT"
 
       - name: Restore integration Rust cache
@@ -161,6 +96,7 @@ jobs:
             queue -> target
             session-manager -> target
             context-manager -> target
+            cron -> target
             iii-directory -> target
             state -> target
             console -> target
@@ -221,6 +157,7 @@ jobs:
           III_DIRECTORY_BIN: ${{ github.workspace }}/target/integration-build/release/iii-directory
           SESSION_MANAGER_BIN: ${{ github.workspace }}/target/integration-build/release/session-manager
           CONTEXT_MANAGER_BIN: ${{ github.workspace }}/target/integration-build/release/context-manager
+          CRON_BIN: ${{ github.workspace }}/target/integration-build/release/cron
           STATE_BIN: ${{ github.workspace }}/target/integration-build/release/state
           DATABASE_BIN: ${{ github.workspace }}/target/integration-build/release/database
           CONSOLE_E2E_ARTIFACTS_DIR: ${{ github.workspace }}/target/console-e2e
@@ -259,6 +196,7 @@ jobs:
             --object target/integration-build/release/iii-directory \
             --object target/integration-build/release/session-manager \
             --object target/integration-build/release/context-manager \
+            --object target/integration-build/release/cron \
             --object target/integration-build/release/state \
             --object target/integration-build/release/harness \
             --object target/integration-build/release/harness-integration \
@@ -279,7 +217,6 @@ jobs:
       - name: Write cache summary
         if: always()
         env:
-          ENGINE_HIT: ${{ steps.engine-cache.outputs.cache-hit }}
           STACK_HIT: ${{ steps.stack-cache.outputs.cache-hit }}
           SAVE_CACHE: ${{ inputs.save-cache }}
           RUNNER_LABEL: ${{ inputs.runner }}
@@ -292,9 +229,10 @@ jobs:
             echo "| --- | --- | --- |"
             echo "| $RUNNER_LABEL | $RUNNER_NAME | $CACHE_COHORT |"
             echo
+            echo "The iii engine is downloaded fresh from the latest @rc channel."
+            echo
             echo "| Cache | Hit | Save enabled |"
             echo "| --- | --- | --- |"
-            echo "| pinned engine | ${ENGINE_HIT:-false} | $SAVE_CACHE |"
             echo "| integration Rust | ${STACK_HIT:-false} | $SAVE_CACHE |"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -306,7 +244,6 @@ jobs:
           path: |
             */target/cargo-timings/*.html
             target/integration-build/cargo-timings/*.html
-            target/integration-engine-src/target/cargo-timings/*.html
           retention-days: 14
           if-no-files-found: ignore
 

--- a/console/web/e2e/harness-stack.ts
+++ b/console/web/e2e/harness-stack.ts
@@ -88,6 +88,7 @@ function workerArgs(): string[] {
     ['iii-directory', 'III_DIRECTORY_BIN'],
     ['session-manager', 'SESSION_MANAGER_BIN'],
     ['context-manager', 'CONTEXT_MANAGER_BIN'],
+    ['cron', 'CRON_BIN'],
     ['state', 'STATE_BIN'],
     ['database', 'DATABASE_BIN'],
   ].flatMap(([name, env]) => ['--worker-bin', `${name}=${required(env)}`])

--- a/harness/Makefile
+++ b/harness/Makefile
@@ -369,10 +369,9 @@ where:
 # Harness integration tests (see harness/tests/integration/README.md)
 #
 # Builds the subject stack + the harness workspace's integration runner and runs every
-# scenario against the pinned engine binary. The
-# engine is never downloaded here: pass III_BIN (CI builds it from
-# tests/integration/engine.lock; locally see that file for the pinned source).
-INTEGRATION_WORKERS := queue iii-directory session-manager context-manager state database
+# scenario against the supplied engine binary. CI downloads the latest iii @rc;
+# locally install that channel with `make install-iii-rc` and pass III_BIN.
+INTEGRATION_WORKERS := queue iii-directory session-manager context-manager cron state database
 INTEGRATION_PROFILE ?= release
 INTEGRATION_FLAG    := $(if $(filter release,$(INTEGRATION_PROFILE)),--release,)
 # ONE target directory for every crate the stack needs. Each worker is its own
@@ -394,8 +393,8 @@ INTEGRATION_PLAYGROUND_ARTIFACTS ?= $(REPO_ROOT)/target/console-e2e
 
 integration-test:
 	@if [ -z "$(III_BIN)" ]; then \
-	  echo "III_BIN is required: path to the pinned iii engine binary."; \
-	  echo "Pinned source: harness/tests/integration/engine.lock"; \
+	  echo "III_BIN is required: path to an iii @rc engine binary."; \
+	  echo "Install it with: make -C harness install-iii-rc"; \
 	  exit 3; \
 	fi
 	@for w in $(INTEGRATION_WORKERS) harness; do \
@@ -412,6 +411,7 @@ integration-test:
 	  --worker-bin "iii-directory=$(INTEGRATION_BIN_DIR)/iii-directory" \
 	  --worker-bin "session-manager=$(INTEGRATION_BIN_DIR)/session-manager" \
 	  --worker-bin "context-manager=$(INTEGRATION_BIN_DIR)/context-manager" \
+	  --worker-bin "cron=$(INTEGRATION_BIN_DIR)/cron" \
 	  --worker-bin "state=$(INTEGRATION_BIN_DIR)/state" \
 	  --worker-bin "database=$(INTEGRATION_BIN_DIR)/database" \
 	  --scenario "$(INTEGRATION_SCENARIO)" \
@@ -433,6 +433,7 @@ integration-coverage:
 	  --object "$(INTEGRATION_BIN_DIR)/iii-directory" \
 	  --object "$(INTEGRATION_BIN_DIR)/session-manager" \
 	  --object "$(INTEGRATION_BIN_DIR)/context-manager" \
+	  --object "$(INTEGRATION_BIN_DIR)/cron" \
 	  --object "$(INTEGRATION_BIN_DIR)/state" \
 	  --object "$(INTEGRATION_BIN_DIR)/harness" \
 	  --object "$(INTEGRATION_BIN_DIR)/harness-integration"
@@ -440,8 +441,8 @@ integration-coverage:
 
 integration-playground:
 	@if [ -z "$(III_BIN)" ]; then \
-	  echo "III_BIN is required: path to the pinned iii engine binary."; \
-	  echo "Pinned source: harness/tests/integration/engine.lock"; \
+	  echo "III_BIN is required: path to an iii @rc engine binary."; \
+	  echo "Install it with: make -C harness install-iii-rc"; \
 	  exit 3; \
 	fi
 	@for w in $(INTEGRATION_WORKERS) harness console; do \
@@ -459,6 +460,7 @@ integration-playground:
 	  --worker-bin "iii-directory=$(INTEGRATION_BIN_DIR)/iii-directory" \
 	  --worker-bin "session-manager=$(INTEGRATION_BIN_DIR)/session-manager" \
 	  --worker-bin "context-manager=$(INTEGRATION_BIN_DIR)/context-manager" \
+	  --worker-bin "cron=$(INTEGRATION_BIN_DIR)/cron" \
 	  --worker-bin "state=$(INTEGRATION_BIN_DIR)/state" \
 	  --worker-bin "database=$(INTEGRATION_BIN_DIR)/database" \
 	  --scenario "$(INTEGRATION_PLAYGROUND_SCENARIO)" \

--- a/harness/tests/integration/README.md
+++ b/harness/tests/integration/README.md
@@ -1,7 +1,7 @@
 # Harness integration E2E
 
 Deterministic public-path regression tests for the harness. Each scenario
-boots a fresh isolated stack with the pinned engine and the real queue,
+boots a fresh isolated stack with the latest published `iii@rc` engine and the real queue,
 session-manager, context-manager, iii-directory, state, database, and harness
 workers. Only the `router::*` model boundary is replaced by a strict scripted
 worker.
@@ -50,17 +50,18 @@ compiler.
 ## Run the direct scenarios
 
 ```bash
-make -C harness integration-test III_BIN=<path-to-pinned-iii>
+make -C harness install-iii-rc
+make -C harness integration-test III_BIN="$(command -v iii)"
 
 # Select one direct scenario by id or slug.
 make -C harness integration-test \
-  III_BIN=<path-to-pinned-iii> \
+  III_BIN="$(command -v iii)" \
   INTEGRATION_SCENARIO=INT-001
 ```
 
-The engine is never downloaded by the runner. CI builds the source revision
-in `engine.lock`; local runs receive the corresponding binary through
-`III_BIN` or `--engine-bin`.
+CI downloads the latest release candidate through the official installer on
+every run; it never builds the `iii` source. Local runs receive an installed
+binary through `III_BIN` or `--engine-bin`.
 
 Exit codes are:
 
@@ -98,6 +99,7 @@ harness-integration playground \
   --worker-bin queue=<queue> \
   --worker-bin session-manager=<session-manager> \
   --worker-bin context-manager=<context-manager> \
+  --worker-bin cron=<cron> \
   --worker-bin iii-directory=<iii-directory> \
   --worker-bin state=<state> \
   --worker-bin database=<database> \
@@ -150,7 +152,7 @@ initiated Console or SDK turn and waits for shutdown after completion.
 
 - Harness readiness, completion, and trace stabilization are awakened by iii
   triggers. A bounded boot-only discovery barrier verifies the authoritative
-  function surface because the pinned engine does not replay its current
+  function surface because the engine does not replay its current
   registry to late subscribers.
 - All RPCs and event waits use bounded monotonic deadlines.
 - The observability worker captures every session trace with 100% sampling.

--- a/harness/tests/integration/engine.lock
+++ b/harness/tests/integration/engine.lock
@@ -1,4 +1,0 @@
-repository = "iii-hq/iii"
-revision = "15dc993ebfdbfcabe5d299cf4cae4dd676db4c06"
-package = "iii"
-binary = "target/release/iii"

--- a/harness/tests/integration/src/discovery.rs
+++ b/harness/tests/integration/src/discovery.rs
@@ -1,6 +1,6 @@
 //! Bounded boot-time discovery for the function surface required by a turn.
 //!
-//! The pinned engine's `engine::functions-available` event has no catch-up
+//! The engine's `engine::functions-available` event has no catch-up
 //! snapshot, so it cannot safely establish initial readiness. This barrier
 //! reads the authoritative registry only during Arm; completion and trace
 //! stabilization remain event-driven.

--- a/harness/tests/integration/src/main.rs
+++ b/harness/tests/integration/src/main.rs
@@ -31,7 +31,7 @@ enum Command {
 
 #[derive(Debug, Args)]
 struct StackBinArgs {
-    /// Path to the pinned iii engine binary. Falls back to $III_BIN.
+    /// Path to the iii engine binary. Falls back to $III_BIN.
     #[arg(long, env = "III_BIN")]
     engine_bin: Option<PathBuf>,
 
@@ -277,7 +277,7 @@ fn resolve_stack_bins(args: &StackBinArgs) -> anyhow::Result<StackBins> {
     let engine = args
         .engine_bin
         .as_deref()
-        .ok_or_else(|| anyhow::anyhow!("--engine-bin (or III_BIN) is required; see engine.lock"))?;
+        .ok_or_else(|| anyhow::anyhow!("--engine-bin (or III_BIN) is required"))?;
     let harness = args
         .harness_bin
         .as_deref()

--- a/harness/tests/integration/src/stack/bins.rs
+++ b/harness/tests/integration/src/stack/bins.rs
@@ -8,7 +8,7 @@ pub struct StackBins {
     pub engine: PathBuf,
     pub harness: PathBuf,
     pub console: Option<PathBuf>,
-    /// queue, iii-directory, session-manager, context-manager.
+    /// queue, iii-directory, session-manager, context-manager, cron, state, database.
     pub workers: BTreeMap<String, PathBuf>,
 }
 

--- a/harness/tests/integration/src/stack/config.rs
+++ b/harness/tests/integration/src/stack/config.rs
@@ -6,11 +6,14 @@ use super::RunLayout;
 
 /// Start order matters: the harness retries `queue::define` only briefly at
 /// boot, so queue precedes harness. The harness itself is spawned after Arm.
-pub const WORKER_START_ORDER: [&str; 6] = [
+pub const WORKER_START_ORDER: [&str; 7] = [
     "queue",
     "iii-directory",
     "session-manager",
     "context-manager",
+    // iii 0.23 removed the legacy in-engine cron service. Run the standalone
+    // worker so timer scenarios exercise the production architecture.
+    "cron",
     // The standalone state worker (NOT the engine builtin): it owns the
     // `state` trigger type in production, and its fan-out is the fire-time
     // metadata-sidecar seam MOT-4209 broke on. INT-006 drives a wake
@@ -41,15 +44,6 @@ workers:
   # iii-state deliberately absent: the standalone `state` worker owns the
   # `state` trigger type (its boot guard refuses to start beside the builtin).
   - name: iii-stream
-  - name: iii-cron
-  - name: iii-observability
-    config:
-      enabled: true
-      service_name: iii
-      exporter: memory
-      memory_max_spans: 10000
-      sampling_ratio: 1.0
-      live_spans: true
 "#,
         config_dir = layout.configuration_dir().display(),
     )

--- a/harness/tests/integration/src/stack/manifest.rs
+++ b/harness/tests/integration/src/stack/manifest.rs
@@ -64,10 +64,8 @@ pub(crate) fn stack_info(bins: &StackBins, layout: &RunLayout, port: u16) -> any
         "run_root": layout.root.to_string_lossy(),
         "binaries": Value::Object(binaries),
         "provenance": {
-            "engine_lock": include_str!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/engine.lock"
-            )).trim()
+            "engine_channel": "rc",
+            "engine_version": std::env::var("III_ENGINE_VERSION").ok()
         },
         "env_allowlist": ENV_ALLOWLIST,
         "start_order": WORKER_START_ORDER,

--- a/harness/tests/integration/src/stack/tests.rs
+++ b/harness/tests/integration/src/stack/tests.rs
@@ -45,6 +45,18 @@ fn directory_seed_separates_agent_and_skill_roots() {
 }
 
 #[test]
+fn engine_config_uses_rc_compatible_builtin_workers() {
+    let artifacts = tempfile::tempdir().unwrap();
+    let layout = RunLayout::allocate(artifacts.path(), "run-001").unwrap();
+    let yaml = config::render_engine_yaml(&layout, 3210);
+
+    assert!(yaml.contains("name: iii-stream"));
+    assert!(!yaml.contains("name: iii-cron"));
+    assert!(!yaml.contains("name: iii-observability"));
+    assert!(config::WORKER_START_ORDER.contains(&"cron"));
+}
+
+#[test]
 fn layout_rejects_path_traversal_components() {
     let artifacts = tempfile::tempdir().unwrap();
     for unsafe_id in ["", ".", "..", "../escape", "nested/run", "/tmp/escape"] {
@@ -78,6 +90,7 @@ fn manifest_is_canonical_and_uses_layout_paths() {
     let value = manifest::stack_info(&bins, &layout, 3210).unwrap();
     assert_eq!(committed, crate::canonical::canonical_json_pretty(&value));
     assert_eq!(value["profile"], "harness-core-v1");
+    assert_eq!(value["provenance"]["engine_channel"], "rc");
     assert_eq!(
         value["components"]["controlled_services"],
         serde_json::json!(["scripted-router", "integration-probe"])


### PR DESCRIPTION
## Summary

- install the latest published `iii` release candidate for Harness integration runs
- remove the source checkout, Cargo build, binary cache, and obsolete engine lock
- run `cron` as an external worker and remove RC-incompatible built-in worker entries
- record the resolved engine version and digest in test evidence

## Validation

- `python3 -m pytest -q .github/scripts/tests/test_rust_ci_workflows.py .github/scripts/tests/test_discover_changed_workers.py`
- `cargo test --locked --manifest-path harness/Cargo.toml -p harness-integration`
- `cargo fmt --manifest-path harness/Cargo.toml -- --check`
- `pnpm -C console/web typecheck:e2e`
- `make -C harness integration-test III_BIN=/tmp/tmp.mWjPJErCoz/bin/iii INTEGRATION_SCENARIO=INT-013 CARGO_BUILD_FLAGS=--locked` (`iii 0.23.0-rc.9`, pass)
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integration testing now uses the latest release-candidate (`iii@rc`) engine downloaded through the official installer.
  * Generated stack manifests identify the engine channel as `rc` and include its installed version when available.
  * Added standalone `cron` worker support to integration tests and Console playground scenarios.
  * Updated generated engine configurations to use the standalone cron worker and remove legacy observability settings.

* **Documentation**
  * Updated integration testing instructions, command guidance, and help text to describe using the downloaded release-candidate engine.
  * Clarified execution summaries and error messages for configuring the engine binary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->