### PR TITLE
perf(ci): parallelize Harness integration jobs

### DIFF
--- a/.github/scripts/harness_stack_bundle.sh
+++ b/.github/scripts/harness_stack_bundle.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly STACK_BINARIES=(
+  queue
+  iii-directory
+  session-manager
+  context-manager
+  cron
+  state
+  database
+  harness
+  harness-integration
+  console
+)
+
+usage() {
+  cat <<'EOF'
+Usage:
+  harness_stack_bundle.sh pack --output FILE --source-sha SHA --engine-version VERSION --engine-bin FILE --bin-dir DIR
+  harness_stack_bundle.sh unpack --archive FILE --destination DIR --expected-source-sha SHA
+EOF
+}
+
+fail() {
+  printf '%s\n' "$*" >&2
+  exit 3
+}
+
+require_sha() {
+  [[ "$1" =~ ^[0-9a-f]{40}$ ]] || fail "invalid source SHA: $1"
+}
+
+pack() {
+  local output='' source_sha='' engine_version='' engine_bin='' bin_dir=''
+  while (($#)); do
+    case "$1" in
+      --output) output=${2:-}; shift 2 ;;
+      --source-sha) source_sha=${2:-}; shift 2 ;;
+      --engine-version) engine_version=${2:-}; shift 2 ;;
+      --engine-bin) engine_bin=${2:-}; shift 2 ;;
+      --bin-dir) bin_dir=${2:-}; shift 2 ;;
+      *) fail "unknown pack argument: $1" ;;
+    esac
+  done
+
+  [[ -n "$output" && -n "$source_sha" && -n "$engine_version" && -n "$engine_bin" && -n "$bin_dir" ]] || {
+    usage >&2
+    exit 2
+  }
+  require_sha "$source_sha"
+  [[ -x "$engine_bin" ]] || fail "engine binary is missing or not executable: $engine_bin"
+  for binary in "${STACK_BINARIES[@]}"; do
+    [[ -x "$bin_dir/$binary" ]] || fail "stack binary is missing or not executable: $bin_dir/$binary"
+  done
+
+  output=$(realpath -m "$output")
+  mkdir -p "$(dirname "$output")"
+  local temp_root
+  temp_root=$(mktemp -d "${RUNNER_TEMP:-/tmp}/harness-stack-bundle.XXXXXX")
+  mkdir -p "$temp_root/bin"
+  install -m 0755 "$engine_bin" "$temp_root/bin/iii"
+  for binary in "${STACK_BINARIES[@]}"; do
+    install -m 0755 "$bin_dir/$binary" "$temp_root/bin/$binary"
+  done
+
+  (
+    cd "$temp_root"
+    sha256sum bin/* > SHA256SUMS
+  )
+  jq -n \
+    --arg source_sha "$source_sha" \
+    --arg engine_version "$engine_version" \
+    --arg runner_os "${RUNNER_OS:-unknown}" \
+    --arg runner_arch "${RUNNER_ARCH:-unknown}" \
+    --argjson binaries "$(printf '%s\n' iii "${STACK_BINARIES[@]}" | jq -R . | jq -s .)" \
+    '{
+      schema: "harness-stack-bundle/v1",
+      source_sha: $source_sha,
+      engine_version: $engine_version,
+      runner: {os: $runner_os, arch: $runner_arch},
+      checksums: "SHA256SUMS",
+      binaries: $binaries
+    }' > "$temp_root/manifest.json"
+
+  tar --zstd -cf "$output" -C "$temp_root" .
+  rm -r -- "$temp_root"
+  printf 'packed %s\n' "$output"
+}
+
+unpack() {
+  local archive='' destination='' expected_source_sha=''
+  while (($#)); do
+    case "$1" in
+      --archive) archive=${2:-}; shift 2 ;;
+      --destination) destination=${2:-}; shift 2 ;;
+      --expected-source-sha) expected_source_sha=${2:-}; shift 2 ;;
+      *) fail "unknown unpack argument: $1" ;;
+    esac
+  done
+
+  [[ -n "$archive" && -n "$destination" && -n "$expected_source_sha" ]] || {
+    usage >&2
+    exit 2
+  }
+  require_sha "$expected_source_sha"
+  [[ -f "$archive" ]] || fail "bundle archive does not exist: $archive"
+  if tar --zstd -tf "$archive" | awk '$0 ~ /^\// || $0 ~ /(^|\/)\.\.($|\/)/ {exit 1}'; then
+    :
+  else
+    fail "bundle archive contains an unsafe path"
+  fi
+  if [[ -e "$destination" ]]; then
+    [[ -d "$destination" ]] || fail "bundle destination is not a directory: $destination"
+    [[ -z "$(find "$destination" -mindepth 1 -print -quit)" ]] || fail "bundle destination is not empty: $destination"
+  fi
+  mkdir -p "$destination"
+  tar --zstd -xf "$archive" -C "$destination"
+
+  [[ $(jq -er '.schema' "$destination/manifest.json") == 'harness-stack-bundle/v1' ]] || fail "unexpected bundle schema"
+  [[ $(jq -er '.source_sha' "$destination/manifest.json") == "$expected_source_sha" ]] || fail "bundle source SHA does not match $expected_source_sha"
+  [[ $(jq -er '.checksums' "$destination/manifest.json") == 'SHA256SUMS' ]] || fail "unexpected checksum manifest"
+  (
+    cd "$destination"
+    sha256sum -c SHA256SUMS
+  )
+  for binary in iii "${STACK_BINARIES[@]}"; do
+    [[ -f "$destination/bin/$binary" ]] || fail "bundle binary is missing: $binary"
+    chmod 0755 "$destination/bin/$binary"
+  done
+  printf 'unpacked source %s into %s\n' "$expected_source_sha" "$destination"
+}
+
+command=${1:-}
+[[ -n "$command" ]] || { usage >&2; exit 2; }
+shift
+case "$command" in
+  pack) pack "$@" ;;
+  unpack) unpack "$@" ;;
+  *) usage >&2; exit 2 ;;
+esac

--- a/.github/scripts/tests/test_harness_stack_bundle.py
+++ b/.github/scripts/tests/test_harness_stack_bundle.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import stat
+import subprocess
+
+
+SCRIPT = Path(__file__).parents[1] / "harness_stack_bundle.sh"
+STACK_BINARIES = [
+    "queue",
+    "iii-directory",
+    "session-manager",
+    "context-manager",
+    "cron",
+    "state",
+    "database",
+    "harness",
+    "harness-integration",
+    "console",
+]
+SOURCE_SHA = "0123456789abcdef0123456789abcdef01234567"
+
+
+def executable(path: Path, contents: str) -> None:
+    path.write_text(contents)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def build_bundle(tmp_path: Path) -> Path:
+    engine = tmp_path / "iii"
+    bin_dir = tmp_path / "release"
+    bin_dir.mkdir()
+    executable(engine, "engine")
+    for binary in STACK_BINARIES:
+        executable(bin_dir / binary, binary)
+
+    archive = tmp_path / "harness-stack.tar.zst"
+    subprocess.run(
+        [
+            SCRIPT,
+            "pack",
+            "--output",
+            archive,
+            "--source-sha",
+            SOURCE_SHA,
+            "--engine-version",
+            "iii 0.9.0-rc.1",
+            "--engine-bin",
+            engine,
+            "--bin-dir",
+            bin_dir,
+        ],
+        check=True,
+        text=True,
+    )
+    return archive
+
+
+def test_bundle_round_trip_preserves_identity_and_executables(tmp_path: Path) -> None:
+    archive = build_bundle(tmp_path)
+    destination = tmp_path / "unpacked"
+
+    subprocess.run(
+        [
+            SCRIPT,
+            "unpack",
+            "--archive",
+            archive,
+            "--destination",
+            destination,
+            "--expected-source-sha",
+            SOURCE_SHA,
+        ],
+        check=True,
+        text=True,
+    )
+
+    manifest = json.loads((destination / "manifest.json").read_text())
+    assert manifest["schema"] == "harness-stack-bundle/v1"
+    assert manifest["source_sha"] == SOURCE_SHA
+    assert manifest["engine_version"] == "iii 0.9.0-rc.1"
+    assert manifest["binaries"] == ["iii", *STACK_BINARIES]
+    for binary in manifest["binaries"]:
+        path = destination / "bin" / binary
+        assert path.read_text() == ("engine" if binary == "iii" else binary)
+        assert path.stat().st_mode & stat.S_IXUSR
+
+
+def test_bundle_rejects_a_different_source_revision(tmp_path: Path) -> None:
+    archive = build_bundle(tmp_path)
+    result = subprocess.run(
+        [
+            SCRIPT,
+            "unpack",
+            "--archive",
+            archive,
+            "--destination",
+            tmp_path / "unpacked",
+            "--expected-source-sha",
+            "f" * 40,
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 3
+    assert "bundle source SHA does not match" in result.stderr
+
+
+def test_bundle_rejects_modified_binary_contents(tmp_path: Path) -> None:
+    archive = build_bundle(tmp_path)
+    altered = tmp_path / "altered"
+    altered.mkdir()
+    subprocess.run(
+        ["tar", "--zstd", "-xf", archive, "-C", altered],
+        check=True,
+    )
+    (altered / "bin" / "harness").write_text("modified")
+    tampered_archive = tmp_path / "tampered.tar.zst"
+    subprocess.run(
+        ["tar", "--zstd", "-cf", tampered_archive, "-C", altered, "."],
+        check=True,
+    )
+
+    result = subprocess.run(
+        [
+            SCRIPT,
+            "unpack",
+            "--archive",
+            tampered_archive,
+            "--destination",
+            tmp_path / "tampered-unpacked",
+            "--expected-source-sha",
+            SOURCE_SHA,
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode != 0
+    assert "FAILED" in result.stdout

--- a/.github/scripts/tests/test_rust_ci_workflows.py
+++ b/.github/scripts/tests/test_rust_ci_workflows.py
@@ -68,13 +68,35 @@ def test_prs_restore_rust_caches_and_main_pushes_publish_them() -> None:
     assert ci["jobs"]["harness-integration"]["with"]["save-cache"] == expected
 
 
-def test_harness_integration_defaults_to_an_available_hosted_runner() -> None:
+def test_harness_integration_builds_once_then_fans_out_on_standard_runners() -> None:
     reusable = workflow("_harness-integration.yml")
     assert reusable["on"]["workflow_call"]["inputs"]["runner"]["default"] == (
+        "workers-ci-linux-8core"
+    )
+    assert reusable["on"]["workflow_call"]["inputs"]["execution-runner"]["default"] == (
         "ubuntu-latest"
     )
-    assert reusable["jobs"]["integration"]["runs-on"] == "${{ inputs.runner }}"
-    assert reusable["jobs"]["integration"]["timeout-minutes"] == "90"
+    assert reusable["jobs"]["build"]["runs-on"] == "${{ inputs.runner }}"
+    for job_name in ("validate", "integration", "playwright", "coverage"):
+        assert reusable["jobs"][job_name]["runs-on"] == "${{ inputs.execution-runner }}"
+
+    build_steps = reusable["jobs"]["build"]["steps"]
+    assert "integration-build" in named_step(build_steps, "Build integration stack once")["run"]
+    assert named_step(build_steps, "Upload stack bundle")["with"]["if-no-files-found"] == "error"
+    for job_name in ("integration", "playwright"):
+        job = reusable["jobs"][job_name]
+        assert job["needs"] == ["validate", "build"]
+        assert named_step(job["steps"], "Download stack bundle")
+
+    integration_run = named_step(
+        reusable["jobs"]["integration"]["steps"], "Run integration scenarios"
+    )["run"]
+    assert "integration-run" in integration_run
+    assert "cargo build" not in integration_run
+
+    playwright_steps = reusable["jobs"]["playwright"]["steps"]
+    playwright_body = "\n".join(str(step.get("run", "")) for step in playwright_steps)
+    assert "cargo build" not in playwright_body
 
 
 def test_harness_benchmark_is_manual_and_keeps_cold_caches_isolated() -> None:
@@ -129,7 +151,8 @@ def test_runner_pool_contract_is_documented() -> None:
     assert "ten candidate executions" in runner_docs
     assert "improvement over `ubuntu-latest` is at least 25%" in runner_docs
     assert "8-core warm | 7 | 8m54 | 9m17" in runner_docs
-    assert "`ubuntu-latest` remains the default" in runner_docs
+    assert "builds the complete stack once on `workers-ci-linux-8core`" in runner_docs
+    assert "Integration and Playwright jobs verify that bundle and run in parallel" in runner_docs
 
 
 def test_interface_smoke_bounds_each_engine_readiness_probe() -> None:
@@ -146,7 +169,7 @@ def test_interface_smoke_bounds_each_engine_readiness_probe() -> None:
 
 def test_harness_integration_downloads_latest_rc_engine_without_building_it() -> None:
     integration = workflow("_harness-integration.yml")
-    steps = integration["jobs"]["integration"]["steps"]
+    steps = integration["jobs"]["build"]["steps"]
     install = named_step(steps, "Install latest iii @rc")
     stack_cache = named_step(steps, "Restore integration Rust cache")
 
@@ -162,7 +185,7 @@ def test_harness_integration_downloads_latest_rc_engine_without_building_it() ->
 
 def test_slow_rust_builds_upload_cargo_timing_reports() -> None:
     integration = workflow("_harness-integration.yml")
-    integration_steps = integration["jobs"]["integration"]["steps"]
+    integration_steps = integration["jobs"]["build"]["steps"]
     timing_upload = named_step(integration_steps, "Upload Rust build timings")
     assert timing_upload["if"] == "always()"
     assert "cargo-timings/*.html" in timing_upload["with"]["path"]

--- a/.github/scripts/tests/test_rust_ci_workflows.py
+++ b/.github/scripts/tests/test_rust_ci_workflows.py
@@ -158,7 +158,7 @@ def test_runner_pool_contract_is_documented() -> None:
     assert "builds the complete stack once" in runner_docs
     assert "trusted `main` push uses\n`workers-ci-linux-8core`" in runner_docs
     assert "Integration and Playwright jobs verify\nthat bundle and run in parallel" in runner_docs
-    assert "PR merge refs build the same bundle on `ubuntu-latest`" in runner_docs
+    assert "PR merge refs build the same bundle on\n`ubuntu-latest`" in runner_docs
 
 
 def test_interface_smoke_bounds_each_engine_readiness_probe() -> None:

--- a/.github/scripts/tests/test_rust_ci_workflows.py
+++ b/.github/scripts/tests/test_rust_ci_workflows.py
@@ -65,6 +65,10 @@ def test_prs_restore_rust_caches_and_main_pushes_publish_them() -> None:
     assert rust_cache["with"]["save-if"] == expected
     assert crate_cache["with"]["save-if"] == expected
     assert "github.event_name == 'pull_request'" in ci["jobs"]["interface-smoke"]["if"]
+    assert ci["jobs"]["harness-integration"]["with"]["runner"] == (
+        "${{ github.event_name == 'push' && 'workers-ci-linux-8core' || "
+        "'ubuntu-latest' }}"
+    )
     assert ci["jobs"]["harness-integration"]["with"]["save-cache"] == expected
 
 
@@ -151,8 +155,10 @@ def test_runner_pool_contract_is_documented() -> None:
     assert "ten candidate executions" in runner_docs
     assert "improvement over `ubuntu-latest` is at least 25%" in runner_docs
     assert "8-core warm | 7 | 8m54 | 9m17" in runner_docs
-    assert "builds the complete stack once on `workers-ci-linux-8core`" in runner_docs
-    assert "Integration and Playwright jobs verify that bundle and run in parallel" in runner_docs
+    assert "builds the complete stack once" in runner_docs
+    assert "trusted `main` push uses\n`workers-ci-linux-8core`" in runner_docs
+    assert "Integration and Playwright jobs verify\nthat bundle and run in parallel" in runner_docs
+    assert "PR merge refs build the same bundle on `ubuntu-latest`" in runner_docs
 
 
 def test_interface_smoke_bounds_each_engine_readiness_probe() -> None:

--- a/.github/workflows/_harness-integration.yml
+++ b/.github/workflows/_harness-integration.yml
@@ -19,7 +19,12 @@ on:
         required: false
         default: ''
       runner:
-        description: GitHub Actions runner label selected by the trusted caller
+        description: Runner label used for the single Harness stack build
+        type: string
+        required: false
+        default: workers-ci-linux-8core
+      execution-runner:
+        description: Runner label used by validation, Integration, Playwright and coverage
         type: string
         required: false
         default: ubuntu-latest
@@ -30,15 +35,41 @@ on:
         default: ''
 
 jobs:
-  integration:
-    name: harness integration
-    runs-on: ${{ inputs.runner }}
-    timeout-minutes: 90
+  validate:
+    name: validate harness scenarios
+    runs-on: ${{ inputs.execution-runner }}
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           persist-credentials: false
           ref: ${{ inputs.source_ref }}
+
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # 1.97.1
+        with:
+          toolchain: 1.97.1
+
+      - name: Integration crate unit tests
+        run: cargo test --locked --manifest-path harness/Cargo.toml -p harness-integration
+
+      - name: Validate integration scenarios
+        run: make -C harness integration-validate
+
+  build:
+    name: build harness stack
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 45
+    outputs:
+      source-sha: ${{ steps.source.outputs.sha }}
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.source_ref }}
+
+      - name: Record source revision
+        id: source
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # 1.97.1
         with:
@@ -86,10 +117,6 @@ jobs:
           # own key so coverage runs never poison the normal cache.
           shared-key: ${{ inputs.coverage && 'harness-integration-coverage' || 'harness-integration' }}${{ inputs.cache-key-suffix && format('-{0}', inputs.cache-key-suffix) || '' }}
           save-if: ${{ inputs.save-cache || inputs.coverage }}
-          # Every release build the stack needs now lands in one shared
-          # target dir (see harness/Makefile INTEGRATION_TARGET_DIR); the
-          # per-workspace entries below stay so the cache key keeps hashing
-          # all eight lockfiles.
           cache-directories: target/integration-build
           workspaces: |
             harness -> target
@@ -102,24 +129,10 @@ jobs:
             console -> target
             database -> target
 
-      - name: Integration crate unit tests
-        run: cargo test --locked --manifest-path harness/Cargo.toml -p harness-integration
-
-      - name: Validate integration scenarios
-        run: make -C harness integration-validate
-
-      - name: Prepare coverage directories
-        if: inputs.coverage
-        run: mkdir -p target/coverage/profraw
-
-      - name: Run integration scenarios
+      - name: Build integration stack once
         env:
           RUSTFLAGS: ${{ inputs.coverage && '-Cinstrument-coverage -Cllvm-args=-runtime-counter-relocation' || '' }}
-          LLVM_PROFILE_FILE: ${{ inputs.coverage && format('{0}/target/coverage/profraw/%m_%p%c.profraw', github.workspace) || '' }}
-        run: >-
-          make -C harness integration-test
-          III_BIN="${{ steps.engine.outputs.bin }}"
-          CARGO_BUILD_FLAGS="--locked --timings"
+        run: make -C harness integration-build CARGO_BUILD_FLAGS="--locked --timings"
 
       - name: Install Console web dependencies
         working-directory: console/web
@@ -132,37 +145,97 @@ jobs:
       - name: Build Console worker
         env:
           RUSTFLAGS: ${{ inputs.coverage && '-Cinstrument-coverage -Cllvm-args=-runtime-counter-relocation' || '' }}
-          LLVM_PROFILE_FILE: ${{ inputs.coverage && format('{0}/target/coverage/profraw/%m_%p%c.profraw', github.workspace) || '' }}
         run: >-
           cargo build --locked --release --timings
           --target-dir "$GITHUB_WORKSPACE/target/integration-build"
           --manifest-path console/Cargo.toml
 
-      - name: Install Playwright Chromium
-        working-directory: console/web
-        run: pnpm exec playwright install --with-deps chromium
+      - name: Package immutable stack bundle
+        run: |
+          .github/scripts/harness_stack_bundle.sh pack \
+            --output "$GITHUB_WORKSPACE/target/harness-stack.tar.zst" \
+            --source-sha "${{ steps.source.outputs.sha }}" \
+            --engine-version "$III_ENGINE_VERSION" \
+            --engine-bin "${{ steps.engine.outputs.bin }}" \
+            --bin-dir "$GITHUB_WORKSPACE/target/integration-build/release"
 
-      - name: Typecheck Console E2E tests
-        working-directory: console/web
-        run: pnpm typecheck:e2e
+      - name: Upload stack bundle
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: harness-stack-bundle
+          path: target/harness-stack.tar.zst
+          compression-level: 0
+          retention-days: 3
+          if-no-files-found: error
 
-      - name: Run Console Playwright scenarios
-        working-directory: console/web
+      - name: Write cache summary
+        if: always()
         env:
-          III_BIN: ${{ steps.engine.outputs.bin }}
-          HARNESS_INTEGRATION_BIN: ${{ github.workspace }}/target/integration-build/release/harness-integration
-          HARNESS_BIN: ${{ github.workspace }}/target/integration-build/release/harness
-          CONSOLE_BIN: ${{ github.workspace }}/target/integration-build/release/console
-          QUEUE_BIN: ${{ github.workspace }}/target/integration-build/release/queue
-          III_DIRECTORY_BIN: ${{ github.workspace }}/target/integration-build/release/iii-directory
-          SESSION_MANAGER_BIN: ${{ github.workspace }}/target/integration-build/release/session-manager
-          CONTEXT_MANAGER_BIN: ${{ github.workspace }}/target/integration-build/release/context-manager
-          CRON_BIN: ${{ github.workspace }}/target/integration-build/release/cron
-          STATE_BIN: ${{ github.workspace }}/target/integration-build/release/state
-          DATABASE_BIN: ${{ github.workspace }}/target/integration-build/release/database
-          CONSOLE_E2E_ARTIFACTS_DIR: ${{ github.workspace }}/target/console-e2e
+          STACK_HIT: ${{ steps.stack-cache.outputs.cache-hit }}
+          SAVE_CACHE: ${{ inputs.save-cache }}
+          RUNNER_LABEL: ${{ inputs.runner }}
+          CACHE_COHORT: ${{ inputs.cache-key-suffix || 'stable' }}
+        run: |
+          {
+            echo "### Harness stack build"
+            echo
+            echo "| Runner label | Runner name | Cache cohort |"
+            echo "| --- | --- | --- |"
+            echo "| $RUNNER_LABEL | $RUNNER_NAME | $CACHE_COHORT |"
+            echo
+            echo "The iii engine is downloaded fresh from the latest @rc channel."
+            echo
+            echo "| Cache | Hit | Save enabled |"
+            echo "| --- | --- | --- |"
+            echo "| integration Rust | ${STACK_HIT:-false} | $SAVE_CACHE |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Rust build timings
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: harness-integration-rust-timings
+          path: target/integration-build/cargo-timings/*.html
+          retention-days: 14
+          if-no-files-found: ignore
+
+  integration:
+    name: run harness integration
+    needs: [validate, build]
+    runs-on: ${{ inputs.execution-runner }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+          ref: ${{ needs.build.outputs.source-sha }}
+
+      - name: Download stack bundle
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: harness-stack-bundle
+          path: target/bundle-download
+
+      - name: Verify and unpack stack bundle
+        run: |
+          .github/scripts/harness_stack_bundle.sh unpack \
+            --archive target/bundle-download/harness-stack.tar.zst \
+            --destination target/harness-stack \
+            --expected-source-sha "${{ needs.build.outputs.source-sha }}"
+          echo "STACK_BIN_DIR=$GITHUB_WORKSPACE/target/harness-stack/bin" >> "$GITHUB_ENV"
+          echo "III_ENGINE_VERSION=$(jq -er '.engine_version' target/harness-stack/manifest.json)" >> "$GITHUB_ENV"
+
+      - name: Prepare coverage directory
+        if: inputs.coverage
+        run: mkdir -p target/coverage/profraw && touch target/coverage/profraw/.keep
+
+      - name: Run integration scenarios
+        env:
           LLVM_PROFILE_FILE: ${{ inputs.coverage && format('{0}/target/coverage/profraw/%m_%p%c.profraw', github.workspace) || '' }}
-        run: pnpm test:e2e
+        run: >-
+          make -C harness integration-run
+          III_BIN="$STACK_BIN_DIR/iii"
+          INTEGRATION_BIN_DIR="$STACK_BIN_DIR"
 
       - name: Verify integration report links
         run: |
@@ -185,67 +258,15 @@ jobs:
             }
           done
 
-      - name: Generate coverage report
-        if: always() && inputs.coverage
-        run: |
-          .github/scripts/coverage_report.sh \
-            --profraw-dir target/coverage/profraw \
-            --output-dir target/coverage/integration \
-            --title harness-integration \
-            --object target/integration-build/release/queue \
-            --object target/integration-build/release/iii-directory \
-            --object target/integration-build/release/session-manager \
-            --object target/integration-build/release/context-manager \
-            --object target/integration-build/release/cron \
-            --object target/integration-build/release/state \
-            --object target/integration-build/release/harness \
-            --object target/integration-build/release/harness-integration \
-            --object target/integration-build/release/console
-
-      - name: Upload coverage report
+      - name: Upload integration coverage profiles
         if: always() && inputs.coverage
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
-          name: harness-integration-coverage
-          path: |
-            target/coverage/integration/html/
-            target/coverage/integration/summary.json
-            target/coverage/integration/report.txt
-          retention-days: 14
-          if-no-files-found: ignore
-
-      - name: Write cache summary
-        if: always()
-        env:
-          STACK_HIT: ${{ steps.stack-cache.outputs.cache-hit }}
-          SAVE_CACHE: ${{ inputs.save-cache }}
-          RUNNER_LABEL: ${{ inputs.runner }}
-          CACHE_COHORT: ${{ inputs.cache-key-suffix || 'stable' }}
-        run: |
-          {
-            echo "### Harness integration execution"
-            echo
-            echo "| Runner label | Runner name | Cache cohort |"
-            echo "| --- | --- | --- |"
-            echo "| $RUNNER_LABEL | $RUNNER_NAME | $CACHE_COHORT |"
-            echo
-            echo "The iii engine is downloaded fresh from the latest @rc channel."
-            echo
-            echo "| Cache | Hit | Save enabled |"
-            echo "| --- | --- | --- |"
-            echo "| integration Rust | ${STACK_HIT:-false} | $SAVE_CACHE |"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Upload Rust build timings
-        if: always()
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
-        with:
-          name: harness-integration-rust-timings
-          path: |
-            */target/cargo-timings/*.html
-            target/integration-build/cargo-timings/*.html
-          retention-days: 14
-          if-no-files-found: ignore
+          name: harness-integration-profraw
+          path: target/coverage/profraw/
+          retention-days: 3
+          include-hidden-files: true
+          if-no-files-found: error
 
       - name: Upload compact results
         if: always()
@@ -258,14 +279,92 @@ jobs:
             target/integration/*/teardown.json
           if-no-files-found: ignore
 
-      - name: Upload full non-pass artifacts
+      - name: Upload full integration diagnostics on failure
         if: failure()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
-          name: integration-artifacts
+          name: integration-failure-diagnostics
           path: target/integration/
           retention-days: 14
           if-no-files-found: ignore
+
+  playwright:
+    name: run Console Playwright
+    needs: [validate, build]
+    runs-on: ${{ inputs.execution-runner }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+          ref: ${{ needs.build.outputs.source-sha }}
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+        with:
+          version: 11.13.1
+
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 22
+
+      - name: Download stack bundle
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: harness-stack-bundle
+          path: target/bundle-download
+
+      - name: Verify and unpack stack bundle
+        run: |
+          .github/scripts/harness_stack_bundle.sh unpack \
+            --archive target/bundle-download/harness-stack.tar.zst \
+            --destination target/harness-stack \
+            --expected-source-sha "${{ needs.build.outputs.source-sha }}"
+          echo "STACK_BIN_DIR=$GITHUB_WORKSPACE/target/harness-stack/bin" >> "$GITHUB_ENV"
+          echo "III_ENGINE_VERSION=$(jq -er '.engine_version' target/harness-stack/manifest.json)" >> "$GITHUB_ENV"
+
+      - name: Install Console web dependencies
+        working-directory: console/web
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        working-directory: console/web
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Typecheck Console E2E tests
+        working-directory: console/web
+        run: pnpm typecheck:e2e
+
+      - name: Prepare coverage directory
+        if: inputs.coverage
+        run: mkdir -p target/coverage/profraw && touch target/coverage/profraw/.keep
+
+      - name: Run Console Playwright scenarios
+        working-directory: console/web
+        env:
+          III_BIN: ${{ github.workspace }}/target/harness-stack/bin/iii
+          HARNESS_INTEGRATION_BIN: ${{ github.workspace }}/target/harness-stack/bin/harness-integration
+          HARNESS_BIN: ${{ github.workspace }}/target/harness-stack/bin/harness
+          CONSOLE_BIN: ${{ github.workspace }}/target/harness-stack/bin/console
+          QUEUE_BIN: ${{ github.workspace }}/target/harness-stack/bin/queue
+          III_DIRECTORY_BIN: ${{ github.workspace }}/target/harness-stack/bin/iii-directory
+          SESSION_MANAGER_BIN: ${{ github.workspace }}/target/harness-stack/bin/session-manager
+          CONTEXT_MANAGER_BIN: ${{ github.workspace }}/target/harness-stack/bin/context-manager
+          CRON_BIN: ${{ github.workspace }}/target/harness-stack/bin/cron
+          STATE_BIN: ${{ github.workspace }}/target/harness-stack/bin/state
+          DATABASE_BIN: ${{ github.workspace }}/target/harness-stack/bin/database
+          CONSOLE_E2E_ARTIFACTS_DIR: ${{ github.workspace }}/target/console-e2e
+          LLVM_PROFILE_FILE: ${{ inputs.coverage && format('{0}/target/coverage/profraw/%m_%p%c.profraw', github.workspace) || '' }}
+        run: pnpm test:e2e
+
+      - name: Upload Playwright coverage profiles
+        if: always() && inputs.coverage
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: harness-playwright-profraw
+          path: target/coverage/profraw/
+          retention-days: 3
+          include-hidden-files: true
+          if-no-files-found: error
 
       - name: Upload Console E2E artifacts
         if: always()
@@ -273,5 +372,70 @@ jobs:
         with:
           name: console-e2e-artifacts
           path: target/console-e2e/
+          retention-days: 14
+          if-no-files-found: ignore
+
+  coverage:
+    name: aggregate harness coverage
+    if: always() && inputs.coverage && needs.build.result == 'success'
+    needs: [build, integration, playwright]
+    runs-on: ${{ inputs.execution-runner }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+          ref: ${{ needs.build.outputs.source-sha }}
+
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # 1.97.1
+        with:
+          toolchain: 1.97.1
+          components: llvm-tools
+
+      - name: Download stack bundle
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: harness-stack-bundle
+          path: target/bundle-download
+
+      - name: Verify and unpack stack bundle
+        run: |
+          .github/scripts/harness_stack_bundle.sh unpack \
+            --archive target/bundle-download/harness-stack.tar.zst \
+            --destination target/harness-stack \
+            --expected-source-sha "${{ needs.build.outputs.source-sha }}"
+
+      - name: Download coverage profiles
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          pattern: harness-*-profraw
+          path: target/coverage/profraw
+          merge-multiple: true
+
+      - name: Generate coverage report
+        run: |
+          .github/scripts/coverage_report.sh \
+            --profraw-dir target/coverage/profraw \
+            --output-dir target/coverage/integration \
+            --title harness-integration \
+            --object target/harness-stack/bin/queue \
+            --object target/harness-stack/bin/iii-directory \
+            --object target/harness-stack/bin/session-manager \
+            --object target/harness-stack/bin/context-manager \
+            --object target/harness-stack/bin/cron \
+            --object target/harness-stack/bin/state \
+            --object target/harness-stack/bin/harness \
+            --object target/harness-stack/bin/harness-integration \
+            --object target/harness-stack/bin/console
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: harness-integration-coverage
+          path: |
+            target/coverage/integration/html/
+            target/coverage/integration/summary.json
+            target/coverage/integration/report.txt
           retention-days: 14
           if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -816,6 +816,10 @@ jobs:
       contents: read
     uses: ./.github/workflows/_harness-integration.yml
     with:
+      # The restricted larger-runner group only admits trusted branch/tag
+      # workflow refs. PR merge refs use the same topology on a standard
+      # runner; the trusted main push builds on the 8-core pool.
+      runner: ${{ github.event_name == 'push' && 'workers-ci-linux-8core' || 'ubuntu-latest' }}
       save-cache: ${{ github.event_name == 'push' }}
 
   # ──────────────────────────────────────────────────────────────

--- a/.github/workflows/harness-integration-benchmark.yml
+++ b/.github/workflows/harness-integration-benchmark.yml
@@ -1,11 +1,11 @@
 name: Harness integration benchmark
-run-name: Harness integration benchmark · ${{ inputs.runner }} · ${{ inputs.cache-mode }} · ${{ inputs.source-ref || github.sha }}
+run-name: Harness integration build benchmark · ${{ inputs.runner }} · ${{ inputs.cache-mode }} · ${{ inputs.source-ref || github.sha }}
 
 on:
   workflow_dispatch:
     inputs:
       runner:
-        description: Runner pool to measure
+        description: Build runner pool to measure (execution stays on ubuntu-latest)
         type: choice
         required: true
         default: workers-ci-linux-8core

--- a/docs/architecture/testing-and-ci.md
+++ b/docs/architecture/testing-and-ci.md
@@ -105,8 +105,8 @@ cost, isolation and performance measurements.
 
 | Label | Infrastructure | Capacity | Current use |
 |---|---|---:|---|
-| `ubuntu-latest` | Standard GitHub-hosted Linux | GitHub-managed | PR checks, normal E2E and the default Harness integration |
-| `workers-ci-linux-8core` | Larger GitHub-hosted Linux | 2 concurrent | Manual Harness integration benchmark only |
+| `ubuntu-latest` | Standard GitHub-hosted Linux | GitHub-managed | PR checks, normal E2E, Harness validation and execution shards |
+| `workers-ci-linux-8core` | Larger GitHub-hosted Linux | 2 concurrent | Single Harness stack build and its manual benchmark |
 | `workers-release-control-linux-2core` | Larger GitHub-hosted Linux | 8 concurrent | Reserved for a later migration of release control jobs; no workflow selects it yet |
 | `workers-release-linux-8core` | Larger GitHub-hosted Linux | 8 concurrent | Linux release builds and, until migrated, release control jobs |
 | `windows-latest` | Standard GitHub-hosted Windows | GitHub-managed | Windows release builds |
@@ -122,12 +122,18 @@ self-hosted label is not part of the Workers routing contract.
 ### Harness integration recovery and benchmark
 
 [`_harness-integration.yml`](../../.github/workflows/_harness-integration.yml)
-defaults to `ubuntu-latest`; callers must opt into any other pool. This keeps
-pull requests running when optional capacity is unavailable.
+builds the complete stack once on `workers-ci-linux-8core`. The build produces
+a checksummed bundle tied to the checked-out commit and containing the freshly
+downloaded latest `iii @rc` plus every compiled stack binary. Independent
+Integration and Playwright jobs verify that bundle and run in parallel on
+`ubuntu-latest`; scenario validation also runs there while the stack builds.
+Callers can override `runner` for the build or `execution-runner` for the other
+jobs without changing this dependency graph.
 
 Use
 [`harness-integration-benchmark.yml`](../../.github/workflows/harness-integration-benchmark.yml)
-to compare `ubuntu-latest` with `workers-ci-linux-8core`:
+to compare `ubuntu-latest` with `workers-ci-linux-8core` for the single build
+job while keeping execution on the standard runner:
 
 1. Select one immutable `source-ref` SHA for the entire cohort.
 2. Run ten candidate executions: seven `warm` and three `cold`. Run matched
@@ -136,9 +142,9 @@ to compare `ubuntu-latest` with `workers-ci-linux-8core`:
    and cannot save it, so it neither restores nor pollutes the warm cache.
 4. Record queue time and execution time from the job API, cache hits from the
    job summary, and billed minutes for the larger runner.
-5. Keep the 8-core pool only when execution p95 is below 10 minutes and the
-   improvement over `ubuntu-latest` is at least 25%. Otherwise retain
-   `ubuntu-latest` as the permanent default.
+5. Keep the 8-core pool only when build p95 is below 10 minutes and the
+   improvement over `ubuntu-latest` is at least 25%. Otherwise move the build
+   back to `ubuntu-latest`; execution shards remain on that pool either way.
 
 Initial service targets are CI queue p95 below 60 seconds, no job waiting more
 than five minutes for a runner, Harness integration execution p95 below ten
@@ -157,12 +163,12 @@ queue is excluded because it includes the one-time runner-group access repair.
 | 8-core cold | 3 | 17m32 | 19m11 |
 
 A matched warm `ubuntu-latest` run took 11m11, so the 8-core warm p50 improved
-execution by about 20%, below the 25% retention threshold. The ten 8-core jobs
-consumed 121 rounded billed minutes, approximately US$2.66 at the price used
-for the pilot. Because standard runners are free for this public repository,
-`ubuntu-latest` remains the default. Keep the 8-core pool restricted and use
-it only for deliberate rebenchmarks after the Harness workload or cache keys
-change.
+the original monolithic job by about 20%, below the 25% retention threshold.
+The ten 8-core jobs consumed 121 rounded billed minutes, approximately US$2.66
+at the price used for the pilot. That result does not measure the current
+topology: the larger runner is now billed only for one shared build, while the
+two execution shards run concurrently on standard runners. Rebenchmark this
+build-only topology after changes to the Harness workload or cache keys.
 
 ## Script tests
 

--- a/docs/architecture/testing-and-ci.md
+++ b/docs/architecture/testing-and-ci.md
@@ -105,8 +105,8 @@ cost, isolation and performance measurements.
 
 | Label | Infrastructure | Capacity | Current use |
 |---|---|---:|---|
-| `ubuntu-latest` | Standard GitHub-hosted Linux | GitHub-managed | PR checks, normal E2E, Harness validation and execution shards |
-| `workers-ci-linux-8core` | Larger GitHub-hosted Linux | 2 concurrent | Single Harness stack build and its manual benchmark |
+| `ubuntu-latest` | Standard GitHub-hosted Linux | GitHub-managed | PR checks, normal E2E, Harness validation/execution shards and PR stack builds |
+| `workers-ci-linux-8core` | Larger GitHub-hosted Linux | 2 concurrent | Trusted `main` Harness stack build and its manual benchmark |
 | `workers-release-control-linux-2core` | Larger GitHub-hosted Linux | 8 concurrent | Reserved for a later migration of release control jobs; no workflow selects it yet |
 | `workers-release-linux-8core` | Larger GitHub-hosted Linux | 8 concurrent | Linux release builds and, until migrated, release control jobs |
 | `windows-latest` | Standard GitHub-hosted Windows | GitHub-managed | Windows release builds |
@@ -122,13 +122,16 @@ self-hosted label is not part of the Workers routing contract.
 ### Harness integration recovery and benchmark
 
 [`_harness-integration.yml`](../../.github/workflows/_harness-integration.yml)
-builds the complete stack once on `workers-ci-linux-8core`. The build produces
-a checksummed bundle tied to the checked-out commit and containing the freshly
-downloaded latest `iii @rc` plus every compiled stack binary. Independent
-Integration and Playwright jobs verify that bundle and run in parallel on
-`ubuntu-latest`; scenario validation also runs there while the stack builds.
-Callers can override `runner` for the build or `execution-runner` for the other
-jobs without changing this dependency graph.
+builds the complete stack once. The trusted `main` push uses
+`workers-ci-linux-8core`; PR merge refs build the same bundle on
+`ubuntu-latest` because the larger-runner group accepts only selected trusted
+branch/tag workflow refs. The build produces a checksummed bundle tied to the
+checked-out commit and containing the freshly downloaded latest `iii @rc` plus
+every compiled stack binary. Independent Integration and Playwright jobs verify
+that bundle and run in parallel on `ubuntu-latest`; scenario validation also
+runs there while the stack builds. Callers can override `runner` for the build
+or `execution-runner` for the other jobs without changing this dependency
+graph.
 
 Use
 [`harness-integration-benchmark.yml`](../../.github/workflows/harness-integration-benchmark.yml)

--- a/harness/Makefile
+++ b/harness/Makefile
@@ -30,7 +30,7 @@ RUST_WORKERS   := $(filter-out $(PYTHON_WORKERS),$(STACK))
 
 GOAL_ARGS        := $(filter-out help install-iii-rc build install-local clean cargo-clean dev-run dev-up dev-down dev-restart \
                     engine wait-engine wait-base wait-stack restart restart-worker stop stop-worker stop-work stop-engine status smoke logs attach \
-                    ensure-session prepare-scrapling require-engine where integration-test integration-coverage integration-playground integration-validate quickstart-validate,$(MAKECMDGOALS))
+                    ensure-session prepare-scrapling require-engine where integration-build integration-run integration-test integration-coverage integration-playground integration-validate quickstart-validate,$(MAKECMDGOALS))
 SELECTED_WORKERS := $(strip $(GOAL_ARGS))
 ACTIVE_WORKERS   := $(if $(SELECTED_WORKERS),$(SELECTED_WORKERS),$(STACK))
 UNKNOWN_WORKERS  := $(filter-out $(STACK),$(SELECTED_WORKERS))
@@ -42,7 +42,7 @@ RUN_FLAG   := $(if $(filter release,$(RUN_PROFILE)),--release,)
 
 .PHONY: help install-iii-rc build install-local clean cargo-clean dev-run dev-up dev-down dev-restart engine wait-engine wait-base wait-stack \
         restart restart-worker stop stop-worker stop-work stop-engine status smoke logs attach ensure-session prepare-scrapling \
-        require-engine where integration-test integration-coverage integration-playground integration-validate quickstart-validate $(STACK)
+        require-engine where integration-build integration-run integration-test integration-coverage integration-playground integration-validate quickstart-validate $(STACK)
 
 help:
 	@printf '%s\n' \
@@ -64,7 +64,9 @@ help:
 	  '  make build [workers...]             cargo build stack or selected workers' \
 	  '  make cargo-clean [workers...]       cargo clean stack or selected workers' \
 	  '  make install-local [workers...]     build and symlink into ~/.iii/workers' \
-	  '  make integration-test III_BIN=<iii>  run the harness integration scenarios (tests/integration)' \
+	  '  make integration-build               build the binaries used by integration scenarios' \
+	  '  make integration-run III_BIN=<iii>   run scenarios using prebuilt binaries' \
+	  '  make integration-test III_BIN=<iii>  build and run the harness integration scenarios' \
 	  '  make integration-coverage III_BIN=<iii>  run the scenarios instrumented and emit an LLVM coverage report' \
 	  '  make integration-playground III_BIN=<iii>  open the Console against an isolated integration stack' \
 	  '  make integration-validate           validate every integration scenario' \
@@ -391,18 +393,27 @@ INTEGRATION_ARTIFACTS ?= $(REPO_ROOT)/target/integration
 INTEGRATION_PLAYGROUND_SCENARIO ?= console-streamed-text
 INTEGRATION_PLAYGROUND_ARTIFACTS ?= $(REPO_ROOT)/target/console-e2e
 
-integration-test:
-	@if [ -z "$(III_BIN)" ]; then \
-	  echo "III_BIN is required: path to an iii @rc engine binary."; \
-	  echo "Install it with: make -C harness install-iii-rc"; \
-	  exit 3; \
-	fi
+integration-build:
 	@for w in $(INTEGRATION_WORKERS) harness; do \
 	  echo "building $$w ($(INTEGRATION_PROFILE))"; \
 	  cargo build $(CARGO_BUILD_FLAGS) $(INTEGRATION_FLAG) --target-dir "$(INTEGRATION_TARGET_DIR)" --manifest-path "$(REPO_ROOT)/$$w/Cargo.toml" || exit 1; \
 	done
 	@echo "building harness-integration ($(INTEGRATION_PROFILE))"
 	@cargo build $(CARGO_BUILD_FLAGS) $(INTEGRATION_FLAG) --target-dir "$(INTEGRATION_TARGET_DIR)" --manifest-path "$(MAKEFILE_DIR)Cargo.toml" -p harness-integration
+
+integration-run:
+	@if [ -z "$(III_BIN)" ]; then \
+	  echo "III_BIN is required: path to an iii @rc engine binary."; \
+	  echo "Install it with: make -C harness install-iii-rc"; \
+	  exit 3; \
+	fi
+	@test -x "$(III_BIN)" || { echo "III_BIN is missing or not executable: $(III_BIN)"; exit 3; }
+	@for bin in $(INTEGRATION_WORKERS) harness harness-integration; do \
+	  test -x "$(INTEGRATION_BIN_DIR)/$$bin" || { \
+	    echo "prebuilt integration binary is missing or not executable: $(INTEGRATION_BIN_DIR)/$$bin"; \
+	    exit 3; \
+	  }; \
+	done
 	@"$(INTEGRATION_BIN_DIR)/harness-integration" \
 	  run \
 	  --engine-bin "$(III_BIN)" \
@@ -416,6 +427,9 @@ integration-test:
 	  --worker-bin "database=$(INTEGRATION_BIN_DIR)/database" \
 	  --scenario "$(INTEGRATION_SCENARIO)" \
 	  --artifacts-dir "$(INTEGRATION_ARTIFACTS)"
+
+integration-test: integration-build
+	@$(MAKE) --no-print-directory integration-run
 
 COVERAGE_RUSTFLAGS := -Cinstrument-coverage -Cllvm-args=-runtime-counter-relocation
 COVERAGE_PROFRAW   := $(REPO_ROOT)/target/coverage/profraw


### PR DESCRIPTION
## Summary

- build the Harness stack once (8-core on trusted `main`/manual runs, standard runner on PR merge refs) and package the downloaded latest `iii @rc` with the compiled binaries
- verify the bundle commit and checksums before running Integration and Playwright in parallel on standard runners
- keep scenario validation parallel to the build and aggregate coverage profiles from both execution jobs
- document the build-only runner topology and adapt the manual benchmark

## Validation

- `python3 -m pytest -q .github/scripts/tests` (295 passed, 3 subtests passed)
- `cargo fmt --manifest-path harness/Cargo.toml -- --check`
- `cargo test --locked --manifest-path harness/Cargo.toml -p harness-integration` (114 passed)
- `pnpm -C console/web typecheck:e2e`
- `actionlint -config-file .github/actionlint.yaml`
- bundle round-trip, revision mismatch, and checksum tampering tests

## Live PR validation

- [CI run 33646707886](https://github.com/iii-hq/workers/actions/runs/33646707886) completed successfully on revision `4416d9523dd56423db883f2c2aa50d4b9950e789`
- the shared build job completed in 5m18; its Rust build step took 3m31 and produced a verified 63.4 MB stack artifact
- Integration and Playwright both started at 15:16:14 from that artifact; Integration completed in 1m50 and Playwright in 3m11
- the manual 8-core validation was canceled after the pool exceeded its five-minute queue SLO; no implementation step ran on that unavailable machine