### PR TITLE
(MOT-4621) feat(console,harness): hold the live traces list while it is read; label turn traces from the root

### DIFF
--- a/console/web/src/pages/TracesV2/components/TraceFilters.test.tsx
+++ b/console/web/src/pages/TracesV2/components/TraceFilters.test.tsx
@@ -19,5 +19,42 @@ describe('StatsBlock', () => {
     expect(html).toContain('50 traces on this page, 2601 total matching traces')
     expect(html).toContain('Page errors')
     expect(html).toContain('Page avg')
+    expect(html).not.toContain('data-trace-list-held')
+  })
+
+  it('shows the held-new segment as a quiet count, or "latest" from a later page', () => {
+    const stats = {
+      totalTraces: 10,
+      pageTraceCount: 10,
+      errorCount: 0,
+      avgDuration: 1,
+    }
+    const onPage1 = renderToStaticMarkup(
+      <StatsBlock
+        stats={stats}
+        heldNew={{ count: 3, onPage1: true, onShow: () => {} }}
+      />,
+    )
+    expect(onPage1).toContain('data-trace-list-held="3"')
+    expect(onPage1).toContain('show 3 new traces')
+    expect(onPage1).toContain('>new<')
+
+    const later = renderToStaticMarkup(
+      <StatsBlock
+        stats={stats}
+        heldNew={{ count: 3, onPage1: false, onShow: () => {} }}
+      />,
+    )
+    expect(later).toContain('show the latest traces on page 1')
+    expect(later).toContain('>latest<')
+
+    expect(
+      renderToStaticMarkup(
+        <StatsBlock
+          stats={stats}
+          heldNew={{ count: 0, onPage1: true, onShow: () => {} }}
+        />,
+      ),
+    ).not.toContain('data-trace-list-held')
   })
 })

--- a/console/web/src/pages/TracesV2/components/TraceFilters.tsx
+++ b/console/web/src/pages/TracesV2/components/TraceFilters.tsx
@@ -20,6 +20,7 @@
 
 import {
   AlertTriangle,
+  ArrowUp,
   ChevronDown,
   Hash,
   Search,
@@ -58,6 +59,13 @@ export interface TraceFiltersProps {
     errorCount: number
     avgDuration: number
   }
+  /**
+   * Rows the live list is holding back while the user reads it (see
+   * index.tsx). Rendered as one more segment of the stats block — a quiet
+   * "N new" next to the counts rather than anything over the rows — that
+   * lands them on click.
+   */
+  heldNew?: HeldNewTraces
   /** Rendered first in the control row (the saved-views dropdown). */
   leading?: React.ReactNode
   /**
@@ -332,10 +340,53 @@ function SearchInput({
   )
 }
 
-export function StatsBlock({ stats }: { stats: TraceFiltersProps['stats'] }) {
+export interface HeldNewTraces {
+  /** held rows that will show once landed */
+  count: number
+  /** on a later page the segment offers the latest traces on page 1 */
+  onPage1: boolean
+  onShow: () => void
+}
+
+export function StatsBlock({
+  stats,
+  heldNew,
+}: {
+  stats: TraceFiltersProps['stats']
+  heldNew?: HeldNewTraces
+}) {
   if (!stats) return null
+  const held = heldNew && heldNew.count > 0 ? heldNew : null
   return (
     <div className="flex items-stretch rounded-md bg-surface">
+      {held ? (
+        <button
+          type="button"
+          onClick={held.onShow}
+          data-trace-list-held={held.count}
+          className="flex items-center gap-1.5 rounded-l-md px-2.5 py-1 font-mono text-[11px] text-accent lowercase transition-colors hover:bg-surface-hover"
+          title={
+            held.onPage1
+              ? `${held.count} new ${held.count === 1 ? 'trace' : 'traces'} waiting — show them at the top`
+              : 'new traces arrived — show the latest on page 1'
+          }
+          aria-label={
+            held.onPage1
+              ? `show ${held.count} new ${held.count === 1 ? 'trace' : 'traces'}`
+              : 'show the latest traces on page 1'
+          }
+        >
+          <ArrowUp className="size-4" />
+          {held.onPage1 ? (
+            <>
+              <span className="tabular-nums">{held.count}</span>
+              <span>new</span>
+            </>
+          ) : (
+            <span>latest</span>
+          )}
+        </button>
+      ) : null}
       <div
         className="flex items-center gap-1.5 px-2.5 py-1 font-mono text-[11px] text-ink-faint lowercase"
         title={`${stats.pageTraceCount} traces on this page, ${stats.totalTraces} total matching traces`}
@@ -376,6 +427,7 @@ export function TraceFilters({
   onSearchChange,
   stats,
   leading,
+  heldNew,
   attributeKeySuggestions = [],
 }: TraceFiltersProps) {
   const [tempInputs, dispatchTempInputs] = useReducer(tempInputsReducer, {
@@ -699,7 +751,7 @@ export function TraceFilters({
         </button>
 
         <div className="ml-auto">
-          <StatsBlock stats={stats} />
+          <StatsBlock stats={stats} heldNew={heldNew} />
         </div>
       </div>
 

--- a/console/web/src/pages/TracesV2/components/timeline/TraceTimeline.tsx
+++ b/console/web/src/pages/TracesV2/components/timeline/TraceTimeline.tsx
@@ -548,6 +548,25 @@ export function TraceTimeline({
   // fitContent: ruler + packed lines, plus room for a classic (non-overlay)
   // horizontal scrollbar so it can't clip the bottom line
   const fitHeight = contentHeight + RULER_H + (scrollableX ? 14 : 0)
+  // On a LIVE trace the stage only grows. Every silent reload and every
+  // one-second live rebuild re-packs the lines, and a pending bar growing
+  // into a neighbour, a closed one settling, or the horizontal scrollbar
+  // coming and going moved the stage by a line (22px) or a scrollbar
+  // (14px) every second or two — with the detail open under its row
+  // (follow mode) everything below jumped along (MOT-4621). Once every
+  // span has closed the exact height applies again, so a finished trace
+  // never keeps stale room.
+  const live = detail.spans.some((s) => s.status === 'pending')
+  const stickyFitRef = useRef(0)
+  const stageHeight = useMemo(() => {
+    if (!live) {
+      stickyFitRef.current = 0
+      return fitHeight
+    }
+    const grown = Math.max(fitHeight, stickyFitRef.current)
+    stickyFitRef.current = grown
+    return grown
+  }, [live, fitHeight])
 
   const trackHover = (id: string) => (e: React.MouseEvent) => {
     if (dragRef.current?.active) return
@@ -634,7 +653,7 @@ export function TraceTimeline({
           'relative min-h-0',
           fitContent ? 'min-h-[120px] max-h-[60dvh]' : 'flex-1',
         )}
-        style={fitContent ? { height: fitHeight } : undefined}
+        style={fitContent ? { height: stageHeight } : undefined}
       >
         {/* filter menu, floating over the canvas below the ruler row:
             funnel expands on hover into the workers + span-group lists

--- a/console/web/src/pages/TracesV2/components/timeline/TraceTimeline.tsx
+++ b/console/web/src/pages/TracesV2/components/timeline/TraceTimeline.tsx
@@ -36,7 +36,14 @@
  * panel). Selection = 2px accent ring, hover = 1px ink ring.
  */
 
-import { Fragment, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import {
+  Fragment,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import { cn } from '@/lib/utils'
 import type { SpanFilterControls } from '../../lib/spanFilters'
 import { internalFamilyOf } from '../../lib/spanLabel'
@@ -92,6 +99,12 @@ export interface TraceTimelineProps {
 
 const PADDING_X = 16
 const RULER_FRACTIONS = [0, 0.25, 0.5, 0.75, 1] as const
+/** A trace with no pending span counts as SETTLED only after this long: a
+ *  running turn has nothing pending for a few milliseconds between two
+ *  engine calls, and shrinking the stage on that gap is the very jump the
+ *  grow-only rule below exists to prevent. */
+const SETTLE_MS = 3_000
+
 /** height of the sticky time ruler row inside the scrollport (h-5) */
 const RULER_H = 20
 /** vertical rhythm of the stacked lines */
@@ -553,20 +566,29 @@ export function TraceTimeline({
   // into a neighbour, a closed one settling, or the horizontal scrollbar
   // coming and going moved the stage by a line (22px) or a scrollbar
   // (14px) every second or two — with the detail open under its row
-  // (follow mode) everything below jumped along (MOT-4621). Once every
-  // span has closed the exact height applies again, so a finished trace
-  // never keeps stale room.
+  // (follow mode) everything below jumped along (MOT-4621). Once the trace
+  // has been quiet for `SETTLE_MS` the exact height applies again, so a
+  // finished trace never keeps stale room.
   const live = detail.spans.some((s) => s.status === 'pending')
+  const [settled, setSettled] = useState(!live)
+  useEffect(() => {
+    if (live) {
+      setSettled(false)
+      return
+    }
+    const timer = setTimeout(() => setSettled(true), SETTLE_MS)
+    return () => clearTimeout(timer)
+  }, [live])
   const stickyFitRef = useRef(0)
   const stageHeight = useMemo(() => {
-    if (!live) {
+    if (settled) {
       stickyFitRef.current = 0
       return fitHeight
     }
     const grown = Math.max(fitHeight, stickyFitRef.current)
     stickyFitRef.current = grown
     return grown
-  }, [live, fitHeight])
+  }, [settled, fitHeight])
 
   const trackHover = (id: string) => (e: React.MouseEvent) => {
     if (dragRef.current?.active) return

--- a/console/web/src/pages/TracesV2/hooks/useSpanFilteredTraceRows.test.ts
+++ b/console/web/src/pages/TracesV2/hooks/useSpanFilteredTraceRows.test.ts
@@ -11,6 +11,7 @@ import {
   reconcileTraceVisibility,
   rowRootFilterKeys,
   selectCompositionReads,
+  showsWithoutProbe,
 } from './useSpanFilteredTraceRows'
 import type { TraceListItem } from './useTraceData'
 
@@ -545,5 +546,26 @@ describe('pruneCompositionReads', () => {
     ])
     pruneCompositionReads(state, new Set(['listed']))
     expect([...state.keys()].sort()).toEqual(['gone-inflight', 'listed'])
+  })
+})
+
+describe('showsWithoutProbe', () => {
+  const sel = selection({ hiddenGroups: new Set(['harness::turn']) })
+
+  it('shows visible-rooted, running and failed rows right away', () => {
+    expect(showsWithoutProbe(row('t-1', 'harness::send'), sel)).toBe(true)
+    expect(
+      showsWithoutProbe(
+        row('t-2', 'harness::turn', { status: 'pending' }),
+        sel,
+      ),
+    ).toBe(true)
+    expect(
+      showsWithoutProbe(row('t-3', 'harness::turn', { status: 'error' }), sel),
+    ).toBe(true)
+  })
+
+  it('does not promise a hidden-rooted settled row', () => {
+    expect(showsWithoutProbe(row('t-4', 'harness::turn'), sel)).toBe(false)
   })
 })

--- a/console/web/src/pages/TracesV2/hooks/useSpanFilteredTraceRows.ts
+++ b/console/web/src/pages/TracesV2/hooks/useSpanFilteredTraceRows.ts
@@ -192,6 +192,24 @@ export function rowRootFilterKeys(row: TraceListItem): SpanFilterKeys {
 }
 
 /**
+ * Whether a listed row shows without waiting on the feed or a probe: it
+ * is failed, still running, or rooted in a visible span. Everything else
+ * is a hidden-rooted settled trace that hides until proven otherwise — the
+ * "new traces" pill counts held rows with this, so it never promises rows
+ * that would not appear. Exported for tests.
+ */
+export function showsWithoutProbe(
+  row: TraceListItem,
+  selection: SpanFilterSelection,
+): boolean {
+  return (
+    row.status === 'error' ||
+    row.status === 'pending' ||
+    !isSpanBarHidden(rowRootFilterKeys(row), selection)
+  )
+}
+
+/**
  * One reconcile pass: refresh `verdicts` from the bars currently in the
  * feed, seed visible-root verdicts from the rows themselves, drop entries
  * for traces gone from both the feed and the list, and return the rows

--- a/console/web/src/pages/TracesV2/hooks/useTraceData.test.ts
+++ b/console/web/src/pages/TracesV2/hooks/useTraceData.test.ts
@@ -3,11 +3,51 @@ import {
   buildTraceListRequestParams,
   filterHiddenTraceRows,
   hiddenFunctionsKey,
+  mergeHeldUpdates,
   mergeNewTraceIds,
   shouldDeferTraceUpdate,
   type TraceListItem,
   traceTotalForResponse,
 } from './useTraceData'
+
+function item(
+  traceId: string,
+  overrides: Partial<TraceListItem> = {},
+): TraceListItem {
+  return {
+    traceId,
+    rootOperation: 'execute fn',
+    status: 'ok',
+    startTime: 1,
+    spanCount: 1,
+    workers: ['w'],
+    ...overrides,
+  }
+}
+
+describe('mergeHeldUpdates', () => {
+  it('keeps the rows and their order, taking in-place updates only', () => {
+    const rendered = [item('a', { status: 'pending' }), item('b')]
+    const latest = [item('new'), item('b'), item('a', { status: 'ok' })]
+    const merged = mergeHeldUpdates(rendered, latest)
+    expect(merged.map((t) => t.traceId)).toEqual(['a', 'b'])
+    expect(merged[0].status).toBe('ok')
+    expect(merged[1]).toBe(latest[1])
+  })
+
+  it('returns the rendered array itself when nothing on screen changed', () => {
+    const a = item('a')
+    const rendered = [a]
+    expect(mergeHeldUpdates(rendered, [item('new'), a])).toBe(rendered)
+  })
+
+  it('keeps a row the latest answer no longer lists', () => {
+    const rendered = [item('a'), item('gone')]
+    expect(
+      mergeHeldUpdates(rendered, [item('a')]).map((t) => t.traceId),
+    ).toEqual(['a', 'gone'])
+  })
+})
 
 describe('mergeNewTraceIds', () => {
   it('keeps rows still flashing when the next answer adds more', () => {

--- a/console/web/src/pages/TracesV2/hooks/useTraceData.ts
+++ b/console/web/src/pages/TracesV2/hooks/useTraceData.ts
@@ -17,18 +17,25 @@ import {
 const DEFAULT_TRACE_PAGE_SIZE = 50
 
 /** Client-side debounce over activity ticks before refetching. The engine
- *  already coalesces to ~one tick per 300ms window; this only collapses the
- *  invalidate → POST round-trips of a burst of consecutive windows. */
-const ACTIVITY_REFETCH_DEBOUNCE_MS = 250
+ *  already coalesces to ~one tick per 300ms window and the coalescer below
+ *  keeps one refetch in flight, so this only needs to fold ticks that land
+ *  within the same frame or two — every millisecond here is on the path
+ *  between a turn starting and its row showing. */
+const ACTIVITY_REFETCH_DEBOUNCE_MS = 100
 /** Floor between two consecutive activity-driven refetch STARTS of the list
- *  and of the group aggregate. Under sustained activity the engine sees one
+ *  and of the group aggregate — every list shape, the session-scoped and
+ *  text-searched ones included. Under sustained activity the engine sees one
  *  scan per surface per second at most, and the rows update at a steady
- *  cadence instead of in bursts (see `createRefetchCoalescer`). */
+ *  cadence instead of in bursts (see `createRefetchCoalescer`).
+ *
+ *  The scoped/searched seeds used to ride a 10s cooldown instead: that
+ *  protected a full-span sweep (parallel multi-MB windows) that no longer
+ *  exists — `engine::traces::list` answers those shapes with compact
+ *  summaries in ~0.5s (measured), and the coalescer already keeps one scan
+ *  in flight. With a chat open, the list is ALWAYS session-scoped, so the
+ *  cooldown was the whole reason a turn's trace took up to ten seconds to
+ *  show while the engine had it within 100ms of the send (MOT-4621). */
 export const ACTIVITY_REFETCH_MIN_INTERVAL_MS = 1_000
-/** Minimum gap between activity-driven reseeds of a filtered/searched list.
- *  The response is compact, but child-span search still scans the engine's
- *  store; riding the short tick debounce would re-run that scan back-to-back. */
-const FILTERED_RESEED_COOLDOWN_MS = 10_000
 
 export function shouldDeferTraceUpdate(
   held: boolean,
@@ -372,16 +379,6 @@ export function useTraceData({
   useEffect(() => {
     isPausedRef.current = isPaused
   }, [isPaused])
-  // Whether the CURRENT seed is the expensive search_all_spans sweep —
-  // read through a ref inside the once-per-lifetime subscription below.
-  const isSearchAllSeed =
-    filterParams.search_all_spans === true ||
-    Boolean(debouncedSearch && !filterParams.name)
-  const searchAllSeedRef = useRef(isSearchAllSeed)
-  useEffect(() => {
-    searchAllSeedRef.current = isSearchAllSeed
-  }, [isSearchAllSeed])
-
   useEffect(() => {
     let stop: (() => void) | undefined
     let disposed = false
@@ -395,15 +392,10 @@ export function useTraceData({
     const invalidate = (queryKey: readonly unknown[]) =>
       qc.invalidateQueries({ queryKey }, { cancelRefetch: false })
 
-    // A search_all_spans seed still performs an engine-side scan: its reseed
-    // rides a longer cooldown so a busy session cannot re-run it back-to-back.
     const traces = createRefetchCoalescer({
       run: () => invalidate(['traces']),
       debounceMs: ACTIVITY_REFETCH_DEBOUNCE_MS,
-      minIntervalMs: () =>
-        searchAllSeedRef.current
-          ? FILTERED_RESEED_COOLDOWN_MS
-          : ACTIVITY_REFETCH_MIN_INTERVAL_MS,
+      minIntervalMs: ACTIVITY_REFETCH_MIN_INTERVAL_MS,
       shouldRun: canRefetch,
     })
     const groups = createRefetchCoalescer({

--- a/console/web/src/pages/TracesV2/hooks/useTraceData.ts
+++ b/console/web/src/pages/TracesV2/hooks/useTraceData.ts
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { getIiiClient } from '@/lib/iii-client'
 import { startTraceActivityFeed } from '@/lib/traces-activity'
 import {
@@ -31,10 +31,33 @@ export const ACTIVITY_REFETCH_MIN_INTERVAL_MS = 1_000
 const FILTERED_RESEED_COOLDOWN_MS = 10_000
 
 export function shouldDeferTraceUpdate(
-  isHovered: boolean,
+  held: boolean,
   hadPreviousRows: boolean,
 ): boolean {
-  return isHovered && hadPreviousRows
+  return held && hadPreviousRows
+}
+
+/**
+ * While the list is HELD (the user is reading it: pointer over the rows,
+ * scrolled away from the top, on a later page, or a detail expanded), a
+ * fresh answer must not move anything — no rows entering or leaving, no
+ * reordering. Rows already on screen still take their in-place updates
+ * (status, duration, late tags), because those never shift layout. Returns
+ * `rendered` itself when nothing on screen changed, so memos hold.
+ */
+export function mergeHeldUpdates(
+  rendered: TraceListItem[],
+  latest: readonly TraceListItem[],
+): TraceListItem[] {
+  const byId = new Map(latest.map((t) => [t.traceId, t]))
+  let changed = false
+  const next = rendered.map((row) => {
+    const update = byId.get(row.traceId)
+    if (!update || update === row) return row
+    changed = true
+    return update
+  })
+  return changed ? next : rendered
 }
 
 export interface TraceListItem {
@@ -83,7 +106,14 @@ export interface UseTraceDataReturn {
   hasOtelConfigured: boolean | null
   isQueryLoading: boolean
   refetch: () => void
-  isHoveredRef: React.RefObject<boolean>
+  /** While `true`, structural changes to the list (rows entering or
+   *  leaving, order) are held back; rows on screen still update in place.
+   *  The page sets it from what the user is doing (see index.tsx). */
+  holdRef: React.RefObject<boolean>
+  /** The latest answer while it is held back (empty otherwise): the page
+   *  derives the "new traces" pill from it against the rows on screen. */
+  heldTraces: readonly TraceListItem[]
+  /** Apply the held answer now: rows enter, leave and reorder. */
   flushPendingTraces: () => void
 }
 
@@ -170,8 +200,9 @@ export function useTraceData({
   const fingerprintRef = useRef<string>('')
   const prevTraceIdsRef = useRef<Set<string>>(new Set())
 
-  const isHoveredRef = useRef(false)
+  const holdRef = useRef(false)
   const pendingTracesRef = useRef<TraceListItem[] | null>(null)
+  const [heldTraces, setHeldTraces] = useState<readonly TraceListItem[]>([])
   const hiddenKey = hiddenFunctionsKey(hiddenFunctions)
 
   const {
@@ -245,6 +276,7 @@ export function useTraceData({
     fingerprintRef.current = ''
     prevTraceIdsRef.current = new Set()
     pendingTracesRef.current = null
+    setHeldTraces([])
     setNewTraceIds(new Set())
   }, [scopeKey, resultSetKey])
 
@@ -294,20 +326,26 @@ export function useTraceData({
       prevTraceIdsRef.current = currentIds
 
       // Freeze churn only when there is already a rendered list whose row
-      // positions must stay stable under the pointer. A scope/search change
-      // clears the list first; deferring that scope's first answer while the
-      // user is still hovering the search field would leave an empty screen
-      // until the pointer happened to leave the traces pane.
-      if (shouldDeferTraceUpdate(isHoveredRef.current, hadPreviousRows)) {
+      // positions must stay stable while the user reads it. A scope/search
+      // change clears the list first; deferring that scope's first answer
+      // while the user is still hovering the search field would leave an
+      // empty screen until the pointer happened to leave the traces pane.
+      // Held answers still refresh the rows on screen in place, and the
+      // pill counts what is waiting above the fold.
+      if (shouldDeferTraceUpdate(holdRef.current, hadPreviousRows)) {
         pendingTracesRef.current = traces
+        setTraceListItems((rendered) => mergeHeldUpdates(rendered, traces))
+        setHeldTraces(traces)
         return
       }
 
+      setHeldTraces([])
       setTraceListItems(traces)
       setHasOtelConfigured(true)
     } else {
       // An empty answer from a working exporter is an empty list — the
       // no-observability message is reserved for the marker above.
+      setHeldTraces([])
       setTraceListItems([])
       setHasOtelConfigured(true)
     }
@@ -423,13 +461,14 @@ export function useTraceData({
     }
   }, [qc])
 
-  const flushPendingTraces = () => {
-    if (pendingTracesRef.current) {
-      setTraceListItems(pendingTracesRef.current)
-      setHasOtelConfigured(true)
-      pendingTracesRef.current = null
-    }
-  }
+  const flushPendingTraces = useCallback(() => {
+    const pending = pendingTracesRef.current
+    if (!pending) return
+    pendingTracesRef.current = null
+    setHeldTraces([])
+    setTraceListItems(pending)
+    setHasOtelConfigured(true)
+  }, [])
 
   return {
     traceGroups,
@@ -439,7 +478,8 @@ export function useTraceData({
     hasOtelConfigured,
     isQueryLoading,
     refetch,
-    isHoveredRef,
+    holdRef,
+    heldTraces,
     flushPendingTraces,
   }
 }

--- a/console/web/src/pages/TracesV2/index.tsx
+++ b/console/web/src/pages/TracesV2/index.tsx
@@ -24,7 +24,6 @@
 
 import {
   AlertCircle,
-  ArrowUp,
   GitBranch,
   MessageSquare,
   RefreshCw,
@@ -611,10 +610,11 @@ export function TracesV2({
   // unreadable under load: everything below the insertion point moves. So
   // structural changes (rows entering or leaving, order) are HELD while the
   // user is evidently reading — pointer over the rows, scrolled away from
-  // the top, on a later page, or a detail expanded — and a pill at the top
-  // counts what is waiting. Rows on screen keep updating in place. The hold
-  // releases (and the held answer lands) when every reason clears: pointer
-  // out, back at the top, back on page 1, detail closed.
+  // the top, on a later page, or a detail expanded — and the stats block
+  // in the filter bar shows a quiet "N new" that lands them on click. Rows
+  // on screen keep updating in place. The hold releases (and the held
+  // answer lands) when every reason clears: pointer out, back at the top,
+  // back on page 1, detail closed.
   const listHoverRef = useRef(false)
   const [listScrolledAway, setListScrolledAway] = useState(false)
   const listHeldByState =
@@ -634,7 +634,7 @@ export function TracesV2({
     const away = event.currentTarget.scrollTop > 0
     setListScrolledAway((prev) => (prev === away ? prev : away))
   }, [])
-  // What the pill promises: held rows not on screen that will actually
+  // What "N new" promises: held rows not on screen that will actually
   // show once landed — a hidden-rooted bookkeeping trace that the span
   // filter would drop must not be counted as "new".
   const heldNewCount = useMemo(() => {
@@ -648,7 +648,7 @@ export function TracesV2({
     }
     return count
   }, [heldTraces, traceGroups, spanFilter])
-  // The pill: back to the top of page 1 with everything that arrived.
+  // "N new": back to the top of page 1 with everything that arrived.
   const showHeldTraces = useCallback(() => {
     if (filterState.page !== 1) updateFilter('page', 1)
     listScrollRef.current?.scrollTo({ top: 0 })
@@ -925,6 +925,15 @@ export function TracesV2({
             searchQuery={searchQuery}
             onSearchChange={handleSearchChange}
             stats={hasOtelConfigured ? stats : undefined}
+            heldNew={
+              heldNewCount > 0
+                ? {
+                    count: heldNewCount,
+                    onPage1: filterState.page === 1,
+                    onShow: showHeldTraces,
+                  }
+                : undefined
+            }
             attributeKeySuggestions={attributeKeySuggestions}
             leading={
               <>
@@ -1039,12 +1048,11 @@ export function TracesV2({
                   </div>
                 ) : (
                   <div className="flex-1 flex flex-col overflow-hidden">
-                    {/* The hover hold wraps the pill too: moving the pointer
-                        onto the pill must not release the hold and pull the
-                        pill away from under the click. */}
                     {/* biome-ignore lint/a11y/noStaticElementInteractions: hover detection for pause/resume of live updates */}
                     <div
-                      className="relative flex-1 min-h-0 flex flex-col"
+                      className="flex-1 overflow-y-auto"
+                      ref={listScrollRef}
+                      onScroll={handleListScroll}
                       onMouseEnter={() => {
                         listHoverRef.current = true
                         syncListHold()
@@ -1054,70 +1062,39 @@ export function TracesV2({
                         syncListHold()
                       }}
                     >
-                      {heldNewCount > 0 ? (
-                        <Button
-                          type="button"
-                          variant="pill"
-                          size="sm"
-                          className="iii-ui-motion-overlay absolute top-3 left-1/2 z-10 h-8 -translate-x-1/2 rounded-full bg-panel-raised/80 pr-3 pl-2.5 font-medium text-[0.8125rem] shadow-raised backdrop-blur-md"
-                          onClick={showHeldTraces}
-                          aria-label={
-                            filterState.page === 1
-                              ? `show ${heldNewCount} new ${heldNewCount === 1 ? 'trace' : 'traces'}`
-                              : 'show the latest traces on page 1'
-                          }
-                          data-trace-list-held={heldNewCount}
-                        >
-                          <ArrowUp
-                            aria-hidden="true"
-                            className="stroke-current"
-                          />
-                          <span>
-                            {filterState.page === 1
-                              ? `${heldNewCount} new ${heldNewCount === 1 ? 'trace' : 'traces'}`
-                              : 'latest traces'}
-                          </span>
-                        </Button>
-                      ) : null}
-                      <div
-                        className="flex-1 overflow-y-auto"
-                        ref={listScrollRef}
-                        onScroll={handleListScroll}
-                      >
-                        {/* detail whose row is on another page (strip click,
+                      {/* detail whose row is on another page (strip click,
                           deep link) pins to the top of the scroll area */}
-                        {selectedTraceId !== null &&
-                          !selectedInPage &&
-                          traceDetail}
-                        {paged.map((trace) => {
-                          const isExpanded = selectedTraceId === trace.traceId
-                          return (
-                            <div
-                              key={trace.traceId}
-                              data-trace-row-id={trace.traceId}
-                            >
-                              <TraceListRow
-                                trace={trace}
-                                isSelected={isExpanded}
-                                isNew={newTraceIds.has(trace.traceId)}
-                                isLive={liveTraceIds.has(trace.traceId)}
-                                label={rowLabel}
-                                onHideFunction={hideFunction}
-                                onSelect={() => toggleTrace(trace.traceId)}
-                                onAnimationEnd={() => {
-                                  if (newTraceIds.has(trace.traceId))
-                                    setNewTraceIds((prev) => {
-                                      const next = new Set(prev)
-                                      next.delete(trace.traceId)
-                                      return next
-                                    })
-                                }}
-                              />
-                              {isExpanded && traceDetail}
-                            </div>
-                          )
-                        })}
-                      </div>
+                      {selectedTraceId !== null &&
+                        !selectedInPage &&
+                        traceDetail}
+                      {paged.map((trace) => {
+                        const isExpanded = selectedTraceId === trace.traceId
+                        return (
+                          <div
+                            key={trace.traceId}
+                            data-trace-row-id={trace.traceId}
+                          >
+                            <TraceListRow
+                              trace={trace}
+                              isSelected={isExpanded}
+                              isNew={newTraceIds.has(trace.traceId)}
+                              isLive={liveTraceIds.has(trace.traceId)}
+                              label={rowLabel}
+                              onHideFunction={hideFunction}
+                              onSelect={() => toggleTrace(trace.traceId)}
+                              onAnimationEnd={() => {
+                                if (newTraceIds.has(trace.traceId))
+                                  setNewTraceIds((prev) => {
+                                    const next = new Set(prev)
+                                    next.delete(trace.traceId)
+                                    return next
+                                  })
+                              }}
+                            />
+                            {isExpanded && traceDetail}
+                          </div>
+                        )
+                      })}
                     </div>
                     <div className="flex-shrink-0 border-t border-rule-2 px-3 py-2">
                       <Pagination

--- a/console/web/src/pages/TracesV2/index.tsx
+++ b/console/web/src/pages/TracesV2/index.tsx
@@ -451,6 +451,13 @@ export function TracesV2({
             // skeleton through the whole multi-second sweep.
             onPage: (accumulated, total) => {
               if (stale()) return
+              // A silent reload lands whole, at the end of its sweep.
+              // Painting its pages as they arrived replaced the open detail
+              // with the sweep's FIRST page — 50 of 155 spans, a 7s window
+              // in place of 24s — and regrew it, on every activity tick of
+              // a running turn: the whole timeline redrew at another scale
+              // about once a second (seen in screen recordings, MOT-4621).
+              if (silent) return
               detailSpansRef.current = accumulated
               setSeedProgress({ loaded: accumulated.size, total })
               // Rebuilding the waterfall on EVERY page saturates the main
@@ -657,6 +664,17 @@ export function TracesV2({
     }
     return count
   }, [heldTraces, traceGroups, spanFilter])
+  // The selected trace's own row is never held back: following opens a
+  // turn from the strip feed before its list row has landed, and holding
+  // that row left the detail pinned above a list reading "1 new" for as
+  // long as it stayed open (seen in a screen recording).
+  useEffect(() => {
+    if (selectedTraceId === null) return
+    if (traceGroups.some((t) => t.traceId === selectedTraceId)) return
+    if (heldTraces.some((t) => t.traceId === selectedTraceId)) {
+      flushPendingTraces()
+    }
+  }, [selectedTraceId, traceGroups, heldTraces, flushPendingTraces])
   // "N new": back to the top of page 1 with everything that arrived.
   const showHeldTraces = useCallback(() => {
     if (filterState.page !== 1) updateFilter('page', 1)

--- a/console/web/src/pages/TracesV2/index.tsx
+++ b/console/web/src/pages/TracesV2/index.tsx
@@ -462,7 +462,15 @@ export function TracesV2({
               if (revealed && now - lastPaint < 600) return
               const wf = rebuildDetail(traceId)
               if (wf) lastPaint = now
-              if (!silent && !revealed && wf) {
+              // ANY paint dismisses the skeleton, a silent reload's included.
+              // Opening a trace that is still producing spans races the
+              // activity feed: its first tick starts a silent reload that
+              // supersedes this seed before the first page lands, and a
+              // silent reload used to leave `isLoadingSpans` alone — the
+              // waterfall was in state, the skeleton stayed on screen for
+              // as long as the detail stayed open (measured: 50s and
+              // counting, on a trace that had finished in 1.5s).
+              if (!revealed && wf) {
                 revealed = true
                 setIsLoadingSpans(false)
               }
@@ -473,6 +481,7 @@ export function TracesV2({
 
         detailSpansRef.current = detailSpans
         const wf = rebuildDetail(traceId)
+        if (wf) setIsLoadingSpans(false)
         if (!wf && !silent) {
           setSpansError('no span data available for this trace')
         }

--- a/console/web/src/pages/TracesV2/index.tsx
+++ b/console/web/src/pages/TracesV2/index.tsx
@@ -24,6 +24,7 @@
 
 import {
   AlertCircle,
+  ArrowUp,
   GitBranch,
   MessageSquare,
   RefreshCw,
@@ -67,7 +68,10 @@ import { WorkerBreakdown } from './components/WorkerBreakdown'
 import { useAllSpans } from './hooks/useAllSpans'
 import { useFollowLiveTurn } from './hooks/useFollowLiveTurn'
 import { useFollowTurns } from './hooks/useFollowTurns'
-import { useSpanFilteredTraceRows } from './hooks/useSpanFilteredTraceRows'
+import {
+  showsWithoutProbe,
+  useSpanFilteredTraceRows,
+} from './hooks/useSpanFilteredTraceRows'
 import { useSpanFilterSelection } from './hooks/useSpanFilterSelection'
 import { useSpanPanelResize } from './hooks/useSpanPanelResize'
 import { useTraceActivity } from './hooks/useTraceActivity'
@@ -196,7 +200,8 @@ export function TracesV2({
     setNewTraceIds,
     hasOtelConfigured,
     isQueryLoading,
-    isHoveredRef,
+    holdRef,
+    heldTraces,
     flushPendingTraces,
   } = useTraceData({
     filterParams,
@@ -601,14 +606,72 @@ export function TracesV2({
     [selectTrace],
   )
 
+  // ── Hold live changes while the user is reading ──
+  // A live newest-first list that inserts rows the moment they arrive is
+  // unreadable under load: everything below the insertion point moves. So
+  // structural changes (rows entering or leaving, order) are HELD while the
+  // user is evidently reading — pointer over the rows, scrolled away from
+  // the top, on a later page, or a detail expanded — and a pill at the top
+  // counts what is waiting. Rows on screen keep updating in place. The hold
+  // releases (and the held answer lands) when every reason clears: pointer
+  // out, back at the top, back on page 1, detail closed.
+  const listHoverRef = useRef(false)
+  const [listScrolledAway, setListScrolledAway] = useState(false)
+  const listHeldByState =
+    listScrolledAway || filterState.page !== 1 || selectedTraceId !== null
+  const listHeldByStateRef = useRef(listHeldByState)
+  listHeldByStateRef.current = listHeldByState
+  const syncListHold = useCallback(() => {
+    const held = listHoverRef.current || listHeldByStateRef.current
+    holdRef.current = held
+    if (!held) flushPendingTraces()
+  }, [holdRef, flushPendingTraces])
+  useEffect(() => {
+    holdRef.current = listHoverRef.current || listHeldByState
+    if (!holdRef.current) flushPendingTraces()
+  }, [holdRef, listHeldByState, flushPendingTraces])
+  const handleListScroll = useCallback((event: React.UIEvent<HTMLElement>) => {
+    const away = event.currentTarget.scrollTop > 0
+    setListScrolledAway((prev) => (prev === away ? prev : away))
+  }, [])
+  // What the pill promises: held rows not on screen that will actually
+  // show once landed — a hidden-rooted bookkeeping trace that the span
+  // filter would drop must not be counted as "new".
+  const heldNewCount = useMemo(() => {
+    if (heldTraces.length === 0) return 0
+    const shown = new Set(traceGroups.map((t) => t.traceId))
+    let count = 0
+    for (const trace of heldTraces) {
+      if (!shown.has(trace.traceId) && showsWithoutProbe(trace, spanFilter)) {
+        count++
+      }
+    }
+    return count
+  }, [heldTraces, traceGroups, spanFilter])
+  // The pill: back to the top of page 1 with everything that arrived.
+  const showHeldTraces = useCallback(() => {
+    if (filterState.page !== 1) updateFilter('page', 1)
+    listScrollRef.current?.scrollTo({ top: 0 })
+    flushPendingTraces()
+  }, [filterState.page, updateFilter, flushPendingTraces])
+
   // The follow toggle's engine: opens the newest live turn trace of the
   // active conversation (once per trace — closing it mid-turn is respected).
+  // Following lands the held rows first, so the opened trace's detail
+  // renders under its own row instead of pinned above a stale list.
+  const openFollowedTrace = useCallback(
+    (traceId: string | null) => {
+      flushPendingTraces()
+      selectTrace(traceId)
+    },
+    [flushPendingTraces, selectTrace],
+  )
   useFollowLiveTurn({
     enabled: followTurns && !isPaused,
     activeSessionId: conversationsCtx?.activeId ?? null,
     spans: allSpans,
     selectedTraceId,
-    onOpenTrace: selectTrace,
+    onOpenTrace: openFollowedTrace,
   })
 
   // Chat linkage of the OPEN trace (session + turn), resolved from the row's
@@ -976,51 +1039,85 @@ export function TracesV2({
                   </div>
                 ) : (
                   <div className="flex-1 flex flex-col overflow-hidden">
+                    {/* The hover hold wraps the pill too: moving the pointer
+                        onto the pill must not release the hold and pull the
+                        pill away from under the click. */}
                     {/* biome-ignore lint/a11y/noStaticElementInteractions: hover detection for pause/resume of live updates */}
                     <div
-                      className="flex-1 overflow-y-auto"
-                      ref={listScrollRef}
+                      className="relative flex-1 min-h-0 flex flex-col"
                       onMouseEnter={() => {
-                        isHoveredRef.current = true
+                        listHoverRef.current = true
+                        syncListHold()
                       }}
                       onMouseLeave={() => {
-                        isHoveredRef.current = false
-                        flushPendingTraces()
+                        listHoverRef.current = false
+                        syncListHold()
                       }}
                     >
-                      {/* detail whose row is on another page (strip click,
+                      {heldNewCount > 0 ? (
+                        <Button
+                          type="button"
+                          variant="pill"
+                          size="sm"
+                          className="iii-ui-motion-overlay absolute top-3 left-1/2 z-10 h-8 -translate-x-1/2 rounded-full bg-panel-raised/80 pr-3 pl-2.5 font-medium text-[0.8125rem] shadow-raised backdrop-blur-md"
+                          onClick={showHeldTraces}
+                          aria-label={
+                            filterState.page === 1
+                              ? `show ${heldNewCount} new ${heldNewCount === 1 ? 'trace' : 'traces'}`
+                              : 'show the latest traces on page 1'
+                          }
+                          data-trace-list-held={heldNewCount}
+                        >
+                          <ArrowUp
+                            aria-hidden="true"
+                            className="stroke-current"
+                          />
+                          <span>
+                            {filterState.page === 1
+                              ? `${heldNewCount} new ${heldNewCount === 1 ? 'trace' : 'traces'}`
+                              : 'latest traces'}
+                          </span>
+                        </Button>
+                      ) : null}
+                      <div
+                        className="flex-1 overflow-y-auto"
+                        ref={listScrollRef}
+                        onScroll={handleListScroll}
+                      >
+                        {/* detail whose row is on another page (strip click,
                           deep link) pins to the top of the scroll area */}
-                      {selectedTraceId !== null &&
-                        !selectedInPage &&
-                        traceDetail}
-                      {paged.map((trace) => {
-                        const isExpanded = selectedTraceId === trace.traceId
-                        return (
-                          <div
-                            key={trace.traceId}
-                            data-trace-row-id={trace.traceId}
-                          >
-                            <TraceListRow
-                              trace={trace}
-                              isSelected={isExpanded}
-                              isNew={newTraceIds.has(trace.traceId)}
-                              isLive={liveTraceIds.has(trace.traceId)}
-                              label={rowLabel}
-                              onHideFunction={hideFunction}
-                              onSelect={() => toggleTrace(trace.traceId)}
-                              onAnimationEnd={() => {
-                                if (newTraceIds.has(trace.traceId))
-                                  setNewTraceIds((prev) => {
-                                    const next = new Set(prev)
-                                    next.delete(trace.traceId)
-                                    return next
-                                  })
-                              }}
-                            />
-                            {isExpanded && traceDetail}
-                          </div>
-                        )
-                      })}
+                        {selectedTraceId !== null &&
+                          !selectedInPage &&
+                          traceDetail}
+                        {paged.map((trace) => {
+                          const isExpanded = selectedTraceId === trace.traceId
+                          return (
+                            <div
+                              key={trace.traceId}
+                              data-trace-row-id={trace.traceId}
+                            >
+                              <TraceListRow
+                                trace={trace}
+                                isSelected={isExpanded}
+                                isNew={newTraceIds.has(trace.traceId)}
+                                isLive={liveTraceIds.has(trace.traceId)}
+                                label={rowLabel}
+                                onHideFunction={hideFunction}
+                                onSelect={() => toggleTrace(trace.traceId)}
+                                onAnimationEnd={() => {
+                                  if (newTraceIds.has(trace.traceId))
+                                    setNewTraceIds((prev) => {
+                                      const next = new Set(prev)
+                                      next.delete(trace.traceId)
+                                      return next
+                                    })
+                                }}
+                              />
+                              {isExpanded && traceDetail}
+                            </div>
+                          )
+                        })}
+                      </div>
                     </div>
                     <div className="flex-shrink-0 border-t border-rule-2 px-3 py-2">
                       <Pagination

--- a/harness/src/functions/send.rs
+++ b/harness/src/functions/send.rs
@@ -319,6 +319,7 @@ async fn start_with_delivery_lock(
 
     // Normalise the incoming message and validate its role.
     let message = normalize_message(req.message)?;
+    tag_send_span_with_message(&message);
 
     // Resolve the session (ensure if id given, else create).
     let (title, metadata) = req
@@ -395,6 +396,20 @@ async fn start_with_delivery_lock(
     }
 
     Ok(outcome)
+}
+
+/// Label the send's own root span with the message preview. The turn step
+/// stamps the same `iii.tag.message` through baggage, but only once the queue
+/// delivers it — well after `execute harness::send` has closed and been
+/// listed. The Console's message-labelled trace rows read the tag from the
+/// trace's merged tags, so without this the row first appeared as
+/// `execute harness::send` and relabelled itself a second later (MOT-4621).
+/// Only the label rides here: session/message identity stays on the step
+/// (see `tag_failed_send_with_session`).
+fn tag_send_span_with_message(message: &AgentMessage) {
+    if let Some(preview) = message_preview(message) {
+        iii_helpers::observability::set_current_span_attribute("iii.tag.message", preview);
+    }
 }
 
 /// Attribute failures that happen after session creation but before the turn
@@ -1330,6 +1345,47 @@ mod tests {
                     .find(|attribute| attribute.key.as_str() == "iii.session.id")
                     .map(|attribute| attribute.value.as_str().to_string())
             })
+    }
+
+    fn send_span_message_tag(message: &AgentMessage) -> Option<String> {
+        let exporter = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_span_processor(SimpleSpanProcessor::new(exporter.clone()))
+            .build();
+        let tracer = provider.tracer("harness-send-test");
+        let span = tracer.start("execute harness::send");
+        let guard = Context::new().with_span(span).attach();
+
+        tag_send_span_with_message(message);
+
+        drop(guard);
+        exporter
+            .get_finished_spans()
+            .expect("exporter")
+            .into_iter()
+            .next()
+            .and_then(|span| {
+                span.attributes
+                    .into_iter()
+                    .find(|attribute| attribute.key.as_str() == "iii.tag.message")
+                    .map(|attribute| attribute.value.as_str().to_string())
+            })
+    }
+
+    #[test]
+    fn send_root_span_carries_the_message_preview_label() {
+        let user = normalize_message(MessageInput::Text(
+            "help me implement the traces v2 new tags please".into(),
+        ))
+        .unwrap();
+        assert_eq!(
+            send_span_message_tag(&user).as_deref(),
+            Some("help me implement the traces v"),
+        );
+
+        // Nothing to label: a blank message leaves the span untouched.
+        let blank = normalize_message(MessageInput::Text("   ".into())).unwrap();
+        assert_eq!(send_span_message_tag(&blank), None);
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to MOT-4621 (#1050, now on `main`).

## Summary

- **Console — hold while reading.** The flat traces list no longer inserts rows the moment they arrive while the user is evidently reading it: pointer over the rows, scrolled away from the top, on a later page, or a detail expanded. Structural changes (rows entering or leaving, order) are held; rows on screen keep taking their in-place updates (status, duration, late tags), which never shift layout. The hold releases, and the held answer lands, when every reason clears. This generalises the pointer-only hold that already existed (`isHoveredRef` → `holdRef`).
- **Console — a quiet "↑ N new".** What is being held shows as one more segment of the filter bar's stats block, next to the trace count — "↑ 3 new" on page 1, "↑ latest" from a later page — in the accent colour, landing the held rows on click (and returning to the top of page 1). Nothing overlays the list. The count only includes held rows that will actually show without waiting on a probe (visible root, running, or failed); a hidden-rooted bookkeeping trace the span filter would drop is never promised as "new". Following the live turn lands the held rows first, so the opened trace renders under its own row.
- **Console — the trace detail no longer sticks on its skeleton.** Opening a trace that is still producing spans races the activity feed: the next tick's silent reload superseded the initial seed before its first page, and only the initial seed cleared the loading flag — the waterfall was in state while the skeleton stayed on screen for as long as the detail was open (measured under load: 50 s, on a trace that had finished in 1.5 s; invisible on engines that never delivered ticks to a namespaced console). Any paint now dismisses the skeleton.
- **Console — a new turn's row shows in under two seconds.** With a chat open the list is always session-scoped, and that seed still rode a 10s cooldown between activity-driven refetches — a guard for the full-span sweep the list ran before compact summaries. The engine lists a new turn within 100ms of `harness::send` returning; the console showed its row 11.6s after the send (browser-measured). The cooldown is gone (scoped and searched shapes answer in ~0.5s and the coalescer keeps one refetch in flight) and the tick debounce drops to 100ms. Same flow after: first row at 1.7–1.9s.
- **Console — a live trace's timeline no longer bounces.** With follow mode on, a turn's detail opens under its row the moment it starts, and the timeline sized itself to its packed lines on every silent reload and every one-second live rebuild: a pending bar growing into a neighbour, a closed one settling, or the horizontal scrollbar coming and going moved the stage by a line (22px) or a scrollbar (14px) every second or two, and everything below jumped along (measured on a 70s turn: fourteen height changes). While the trace is live the stage keeps the tallest height it has reached; it only shrinks after 3s without a pending span, since a running turn has nothing pending for a few ms between two engine calls. Same prompt after: one growth at 12.7s, one shrink 2s after the turn finished.
- **Console — a silent detail reload lands whole; the selected row is never held.** Two things the user's screen recordings showed on a long turn with follow mode on. A silent reload painted its pages as they arrived, and its first page replaced the whole open detail (50 of 155 spans, a 7s window in place of 24s) before the full trace came back — the timeline, ruler and every bar re-laid about once a second. It now applies once, at the end of its sweep (the initial seed still paints progressively). And following opens a turn from the strip feed before its list row has landed; with the detail open the list was held, so the row never landed and the detail sat pinned above a list reading "1 new". The selected trace's own row now lands regardless. Re-measured on the same prompt: the detail's duration and span count only ever grow (1.6s → 15.3s, 31 → 69 spans), no redraw at another scale.
- **Harness — stable row label.** `harness::send` stamps `iii.tag.message` on its own root span. The turn step stamps the same tag through baggage, but only once the queue delivers it, well after the root has closed and been listed: in the message-labelled view a new row read `execute harness::send` and relabelled itself a second later. Only the label rides on the root; session and message identity stay on the step so the session-scoped list keeps one row per turn.

## Validation

Browser-driven under three to four concurrent harness turns (~1.5–2 turns/s):

| phase | rows entering/leaving/reordering | in-place updates | "N new" segment |
|---|---|---|---|
| pointer over the list, 20 s | 0 | 2 status flips landed | counts up ("4 new" … "9 new") |
| pointer leaves | held answer lands (rows enter) | — | gone |
| page 2, 12 s | 0 after the initial probes | — | "latest" while page-2 answers keep shifting underneath |
| detail expanded, 12 s | 0 | — | counts new arrivals |

Unit tests: 217 pass in `TracesV2` (new coverage for `mergeHeldUpdates`, `showsWithoutProbe`, the stats segment); `pnpm typecheck` and biome clean on the touched files. Harness: `cargo test functions::send::tests` (48, including the new root-span tag test) and `cargo clippy --all-targets` clean. The harness change was validated by unit test only — the running local stack keeps its own harness binary.

## Not covered

- The grouped view still inserts new session groups live; the same hold would apply there as a follow-up.
- The timeline strip re-seeds up to 500 full spans (~5 MB) per activity window under load — the heaviest remaining cost on the connection; a separate decision on its density.

https://claude.ai/code/session_01Ass3crjJFx4s776BYMpdxw






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Live trace updates are now held while users read, with a visible count of new traces and one-click access to them.
  - Pending and error traces can appear immediately, even when filtering would otherwise hide their parent trace.
  - Send operations now display the message preview directly in trace listings when available.

- **Bug Fixes**
  - Trace timeline heights remain stable while live spans are pending, reducing visual shifting.
  - Trace updates preserve row order and retain visible rows during refreshes.
  - Detail reloads now appear together without intermediate pages or lingering loading indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->