### PR TITLE
(MOT-4621) fix(console): calm the traces list under sustained activity

### DIFF
--- a/.github/scripts/tests/test_worker_dependency_compatibility.py
+++ b/.github/scripts/tests/test_worker_dependency_compatibility.py
@@ -37,7 +37,9 @@ DEPENDENCY_RANGES = {
     "queue": "^0.21.5",
     "session-manager": "^1.0.13",
     "shell": "^0.11.9",
-    "skills": "0.x",
+    # `skills` left this table with the worker itself: its functionality was
+    # folded into iii-directory and the last consumer (mcp) dropped the
+    # dependency in #1018, so a range here would fail the consumer check.
     "state": "^0.22.2",
 }
 

--- a/console/web/src/lib/trace-hidden-functions.test.ts
+++ b/console/web/src/lib/trace-hidden-functions.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { sameHiddenIdSet } from './trace-hidden-functions'
+
+describe('sameHiddenIdSet', () => {
+  it('treats equal contents as the same set, whatever the instances', () => {
+    expect(sameHiddenIdSet(new Set(['a', 'b']), new Set(['b', 'a']))).toBe(true)
+  })
+
+  it('sees any difference in membership', () => {
+    expect(sameHiddenIdSet(new Set(['a']), new Set(['a', 'b']))).toBe(false)
+    expect(sameHiddenIdSet(new Set(['a', 'b']), new Set(['a', 'c']))).toBe(
+      false,
+    )
+  })
+
+  it('never matches a missing previous value', () => {
+    expect(sameHiddenIdSet(undefined, new Set())).toBe(false)
+  })
+})

--- a/console/web/src/lib/trace-hidden-functions.ts
+++ b/console/web/src/lib/trace-hidden-functions.ts
@@ -37,6 +37,21 @@ function parseTraceHiddenIds(res: unknown): ReadonlySet<string> {
 }
 
 /**
+ * Same ids, whatever the Set instances. A refetch parses a fresh Set even
+ * when nothing changed, and react-query's structural sharing only reuses
+ * plain objects and arrays — callers that key memos (and the span-filter
+ * verdict caches) on the set's identity use this to keep the old instance.
+ */
+export function sameHiddenIdSet(
+  previous: ReadonlySet<string> | undefined,
+  next: ReadonlySet<string>,
+): boolean {
+  if (!previous || previous.size !== next.size) return false
+  for (const id of next) if (!previous.has(id)) return false
+  return true
+}
+
+/**
  * Function ids registered with `trace_hidden: true`. Resolves to the empty
  * set on any failure — the traces page then simply hides nothing by default.
  */

--- a/console/web/src/pages/TracesV2/components/GroupedTraceList.tsx
+++ b/console/web/src/pages/TracesV2/components/GroupedTraceList.tsx
@@ -9,7 +9,7 @@
 // reuses `TraceListRow`, so selection, labelling, and hide-function all
 // behave exactly like the flat list.
 
-import { useQuery } from '@tanstack/react-query'
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { ChevronRight, Layers, Loader2 } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import { cn } from '@/lib/utils'
@@ -271,6 +271,9 @@ function GroupMembers({
 }: GroupMembersProps) {
   // Keyed by group identity + member-count so live growth refetches, while
   // the id list itself rides in via closure (it can be hundreds of entries).
+  // The previous rows stay on screen while the grown key loads: without
+  // that, every new trace in an expanded group unmounted its rows behind a
+  // "loading traces…" spinner and remounted them a moment later.
   const { data, isLoading } = useQuery<TraceListItem[]>({
     queryKey: [
       'traceGroupMembers',
@@ -295,6 +298,7 @@ function GroupMembers({
       rows.sort((a, b) => b.startTime - a.startTime)
       return rows
     },
+    placeholderData: keepPreviousData,
     staleTime: 1000,
   })
 

--- a/console/web/src/pages/TracesV2/hooks/useAllSpans.test.ts
+++ b/console/web/src/pages/TracesV2/hooks/useAllSpans.test.ts
@@ -136,7 +136,7 @@ describe('fetchLiveSpanSeed', () => {
       include_internal: false,
       sort_by: 'start_time',
       sort_order: 'desc',
-      limit: 500,
+      limit: 120,
     })
     expect(fetchTraceSpansMock).toHaveBeenCalledWith({
       trace_ids: ['t-1', 't-2'],

--- a/console/web/src/pages/TracesV2/hooks/useAllSpans.ts
+++ b/console/web/src/pages/TracesV2/hooks/useAllSpans.ts
@@ -29,16 +29,29 @@ import {
   type StoredSpan,
   type TraceSummary,
 } from '../api/traces'
+import { createRefetchCoalescer } from '../lib/refetchCoalescer'
 import { isPendingSpan, toMs } from '../lib/traceTransform'
 
 /** Forget spans that ended this long ago (strip window + wide slack). */
 const RETENTION_MS = 120_000
 /** Seed read size — bounds a busy engine's history, not the live feed. */
 const SEED_LIMIT = 500
-/** Maximum compact summaries examined to find the seed's trace IDs. */
-const SEED_TRACE_LIMIT = 500
+/**
+ * Maximum compact summaries examined to find the seed's trace IDs. The
+ * summary RPC prices by the spans it must load to aggregate, so this bounds
+ * the engine's work per reseed: 500 summaries of ~40-span turns meant ~20k
+ * spans decoded per tick — measured live under four concurrent turns at
+ * ~8s per call, the single heaviest query on the connection (MOT-4621). The
+ * strip only needs enough recent traces to fill `SEED_LIMIT` spans, which
+ * 120 covers unless every recent trace is a single span.
+ */
+const SEED_TRACE_LIMIT = 120
 /** Debounce over activity ticks before re-seeding the strip. */
 const ACTIVITY_RESEED_DEBOUNCE_MS = 300
+/** Floor between two consecutive activity-driven reseed STARTS: the seed is
+ *  two engine reads (summaries + spans), so a busy engine gets at most one
+ *  pair per second, one pair in flight (see `createRefetchCoalescer`). */
+const ACTIVITY_RESEED_MIN_INTERVAL_MS = 1_000
 /** Hard ceiling on retained spans; oldest effective-end evicted first. */
 const MAX_SPANS = 1_500
 /** Let focus/visibility churn settle before the expensive seed read. */
@@ -207,17 +220,18 @@ export function useAllSpans(isPaused: boolean): readonly StoredSpan[] {
       const client = await getIiiClient()
       if (disposed) return
       // Notify-then-query: each activity tick re-seeds the strip's recent
-      // window (REPLACE semantics, same reads as the initial seed), debounced
-      // so a burst of consecutive 300ms windows costs one read.
-      let reseedTimer: ReturnType<typeof setTimeout> | undefined
+      // window (REPLACE semantics, same reads as the initial seed). One seed
+      // in flight at a time; a tick that lands mid-seed queues one trailing
+      // reseed, so the strip always settles on the engine's latest state.
+      const reseed = createRefetchCoalescer({
+        run: () => seedRef.current(),
+        debounceMs: ACTIVITY_RESEED_DEBOUNCE_MS,
+        minIntervalMs: ACTIVITY_RESEED_MIN_INTERVAL_MS,
+        shouldRun: () => !disposed && !isPausedRef.current && !isHidden(),
+      })
       const offFeed = startTraceActivityFeed(client, () => {
         if (isPausedRef.current || isHidden()) return
-        if (reseedTimer !== undefined) return
-        reseedTimer = setTimeout(() => {
-          reseedTimer = undefined
-          if (disposed || isPausedRef.current || isHidden()) return
-          void seedRef.current()
-        }, ACTIVITY_RESEED_DEBOUNCE_MS)
+        reseed.request()
       })
       const offConn = client.addConnectionStateListener((state) => {
         if (state === 'connected' && !isPausedRef.current) {
@@ -254,10 +268,7 @@ export function useAllSpans(isPaused: boolean): readonly StoredSpan[] {
         offFeed()
         offConn()
         offVisibility?.()
-        if (reseedTimer !== undefined) {
-          clearTimeout(reseedTimer)
-          reseedTimer = undefined
-        }
+        reseed.dispose()
       }
     })()
 

--- a/console/web/src/pages/TracesV2/hooks/useSpanFilterSelection.ts
+++ b/console/web/src/pages/TracesV2/hooks/useSpanFilterSelection.ts
@@ -30,6 +30,7 @@ import type { ConsoleConfigValue } from '@/lib/console-config'
 import {
   EMPTY_HIDDEN_IDS,
   fetchTraceHiddenFunctionIds,
+  sameHiddenIdSet,
 } from '@/lib/trace-hidden-functions'
 import {
   EMPTY_SPAN_FILTER_PREFS,
@@ -57,11 +58,22 @@ export function useSpanFilterSelection(): SpanFilterControls {
   // Producer-default-hidden groups (`trace_hidden: true` registration
   // metadata). Registrations only change on worker deploys, so a long
   // staleTime is fine; failures resolve to the empty set (hide nothing).
+  // A refetch that finds the same ids keeps the same Set instance: the
+  // selection below — and the trace list's verdict cache, keyed on the
+  // selection's identity — hangs off it, and a fresh-but-equal Set used to
+  // reset that cache mid-session, blinking rows out and back in (MOT-4621).
   const { data: producerHidden } = useQuery<ReadonlySet<string>>({
     queryKey: TRACE_HIDDEN_FUNCTIONS_QUERY_KEY,
     queryFn: fetchTraceHiddenFunctionIds,
     staleTime: 5 * 60_000,
     retry: 1,
+    structuralSharing: (previous, next) =>
+      sameHiddenIdSet(
+        previous as ReadonlySet<string> | undefined,
+        next as ReadonlySet<string>,
+      )
+        ? previous
+        : next,
   })
   const producerHiddenRef = useRef<ReadonlySet<string>>(EMPTY_HIDDEN_IDS)
   producerHiddenRef.current = producerHidden ?? EMPTY_HIDDEN_IDS

--- a/console/web/src/pages/TracesV2/hooks/useSpanFilteredTraceRows.test.ts
+++ b/console/web/src/pages/TracesV2/hooks/useSpanFilteredTraceRows.test.ts
@@ -3,8 +3,8 @@ import type { StoredSpan } from '../api/traces'
 import type { TimelineSpan } from '../components/timeline/layout'
 import type { SpanFilterSelection } from '../lib/spanFilters'
 import {
-  liveTraceIds,
   mergeFetchedVerdicts,
+  pendingTraceIds,
   reconcileTraceVisibility,
   rowRootFilterKeys,
 } from './useSpanFilteredTraceRows'
@@ -116,9 +116,25 @@ describe('reconcileTraceVisibility', () => {
       ],
       sel,
     )
-    // t-2 has no coverage yet (hidden root, feed silent) → visible until a
-    // composition read decides.
-    expect(ids(kept)).toEqual(['t-2'])
+    // t-2 has no coverage yet (hidden root, feed silent) → hidden until a
+    // composition read or the feed proves visible work, so a bookkeeping
+    // trace never flashes into the list and vanishes.
+    expect(ids(kept)).toEqual([])
+  })
+
+  it('keeps a still-running row visible while its composition is unknown', () => {
+    // A live turn under a hidden dispatch root: nothing in the feed yet,
+    // no read yet — the row's own pending status is the evidence.
+    const kept = reconcileTraceVisibility(
+      new Map(),
+      [],
+      [
+        row('t-live', 'harness::turn', { status: 'pending' }),
+        row('t-done', 'harness::turn', { status: 'ok' }),
+      ],
+      selection({ hiddenGroups: new Set(['harness::turn']) }),
+    )
+    expect(ids(kept)).toEqual(['t-live'])
   })
 
   it('keeps the row while any bar of its trace survives — a hidden root is not enough', () => {
@@ -371,6 +387,39 @@ describe('mergeFetchedVerdicts', () => {
     expect(verdicts.has('t-hidden')).toBe(false)
   })
 
+  it('records no verdict for a trace still running, and reports it for a later read', () => {
+    const verdicts = new Map<string, boolean>()
+    const undecided = mergeFetchedVerdicts(
+      verdicts,
+      ['t-running', 't-settled'],
+      [
+        stored({
+          span_id: 'r1',
+          trace_id: 't-running',
+          attributes: [['function_id', 'fn']],
+        }),
+        stored({
+          span_id: 'r2',
+          trace_id: 't-running',
+          name: 'call router::generate',
+          parent_span_id: 'r1',
+          pending: true,
+          end_time_unix_nano: 0,
+          attributes: [['function_id', 'fn']],
+        }),
+        stored({
+          span_id: 's1',
+          trace_id: 't-settled',
+          attributes: [['function_id', 'fn']],
+        }),
+      ],
+      sel,
+    )
+    expect(verdicts.has('t-running')).toBe(false)
+    expect(verdicts.get('t-settled')).toBe(false)
+    expect([...undecided]).toEqual(['t-running'])
+  })
+
   it('never downgrades a visible verdict — the read raced a newer feed frame', () => {
     const verdicts = new Map<string, boolean>([['t-1', true]])
     mergeFetchedVerdicts(
@@ -388,31 +437,24 @@ describe('mergeFetchedVerdicts', () => {
   })
 })
 
-describe('liveTraceIds', () => {
-  // Realistic epoch ms — `toMs` sniffs nano vs ms by magnitude.
-  const now = 1_700_000_000_000
-
-  it('counts a pending snapshot as live', () => {
-    const live = liveTraceIds(
-      [stored({ span_id: 's1', trace_id: 't-1', pending: true })],
-      now,
-    )
-    expect(live.has('t-1')).toBe(true)
+describe('pendingTraceIds', () => {
+  it('counts a pending snapshot as running', () => {
+    const live = pendingTraceIds([
+      stored({ span_id: 's1', trace_id: 't-1', pending: true }),
+    ])
+    expect([...live]).toEqual(['t-1'])
   })
 
-  it('counts a just-ended span as live, an old one as settled', () => {
-    const justEnded = stored({
-      span_id: 's1',
-      trace_id: 't-recent',
-      end_time_unix_nano: (now - 2_000) * 1e6,
-    })
-    const longSettled = stored({
-      span_id: 's2',
-      trace_id: 't-old',
-      end_time_unix_nano: (now - 60_000) * 1e6,
-    })
-    const live = liveTraceIds([justEnded, longSettled], now)
-    expect(live.has('t-recent')).toBe(true)
-    expect(live.has('t-old')).toBe(false)
+  it('never counts a closed span as running, however recent', () => {
+    // A "just ended" window used to keep hidden bookkeeping traces visible
+    // for its whole length and then hide them — the flicker itself.
+    const live = pendingTraceIds([
+      stored({
+        span_id: 's1',
+        trace_id: 't-1',
+        end_time_unix_nano: Date.now() * 1_000_000,
+      }),
+    ])
+    expect(live.size).toBe(0)
   })
 })

--- a/console/web/src/pages/TracesV2/hooks/useSpanFilteredTraceRows.test.ts
+++ b/console/web/src/pages/TracesV2/hooks/useSpanFilteredTraceRows.test.ts
@@ -3,10 +3,14 @@ import type { StoredSpan } from '../api/traces'
 import type { TimelineSpan } from '../components/timeline/layout'
 import type { SpanFilterSelection } from '../lib/spanFilters'
 import {
+  type CompositionReadState,
+  FETCH_RETRY_MS,
   mergeFetchedVerdicts,
   pendingTraceIds,
+  pruneCompositionReads,
   reconcileTraceVisibility,
   rowRootFilterKeys,
+  selectCompositionReads,
 } from './useSpanFilteredTraceRows'
 import type { TraceListItem } from './useTraceData'
 
@@ -456,5 +460,66 @@ describe('pendingTraceIds', () => {
       }),
     ])
     expect(live.size).toBe(0)
+  })
+})
+
+describe('selectCompositionReads', () => {
+  const now = 1_000_000
+  const reads = (entries: [string, CompositionReadState][]) =>
+    new Map<string, CompositionReadState>(entries)
+
+  it('reads unverdicted rows that have no read state, and nothing else', () => {
+    const picked = selectCompositionReads(
+      [row('t-new'), row('t-known'), row('t-inflight')],
+      new Map([['t-known', false]]),
+      reads([['t-inflight', { kind: 'inflight' }]]),
+      now,
+    )
+    expect(picked).toEqual(['t-new'])
+  })
+
+  it('re-reads a trace found running only once its row settles', () => {
+    const state = reads([['t-1', { kind: 'running' }]])
+    expect(
+      selectCompositionReads(
+        [row('t-1', 'fn', { status: 'pending' })],
+        new Map(),
+        state,
+        now,
+      ),
+    ).toEqual([])
+    expect(selectCompositionReads([row('t-1')], new Map(), state, now)).toEqual(
+      ['t-1'],
+    )
+  })
+
+  it('retries a failed read only after the backoff', () => {
+    const state = reads([['t-1', { kind: 'failed', at: now }]])
+    expect(
+      selectCompositionReads([row('t-1')], new Map(), state, now + 1_000),
+    ).toEqual([])
+    expect(
+      selectCompositionReads(
+        [row('t-1')],
+        new Map(),
+        state,
+        now + FETCH_RETRY_MS,
+      ),
+    ).toEqual(['t-1'])
+  })
+})
+
+describe('pruneCompositionReads', () => {
+  it('forgets states of traces that left the list, keeping reads in flight', () => {
+    // The page-2-and-back case: verdicts are pruned when a trace leaves the
+    // list, so its read state must go too or it stays hidden on return.
+    const state = new Map<string, CompositionReadState>([
+      ['gone-settled', { kind: 'running' }],
+      ['gone-failed', { kind: 'failed', at: 1 }],
+      ['gone-inflight', { kind: 'inflight' }],
+      ['listed', { kind: 'running' }],
+    ])
+    pruneCompositionReads(state, new Set(['listed']))
+    expect([...state.keys()].sort()).toEqual(['gone-inflight', 'listed'])
   })
 })

--- a/console/web/src/pages/TracesV2/hooks/useSpanFilteredTraceRows.test.ts
+++ b/console/web/src/pages/TracesV2/hooks/useSpanFilteredTraceRows.test.ts
@@ -421,7 +421,31 @@ describe('mergeFetchedVerdicts', () => {
     )
     expect(verdicts.has('t-running')).toBe(false)
     expect(verdicts.get('t-settled')).toBe(false)
-    expect([...undecided]).toEqual(['t-running'])
+    expect([...undecided]).toEqual([['t-running', 'running']])
+  })
+
+  it('reports a truncated probe with no visible span as inconclusive', () => {
+    const verdicts = new Map<string, boolean>()
+    const undecided = mergeFetchedVerdicts(
+      verdicts,
+      ['t-fat'],
+      [
+        stored({
+          span_id: 'h1',
+          trace_id: 't-fat',
+          attributes: [['function_id', 'fn']],
+        }),
+        stored({
+          span_id: 'h2',
+          trace_id: 't-fat',
+          attributes: [['function_id', 'fn']],
+        }),
+      ],
+      sel,
+      2,
+    )
+    expect(verdicts.has('t-fat')).toBe(false)
+    expect(undecided.get('t-fat')).toBe('truncated')
   })
 
   it('never downgrades a visible verdict — the read raced a newer feed frame', () => {
@@ -493,8 +517,8 @@ describe('selectCompositionReads', () => {
     )
   })
 
-  it('retries a failed read only after the backoff', () => {
-    const state = reads([['t-1', { kind: 'failed', at: now }]])
+  it('retries a failed or inconclusive probe only after the backoff', () => {
+    const state = reads([['t-1', { kind: 'retry', at: now }]])
     expect(
       selectCompositionReads([row('t-1')], new Map(), state, now + 1_000),
     ).toEqual([])
@@ -515,7 +539,7 @@ describe('pruneCompositionReads', () => {
     // list, so its read state must go too or it stays hidden on return.
     const state = new Map<string, CompositionReadState>([
       ['gone-settled', { kind: 'running' }],
-      ['gone-failed', { kind: 'failed', at: 1 }],
+      ['gone-retry', { kind: 'retry', at: 1 }],
       ['gone-inflight', { kind: 'inflight' }],
       ['listed', { kind: 'running' }],
     ])

--- a/console/web/src/pages/TracesV2/hooks/useSpanFilteredTraceRows.ts
+++ b/console/web/src/pages/TracesV2/hooks/useSpanFilteredTraceRows.ts
@@ -84,6 +84,63 @@ import type { TraceListItem } from './useTraceData'
  *  turn traces a few hundred). */
 const FETCH_TRACE_CHUNK = 20
 const FETCH_SPAN_LIMIT = 10_000
+/** Backoff before a failed composition read is attempted again. */
+export const FETCH_RETRY_MS = 10_000
+
+/**
+ * Why a listed row without a verdict is not being read right now: its read
+ * is in flight; its last read found the trace still running (read again
+ * once the row settles); or its last read failed (retry after the backoff).
+ */
+export type CompositionReadState =
+  | { kind: 'inflight' }
+  | { kind: 'running' }
+  | { kind: 'failed'; at: number }
+
+/**
+ * The listed rows whose composition must be read now: no verdict, and no
+ * read state that says to wait. A row a previous read found running is
+ * read again only once it has settled, so a long turn costs one read at its
+ * start and one at its end, not one per list refresh. Exported for tests.
+ */
+export function selectCompositionReads(
+  rows: readonly TraceListItem[],
+  verdicts: ReadonlyMap<string, boolean>,
+  reads: ReadonlyMap<string, CompositionReadState>,
+  now: number,
+): string[] {
+  const out: string[] = []
+  for (const row of rows) {
+    if (verdicts.has(row.traceId)) continue
+    const state = reads.get(row.traceId)
+    if (
+      state === undefined ||
+      (state.kind === 'running' && row.status !== 'pending') ||
+      (state.kind === 'failed' && now - state.at >= FETCH_RETRY_MS)
+    ) {
+      out.push(row.traceId)
+    }
+  }
+  return out
+}
+
+/**
+ * Forget read states for traces no longer listed, in-flight reads aside.
+ * Verdicts are pruned the same way when a trace leaves both the list and
+ * the feed (`reconcileTraceVisibility`), so a trace that pages back in is
+ * read again — without this, a state left behind from its earlier visit
+ * would keep it hidden for good. Mutates `reads`. Exported for tests.
+ */
+export function pruneCompositionReads(
+  reads: Map<string, CompositionReadState>,
+  listed: ReadonlySet<string>,
+): void {
+  for (const [traceId, state] of [...reads]) {
+    if (!listed.has(traceId) && state.kind !== 'inflight') {
+      reads.delete(traceId)
+    }
+  }
+}
 
 /**
  * Traces with work still in flight, judged from raw spans: a pending
@@ -270,14 +327,12 @@ export function useSpanFilteredTraceRows(
   // Verdict cache, keyed by selection IDENTITY: `useSpanFilterSelection`
   // memoizes its controls object on the effective selection, so a new
   // reference means the selection changed and every cached verdict is
-  // stale. `requested` remembers which traces already went through a
-  // composition read (in-flight, done, or failed) so they are asked once
-  // per selection — except a trace the read found still running, which is
-  // asked once more after its row settles.
+  // stale. `reads` remembers why a still-unverdicted trace is not being
+  // read right now (see `CompositionReadState`).
   const cacheRef = useRef<{
     selection: SpanFilterSelection
     verdicts: Map<string, boolean>
-    requested: Map<string, 'settled' | 'running'>
+    reads: Map<string, CompositionReadState>
   } | null>(null)
 
   // Bumped when a composition read lands verdicts, to re-run the memo.
@@ -291,7 +346,7 @@ export function useSpanFilteredTraceRows(
   const visibleRows = useMemo(() => {
     let cache = cacheRef.current
     if (!cache || cache.selection !== selection) {
-      cache = { selection, verdicts: new Map(), requested: new Map() }
+      cache = { selection, verdicts: new Map(), reads: new Map() }
       cacheRef.current = cache
     }
     return reconcileTraceVisibility(
@@ -307,26 +362,34 @@ export function useSpanFilteredTraceRows(
   // root, no feed coverage. Runs after the memo above, so feed verdicts
   // are already in the cache. Deliberately NO cancellation on dep churn —
   // live row appends must not orphan an in-flight read (its traces would
-  // stay `requested` but never verdicted); a stale SELECTION is detected
-  // by cache identity instead. Failed reads leave their traces visible
-  // and unretried until the selection changes.
+  // stay in flight but never verdicted); a stale SELECTION is detected by
+  // cache identity instead. A failed read leaves its rows hidden until the
+  // feed decides or the read is retried after `FETCH_RETRY_MS` — the timer
+  // re-arms this effect so the retry does not wait for the next row change.
+  const [retryTick, setRetryTick] = useState(0)
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(
+    () => () => {
+      if (retryTimerRef.current !== null) clearTimeout(retryTimerRef.current)
+    },
+    [],
+  )
+  // retryTick isn't read in the body — it re-runs the selection after a
+  // failed read's backoff.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: see above
   useEffect(() => {
     const cache = cacheRef.current
     if (!cache || cache.selection !== selection) return
-    // Never read, or read while still running and settled since — a
-    // running row is visible on its own and is not re-read until it
-    // settles, so a long turn costs one read at its start and one at its
-    // end, not one per list refresh.
-    const unknown = rows
-      .filter((r) => {
-        if (cache.verdicts.has(r.traceId)) return false
-        const requested = cache.requested.get(r.traceId)
-        if (requested === undefined) return true
-        return requested === 'running' && r.status !== 'pending'
-      })
-      .map((r) => r.traceId)
+    pruneCompositionReads(cache.reads, new Set(rows.map((r) => r.traceId)))
+    const unknown = selectCompositionReads(
+      rows,
+      cache.verdicts,
+      cache.reads,
+      Date.now(),
+    )
     if (unknown.length === 0) return
-    for (const traceId of unknown) cache.requested.set(traceId, 'settled')
+    for (const traceId of unknown)
+      cache.reads.set(traceId, { kind: 'inflight' })
     void (async () => {
       for (let i = 0; i < unknown.length; i += FETCH_TRACE_CHUNK) {
         const chunk = unknown.slice(i, i + FETCH_TRACE_CHUNK)
@@ -344,17 +407,31 @@ export function useSpanFilteredTraceRows(
             res.spans,
             selection,
           )
-          for (const traceId of running) {
-            cache.requested.set(traceId, 'running')
+          for (const traceId of chunk) {
+            if (running.has(traceId)) {
+              cache.reads.set(traceId, { kind: 'running' })
+            } else {
+              cache.reads.delete(traceId)
+            }
           }
           setFetchTick((t) => t + 1)
         } catch {
           // Traces unavailable (memory exporter off, transient error) —
-          // the rows stay as they are until the feed decides.
+          // the rows stay hidden until the feed decides or the retry lands.
+          if (cacheRef.current !== cache) return
+          const at = Date.now()
+          for (const traceId of chunk)
+            cache.reads.set(traceId, { kind: 'failed', at })
+          if (retryTimerRef.current === null) {
+            retryTimerRef.current = setTimeout(() => {
+              retryTimerRef.current = null
+              setRetryTick((t) => t + 1)
+            }, FETCH_RETRY_MS)
+          }
         }
       }
     })()
-  }, [rows, selection])
+  }, [rows, selection, retryTick])
 
   return visibleRows
 }

--- a/console/web/src/pages/TracesV2/hooks/useSpanFilteredTraceRows.ts
+++ b/console/web/src/pages/TracesV2/hooks/useSpanFilteredTraceRows.ts
@@ -79,23 +79,31 @@ import { isPendingSpan } from '../lib/traceTransform'
 import { getWorkerName } from '../lib/traceUtils'
 import type { TraceListItem } from './useTraceData'
 
-/** Traces per composition read — small enough that `FETCH_SPAN_LIMIT`
- *  practically never truncates (bookkeeping traces run a handful of spans;
- *  turn traces a few hundred). */
-const FETCH_TRACE_CHUNK = 20
-const FETCH_SPAN_LIMIT = 10_000
-/** Backoff before a failed composition read is attempted again. */
+/**
+ * Spans per composition PROBE — one trace per read. A probe is complete for
+ * the traces this path exists to judge (bookkeeping runs a handful of
+ * spans) and a bounded slice of a fat one, which can only prove visibility.
+ * The old shape — twenty traces per read, ten thousand spans — served a
+ * turn's ~75KB spans as a multi-MB response that outgrew the transport's
+ * ~16MiB delivery cap under load and never arrived, and with unknown
+ * verdicts hiding, a read that never arrives is a row that never shows.
+ */
+const FETCH_SPAN_LIMIT = 80
+/** Probes in flight at once — many rows can need one after a page change. */
+const FETCH_CONCURRENCY = 4
+/** Backoff before a failed or inconclusive probe is attempted again. */
 export const FETCH_RETRY_MS = 10_000
 
 /**
- * Why a listed row without a verdict is not being read right now: its read
- * is in flight; its last read found the trace still running (read again
- * once the row settles); or its last read failed (retry after the backoff).
+ * Why a listed row without a verdict is not being read right now: its probe
+ * is in flight; its last probe found the trace still running (probe again
+ * once the row settles); or its last probe failed or was inconclusive — a
+ * truncated slice with no visible span — and waits out a backoff.
  */
 export type CompositionReadState =
   | { kind: 'inflight' }
   | { kind: 'running' }
-  | { kind: 'failed'; at: number }
+  | { kind: 'retry'; at: number }
 
 /**
  * The listed rows whose composition must be read now: no verdict, and no
@@ -116,7 +124,7 @@ export function selectCompositionReads(
     if (
       state === undefined ||
       (state.kind === 'running' && row.status !== 'pending') ||
-      (state.kind === 'failed' && now - state.at >= FETCH_RETRY_MS)
+      (state.kind === 'retry' && now - state.at >= FETCH_RETRY_MS)
     ) {
       out.push(row.traceId)
     }
@@ -273,20 +281,23 @@ function verdictBars(spans: readonly StoredSpan[]): TimelineSpan[] {
   return builtins.size === 0 ? bars : bars.filter((b) => !builtins.has(b.id))
 }
 
+/** Why a probed trace is still undecided after its probe. */
+export type UndecidedReason = 'running' | 'truncated'
+
 /**
- * Fold one composition read into the verdicts: every requested trace's
+ * Fold one composition probe into the verdicts: every requested trace's
  * verdict is "any of its bars survives the filter" — a trace the store no
  * longer has spans for counts as hidden (its detail would be empty). A
  * truncated response (span count at the limit) only trusts POSITIVE
  * verdicts: a visible span proves visibility, but "all hidden" might just
  * mean the visible spans were cut off. A `true` verdict already in the
- * cache is never downgraded — the read raced a feed frame that proved
+ * cache is never downgraded — the probe raced a feed frame that proved
  * visibility after the snapshot was taken.
  *
- * A trace the read finds still RUNNING (a pending snapshot among its
+ * A trace the probe finds still RUNNING (a pending snapshot among its
  * spans) gets no negative verdict either — its visible work may not have
- * closed yet. Those ids are returned so the caller can read them again
- * once they settle. Exported for tests.
+ * closed yet. Every trace left undecided is returned with the reason, so
+ * the caller can probe again at the right time. Exported for tests.
  */
 export function mergeFetchedVerdicts(
   verdicts: Map<string, boolean>,
@@ -294,7 +305,7 @@ export function mergeFetchedVerdicts(
   spans: readonly StoredSpan[],
   selection: SpanFilterSelection,
   spanLimit: number = FETCH_SPAN_LIMIT,
-): ReadonlySet<string> {
+): ReadonlyMap<string, UndecidedReason> {
   const visible = new Set<string>()
   for (const bar of verdictBars(spans)) {
     if (bar.traceId && !isSpanBarHidden(bar, selection)) {
@@ -303,13 +314,12 @@ export function mergeFetchedVerdicts(
   }
   const truncated = spans.length >= spanLimit
   const running = pendingTraceIds(spans)
-  const undecided = new Set<string>()
+  const undecided = new Map<string, UndecidedReason>()
   for (const traceId of requested) {
     if (visible.has(traceId)) verdicts.set(traceId, true)
-    else if (running.has(traceId)) undecided.add(traceId)
-    else if (!truncated && !verdicts.get(traceId)) {
-      verdicts.set(traceId, false)
-    }
+    else if (running.has(traceId)) undecided.set(traceId, 'running')
+    else if (truncated) undecided.set(traceId, 'truncated')
+    else if (!verdicts.get(traceId)) verdicts.set(traceId, false)
   }
   return undecided
 }
@@ -358,14 +368,15 @@ export function useSpanFilteredTraceRows(
     )
   }, [rows, bars, feedSpans, selection, fetchTick])
 
-  // Composition reads for the rows neither source could judge: hidden
+  // Composition probes for the rows neither source could judge: hidden
   // root, no feed coverage. Runs after the memo above, so feed verdicts
   // are already in the cache. Deliberately NO cancellation on dep churn —
-  // live row appends must not orphan an in-flight read (its traces would
+  // live row appends must not orphan an in-flight probe (its trace would
   // stay in flight but never verdicted); a stale SELECTION is detected by
-  // cache identity instead. A failed read leaves its rows hidden until the
-  // feed decides or the read is retried after `FETCH_RETRY_MS` — the timer
-  // re-arms this effect so the retry does not wait for the next row change.
+  // cache identity instead. A failed or inconclusive probe leaves its row
+  // hidden until the feed decides or the probe is retried after
+  // `FETCH_RETRY_MS` — the timer re-arms this effect so the retry does not
+  // wait for the next row change.
   const [retryTick, setRetryTick] = useState(0)
   const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   useEffect(
@@ -375,7 +386,7 @@ export function useSpanFilteredTraceRows(
     [],
   )
   // retryTick isn't read in the body — it re-runs the selection after a
-  // failed read's backoff.
+  // retry backoff.
   // biome-ignore lint/correctness/useExhaustiveDependencies: see above
   useEffect(() => {
     const cache = cacheRef.current
@@ -390,47 +401,63 @@ export function useSpanFilteredTraceRows(
     if (unknown.length === 0) return
     for (const traceId of unknown)
       cache.reads.set(traceId, { kind: 'inflight' })
-    void (async () => {
-      for (let i = 0; i < unknown.length; i += FETCH_TRACE_CHUNK) {
-        const chunk = unknown.slice(i, i + FETCH_TRACE_CHUNK)
-        try {
-          const res = await fetchTraceSpans({
-            trace_ids: chunk,
-            search_all_spans: true,
-            include_internal: true,
-            limit: FETCH_SPAN_LIMIT,
-          })
-          if (cacheRef.current !== cache) return
-          const running = mergeFetchedVerdicts(
-            cache.verdicts,
-            chunk,
-            res.spans,
-            selection,
-          )
-          for (const traceId of chunk) {
-            if (running.has(traceId)) {
-              cache.reads.set(traceId, { kind: 'running' })
-            } else {
-              cache.reads.delete(traceId)
-            }
-          }
-          setFetchTick((t) => t + 1)
-        } catch {
-          // Traces unavailable (memory exporter off, transient error) —
-          // the rows stay hidden until the feed decides or the retry lands.
-          if (cacheRef.current !== cache) return
-          const at = Date.now()
-          for (const traceId of chunk)
-            cache.reads.set(traceId, { kind: 'failed', at })
-          if (retryTimerRef.current === null) {
-            retryTimerRef.current = setTimeout(() => {
-              retryTimerRef.current = null
-              setRetryTick((t) => t + 1)
-            }, FETCH_RETRY_MS)
-          }
+    const scheduleRetry = () => {
+      if (retryTimerRef.current !== null) return
+      retryTimerRef.current = setTimeout(() => {
+        retryTimerRef.current = null
+        setRetryTick((t) => t + 1)
+      }, FETCH_RETRY_MS)
+    }
+    const probe = async (traceId: string) => {
+      try {
+        const res = await fetchTraceSpans({
+          trace_id: traceId,
+          search_all_spans: true,
+          include_internal: true,
+          sort_by: 'start_time',
+          sort_order: 'asc',
+          limit: FETCH_SPAN_LIMIT,
+        })
+        if (cacheRef.current !== cache) return
+        const undecided = mergeFetchedVerdicts(
+          cache.verdicts,
+          [traceId],
+          res.spans,
+          selection,
+        )
+        const reason = undecided.get(traceId)
+        if (reason === 'running') {
+          cache.reads.set(traceId, { kind: 'running' })
+        } else if (reason === 'truncated') {
+          cache.reads.set(traceId, { kind: 'retry', at: Date.now() })
+          scheduleRetry()
+        } else {
+          cache.reads.delete(traceId)
         }
+        setFetchTick((t) => t + 1)
+      } catch {
+        // Traces unavailable (memory exporter off, transient error) —
+        // the row stays hidden until the feed decides or the retry lands.
+        if (cacheRef.current !== cache) return
+        cache.reads.set(traceId, { kind: 'retry', at: Date.now() })
+        scheduleRetry()
       }
-    })()
+    }
+    // A small pool: probes are cheap and indexed by trace id, but a page
+    // change can leave dozens of rows to judge at once.
+    let next = 0
+    const worker = async () => {
+      while (next < unknown.length) {
+        const traceId = unknown[next++]
+        await probe(traceId)
+      }
+    }
+    void Promise.all(
+      Array.from(
+        { length: Math.min(FETCH_CONCURRENCY, unknown.length) },
+        worker,
+      ),
+    )
   }, [rows, selection, retryTick])
 
   return visibleRows

--- a/console/web/src/pages/TracesV2/hooks/useSpanFilteredTraceRows.ts
+++ b/console/web/src/pages/TracesV2/hooks/useSpanFilteredTraceRows.ts
@@ -41,17 +41,26 @@
 // prunes the visible bars while hidden bookkeeping keeps the trace in the
 // feed — and a feed-only recompute would flip the row back to hidden.
 // Fetched verdicts land in the same cache. The cache resets when the
-// selection changes; a row stays visible while its verdict is unknown or
-// its read failed — better to show a hideable row than to hide real work
-// on a guess.
+// selection changes.
 //
-// LIVE traces get one more guard: worker spans reach the store only when
+// A row with a hidden root and NO verdict yet stays HIDDEN until a read or
+// the feed proves visible work. The other default — show while unknown —
+// made every hidden bookkeeping trace (state polls, function-change
+// fan-outs) flash into the live list and vanish a moment later when its
+// composition read landed, which under a busy engine read as rows switching
+// states all over the page (MOT-4621). The cost is a short delay before a
+// hidden-rooted trace with real work under it earns its row; the common
+// turn shape is rooted visibly and never waits.
+//
+// RUNNING traces are the exception: worker spans reach the store only when
 // they CLOSE, so a running turn's composition is structurally incomplete —
 // its first visible span may be an LLM call that takes minutes to close.
-// A negative verdict is a guess there, so a row whose trace is still live
-// (pending span in the feed, or a span end within the last few seconds)
-// stays visible regardless. Bookkeeping traces settle in well under a
-// second, so the exemption never resurfaces them.
+// A row whose trace is still running (the row's own `pending` status, or a
+// pending snapshot in the feed) stays visible regardless, and a composition
+// read that finds the trace still running records NO verdict: the read is
+// repeated once the row settles, so the eventual verdict sees the closed
+// work. Bookkeeping traces are already complete when they are listed, so
+// the exemption never resurfaces them.
 
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { fetchTraceSpans, type StoredSpan } from '../api/traces'
@@ -66,7 +75,7 @@ import {
   spanFilterGroupKey,
   storedSpansToTimelineSpans,
 } from '../lib/timelineSpans'
-import { isPendingSpan, toMs } from '../lib/traceTransform'
+import { isPendingSpan } from '../lib/traceTransform'
 import { getWorkerName } from '../lib/traceUtils'
 import type { TraceListItem } from './useTraceData'
 
@@ -76,30 +85,22 @@ import type { TraceListItem } from './useTraceData'
 const FETCH_TRACE_CHUNK = 20
 const FETCH_SPAN_LIMIT = 10_000
 
-/** How recently a span of the trace must have ENDED for the trace to still
- *  count as live when no pending snapshot is in the feed (engines with
- *  `live_spans` off). Generous on purpose — liveness only defers hiding. */
-const LIVE_END_SLACK_MS = 10_000
-
 /**
- * Traces with work still in flight, judged from the raw feed: a pending
+ * Traces with work still in flight, judged from raw spans: a pending
  * snapshot (the engine's queue wrapper stays pending for a turn's whole
- * lifetime — see `followTurn.ts`), or a span that ended moments ago.
- * Exported for tests.
+ * lifetime — see `followTurn.ts`). A closed span is never evidence of
+ * liveness, however recent: a "just ended" window kept every hidden
+ * bookkeeping trace visible for its duration and then hid it — the flicker
+ * this module exists to avoid. Engines without live snapshots simply reveal
+ * a hidden-rooted trace once its first visible span closes. Exported for
+ * tests.
  */
-export function liveTraceIds(
+export function pendingTraceIds(
   spans: readonly StoredSpan[],
-  now: number,
 ): ReadonlySet<string> {
   const live = new Set<string>()
   for (const span of spans) {
-    if (live.has(span.trace_id)) continue
-    if (
-      isPendingSpan(span) ||
-      now - toMs(span.end_time_unix_nano) <= LIVE_END_SLACK_MS
-    ) {
-      live.add(span.trace_id)
-    }
+    if (isPendingSpan(span)) live.add(span.trace_id)
   }
   return live
 }
@@ -129,11 +130,13 @@ export function rowRootFilterKeys(row: TraceListItem): SpanFilterKeys {
  * One reconcile pass: refresh `verdicts` from the bars currently in the
  * feed, seed visible-root verdicts from the rows themselves, drop entries
  * for traces gone from both the feed and the list, and return the rows
- * that survive (unknown verdicts stay visible, and so do rows in
- * `liveTraces` — a running trace's negative verdict is a guess, its
- * visible spans may simply not have closed yet). Verdicts are monotone
- * within a selection: `true` sticks, `false` re-evaluates. Mutates
- * `verdicts` — the hook owns the map across renders. Exported for tests.
+ * that survive: a proven-visible verdict, a failed trace, or a trace still
+ * running (the row's `pending` status, or a pending snapshot in the feed
+ * via `liveTraces`) — a running trace's negative verdict is a guess, its
+ * visible spans may simply not have closed yet. Unknown verdicts hide.
+ * Verdicts are monotone within a selection: `true` sticks, `false`
+ * re-evaluates. Mutates `verdicts` — the hook owns the map across renders.
+ * Exported for tests.
  */
 export function reconcileTraceVisibility(
   verdicts: Map<string, boolean>,
@@ -175,7 +178,8 @@ export function reconcileTraceVisibility(
   const kept = rows.filter(
     (r) =>
       r.status === 'error' ||
-      verdicts.get(r.traceId) !== false ||
+      r.status === 'pending' ||
+      verdicts.get(r.traceId) === true ||
       liveTraces.has(r.traceId),
   )
   // Identity-stable when nothing is hidden, so downstream memos hold.
@@ -220,7 +224,12 @@ function verdictBars(spans: readonly StoredSpan[]): TimelineSpan[] {
  * verdicts: a visible span proves visibility, but "all hidden" might just
  * mean the visible spans were cut off. A `true` verdict already in the
  * cache is never downgraded — the read raced a feed frame that proved
- * visibility after the snapshot was taken. Exported for tests.
+ * visibility after the snapshot was taken.
+ *
+ * A trace the read finds still RUNNING (a pending snapshot among its
+ * spans) gets no negative verdict either — its visible work may not have
+ * closed yet. Those ids are returned so the caller can read them again
+ * once they settle. Exported for tests.
  */
 export function mergeFetchedVerdicts(
   verdicts: Map<string, boolean>,
@@ -228,7 +237,7 @@ export function mergeFetchedVerdicts(
   spans: readonly StoredSpan[],
   selection: SpanFilterSelection,
   spanLimit: number = FETCH_SPAN_LIMIT,
-): void {
+): ReadonlySet<string> {
   const visible = new Set<string>()
   for (const bar of verdictBars(spans)) {
     if (bar.traceId && !isSpanBarHidden(bar, selection)) {
@@ -236,12 +245,16 @@ export function mergeFetchedVerdicts(
     }
   }
   const truncated = spans.length >= spanLimit
+  const running = pendingTraceIds(spans)
+  const undecided = new Set<string>()
   for (const traceId of requested) {
     if (visible.has(traceId)) verdicts.set(traceId, true)
+    else if (running.has(traceId)) undecided.add(traceId)
     else if (!truncated && !verdicts.get(traceId)) {
       verdicts.set(traceId, false)
     }
   }
+  return undecided
 }
 
 export function useSpanFilteredTraceRows(
@@ -259,25 +272,26 @@ export function useSpanFilteredTraceRows(
   // reference means the selection changed and every cached verdict is
   // stale. `requested` remembers which traces already went through a
   // composition read (in-flight, done, or failed) so they are asked once
-  // per selection.
+  // per selection — except a trace the read found still running, which is
+  // asked once more after its row settles.
   const cacheRef = useRef<{
     selection: SpanFilterSelection
     verdicts: Map<string, boolean>
-    requested: Set<string>
+    requested: Map<string, 'settled' | 'running'>
   } | null>(null)
 
   // Bumped when a composition read lands verdicts, to re-run the memo.
   const [fetchTick, setFetchTick] = useState(0)
 
   // fetchTick isn't read in the body — it signals `cache.verdicts` grew.
-  // The liveness set is derived from the feed at reconcile time (feed
+  // The running set is derived from the feed at reconcile time (feed
   // frames arrive continuously while anything is live, so it stays fresh
   // without its own clock).
   // biome-ignore lint/correctness/useExhaustiveDependencies: see above
   const visibleRows = useMemo(() => {
     let cache = cacheRef.current
     if (!cache || cache.selection !== selection) {
-      cache = { selection, verdicts: new Map(), requested: new Set() }
+      cache = { selection, verdicts: new Map(), requested: new Map() }
       cacheRef.current = cache
     }
     return reconcileTraceVisibility(
@@ -285,7 +299,7 @@ export function useSpanFilteredTraceRows(
       bars,
       rows,
       selection,
-      liveTraceIds(feedSpans, Date.now()),
+      pendingTraceIds(feedSpans),
     )
   }, [rows, bars, feedSpans, selection, fetchTick])
 
@@ -299,14 +313,20 @@ export function useSpanFilteredTraceRows(
   useEffect(() => {
     const cache = cacheRef.current
     if (!cache || cache.selection !== selection) return
+    // Never read, or read while still running and settled since — a
+    // running row is visible on its own and is not re-read until it
+    // settles, so a long turn costs one read at its start and one at its
+    // end, not one per list refresh.
     const unknown = rows
-      .filter(
-        (r) =>
-          !cache.verdicts.has(r.traceId) && !cache.requested.has(r.traceId),
-      )
+      .filter((r) => {
+        if (cache.verdicts.has(r.traceId)) return false
+        const requested = cache.requested.get(r.traceId)
+        if (requested === undefined) return true
+        return requested === 'running' && r.status !== 'pending'
+      })
       .map((r) => r.traceId)
     if (unknown.length === 0) return
-    for (const traceId of unknown) cache.requested.add(traceId)
+    for (const traceId of unknown) cache.requested.set(traceId, 'settled')
     void (async () => {
       for (let i = 0; i < unknown.length; i += FETCH_TRACE_CHUNK) {
         const chunk = unknown.slice(i, i + FETCH_TRACE_CHUNK)
@@ -318,11 +338,19 @@ export function useSpanFilteredTraceRows(
             limit: FETCH_SPAN_LIMIT,
           })
           if (cacheRef.current !== cache) return
-          mergeFetchedVerdicts(cache.verdicts, chunk, res.spans, selection)
+          const running = mergeFetchedVerdicts(
+            cache.verdicts,
+            chunk,
+            res.spans,
+            selection,
+          )
+          for (const traceId of running) {
+            cache.requested.set(traceId, 'running')
+          }
           setFetchTick((t) => t + 1)
         } catch {
           // Traces unavailable (memory exporter off, transient error) —
-          // the rows simply stay visible.
+          // the rows stay as they are until the feed decides.
         }
       }
     })()

--- a/console/web/src/pages/TracesV2/hooks/useTraceData.test.ts
+++ b/console/web/src/pages/TracesV2/hooks/useTraceData.test.ts
@@ -3,10 +3,31 @@ import {
   buildTraceListRequestParams,
   filterHiddenTraceRows,
   hiddenFunctionsKey,
+  mergeNewTraceIds,
   shouldDeferTraceUpdate,
   type TraceListItem,
   traceTotalForResponse,
 } from './useTraceData'
+
+describe('mergeNewTraceIds', () => {
+  it('keeps rows still flashing when the next answer adds more', () => {
+    const merged = mergeNewTraceIds(
+      new Set(['a']),
+      new Set(['b']),
+      new Set(['a', 'b', 'c']),
+    )
+    expect([...merged].sort()).toEqual(['a', 'b'])
+  })
+
+  it('drops ids that left the page so the set stays bounded', () => {
+    const merged = mergeNewTraceIds(
+      new Set(['gone', 'a']),
+      new Set(['b']),
+      new Set(['a', 'b']),
+    )
+    expect([...merged].sort()).toEqual(['a', 'b'])
+  })
+})
 
 describe('shouldDeferTraceUpdate', () => {
   it('renders the first answer of an empty scope while hovered', () => {

--- a/console/web/src/pages/TracesV2/hooks/useTraceData.ts
+++ b/console/web/src/pages/TracesV2/hooks/useTraceData.ts
@@ -7,6 +7,7 @@ import {
   type TracesFilterParams,
   type TracesResponse,
 } from '../api/traces'
+import { createRefetchCoalescer } from '../lib/refetchCoalescer'
 import { withHiddenFunctionExclusions } from '../lib/traceFilters'
 import {
   fingerprintTraceList,
@@ -19,6 +20,11 @@ const DEFAULT_TRACE_PAGE_SIZE = 50
  *  already coalesces to ~one tick per 300ms window; this only collapses the
  *  invalidate → POST round-trips of a burst of consecutive windows. */
 const ACTIVITY_REFETCH_DEBOUNCE_MS = 250
+/** Floor between two consecutive activity-driven refetch STARTS of the list
+ *  and of the group aggregate. Under sustained activity the engine sees one
+ *  scan per surface per second at most, and the rows update at a steady
+ *  cadence instead of in bursts (see `createRefetchCoalescer`). */
+export const ACTIVITY_REFETCH_MIN_INTERVAL_MS = 1_000
 /** Minimum gap between activity-driven reseeds of a filtered/searched list.
  *  The response is compact, but child-span search still scans the engine's
  *  store; riding the short tick debounce would re-run that scan back-to-back. */
@@ -94,6 +100,23 @@ export function filterHiddenTraceRows(
   return traces.filter(
     (trace) => !(trace.functionId && hidden.includes(trace.functionId)),
   )
+}
+
+/**
+ * Rows still playing their arrival flash keep it when the next answer lands:
+ * replacing the set would cut the animation short on every refetch during a
+ * busy stretch. Ids no longer on the page are dropped so the set stays
+ * bounded even where `animationend` never fires (reduced motion).
+ */
+export function mergeNewTraceIds(
+  previous: ReadonlySet<string>,
+  fresh: ReadonlySet<string>,
+  listed: ReadonlySet<string>,
+): Set<string> {
+  const next = new Set<string>()
+  for (const id of previous) if (listed.has(id)) next.add(id)
+  for (const id of fresh) next.add(id)
+  return next
 }
 
 export function traceTotalForResponse(
@@ -264,7 +287,9 @@ export function useTraceData({
         for (const id of currentIds) {
           if (!prevTraceIdsRef.current.has(id)) freshIds.add(id)
         }
-        if (freshIds.size > 0) setNewTraceIds(freshIds)
+        if (freshIds.size > 0) {
+          setNewTraceIds((prev) => mergeNewTraceIds(prev, freshIds, currentIds))
+        }
       }
       prevTraceIdsRef.current = currentIds
 
@@ -296,6 +321,14 @@ export function useTraceData({
   // client-side append/merge to drift from the server's view. Pause /
   // tab-hidden freeze it; reconnect and tab-visible re-seed once to recover
   // anything missed while away. Subscribes once for the hook's lifetime.
+  //
+  // Ticks never CANCEL a refetch in flight: each surface runs one scan at a
+  // time, a tick that lands mid-scan queues exactly one trailing rerun, and
+  // consecutive scans keep a 1s floor. Invalidating on every tick used to
+  // cancel the in-flight fetch client-side while the engine kept executing
+  // it — under a busy session the overlapping scans pushed latency past the
+  // tick interval and the list froze until the activity paused, then jumped
+  // (MOT-4621). See `createRefetchCoalescer`.
   const qc = useQueryClient()
   const isPausedRef = useRef(isPaused)
   useEffect(() => {
@@ -317,51 +350,37 @@ export function useTraceData({
 
     const isHidden = () =>
       typeof document !== 'undefined' && document.visibilityState === 'hidden'
-    // A search_all_spans seed still performs an engine-side scan. Its reseed
-    // rides a trailing cooldown so a busy session cannot re-run it back-to-back.
-    let reseedCooldownTimer: ReturnType<typeof setTimeout> | undefined
-    let lastTracesReseed = 0
-    const reseedTraces = () => {
-      lastTracesReseed = Date.now()
-      qc.invalidateQueries({ queryKey: ['traces'] })
-    }
-    const throttledFilteredReseed = () => {
-      const wait = Math.max(
-        0,
-        lastTracesReseed + FILTERED_RESEED_COOLDOWN_MS - Date.now(),
-      )
-      if (wait === 0) {
-        reseedTraces()
-        return
-      }
-      if (reseedCooldownTimer !== undefined) return
-      reseedCooldownTimer = setTimeout(() => {
-        reseedCooldownTimer = undefined
-        reseedTraces()
-      }, wait)
-    }
-    const refetchGroups = () => {
-      qc.invalidateQueries({ queryKey: ['traceGroups'] })
-      qc.invalidateQueries({ queryKey: ['traceGroupMembers'] })
-    }
-    const refetchAll = () => {
-      reseedTraces()
-      refetchGroups()
-    }
+    const canRefetch = () => !disposed && !isPausedRef.current && !isHidden()
 
-    let refetchTimer: ReturnType<typeof setTimeout> | undefined
-    const scheduleRefetch = () => {
-      if (refetchTimer !== undefined) return
-      refetchTimer = setTimeout(() => {
-        refetchTimer = undefined
-        if (disposed || isPausedRef.current || isHidden()) return
-        if (searchAllSeedRef.current) {
-          throttledFilteredReseed()
-          refetchGroups()
-        } else {
-          refetchAll()
-        }
-      }, ACTIVITY_REFETCH_DEBOUNCE_MS)
+    // `cancelRefetch: false` keeps react-query from abandoning a fetch that is
+    // already running; the coalescer guarantees there is at most one anyway.
+    const invalidate = (queryKey: readonly unknown[]) =>
+      qc.invalidateQueries({ queryKey }, { cancelRefetch: false })
+
+    // A search_all_spans seed still performs an engine-side scan: its reseed
+    // rides a longer cooldown so a busy session cannot re-run it back-to-back.
+    const traces = createRefetchCoalescer({
+      run: () => invalidate(['traces']),
+      debounceMs: ACTIVITY_REFETCH_DEBOUNCE_MS,
+      minIntervalMs: () =>
+        searchAllSeedRef.current
+          ? FILTERED_RESEED_COOLDOWN_MS
+          : ACTIVITY_REFETCH_MIN_INTERVAL_MS,
+      shouldRun: canRefetch,
+    })
+    const groups = createRefetchCoalescer({
+      run: () =>
+        Promise.all([
+          invalidate(['traceGroups']),
+          invalidate(['traceGroupMembers']),
+        ]),
+      debounceMs: ACTIVITY_REFETCH_DEBOUNCE_MS,
+      minIntervalMs: ACTIVITY_REFETCH_MIN_INTERVAL_MS,
+      shouldRun: canRefetch,
+    })
+    const refetchAll = () => {
+      traces.request()
+      groups.request()
     }
 
     void (async () => {
@@ -370,7 +389,7 @@ export function useTraceData({
 
       const offActivity = startTraceActivityFeed(client, () => {
         if (isPausedRef.current || isHidden()) return
-        scheduleRefetch()
+        refetchAll()
       })
 
       const offConn = client.addConnectionStateListener((state) => {
@@ -393,20 +412,14 @@ export function useTraceData({
         offActivity()
         offConn()
         offVisibility?.()
-        if (refetchTimer !== undefined) {
-          clearTimeout(refetchTimer)
-          refetchTimer = undefined
-        }
-        if (reseedCooldownTimer !== undefined) {
-          clearTimeout(reseedCooldownTimer)
-          reseedCooldownTimer = undefined
-        }
       }
     })()
 
     return () => {
       disposed = true
       stop?.()
+      traces.dispose()
+      groups.dispose()
     }
   }, [qc])
 

--- a/console/web/src/pages/TracesV2/hooks/useTraceGroups.ts
+++ b/console/web/src/pages/TracesV2/hooks/useTraceGroups.ts
@@ -1,13 +1,15 @@
 import { useQuery } from '@tanstack/react-query'
+import { useMemo } from 'react'
 import {
   fetchTracesGroupBy,
   type TraceGroup,
   type TracesGroupByResponse,
 } from '../api/traces'
 import type { GroupByOption } from '../lib/groupTraces'
-import { isGroupByUnavailable } from '../lib/groupTraces'
+import { isGroupByUnavailable, orderTraceGroups } from '../lib/groupTraces'
 
 const DEFAULT_GROUP_LIMIT = 100
+const EMPTY_GROUPS: readonly TraceGroup[] = []
 
 export interface UseTraceGroupsOptions {
   /** When 'none', the hook is disabled (no network calls). */
@@ -23,7 +25,7 @@ export interface UseTraceGroupsOptions {
 }
 
 export interface UseTraceGroupsReturn {
-  groups: TraceGroup[]
+  groups: readonly TraceGroup[]
   isLoading: boolean
   /**
    * Set when the engine doesn't expose `engine::traces::group_by` (older
@@ -79,8 +81,14 @@ export function useTraceGroups({
     },
   })
 
+  // Deterministic order: the engine's tie order changes call to call.
+  const groups = useMemo(
+    () => orderTraceGroups(data?.groups ?? EMPTY_GROUPS),
+    [data],
+  )
+
   return {
-    groups: data?.groups ?? [],
+    groups,
     isLoading,
     unavailable: !!error && isGroupByUnavailable(error),
     refetch,

--- a/console/web/src/pages/TracesV2/lib/groupTraces.test.ts
+++ b/console/web/src/pages/TracesV2/lib/groupTraces.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import type { TraceGroup } from '../api/traces'
+import { orderTraceGroups } from './groupTraces'
+
+function group(value: string, firstSeenMs: number): TraceGroup {
+  return {
+    value,
+    trace_ids: [`${value}-t`],
+    span_count: 1,
+    first_seen_ms: firstSeenMs,
+    last_seen_ms: firstSeenMs + 1,
+    duration_ms: 1,
+    error_count: 0,
+  }
+}
+
+describe('orderTraceGroups', () => {
+  it('orders newest first and breaks first_seen ties by value, whatever the input order', () => {
+    // Two sessions spawned in the same millisecond: the engine returns
+    // them in hash-map order, which differs call to call.
+    const a = group('a', 1_000)
+    const b = group('b', 1_000)
+    const newer = group('z', 2_000)
+    expect(orderTraceGroups([b, newer, a]).map((g) => g.value)).toEqual([
+      'z',
+      'a',
+      'b',
+    ])
+    expect(orderTraceGroups([a, b, newer]).map((g) => g.value)).toEqual([
+      'z',
+      'a',
+      'b',
+    ])
+  })
+
+  it('returns the input array when it is already in order', () => {
+    const groups = [group('z', 2_000), group('a', 1_000)]
+    expect(orderTraceGroups(groups)).toBe(groups)
+  })
+})

--- a/console/web/src/pages/TracesV2/lib/groupTraces.ts
+++ b/console/web/src/pages/TracesV2/lib/groupTraces.ts
@@ -118,6 +118,26 @@ export function groupHeadingIsOpaque(
   return option === 'iii.session.id' || option === 'iii.message.id'
 }
 
+/**
+ * The order the grouped list renders: newest group first by `first_seen_ms`,
+ * ties broken by the grouped value. The engine sorts by `first_seen_ms`
+ * alone over a hash map, so two groups whose first spans share a
+ * millisecond — sessions spawned together, parallel agents — come back in
+ * a different order on every refetch, and the rows swapped places about
+ * once a second under activity (MOT-4621). Returns the input when it is
+ * already in order, so memos downstream hold.
+ */
+export function orderTraceGroups(
+  groups: readonly TraceGroup[],
+): readonly TraceGroup[] {
+  const sorted = [...groups].sort(
+    (a, b) => b.first_seen_ms - a.first_seen_ms || (a.value < b.value ? -1 : 1),
+  )
+  return sorted.every((group, index) => group === groups[index])
+    ? groups
+    : sorted
+}
+
 function formatDurationMs(ms: number): string {
   if (ms < 1) return '<1ms'
   if (ms < 1_000) return `${Math.round(ms)}ms`

--- a/console/web/src/pages/TracesV2/lib/refetchCoalescer.test.ts
+++ b/console/web/src/pages/TracesV2/lib/refetchCoalescer.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRefetchCoalescer } from './refetchCoalescer'
+
+interface Deferred {
+  resolve: () => void
+  reject: (error: unknown) => void
+}
+
+function makeRun() {
+  const pending: Deferred[] = []
+  const run = vi.fn(
+    () =>
+      new Promise<void>((resolve, reject) => {
+        pending.push({ resolve, reject })
+      }),
+  )
+  return { run, pending }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('createRefetchCoalescer', () => {
+  it('collapses a burst of notifications into one refetch after the debounce', () => {
+    const { run } = makeRun()
+    const c = createRefetchCoalescer({ run, debounceMs: 250, minIntervalMs: 0 })
+    c.request()
+    c.request()
+    vi.advanceTimersByTime(100)
+    c.request()
+    expect(run).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(250)
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+
+  it('never overlaps refetches: a mid-flight notification runs exactly once, after settle', async () => {
+    const { run, pending } = makeRun()
+    const c = createRefetchCoalescer({ run, debounceMs: 250, minIntervalMs: 0 })
+    c.request()
+    vi.advanceTimersByTime(250)
+    expect(run).toHaveBeenCalledTimes(1)
+    expect(c.inFlight).toBe(true)
+
+    // ticks keep landing while the engine is still answering
+    c.request()
+    c.request()
+    vi.advanceTimersByTime(2_000)
+    expect(run).toHaveBeenCalledTimes(1)
+
+    pending[0].resolve()
+    await vi.advanceTimersByTimeAsync(250)
+    expect(run).toHaveBeenCalledTimes(2)
+    expect(c.inFlight).toBe(true)
+
+    // nothing arrived during the rerun: it settles and stays quiet
+    pending[1].resolve()
+    await vi.advanceTimersByTimeAsync(5_000)
+    expect(run).toHaveBeenCalledTimes(2)
+    expect(c.inFlight).toBe(false)
+  })
+
+  it('spaces consecutive starts by the minimum interval', async () => {
+    const { run, pending } = makeRun()
+    const c = createRefetchCoalescer({
+      run,
+      debounceMs: 250,
+      minIntervalMs: 1_000,
+    })
+    c.request()
+    vi.advanceTimersByTime(250)
+    expect(run).toHaveBeenCalledTimes(1)
+    pending[0].resolve()
+    await vi.advanceTimersByTimeAsync(0)
+
+    // a fast answer plus an immediate tick: the floor (1s from the previous
+    // START), not the debounce, paces the next refetch
+    c.request()
+    await vi.advanceTimersByTimeAsync(900)
+    expect(run).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(100)
+    expect(run).toHaveBeenCalledTimes(2)
+  })
+
+  it('reads a dynamic minimum interval when arming', async () => {
+    const { run, pending } = makeRun()
+    let floor = 0
+    const c = createRefetchCoalescer({
+      run,
+      debounceMs: 100,
+      minIntervalMs: () => floor,
+    })
+    c.request()
+    await vi.advanceTimersByTimeAsync(100)
+    pending[0].resolve()
+    await vi.advanceTimersByTimeAsync(0)
+    floor = 5_000
+    c.request()
+    await vi.advanceTimersByTimeAsync(4_000)
+    expect(run).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(run).toHaveBeenCalledTimes(2)
+  })
+
+  it('drops a refetch the gate refuses and accepts a later one', () => {
+    const { run } = makeRun()
+    let open = false
+    const c = createRefetchCoalescer({
+      run,
+      debounceMs: 100,
+      minIntervalMs: 0,
+      shouldRun: () => open,
+    })
+    c.request()
+    vi.advanceTimersByTime(100)
+    expect(run).not.toHaveBeenCalled()
+    open = true
+    c.request()
+    vi.advanceTimersByTime(100)
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+
+  it('frees the slot when the refetch rejects', async () => {
+    const { run, pending } = makeRun()
+    const c = createRefetchCoalescer({ run, debounceMs: 100, minIntervalMs: 0 })
+    c.request()
+    vi.advanceTimersByTime(100)
+    pending[0].reject(new Error('engine busy'))
+    await vi.advanceTimersByTimeAsync(0)
+    expect(c.inFlight).toBe(false)
+    c.request()
+    await vi.advanceTimersByTimeAsync(100)
+    expect(run).toHaveBeenCalledTimes(2)
+  })
+
+  it('does nothing after dispose, including the trailing rerun', async () => {
+    const { run, pending } = makeRun()
+    const c = createRefetchCoalescer({ run, debounceMs: 100, minIntervalMs: 0 })
+    c.request()
+    vi.advanceTimersByTime(100)
+    c.request() // would be the trailing rerun
+    c.dispose()
+    pending[0].resolve()
+    await vi.advanceTimersByTimeAsync(1_000)
+    c.request()
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+})

--- a/console/web/src/pages/TracesV2/lib/refetchCoalescer.ts
+++ b/console/web/src/pages/TracesV2/lib/refetchCoalescer.ts
@@ -1,0 +1,130 @@
+/**
+ * Coalesces a stream of "something changed" notifications into bounded
+ * refetches: at most one refetch in flight, exactly one trailing rerun for
+ * notifications that landed mid-flight, and a floor on the interval between
+ * consecutive starts.
+ *
+ * Why the trace surfaces cannot simply invalidate on every activity tick:
+ * react-query's `invalidateQueries` CANCELS the fetch already in flight
+ * (`cancelRefetch` defaults to true) and starts another. That cancellation is
+ * client-side only — the engine keeps executing the abandoned scan — so under
+ * sustained span activity (the `trace` trigger ticks every ~300ms) the engine
+ * accumulates overlapping scans, their latency climbs past the tick interval,
+ * and every response is discarded before it can land. Measured live
+ * (MOT-4621, four concurrent harness turns): six `engine::traces::list` calls
+ * in flight at once, p50 1.9s and max 5.9s per call, and a list that stayed
+ * frozen for a minute of activity, then jumped to the final state in one
+ * batch — rows appearing, flashing and switching status all at once.
+ *
+ * With the coalescer a busy engine sees one scan per surface at a time, the
+ * list settles after every burst (the trailing rerun carries whatever the
+ * in-flight scan missed), and updates arrive at a steady cadence instead of
+ * in bursts.
+ */
+
+type TimerId = ReturnType<typeof setTimeout>
+
+export interface RefetchCoalescerOptions {
+  /** The refetch. Its promise settling (either way) frees the in-flight slot. */
+  run: () => Promise<unknown>
+  /** Notifications closer together than this collapse into one refetch. */
+  debounceMs: number
+  /** Minimum ms between two consecutive refetch STARTS. A function is read
+   *  each time a refetch is armed, so callers can vary it with their state
+   *  (e.g. a costlier seed under a text search). */
+  minIntervalMs: number | (() => number)
+  /** Checked right before a refetch starts; `false` drops it (a later
+   *  notification arms a fresh one). Paused / hidden-tab gates live here. */
+  shouldRun?: () => boolean
+  /** Clock and timers, injectable for tests. */
+  now?: () => number
+  setTimeout?: (fn: () => void, ms: number) => TimerId
+  clearTimeout?: (id: TimerId) => void
+}
+
+export interface RefetchCoalescer {
+  /** A change notification landed. */
+  request(): void
+  /** True while a refetch is running. */
+  readonly inFlight: boolean
+  /** Drop the armed timer and any pending rerun; an in-flight refetch still
+   *  settles on its own but nothing follows it. */
+  dispose(): void
+}
+
+export function createRefetchCoalescer(
+  options: RefetchCoalescerOptions,
+): RefetchCoalescer {
+  const now = options.now ?? (() => Date.now())
+  const schedule =
+    options.setTimeout ?? ((fn: () => void, ms: number) => setTimeout(fn, ms))
+  const cancel = options.clearTimeout ?? ((id: TimerId) => clearTimeout(id))
+  const minInterval = () =>
+    typeof options.minIntervalMs === 'function'
+      ? options.minIntervalMs()
+      : options.minIntervalMs
+
+  let timer: TimerId | undefined
+  let inFlight = false
+  let rerun = false
+  let disposed = false
+  let lastStart = Number.NEGATIVE_INFINITY
+
+  const settle = () => {
+    inFlight = false
+    if (disposed || !rerun) return
+    rerun = false
+    arm()
+  }
+
+  const start = () => {
+    inFlight = true
+    lastStart = now()
+    let promise: Promise<unknown>
+    try {
+      promise = Promise.resolve(options.run())
+    } catch (error) {
+      promise = Promise.reject(error)
+    }
+    // A failed refetch must not wedge the slot — the next notification
+    // simply tries again.
+    promise.then(settle, settle)
+  }
+
+  const arm = () => {
+    if (disposed || timer !== undefined) return
+    const wait = Math.max(options.debounceMs, lastStart + minInterval() - now())
+    timer = schedule(() => {
+      timer = undefined
+      if (disposed) return
+      if (inFlight) {
+        rerun = true
+        return
+      }
+      if (options.shouldRun && !options.shouldRun()) return
+      start()
+    }, wait)
+  }
+
+  return {
+    request() {
+      if (disposed) return
+      if (inFlight) {
+        rerun = true
+        return
+      }
+      arm()
+    },
+    get inFlight() {
+      return inFlight
+    },
+    dispose() {
+      disposed = true
+      rerun = false
+      if (timer !== undefined) {
+        cancel(timer)
+        timer = undefined
+      }
+    },
+  }
+}


### PR DESCRIPTION
Fixes MOT-4621

## Summary

- add `lib/refetchCoalescer.ts`: one refetch in flight per surface (list, group aggregate, timeline strip), exactly one trailing rerun for ticks that land mid-flight, a 1s floor between starts, `cancelRefetch: false`
- hide span-filtered rows whose composition verdict is still unknown until a read or the feed proves visible work; keep rows that are still running (`pending` status or a pending snapshot in the feed), record no verdict for a trace a read finds running and read it again once it settles; drop the "ended within 10s" liveness slack
- keep the span-filter selection identity stable across producer-hidden refetches (`structuralSharing` on equal id sets)
- bound the strip's summary seed to 120 traces (was 500)
- keep grouped member rows on screen while the count-keyed refetch loads (`keepPreviousData`); stop cutting a row's arrival flash short when the next answer lands

## Context

Reported from a three-agent orchestration run: new traces "jump a lot" and rows keep switching states. Reproduced with four concurrent harness turns (~2 turns/s, ~40 spans each) against a local engine, watching the page with Playwright (row sampling every 100ms + WebSocket frame capture). Four independent causes, all in the console:

1. **Every `trace` trigger tick invalidated the list, the group aggregate and the strip seed.** react-query cancels the fetch already in flight on `invalidateQueries` (`cancelRefetch` defaults to `true`) — client-side only, the engine keeps executing the abandoned scan. Under sustained ticks the scans piled up (six `engine::traces::list` in flight at once, p50 1.9s, max 5.9s) and every answer was discarded before it landed: the list froze while activity lasted, then jumped to the final state in one batch, with dozens of rows appearing, flashing and changing status at once.
2. **Rows with a hidden root were shown while their verdict was unknown.** Every hidden bookkeeping trace (`harness::state::list`, `*::on-functions-change`, `session::messages`) flashed into the live list and vanished when its composition read landed, shifting everything below it.
3. **The span-filter selection identity changed on every `engine::functions::list` refetch** (a fresh Set with equal contents), resetting the verdict cache and blinking rows out and back in.
4. **The strip re-seeded 500 trace summaries per tick** (~157KB, ~8s per call under load) — the engine loads every span of those traces to aggregate them, the single heaviest query on the connection.

## Validation

Same load, flat list, 60s of observation, before → after:

| metric | before | after |
|---|---|---|
| concurrent `traces::list` calls in flight | 6 | 1 |
| rows that vanished and came back | 2 | 0 |
| reorders / re-flashes | 0 / 0 | 0 / 0 |
| UI updates during the load | frozen until activity paused, then one batch | steady, every ~1–2s |

The grouped view now updates counts continuously under the same load (44 count changes in 55s vs. none before). Unit tests: 207 pass in `TracesV2` + `lib` (new coverage for the coalescer, `mergeFetchedVerdicts`, `pendingTraceIds`, `mergeNewTraceIds`, `sameHiddenIdSet`); `pnpm typecheck` clean; biome clean on the touched files. Two failures in `MessageList.test.tsx` are pre-existing on `main`.

## Notes

- Live updates depend on the engine delivering the `trace` trigger in the console's namespace — engines older than iii-hq/iii#2101 (2026-08-28) only deliver it in `default`, so a namespaced console never refreshes; that is engine-side and unrelated to this change.
- Inherent to the data model and left alone: the `iii.tag.message` row label arrives after the root, so a turn row relabels from `execute harness::send` to the message text once the tag-bearing span closes. Stamping the tag on the root span would be a harness change.

https://claude.ai/code/session_01Ass3crjJFx4s776BYMpdxw


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented visible trace rows from disappearing and reappearing during refreshes.
  - Improved filtering of unknown, pending, running, and error traces.
  - Added deferred checks and retries for composition-based filtering.
  - Preserved new-trace indicators and hidden-function filtering across updates.
  - Stabilized the ordering of grouped trace results.

- **Performance**
  - Smoothed activity-driven refreshes and reduced summary loading work.
  - Preserved existing results while grouped trace data refreshes.
  - Reduced unnecessary updates when hidden-function selections are unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->