### PR TITLE
(MOT-4639) perf(harness,shell): trim function contract prose to what the model needs

### DIFF
--- a/harness/src/functions/mod.rs
+++ b/harness/src/functions/mod.rs
@@ -41,14 +41,10 @@ pub const SEND_DESC: &str =
 
 pub const SPAWN_ID: &str = "harness::spawn";
 pub const SPAWN_DESC: &str =
-    "Spawn a sub-agent in a child session (direct call only — never a trigger target). \
-     Fire-and-forget: returns { child_session_id, child_turn_id } immediately; the child's \
-     outcome reaches you only through whatever destination its task names. The child is a \
-     LEAF by default (no spawn/send/trigger registration); pass options.orchestrator: true \
-     to grant the orchestration surface, still capped by the caller's own policy. The task \
-     must include literal values for every required resource selector (for example \
-     `db: \"primary\"`). Omit child `max_turns` unless its budget covers discovery, \
-     contract lookup, work, and the deliverable.";
+    "Spawn a sub-agent in a child session (never a trigger target) and return \
+     { child_session_id, child_turn_id } immediately; the child's outcome reaches you only \
+     through whatever destination its task names. Children are leaves unless \
+     options.orchestrator is true.";
 
 pub const TURN_ID: &str = "harness::turn";
 pub const TURN_DESC: &str =

--- a/harness/src/functions/send.rs
+++ b/harness/src/functions/send.rs
@@ -62,24 +62,14 @@ impl From<String> for MessageInput {
 /// Per-send options frozen onto the turn record (harness.md § `harness::send`).
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct SendOptions {
-    /// Run the session as a directory agent profile (`directory::agents::*`
-    /// id). Session-creating sends only — the profile's resolved system
-    /// prompt (its `extends` chain composed by the directory) REPLACES the
-    /// built-in identity (only the `mode` paragraph is prepended), its skill
-    /// filter becomes the session's skill selection, its `model` is the
-    /// fallback when this send names none, and its identity sticks like the
-    /// system prompt (later sends inherit; naming an explicit prompt field
-    /// sheds it). Refused on an existing session, combined with either
-    /// prompt field, or when the profile's `extends` chain does not resolve.
+    /// Directory agent profile id (`directory::agents::*`) replacing the
+    /// built-in identity; new sessions only, refused with a prompt field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub system_prompt: Option<String>,
-    /// How `system_prompt` combines with the built-in prompt: `override`
-    /// replaces it; `enrich` (default) appends to it; `disabled` omits it.
-    /// When BOTH prompt fields are omitted on an existing session, the prior
-    /// turn's resolved prompt is inherited; naming a strategy (even bare)
-    /// resolves fresh — the reset-to-default escape hatch.
+    /// How `system_prompt` combines with the built-in prompt; omitting both
+    /// prompt fields on an existing session inherits the prior prompt.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub system_prompt_strategy: Option<SystemPromptStrategy>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -105,26 +95,18 @@ pub struct SendOptions {
     /// The turn's deliverable; default `{ type: "text" }`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub output: Option<OutputContract>,
-    /// The fail-closed dispatch policy. Omitted on a NEW session → deny every
-    /// call; omitted when steering an EXISTING session → inherit the prior
-    /// turn's policy (a nudge must not disarm a live run). Pass
-    /// `{ allow: [] }` to strip explicitly. On a NEW `ask`-mode turn the
-    /// effective policy is capped at the configured default policy; a
-    /// steer folded into an already-running turn keeps that turn's frozen
-    /// policy until it finalises.
+    /// Fail-closed dispatch policy; omitted means deny all on a new session
+    /// and inherit on an existing one (`{ allow: [] }` strips explicitly).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub functions: Option<FunctionPolicy>,
-    /// Exact skill ids advertised to the model. On a fresh session, omitted or
-    /// empty means all. On an existing session, omitted inherits its filter and
-    /// empty resets to all. Explicit changes require no active turn. This is
-    /// index curation, not authorization.
+    /// Exact skill ids advertised to the model; omitted or empty means all on
+    /// a new session (existing: omitted inherits, empty resets).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub skills: Option<Vec<String>>,
     /// Tracing passthrough.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Value>,
-    /// Per-turn override of the configured validation-retry budget (also the
-    /// bound on `harness::hook::post-turn` deny re-prompts).
+    /// Per-turn override of the validation-retry budget.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_validation_retries: Option<u32>,
 }
@@ -145,11 +127,8 @@ pub struct SendRequest {
     pub session_id: Option<String>,
     /// The incoming user message text.
     pub message: MessageInput,
-    /// Required to start a NEW session unless `options.agent` supplies a
-    /// model. Steering or waking an EXISTING session may omit it — the
-    /// session's last turn's model (and provider, unless overridden) is
-    /// inherited, the same rule the notification inject path uses. A model
-    /// declared by the selected agent profile is authoritative.
+    /// Required on a new session unless `options.agent` supplies a model;
+    /// an existing session inherits its last turn's model when omitted.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -683,10 +662,11 @@ fn latest_seed_record<'a>(
 }
 
 /// The lineage a seeded turn carries: empty for a top-level send or a
-/// notification wake, populated for a spawned child. It exists so ONE seeding
-/// path can serve every entry point — before this, the child path hand-rolled
-/// its own `TurnRecord` and `put_turn`, which skipped the CAS/merge check and
-/// clobbered a running turn whenever a spawn reused a live session id.
+/// notification wake, populated for a spawned child.
+// It exists so ONE seeding path can serve every entry point — before this,
+// the child path hand-rolled its own `TurnRecord` and `put_turn`, which
+// skipped the CAS/merge check and clobbered a running turn whenever a spawn
+// reused a live session id.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct TurnLineage {
     pub depth: u32,

--- a/harness/src/functions/spawn.rs
+++ b/harness/src/functions/spawn.rs
@@ -45,8 +45,7 @@ pub enum SubagentColor {
 /// title; icon and color are closed semantic tokens consumed by UIs.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct SubagentDisplay {
-    /// Short functional name, such as `Frontend` or `Explorer`. Leading and
-    /// trailing whitespace is removed; the result must be 1-48 characters.
+    /// Short functional name such as `Frontend`, 1-48 characters after trimming.
     #[schemars(length(min = 1, max = 48))]
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -59,16 +58,13 @@ pub struct SubagentDisplay {
 pub struct SpawnOptions {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub system_prompt: Option<String>,
-    /// How `system_prompt` combines with the built-in prompt: `override`
-    /// replaces it; `enrich` (default) appends to it; `disabled` omits it.
+    /// How `system_prompt` combines with the built-in prompt.
     #[serde(default)]
     pub system_prompt_strategy: SystemPromptStrategy,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mode: Option<Mode>,
-    /// Capped at the parent's remaining turn budget. Omit unless a strict
-    /// child-specific cap is required. It must cover discovery/contract calls
-    /// plus every work call; very small values (for example 2-3) commonly
-    /// strand the child before it can produce its deliverable.
+    /// Turn cap for the child, capped at the parent's remaining budget; omit
+    /// unless required (small values strand the child).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_turns: Option<u32>,
     /// Inherits the parent's ceiling unless explicitly narrowed/overridden.
@@ -79,78 +75,54 @@ pub struct SpawnOptions {
     /// The child's deliverable: text / json / json+schema.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub output: Option<OutputContract>,
-    /// Override the child's validation-retry budget (output contract AND
-    /// `harness::hook::post-turn` deny re-prompts). Default: worker config.
+    /// Override of the child's validation-retry budget.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_validation_retries: Option<u32>,
-    /// Intersected with the parent policy — narrow, never escalate. An
-    /// `ask`-mode child is further capped at the configured default policy.
+    /// Dispatch policy for the child, intersected with the parent's (narrow,
+    /// never escalate).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub functions: Option<FunctionPolicy>,
-    /// Exact skill ids advertised to the child. On a fresh child, omitted or
-    /// empty means all. A reused child inherits when omitted and resets to all
-    /// when empty. Explicit changes require no active child turn.
+    /// Exact skill ids advertised to the child; omitted or empty means all (a
+    /// reused child inherits when omitted).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub skills: Option<Vec<String>>,
-    /// Grant this child the orchestration surface. Default false: a spawned
-    /// child is a LEAF — its policy gains deny globs for `harness::spawn`,
-    /// `harness::send`, `engine::register_trigger`, `engine::unregister_trigger`
-    /// and `engine::registered-triggers::*`, so it performs its assignment and
-    /// updates shared state without spawning, messaging sessions, or touching
-    /// trigger registrations. `true` skips those denies; the child still never
-    /// exceeds its parent's policy.
+    /// Let the child spawn, send, and register triggers (still capped by the
+    /// parent's policy); default false makes it a leaf.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub orchestrator: Option<bool>,
     /// Fan-out guard for the child's own spawns.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_children: Option<u32>,
-    /// Absolute filesystem root for the child turn (e.g. an isolated
-    /// `worktree::create` checkout), written to the child's
-    /// `metadata.fs_scope.root`. When set it overrides the inherited scope
-    /// for this child; when absent the child inherits its direct parent's
-    /// root unchanged.
+    /// Absolute filesystem root for the child turn; omit to inherit the
+    /// parent's.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub filesystem_root: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct SpawnRequest {
-    /// The child's self-contained goal — its opening user message. Include
-    /// every resolved required selector literally (for example `Use database
-    /// db: "primary"`); the child cannot infer resources from the parent.
+    /// The child's self-contained goal, its opening user message; name every
+    /// required resource selector literally (the child cannot infer them).
     pub task: MessageInput,
-    /// Run the child as a directory agent profile (`directory::agents::*`
-    /// id). The profile's resolved system prompt (its `extends` chain
-    /// composed by the directory) becomes the child's whole identity — no
-    /// shared identity underneath, only the `mode` paragraph in front — its
-    /// skill filter applies when `options.skills` is omitted, its `model`
-    /// slots between an explicit `model` and the parent's, and its name/icon
-    /// become the display defaults. Which agent profile to name is the
-    /// prompt's decision. Refused combined with `options.system_prompt`, and
-    /// when the profile's `extends` chain does not resolve.
+    /// Directory agent profile id (`directory::agents::*`) supplying the
+    /// child's prompt, skills, model, and display; refused with
+    /// `options.system_prompt`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent: Option<String>,
-    /// Optional display-only identity for the child session. This never affects
-    /// session ids, policy, routing, or execution. On named-session reuse the
-    /// existing session title and metadata are retained.
+    /// Display-only name/icon/color for the child session; never affects ids,
+    /// policy, or routing.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub display: Option<SubagentDisplay>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,
-    /// Spawn into this session, creating it if it does not exist (e.g. a fork,
-    /// or a pre-chosen id to filter `turn-completed` subscriptions on); default:
-    /// create fresh. An in-turn spawn may reuse an EXISTING id only inside its
-    /// own tree (itself, or a child it spawned) — anything else is refused as a
-    /// cross-run id collision. The response reports `reused: true` on reuse.
+    /// Session id to spawn into, created if absent; an existing id may be
+    /// reused only inside the caller's own tree.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub session_id: Option<String>,
-    /// Display-only parent for the console session tree, used when there is no
-    /// live parent turn (e.g. a console- or workflow-issued spawn).
-    /// Writes `SessionMeta.metadata.parent_session_id` so the console nests this
-    /// child; it does NOT grant policy inheritance or parent-call resolution.
-    /// Ignored when the dispatcher injects a real parent link (an in-turn spawn).
+    /// Display-only parent for the console tree when there is no live parent
+    /// turn; grants no policy inheritance.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parent_session_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/harness/src/functions/subscribe.rs
+++ b/harness/src/functions/subscribe.rs
@@ -58,58 +58,38 @@ pub const UNREGISTER_TRIGGER_ID: &str = "engine::unregister_trigger";
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[schemars(rename = "SubscribeArgs")]
 pub struct SubscribeRequest {
-    /// The iii trigger type to listen on: `cron`, `state`, `stream`, `timer`
-    /// (one-shot deadline: `{ "in_ms": <ms> }` or `{ "at": <epoch ms> }`), or
-    /// another worker's custom trigger type (e.g. `database::row-changed`).
-    /// For an ad-hoc signal, subscribe to `state` on a key and have the
-    /// signaller call `state::set` on it (no dedicated emit needed — the
-    /// engine fans the trigger out to every subscriber).
+    /// Trigger type to listen on: `cron`, `state`, `stream`, `timer`, or
+    /// another worker's custom type (e.g. `database::row-changed`).
     pub trigger_type: String,
-    /// The trigger config, passed verbatim to the engine — e.g.
-    /// `{ "expression": "0 */5 * * * *" }` for cron, or a `state` scope/key.
+    /// Trigger config passed verbatim to the engine: cron `{ "expression" }`,
+    /// state scope/key, timer `{ "in_ms" }` or `{ "at" }` (epoch ms).
     #[serde(default)]
     pub config: Value,
     /// A short human label echoed back in the notification text.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
-    /// Auto-unsubscribe after the first delivered fire. Defaults by SHAPE:
-    /// a WAKE (no `function_id`) is once — it parks this session until the
-    /// event; a CALL binding is STANDING — it runs per matching event until
-    /// unregistered or its lifecycle ends; `cron` is recurring; `timer` is
-    /// once. Pass `once` explicitly to override any of these.
+    /// Auto-unsubscribe after the first fire; defaults to true for a wake (no
+    /// `function_id`) and `timer`, false for a call binding and `cron`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub once: Option<bool>,
-    /// Target function called on each event. Omit for a notification message
-    /// into this session — the only shape that can reach you. Any non-harness
-    /// function your policy allows may be named; `harness::spawn` is NOT a
-    /// binding target — a binding never starts an agent. Spawn children
-    /// directly from a turn and register a wake on what they write.
+    /// Function called on each event; omit to be notified in this session
+    /// instead. `harness::spawn` is never a valid target.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub function_id: Option<String>,
-    /// Presentation metadata plus the optional call-binding template:
-    /// `{ action?, payload?, event_into? }`. `action` is a short user-facing
-    /// description of the event shown when this trigger fires (for example,
-    /// "new Explorer message received"); unlike `label`, it describes what
-    /// happened rather than naming the binding. `payload` is the fixed
-    /// argument object sent to a call target; `event_into` is a JSON pointer
-    /// naming where the fired event is injected into that payload. For a
-    /// wake, only `action` has meaning. Sub-agent fields
-    /// (task/model/session_id/options) are rejected — spawning is not
-    /// something a binding does.
+    /// Optional `{ action?, payload?, event_into? }`: user-facing event text,
+    /// the fixed call payload, and the JSON pointer where the event is
+    /// injected into it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Value>,
-    /// Explicit target, the long form of `function_id` + `metadata`:
-    /// `{ function_id, payload?, event_into? }`. The shorthands stay valid and
-    /// mean exactly this.
+    /// Long form of `function_id` + `metadata`: `{ function_id, payload?,
+    /// event_into? }`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub target: Option<BindingTarget>,
-    /// Gates evaluated at fire time, in order, each an ordinary iii function
-    /// answering `{ decision: "allow" | "skip", payload?, reason? }`. The
-    /// built-in safety gates run first and are not listed here.
+    /// Fire-time gates, in order; each is an iii function answering
+    /// `{ decision: "allow" | "skip", payload?, reason? }`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub conditions: Vec<ConditionSpec>,
-    /// When the binding stops firing. `once` may also be given at the top
-    /// level (the shorthand every prompt uses).
+    /// When the binding stops firing; top-level `once` is the shorthand.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lifecycle: Option<LifecycleRequest>,
 }
@@ -120,19 +100,18 @@ pub struct SubscribeRequest {
 #[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct LifecycleRequest {
-    /// Auto-unsubscribe after the first delivered fire. The top-level `once`
-    /// field remains accepted as shorthand.
+    /// Auto-unsubscribe after the first fire (same as top-level `once`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub once: Option<bool>,
     /// Lifetime delivery budget; the binding retires on its Nth delivery.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_fires: Option<u64>,
-    /// RELATIVE deadline: the binding stops this many milliseconds from
-    /// registration (resolved to an absolute instant server-side). The ONLY
-    /// deadline form — absolute `expires_at` was retired from this contract
-    /// after repeated stale-epoch guesses (verify-wake-fix-1/-4: models sent
-    /// months-old round numbers); `deny_unknown_fields` turns it into a
-    /// field-naming error instead of a silently dropped deadline.
+    /// Relative deadline: the binding stops this many milliseconds after
+    /// registration (the only deadline form).
+    // Absolute `expires_at` was retired after repeated stale-epoch guesses
+    // (verify-wake-fix-1/-4: models sent months-old round numbers);
+    // `deny_unknown_fields` turns it into a field-naming error instead of a
+    // silently dropped deadline.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub expires_in_ms: Option<i64>,
 }

--- a/harness/src/functions/system_prompt.rs
+++ b/harness/src/functions/system_prompt.rs
@@ -18,10 +18,8 @@ pub struct SelectedSystemPrompt {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct SystemPromptRequest {
     pub session_id: String,
-    /// Return only the built-in default layer — the stored
-    /// `system-prompts/default` override when one is active, else the
-    /// embedded Harness default — without session, runtime, registry, or
-    /// hook layers. The part's `name` states which source served it.
+    /// Return only the built-in default layer, without session, runtime,
+    /// registry, or hook layers.
     #[serde(default)]
     pub default_only: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/harness/src/functions/triggers_list.rs
+++ b/harness/src/functions/triggers_list.rs
@@ -27,24 +27,20 @@ use crate::subscriptions::fired;
 
 pub const TRIGGERS_LIST_ID: &str = "harness::triggers::list";
 pub const TRIGGERS_LIST_DESC: &str =
-    "Read-only: the trigger bindings a session owns (durable records) — subscription id, \
-     trigger type/config, delivery target (absent = notifies the owner), label/event \
-     action, conditions, lifecycle, and fire count. In-turn agent calls may omit \
-     `session_id` (defaults to the calling session).";
+    "List the trigger bindings a session owns: subscription id, trigger type/config, \
+     target (absent = notifies the owner), label, conditions, lifecycle, and fire count. \
+     In-turn calls may omit `session_id`.";
 
 pub const TRIGGERS_UNREGISTER_ID: &str = "harness::triggers::unregister";
 pub const TRIGGERS_UNREGISTER_DESC: &str =
-    "Tear down one trigger binding by subscription id: unregister the engine trigger AND \
-     delete the durable record (an engine-side unregister alone strands the owner's armed \
-     wake). `session_id` must name the binding's owner; in-turn agent calls may omit it \
-     (defaults to the calling session). A still-armed wake torn down this way notifies \
-     its parked owner.";
+    "Tear down one trigger binding by subscription id (engine trigger and durable record); \
+     a still-armed wake notifies its parked owner. `session_id` must name the owner; \
+     in-turn calls may omit it.";
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 pub struct TriggersListRequest {
-    /// The owning session whose bindings to list. In-turn agent calls may
-    /// omit it — the harness injects the calling session. External callers
-    /// (console, CLI) must name the owner explicitly.
+    /// Owner session whose bindings to list; in-turn calls may omit it (the
+    /// calling session is injected).
     #[serde(default)]
     pub session_id: Option<String>,
 }
@@ -140,16 +136,14 @@ fn row_from(binding: &Binding) -> TriggerRow {
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 pub struct TriggersUnregisterRequest {
-    /// `id` accepted as an alias: the sibling teardown contract
-    /// (`engine::unregister_trigger`) calls this field `id`, and models carry
-    /// that name over — verify-wake-fix-1 postmortem: the first unregister of
-    /// the run failed on a raw serde "missing field" for exactly this.
+    /// The subscription to remove (`id` is accepted as an alias).
+    // The sibling `engine::unregister_trigger` calls this field `id` and models
+    // carry that name over — verify-wake-fix-1 postmortem: the first unregister
+    // of the run failed on a raw serde "missing field" for exactly this.
     #[serde(alias = "id")]
     pub subscription_id: String,
-    /// The binding's owner session — a correctness handshake, checked against
-    /// the record. In-turn agent calls may omit it (the harness injects the
-    /// calling session). The console's privileged path supplies the owner it
-    /// just listed.
+    /// The binding's owner session; in-turn calls may omit it (the calling
+    /// session is injected).
     #[serde(default)]
     pub session_id: Option<String>,
 }

--- a/harness/src/prompt/mode.rs
+++ b/harness/src/prompt/mode.rs
@@ -3,9 +3,8 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-/// Console / send operating mode — prepends a short paragraph before the
-/// shared identity prompt. `ask` is also structural: the turn's dispatch
-/// policy is capped at the configured default policy, never widened.
+/// Operating mode prepended to the identity prompt; `ask` also caps the
+/// dispatch policy at the configured default.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum Mode {

--- a/harness/src/turn_loop.rs
+++ b/harness/src/turn_loop.rs
@@ -117,11 +117,11 @@ pub struct TurnStepPayload {
     /// `iii.tag.message` baggage before any state read.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub message_preview: Option<String>,
-    /// Sub-agent depth carried from the turn record (0 = top-level), so the
-    /// step can stamp the `iii.tag.kind` baggage (`harness.turn` /
-    /// `harness.subagent`) before any state read. Defaults to 0 so stale
-    /// in-flight payloads from before this field existed still classify as
-    /// top-level turns.
+    /// Sub-agent depth carried from the turn record (0 = top-level).
+    // Lets the step stamp the `iii.tag.kind` baggage (`harness.turn` /
+    // `harness.subagent`) before any state read. Defaults to 0 so stale
+    // in-flight payloads from before this field existed still classify as
+    // top-level turns.
     #[serde(default)]
     pub depth: u32,
 }

--- a/harness/tests/golden/schemas/harness.send.json
+++ b/harness/tests/golden/schemas/harness.send.json
@@ -40,7 +40,7 @@
         "type": "object"
       },
       "Mode": {
-        "description": "Console / send operating mode — prepends a short paragraph before the shared identity prompt. `ask` is also structural: the turn's dispatch policy is capped at the configured default policy, never widened.",
+        "description": "Operating mode prepended to the identity prompt; `ask` also caps the dispatch policy at the configured default.",
         "enum": [
           "ask",
           "agent"
@@ -85,7 +85,7 @@
         "description": "Per-send options frozen onto the turn record (harness.md § `harness::send`).",
         "properties": {
           "agent": {
-            "description": "Run the session as a directory agent profile (`directory::agents::*` id). Session-creating sends only — the profile's resolved system prompt (its `extends` chain composed by the directory) REPLACES the built-in identity (only the `mode` paragraph is prepended), its skill filter becomes the session's skill selection, its `model` is the fallback when this send names none, and its identity sticks like the system prompt (later sends inherit; naming an explicit prompt field sheds it). Refused on an existing session, combined with either prompt field, or when the profile's `extends` chain does not resolve.",
+            "description": "Directory agent profile id (`directory::agents::*`) replacing the built-in identity; new sessions only, refused with a prompt field.",
             "type": [
               "string",
               "null"
@@ -100,7 +100,7 @@
                 "type": "null"
               }
             ],
-            "description": "The fail-closed dispatch policy. Omitted on a NEW session → deny every call; omitted when steering an EXISTING session → inherit the prior turn's policy (a nudge must not disarm a live run). Pass `{ allow: [] }` to strip explicitly. On a NEW `ask`-mode turn the effective policy is capped at the configured default policy; a steer folded into an already-running turn keeps that turn's frozen policy until it finalises."
+            "description": "Fail-closed dispatch policy; omitted means deny all on a new session and inherit on an existing one (`{ allow: [] }` strips explicitly)."
           },
           "max_cost_usd": {
             "description": "Hard USD budget for the complete root-and-subagent session tree. Every model used by the tree must advertise catalog pricing.",
@@ -137,7 +137,7 @@
             ]
           },
           "max_validation_retries": {
-            "description": "Per-turn override of the configured validation-retry budget (also the bound on `harness::hook::post-turn` deny re-prompts).",
+            "description": "Per-turn override of the validation-retry budget.",
             "format": "uint32",
             "minimum": 0.0,
             "type": [
@@ -178,7 +178,7 @@
             ]
           },
           "skills": {
-            "description": "Exact skill ids advertised to the model. On a fresh session, omitted or empty means all. On an existing session, omitted inherits its filter and empty resets to all. Explicit changes require no active turn. This is index curation, not authorization.",
+            "description": "Exact skill ids advertised to the model; omitted or empty means all on a new session (existing: omitted inherits, empty resets).",
             "items": {
               "type": "string"
             },
@@ -202,7 +202,7 @@
                 "type": "null"
               }
             ],
-            "description": "How `system_prompt` combines with the built-in prompt: `override` replaces it; `enrich` (default) appends to it; `disabled` omits it. When BOTH prompt fields are omitted on an existing session, the prior turn's resolved prompt is inherited; naming a strategy (even bare) resolves fresh — the reset-to-default escape hatch."
+            "description": "How `system_prompt` combines with the built-in prompt; omitting both prompt fields on an existing session inherits the prior prompt."
           },
           "thinking_level": {
             "anyOf": [
@@ -280,7 +280,7 @@
         "type": "string"
       },
       "model": {
-        "description": "Required to start a NEW session unless `options.agent` supplies a model. Steering or waking an EXISTING session may omit it — the session's last turn's model (and provider, unless overridden) is inherited, the same rule the notification inject path uses. A model declared by the selected agent profile is authoritative.",
+        "description": "Required on a new session unless `options.agent` supplies a model; an existing session inherits its last turn's model when omitted.",
         "type": [
           "string",
           "null"

--- a/harness/tests/golden/schemas/harness.spawn.json
+++ b/harness/tests/golden/schemas/harness.spawn.json
@@ -40,7 +40,7 @@
         "type": "object"
       },
       "Mode": {
-        "description": "Console / send operating mode — prepends a short paragraph before the shared identity prompt. `ask` is also structural: the turn's dispatch policy is capped at the configured default policy, never widened.",
+        "description": "Operating mode prepended to the identity prompt; `ask` also caps the dispatch policy at the configured default.",
         "enum": [
           "ask",
           "agent"
@@ -84,7 +84,7 @@
       "SpawnOptions": {
         "properties": {
           "filesystem_root": {
-            "description": "Absolute filesystem root for the child turn (e.g. an isolated `worktree::create` checkout), written to the child's `metadata.fs_scope.root`. When set it overrides the inherited scope for this child; when absent the child inherits its direct parent's root unchanged.",
+            "description": "Absolute filesystem root for the child turn; omit to inherit the parent's.",
             "type": [
               "string",
               "null"
@@ -99,7 +99,7 @@
                 "type": "null"
               }
             ],
-            "description": "Intersected with the parent policy — narrow, never escalate. An `ask`-mode child is further capped at the configured default policy."
+            "description": "Dispatch policy for the child, intersected with the parent's (narrow, never escalate)."
           },
           "max_children": {
             "description": "Fan-out guard for the child's own spawns.",
@@ -120,7 +120,7 @@
             ]
           },
           "max_turns": {
-            "description": "Capped at the parent's remaining turn budget. Omit unless a strict child-specific cap is required. It must cover discovery/contract calls plus every work call; very small values (for example 2-3) commonly strand the child before it can produce its deliverable.",
+            "description": "Turn cap for the child, capped at the parent's remaining budget; omit unless required (small values strand the child).",
             "format": "uint32",
             "minimum": 0.0,
             "type": [
@@ -129,7 +129,7 @@
             ]
           },
           "max_validation_retries": {
-            "description": "Override the child's validation-retry budget (output contract AND `harness::hook::post-turn` deny re-prompts). Default: worker config.",
+            "description": "Override of the child's validation-retry budget.",
             "format": "uint32",
             "minimum": 0.0,
             "type": [
@@ -148,7 +148,7 @@
             ]
           },
           "orchestrator": {
-            "description": "Grant this child the orchestration surface. Default false: a spawned child is a LEAF — its policy gains deny globs for `harness::spawn`, `harness::send`, `engine::register_trigger`, `engine::unregister_trigger` and `engine::registered-triggers::*`, so it performs its assignment and updates shared state without spawning, messaging sessions, or touching trigger registrations. `true` skips those denies; the child still never exceeds its parent's policy.",
+            "description": "Let the child spawn, send, and register triggers (still capped by the parent's policy); default false makes it a leaf.",
             "type": [
               "boolean",
               "null"
@@ -166,7 +166,7 @@
             "description": "The child's deliverable: text / json / json+schema."
           },
           "skills": {
-            "description": "Exact skill ids advertised to the child. On a fresh child, omitted or empty means all. A reused child inherits when omitted and resets to all when empty. Explicit changes require no active child turn.",
+            "description": "Exact skill ids advertised to the child; omitted or empty means all (a reused child inherits when omitted).",
             "items": {
               "type": "string"
             },
@@ -188,7 +188,7 @@
               }
             ],
             "default": "enrich",
-            "description": "How `system_prompt` combines with the built-in prompt: `override` replaces it; `enrich` (default) appends to it; `disabled` omits it."
+            "description": "How `system_prompt` combines with the built-in prompt."
           },
           "thinking_level": {
             "anyOf": [
@@ -239,7 +239,7 @@
             ]
           },
           "name": {
-            "description": "Short functional name, such as `Frontend` or `Explorer`. Leading and trailing whitespace is removed; the result must be 1-48 characters.",
+            "description": "Short functional name such as `Frontend`, 1-48 characters after trimming.",
             "maxLength": 48,
             "minLength": 1,
             "type": "string"
@@ -303,7 +303,7 @@
     },
     "properties": {
       "agent": {
-        "description": "Run the child as a directory agent profile (`directory::agents::*` id). The profile's resolved system prompt (its `extends` chain composed by the directory) becomes the child's whole identity — no shared identity underneath, only the `mode` paragraph in front — its skill filter applies when `options.skills` is omitted, its `model` slots between an explicit `model` and the parent's, and its name/icon become the display defaults. Which agent profile to name is the prompt's decision. Refused combined with `options.system_prompt`, and when the profile's `extends` chain does not resolve.",
+        "description": "Directory agent profile id (`directory::agents::*`) supplying the child's prompt, skills, model, and display; refused with `options.system_prompt`.",
         "type": [
           "string",
           "null"
@@ -318,7 +318,7 @@
             "type": "null"
           }
         ],
-        "description": "Optional display-only identity for the child session. This never affects session ids, policy, routing, or execution. On named-session reuse the existing session title and metadata are retained."
+        "description": "Display-only name/icon/color for the child session; never affects ids, policy, or routing."
       },
       "model": {
         "type": [
@@ -337,7 +337,7 @@
         ]
       },
       "parent_session_id": {
-        "description": "Display-only parent for the console session tree, used when there is no live parent turn (e.g. a console- or workflow-issued spawn). Writes `SessionMeta.metadata.parent_session_id` so the console nests this child; it does NOT grant policy inheritance or parent-call resolution. Ignored when the dispatcher injects a real parent link (an in-turn spawn).",
+        "description": "Display-only parent for the console tree when there is no live parent turn; grants no policy inheritance.",
         "type": [
           "string",
           "null"
@@ -350,14 +350,14 @@
         ]
       },
       "session_id": {
-        "description": "Spawn into this session, creating it if it does not exist (e.g. a fork, or a pre-chosen id to filter `turn-completed` subscriptions on); default: create fresh. An in-turn spawn may reuse an EXISTING id only inside its own tree (itself, or a child it spawned) — anything else is refused as a cross-run id collision. The response reports `reused: true` on reuse.",
+        "description": "Session id to spawn into, created if absent; an existing id may be reused only inside the caller's own tree.",
         "type": [
           "string",
           "null"
         ]
       },
       "task": {
-        "description": "The child's self-contained goal — its opening user message. Include every resolved required selector literally (for example `Use database db: \"primary\"`); the child cannot infer resources from the parent.",
+        "description": "The child's self-contained goal, its opening user message; name every required resource selector literally (the child cannot infer them).",
         "type": "string"
       }
     },

--- a/harness/tests/golden/schemas/harness.system-prompt.get.json
+++ b/harness/tests/golden/schemas/harness.system-prompt.get.json
@@ -4,7 +4,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
       "Mode": {
-        "description": "Console / send operating mode — prepends a short paragraph before the shared identity prompt. `ask` is also structural: the turn's dispatch policy is capped at the configured default policy, never widened.",
+        "description": "Operating mode prepended to the identity prompt; `ask` also caps the dispatch policy at the configured default.",
         "enum": [
           "ask",
           "agent"
@@ -64,7 +64,7 @@
     "properties": {
       "default_only": {
         "default": false,
-        "description": "Return only the built-in default layer — the stored `system-prompts/default` override when one is active, else the embedded Harness default — without session, runtime, registry, or hook layers. The part's `name` states which source served it.",
+        "description": "Return only the built-in default layer, without session, runtime, registry, or hook layers.",
         "type": "boolean"
       },
       "filesystem_root": {

--- a/harness/tests/golden/schemas/harness.triggers.list.json
+++ b/harness/tests/golden/schemas/harness.triggers.list.json
@@ -5,7 +5,7 @@
     "properties": {
       "session_id": {
         "default": null,
-        "description": "The owning session whose bindings to list. In-turn agent calls may omit it — the harness injects the calling session. External callers (console, CLI) must name the owner explicitly.",
+        "description": "Owner session whose bindings to list; in-turn calls may omit it (the calling session is injected).",
         "type": [
           "string",
           "null"

--- a/harness/tests/golden/schemas/harness.triggers.unregister.json
+++ b/harness/tests/golden/schemas/harness.triggers.unregister.json
@@ -5,14 +5,14 @@
     "properties": {
       "session_id": {
         "default": null,
-        "description": "The binding's owner session — a correctness handshake, checked against the record. In-turn agent calls may omit it (the harness injects the calling session). The console's privileged path supplies the owner it just listed.",
+        "description": "The binding's owner session; in-turn calls may omit it (the calling session is injected).",
         "type": [
           "string",
           "null"
         ]
       },
       "subscription_id": {
-        "description": "`id` accepted as an alias: the sibling teardown contract (`engine::unregister_trigger`) calls this field `id`, and models carry that name over — verify-wake-fix-1 postmortem: the first unregister of the run failed on a raw serde \"missing field\" for exactly this.",
+        "description": "The subscription to remove (`id` is accepted as an alias).",
         "type": "string"
       }
     },

--- a/harness/tests/golden/schemas/harness.turn.json
+++ b/harness/tests/golden/schemas/harness.turn.json
@@ -6,7 +6,7 @@
     "properties": {
       "depth": {
         "default": 0,
-        "description": "Sub-agent depth carried from the turn record (0 = top-level), so the step can stamp the `iii.tag.kind` baggage (`harness.turn` / `harness.subagent`) before any state read. Defaults to 0 so stale in-flight payloads from before this field existed still classify as top-level turns.",
+        "description": "Sub-agent depth carried from the turn record (0 = top-level).",
         "format": "uint32",
         "minimum": 0.0,
         "type": "integer"

--- a/shell/src/code/functions/create_file.rs
+++ b/shell/src/code/functions/create_file.rs
@@ -41,10 +41,7 @@ impl<'de> Deserialize<'de> for CreateFileInput {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct CreateFileSpec {
-    /// Path relative to the primary allowed root, or an absolute path inside
-    /// any allowed root. Call `coder::info` to see the allowed roots. Paths
-    /// outside every allowed root are rejected — use the shell worker's
-    /// `shell::fs::*` for host paths outside the jail.
+    /// File to create.
     pub path: String,
     pub content: String,
     /// Octal permission bits as a string, e.g. "0644". Defaults to "0644".
@@ -57,10 +54,8 @@ pub struct CreateFileSpec {
     /// When false (the default), refuse to write if `path` already exists.
     #[serde(default)]
     pub overwrite: bool,
-    /// Optional optimistic concurrency precondition for an overwrite. Pass
-    /// the opaque `revision` returned by `coder::read-file`; if the file no
-    /// longer has that exact content, the entry fails with C221 and is not
-    /// written. Omit for backward-compatible unconditional overwrite.
+    /// Optimistic-concurrency guard for an overwrite: the `revision` from
+    /// coder::read-file; if the content changed the entry fails C221 unwritten.
     #[serde(default)]
     pub expected_revision: Option<String>,
 }

--- a/shell/src/code/functions/delete_file.rs
+++ b/shell/src/code/functions/delete_file.rs
@@ -17,11 +17,7 @@ use crate::code::path::PathResolver;
 #[derive(Debug, Deserialize, JsonSchema)]
 #[schemars(example = "example_delete_file_input")]
 pub struct DeleteFileInput {
-    /// Paths to remove. Each entry is relative to the primary allowed root,
-    /// or an absolute path inside any allowed root. Call `coder::info` to
-    /// see the allowed roots. Paths outside every allowed root are rejected
-    /// — use the shell worker's `shell::fs::*` for host paths outside the
-    /// jail.
+    /// Paths to remove.
     pub paths: Vec<String>,
     /// Required for non-empty directories. Files and empty dirs ignore it.
     #[serde(default)]

--- a/shell/src/code/functions/list_folder.rs
+++ b/shell/src/code/functions/list_folder.rs
@@ -16,17 +16,13 @@ use crate::code::path::PathResolver;
 #[derive(Debug, Deserialize, JsonSchema)]
 #[schemars(example = "example_list_folder_input")]
 pub struct ListFolderInput {
-    /// Folder to list. Relative to the primary allowed root, or an absolute
-    /// path inside any allowed root. Defaults to `.` (the primary root
-    /// itself). Call `coder::info` to see the allowed roots. Paths outside
-    /// every allowed root are rejected — use the shell worker's
-    /// `shell::fs::*` for host paths outside the jail.
+    /// Folder to list (default `.`).
     #[serde(default = "default_path")]
     pub path: String,
     #[serde(default = "default_page")]
     pub page: u32,
-    /// Capped by `config.list_max_page_size`; falls back to
-    /// `config.list_default_page_size` when omitted.
+    /// Capped at list_max_page_size; defaults to list_default_page_size (see
+    /// coder::info).
     #[serde(default)]
     pub page_size: Option<u32>,
     /// Internal harness filesystem scope; omitted from published schema.

--- a/shell/src/code/functions/mod.rs
+++ b/shell/src/code/functions/mod.rs
@@ -67,157 +67,76 @@ pub(crate) fn files_batch_or_single<T: serde::de::DeserializeOwned>(
 // ---------------------------------------------------------------------------
 // Function ids + registration descriptions (ONE place).
 //
-// The jail-contract sentence in every description below also appears in
-// the schema field docs of each input struct. This duplication is
-// deliberate: the catalog description and the schema docs reach agents
-// through DIFFERENT surfaces — `functions::list` shows descriptions only,
-// while the schema docs surface via `functions::info`. Do not "DRY" one
-// into the other.
+// Each description carries the jail-contract clause ONCE; schema field docs
+// state only what the field is (MOT-4639: the prose IS the contract the model
+// sees via functions::info, so keep it short).
 // ---------------------------------------------------------------------------
 
 const INFO_ID: &str = "coder::info";
-const INFO_DESC: &str = "Report the coder access contract: the effective mode (jailed = \
-     paths confined to the allowed roots; unjailed = deny-only, absolute \
-     paths anywhere on the host, roots anchor relative paths only), \
-     canonical allowed roots (primary first), the session_root that \
-     relative paths actually anchor against when the session is scoped \
-     (it overrides primary_root and may sit outside every allowed root), \
-     per-file size caps, \
-     response budgets (max_output_bytes, batch_read_budget_bytes, \
-     search_response_budget_bytes), listing/search limits, the \
-     non-accessible glob patterns, and the default_exclude_globs noise \
-     filter applied by tree/search. Call this FIRST when unsure where \
-     coder may read or write, or when a path was rejected — in jailed \
-     mode, paths outside every allowed root need the shell worker's \
-     shell::fs::* instead.";
+const INFO_DESC: &str = "Report the coder access contract: mode (jailed | unjailed), allowed \
+     roots (primary first), the session_root relative paths anchor against, \
+     size caps, response budgets, listing/search limits, non-accessible \
+     globs and default_exclude_globs. Call it first when a path is \
+     rejected.";
 
 const READ_FILE_ID: &str = "coder::read-file";
-const READ_FILE_DESC: &str = "Read a file window-first: probe with stat: true (size/mtime/mode \
-     plus total_lines, no content), then fetch just the lines you need \
-     with line_from/line_to (1-based, inclusive) — windows keep files \
-     larger than max_read_bytes readable window by window, with \
-     more_lines/total_lines reporting what remains. numbered: true \
-     prefixes each line with its absolute 1-based file line number, \
-     matching coder::update-file's line ops exactly. Full reads are \
-     budgeted by max_output_bytes (default 128 KiB; per-call override \
-     clamped to max_read_bytes) — an over-budget full read fails with \
-     a C218 carrying the file's size, line count, and the window/stat \
-     recovery calls. encoding: base64 (single-path full reads only) \
-     returns the file's exact bytes base64-encoded — the binary-aware \
-     read for images and other non-text payloads. Batch mode: pass \
-     paths[] (XOR path) \
-     to read multiple files in one call — entries are processed in \
-     request order against batch_read_budget_bytes, measured in \
-     bytes of returned content (after UTF-8 sanitization); per-entry \
-     errors (C211/C218) leave other entries unaffected. Paths are relative \
-     to the primary allowed root or absolute inside any allowed root \
-     (coder::info lists them); for host paths outside the jail use \
-     shell::fs::*. Non-accessible paths return C211.";
+const READ_FILE_DESC: &str =
+    "Read a file. stat: true probes size/mtime/total_lines without content; \
+     line_from/line_to (1-based, inclusive) read a window of a file of any \
+     size; numbered: true prefixes absolute line numbers; paths[] (XOR \
+     path) batch-reads. Paths: relative to the primary root or absolute \
+     inside an allowed root (see coder::info).";
 
 const SEARCH_ID: &str = "coder::search";
-const SEARCH_DESC: &str = "Search file contents and/or paths. Path search matches files AND \
-     directories (each path_match carries kind: file|dir); content \
-     search reads files only. Supports literal or regex \
-     queries with include/exclude globs; non-accessible files are \
-     excluded from both content and path results. Only the FIRST match \
-     on each line is reported (one content match per matching line). \
-     Optional context_lines_before/context_lines_after (max 10) attach \
-     surrounding lines to each content match so many edits can go \
-     straight to coder::update-file with no read in between. Noise \
-     paths matching default_exclude_globs (.git, node_modules, target, \
-     … — coder::info lists them) are skipped by default; pass \
-     use_default_excludes: false to search inside them. Files larger \
-     than max_read_bytes are silently skipped during content scanning. \
-     Results are capped by max_matches AND a response byte budget \
-     (search_response_budget_bytes); when truncated is true, refine \
-     the query or add include_globs rather than paginate. Paths are relative \
-     to the primary allowed root or absolute inside any allowed root \
-     (coder::info lists them); for host paths outside the jail use \
-     shell::fs::*.";
+const SEARCH_DESC: &str = "Search file contents (literal or regex) and/or paths (files and dirs); \
+     first match per line only. default_exclude_globs noise is skipped \
+     unless use_default_excludes: false. truncated: true means refine the \
+     query, not paginate. Paths: relative to the primary root or absolute \
+     inside an allowed root (see coder::info).";
 
 const UPDATE_FILE_ID: &str = "coder::update-file";
-const UPDATE_FILE_DESC: &str = "Apply batched line-oriented and regex edits across one or more \
-     files. Request shape: {\"files\": [{\"path\": \"...\", \"ops\": [...]}]}. \
-     Line ops: { op: 'insert', at_line, content } | \
-     { op: 'remove', from_line, to_line } | \
-     { op: 'update_lines', from_line, to_line, content } — 1-based, \
-     inclusive, applied bottom-up. Regex op: { op: 'replace', pattern, \
-     replacement, ignore_case?, dot_matches_newline?, expect_matches? } \
-     runs on the file body after line ops. Replace large regions \
-     WITHOUT quoting them: two short anchors joined by .*? with \
-     dot_matches_newline: true — always prefer wildcards over pasting \
-     the block into the pattern. expect_matches: 1 turns a silent \
-     multi-site clobber into a safe pre-write C210; expect_matches: 0 \
-     asserts absence. In `replacement`, $1/${name} are capture \
-     references and a literal $ must be written $$ (JS/TS template \
-     literals: `Hello, $${name}!`); undefined references fail \
-     pre-write with C210. Each file commits atomically via temp + \
-     rename. On success each applied line op returns a bounded \
-     post-apply echo (±2 context lines); regex replace ops return up \
-     to 5 per-match-site echoes (first + last line of each replaced \
-     region, inner lines elided) — verify from the echoes instead of \
-     re-reading the file. Paths are relative to the primary \
-     allowed root or absolute inside any allowed root (coder::info \
-     lists them); for host paths outside the jail use shell::fs::*.";
+const UPDATE_FILE_DESC: &str =
+    "Apply batched line ops (1-based, inclusive, applied bottom-up) then \
+     regex replace ops to one or more files; each file commits atomically. \
+     To replace a large region use two short anchors joined by .*? with \
+     dot_matches_newline: true instead of quoting it. Paths: relative to \
+     the primary root or absolute inside an allowed root (see coder::info).";
 
 const CREATE_FILE_ID: &str = "coder::create-file";
-const CREATE_FILE_DESC: &str = "Create one or more files. Request shape: {\"files\": [{\"path\": \
-     \"...\", \"content\": \"...\"}]}. Per-file `overwrite` and `parents` \
-     flags; writes publish atomically. For a conflict-safe overwrite, pass \
-     the `revision` returned by coder::read-file as `expected_revision`; \
-     stale revisions return C221 without writing. Non-accessible paths \
-     return C211. Paths are relative to \
-     the primary allowed root or absolute inside any allowed root \
-     (coder::info lists them); for host paths outside the jail use \
-     shell::fs::*.";
+const CREATE_FILE_DESC: &str =
+    "Create one or more files atomically; per-file overwrite and parents \
+     flags. For a conflict-safe overwrite pass the revision from \
+     coder::read-file as expected_revision (stale revision: C221, nothing \
+     written). Paths: relative to the primary root or absolute inside an \
+     allowed root (see coder::info).";
 
 const DELETE_FILE_ID: &str = "coder::delete-file";
-const DELETE_FILE_DESC: &str = "Remove one or more paths. Request shape: {\"paths\": [\"...\"]}. \
-     Directories need `recursive: true`; \
-     missing paths are idempotent successes; recursive removal \
-     refuses to descend through non-accessible entries. Paths are \
-     relative to the primary allowed root or absolute inside any \
-     allowed root (coder::info lists them); for host paths outside \
-     the jail use shell::fs::*.";
+const DELETE_FILE_DESC: &str =
+    "Remove one or more paths. Directories need recursive: true; missing \
+     paths succeed; recursion refuses to descend through non-accessible \
+     entries. Paths: relative to the primary root or absolute inside an \
+     allowed root (see coder::info).";
 
 const LIST_FOLDER_ID: &str = "coder::list-folder";
-const LIST_FOLDER_DESC: &str = "Paginated single-folder listing, sorted by name. Entries carry \
-     only `name`; derive an entry's absolute path as the response's \
-     `path` + '/' + name. Non-accessible entries are still listed with a \
-     `non_accessible: true` flag. Paths are relative to the primary \
-     allowed root or absolute inside any allowed root (coder::info \
-     lists them); for host paths outside the jail use shell::fs::*.";
+const LIST_FOLDER_DESC: &str =
+    "Paginated single-folder listing sorted by name. Entries carry only \
+     name; entry path = response path + '/' + name. Non-accessible entries \
+     are listed with non_accessible: true. Paths: relative to the primary \
+     root or absolute inside an allowed root (see coder::info).";
 
 const TREE_ID: &str = "coder::tree";
-const TREE_DESC: &str = "Recursive directory snapshot bounded by `max_depth` and a \
-     `per_folder_limit`. Slim wire shape: nodes carry only `name` — \
-     the root node's path IS the response's top-level `path`; derive \
-     any child's path as parent path + '/' + name. Folders that hit \
-     the limit are flagged `truncated` and the caller is pointed at \
-     coder::list-folder for pagination. Noise directories matching \
-     default_exclude_globs (.git, node_modules, target, … — \
-     coder::info lists them) appear as childless `truncated` stubs; \
-     pass use_default_excludes: false to descend into them. Pass \
-     include_hidden: false to omit dot-prefixed entries (they then \
-     don't count toward per_folder_limit). A total node budget bounds \
-     every snapshot; folders past it are stubs with reason max_nodes \
-     — re-root there or paginate with coder::list-folder. Paths are \
-     relative to the primary allowed root or absolute inside any \
-     allowed root (coder::info lists them); for host paths outside \
-     the jail use shell::fs::*.";
+const TREE_DESC: &str = "Recursive directory snapshot bounded by max_depth, per_folder_limit \
+     and a node budget. Nodes carry only name (child path = parent path + \
+     '/' + name); over-limit folders are truncated stubs to paginate with \
+     coder::list-folder. Paths: relative to the primary root or absolute \
+     inside an allowed root (see coder::info).";
 
 const MOVE_FILE_ID: &str = "coder::move";
-const MOVE_FILE_DESC: &str = "Move or rename one or more paths inside the jail. Request shape: \
-     {\"files\": [{\"from\": \"...\", \"to\": \"...\"}]}. Paths are \
-     relative to the primary allowed root or absolute inside any \
-     allowed root (coder::info lists them); for host paths outside \
-     the jail use shell::fs::*. Per-entry `overwrite` and `parents` \
-     flags. Same-root moves use a per-file-atomic rename; cross-root \
-     moves use copy+delete (files only — cross-root directory moves \
-     are unsupported, move files individually). Copy+delete is \
-     rollback-safe: if source deletion fails after a successful copy \
-     the copy is removed and the error names the failure; if rollback \
-     also fails the error names both states for manual cleanup.";
+const MOVE_FILE_DESC: &str = "Move or rename one or more paths; per-entry overwrite and parents \
+     flags. Same-root moves rename atomically; cross-root moves copy+delete \
+     files only (move directory contents individually) and remove the copy \
+     if the delete fails. Paths: relative to the primary root or absolute \
+     inside an allowed root (see coder::info).";
 
 /// One function's complete agent-facing wire surface: id, registration
 /// description, and the schemars-derived request/response schemas.

--- a/shell/src/code/functions/move_file.rs
+++ b/shell/src/code/functions/move_file.rs
@@ -34,16 +34,10 @@ pub struct MoveFileInput {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct MoveFileSpec {
-    /// Source path: relative to the primary allowed root, or an absolute path
-    /// inside any allowed root. Call `coder::info` to see the allowed roots.
-    /// Paths outside every allowed root are rejected — use the shell worker's
-    /// `shell::fs::*` for host paths outside the jail.
+    /// Source path.
     pub from: String,
 
-    /// Destination path: relative to the primary allowed root, or an absolute
-    /// path inside any allowed root. Call `coder::info` to see the allowed
-    /// roots. Paths outside every allowed root are rejected — use the shell
-    /// worker's `shell::fs::*` for host paths outside the jail.
+    /// Destination path.
     pub to: String,
 
     /// When false (the default), refuse to overwrite an existing destination.

--- a/shell/src/code/functions/read_file.rs
+++ b/shell/src/code/functions/read_file.rs
@@ -70,44 +70,33 @@ use super::read_window::{count_lines, lossy_utf8, number_lines, read_window, rea
 // Input types
 // ---------------------------------------------------------------------------
 
-/// A single entry in a `paths[]` batch request. Pass either a bare file
-/// path string (whole-file read, same cap as `max_read_bytes`) or an
-/// object with optional per-entry `line_from`/`line_to` window parameters
-/// (1-based, inclusive — same rules as the top-level `path` mode).
+/// One batch entry: a bare path string (whole-file read) or an object with a
+/// per-entry window, stat or numbered flag.
 #[derive(Debug, Deserialize, JsonSchema)]
 #[serde(untagged)]
 pub enum ReadTarget {
-    /// Bare path string: read the whole file (within remaining batch budget
-    /// and `max_read_bytes`).
+    /// Bare path string: read the whole file.
     Path(String),
-    /// Object form: path plus optional 1-based window parameters. Omit
-    /// `line_from` to start from line 1; omit `line_to` to read to EOF.
+    /// Object form: path plus optional window and flags.
     Window {
-        /// File to read. Same jail rules as the top-level `path` field.
+        /// File to read.
         path: String,
-        /// First line of the window, 1-based inclusive (must be >= 1; 0
-        /// is rejected with C210 for this entry). Defaults to 1 when
-        /// only `line_to` is set.
+        /// First line of the window, 1-based inclusive (>= 1); defaults to 1
+        /// when only `line_to` is set.
         #[serde(default)]
         #[schemars(range(min = 1))]
         line_from: Option<u64>,
-        /// Last line of the window, 1-based inclusive. Must be >=
-        /// `line_from` (C210 for this entry otherwise). Omit to read from
-        /// `line_from` to EOF.
+        /// Last line of the window, 1-based inclusive, >= `line_from`; omit to
+        /// read to EOF.
         #[serde(default)]
         #[schemars(range(min = 1))]
         line_to: Option<u64>,
-        /// Per-entry metadata probe: same semantics as the top-level
-        /// `stat` field — size/mode/mtime always, `total_lines`/`is_utf8`
-        /// when the file fits `max_read_bytes`, content null, no batch
-        /// budget consumed. C210 when combined with this entry's
-        /// `line_from`/`line_to` or `numbered`.
+        /// Metadata probe for this entry: size/mode/mtime plus total_lines,
+        /// content null, no budget consumed; C210 with a window or `numbered`.
         #[serde(default)]
         stat: bool,
-        /// Prefix this entry's content lines with their absolute 1-based
-        /// file line numbers (`N→`) — same semantics as the top-level
-        /// `numbered` field. Prefix bytes are charged against
-        /// `batch_read_budget_bytes`.
+        /// Prefix this entry's lines with their absolute 1-based line numbers
+        /// (`N→`); prefix bytes count toward the batch budget.
         #[serde(default)]
         numbered: bool,
     },
@@ -147,92 +136,39 @@ impl ReadTarget {
     example = "example_read_file_batch"
 )]
 pub struct ReadFileInput {
-    /// Single file to read. Relative to the primary allowed root, or an
-    /// absolute path inside any allowed root. Call `coder::info` to see
-    /// the allowed roots. Paths outside every allowed root are rejected —
-    /// use the shell worker's `shell::fs::*` for host paths outside the
-    /// jail. Mutually exclusive with `paths` (XOR): pass either `path` or
-    /// `paths`, not both — C210 if both or neither is set.
+    /// Single file to read; XOR with `paths` (C210 if both or neither is set).
     #[serde(default)]
     pub path: Option<String>,
-    /// First line of the window, 1-based inclusive (must be >= 1; 0 is
-    /// rejected with C210). Setting `line_from` and/or `line_to` switches
-    /// to windowed mode: the file is streamed and only the requested
-    /// lines are returned, so files larger than `max_read_bytes` stay
-    /// readable slice by slice — the byte cap then applies to the
-    /// returned window, never the file size. Defaults to 1 when only
-    /// `line_to` is set. A window starting past EOF succeeds with empty
-    /// content and reports the file's `total_lines`. Only valid in
-    /// single-path mode (`path`); ignored when `paths` is set. Lines are
-    /// 0x0A- or EOF-terminated segments; a trailing newline does not
-    /// create a phantom line (same convention as `coder::update-file`).
+    /// First line (1-based, >= 1) of a windowed read; windows keep files over
+    /// max_read_bytes readable slice by slice. `path` mode only.
     #[serde(default)]
     #[schemars(range(min = 1))]
     pub line_from: Option<u64>,
-    /// Last line of the window, 1-based inclusive. Must be >= `line_from`
-    /// (C210 otherwise). Omit to read from `line_from` to end-of-file
-    /// (still bounded by `max_read_bytes` on the returned bytes). Only
-    /// valid in single-path mode (`path`); ignored when `paths` is set.
+    /// Last line of the window, 1-based inclusive, >= `line_from`; omit to read
+    /// from `line_from` to EOF. `path` mode only.
     #[serde(default)]
     #[schemars(range(min = 1))]
     pub line_to: Option<u64>,
-    /// Metadata probe — the cheap "how big is it" call. When true the
-    /// response carries size/mode/mtime plus `total_lines` and `is_utf8`
-    /// (both null when the file exceeds `max_read_bytes` — size/mode/mtime
-    /// still populate, so stat on a huge file SUCCEEDS); `content` is
-    /// null, `lines_returned` 0, `more_lines` false. Probe BEFORE reading
-    /// an unknown file, then fetch just the slice you need with
-    /// `line_from`/`line_to`. Mutually exclusive with `line_from`,
-    /// `line_to`, `numbered`, and `max_output_bytes` (C210 — stat returns
-    /// no content for them to act on). Batch entries take a per-entry
-    /// `stat` field instead; this top-level flag is ignored when `paths`
-    /// is set.
+    /// Metadata probe: size/mode/mtime plus total_lines/is_utf8, no content;
+    /// C210 with line_from/line_to/numbered/max_output_bytes.
     #[serde(default)]
     pub stat: bool,
-    /// When true every returned content line is prefixed `N→`, where N is
-    /// the line's ABSOLUTE 1-based number in the file — a window starting
-    /// at `line_from: 40` is numbered from 40, not 1. Numbers match
-    /// `coder::update-file`'s 1-based line ops exactly, so you can go
-    /// from a numbered read straight to a line edit. Prefix bytes count
-    /// toward all byte caps and budgets (no hidden bypass). C210 with
-    /// `stat: true` (no content to number). Batch entries take a
-    /// per-entry `numbered` field instead; this top-level flag is ignored
-    /// when `paths` is set.
+    /// Prefix each line with its absolute 1-based file line number (`N→`),
+    /// matching coder::update-file line ops; C210 with `stat`. `path` mode
+    /// only.
     #[serde(default)]
     pub numbered: bool,
-    /// Per-call override of the `max_output_bytes` config (default
-    /// 131072) that budgets single-path FULL reads, measured in returned
-    /// content bytes after UTF-8 conversion (numbered prefixes included).
-    /// Values above `max_read_bytes` are silently clamped to it. When the
-    /// full content would exceed the effective budget the call fails with
-    /// a C218 naming the file's size and `total_lines` — recover by
-    /// windowing with `line_from`/`line_to`, probing with `stat: true`,
-    /// or raising this field. Full reads only: combining it with
-    /// `line_from`/`line_to` is C210 (windows are bounded by
-    /// `max_read_bytes` instead); ignored when `paths` is set (batch mode
-    /// is governed by `batch_read_budget_bytes`).
+    /// Full-read byte budget (returned bytes, clamped to max_read_bytes); over
+    /// budget fails C218 naming size/total_lines. C210 with a window.
     #[serde(default)]
     pub max_output_bytes: Option<u64>,
-    /// Content encoding for single-path FULL reads. Default `text`
-    /// returns UTF-8 (binary bytes replaced by U+FFFD); `base64` returns
-    /// the file's exact bytes base64-encoded (standard alphabet, padded)
-    /// — for binary payloads like images that a caller needs to
-    /// reconstruct. The ENCODED length is what's charged against
-    /// `max_output_bytes`. C210 combined with `stat`,
-    /// `line_from`/`line_to`, or `numbered` (text-shaping fields);
-    /// ignored when `paths` is set.
+    /// Content encoding for full reads; `base64` returns the exact file bytes
+    /// (encoded length is budgeted). C210 with stat/window/numbered.
     #[serde(default)]
     pub encoding: ReadEncoding,
-    /// Batch of files (or windowed slices) to read in a single call.
-    /// Each entry is either a plain path string (whole-file read) or an
-    /// object `{path, line_from?, line_to?}` with per-entry window
-    /// parameters. Entries are processed in request order against a
-    /// shared `batch_read_budget_bytes` cap, measured in bytes of
-    /// returned content (after UTF-8 sanitization) — see `coder::info`
-    /// for the configured value. Results are returned in the `results`
-    /// field; top-level fields are null. Mutually exclusive with `path`
-    /// (XOR): pass either `path` or `paths`, not both — C210 if both or
-    /// neither is set.
+    /// Batch of files to read in one call (bare path strings or window
+    /// objects), processed in order against batch_read_budget_bytes; XOR with
+    /// `path`.
     #[serde(default)]
     pub paths: Option<Vec<ReadTarget>>,
     /// Internal harness filesystem scope; omitted from published schema.

--- a/shell/src/code/functions/search.rs
+++ b/shell/src/code/functions/search.rs
@@ -35,23 +35,15 @@ pub struct SearchInput {
     /// Pattern to search for. Treated as a regex when `regex: true`,
     /// otherwise as a literal substring.
     pub query: String,
-    /// Folder scoping the walk. Relative to the primary allowed root, or an
-    /// absolute path inside any allowed root. Defaults to `.` (the primary
-    /// root itself). Globs are matched relative to the containing root;
-    /// result paths are absolute regardless of this value. Call
-    /// `coder::info` to see the allowed roots. Paths outside every allowed
-    /// root are rejected — use the shell worker's `shell::fs::*` for host
-    /// paths outside the jail.
+    /// Folder to search (default `.`); globs match relative to its root, result
+    /// paths are absolute.
     #[serde(default = "default_path")]
     pub path: String,
     #[serde(default)]
     pub regex: bool,
     #[serde(default)]
     pub ignore_case: bool,
-    /// Glob patterns (matched against the path relative to its containing
-    /// root — or, for a walk root outside every configured root, relative
-    /// to the session directory `coder::info` reports as `session_root`)
-    /// that paths must match to be considered. Empty = include everything.
+    /// Root-relative glob patterns paths must match; empty = everything.
     #[serde(default)]
     pub include_globs: Vec<String>,
     /// Glob patterns (same relative-to-root matching) that exclude paths.
@@ -64,24 +56,16 @@ pub struct SearchInput {
     /// truncated for the match snippet.
     #[serde(default)]
     pub max_line_bytes: Option<u32>,
-    /// Lines of context to return BEFORE each content match (same file
-    /// only, in file order), max 10 — larger values are rejected with
-    /// C210. With context lines many edit tasks can go straight from
-    /// search output to coder::update-file with no read in between.
-    /// Context lines are truncated to `max_line_bytes` like the matched
-    /// text and count toward the response byte budget. Unset = 0.
+    /// Lines of context before each content match (max 10, C210 above);
+    /// truncated to max_line_bytes and counted in the budget. Default 0.
     #[serde(default)]
     pub context_lines_before: Option<u32>,
-    /// Lines of context to return AFTER each content match. Same max
-    /// (10), truncation, and budget rules as `context_lines_before`;
-    /// unset = 0.
+    /// Lines of context after each content match; same rules as
+    /// `context_lines_before`.
     #[serde(default)]
     pub context_lines_after: Option<u32>,
-    /// Apply the worker's `default_exclude_globs` config (noise paths
-    /// like .git, node_modules, target, dist — call coder::info for the
-    /// active list): the walk does not descend into matching directories
-    /// and matching files are omitted from BOTH content and path
-    /// results. Pass `false` to search inside them.
+    /// Skip paths matching default_exclude_globs (.git, node_modules, …; see
+    /// coder::info) in content and path results; false searches inside them.
     #[serde(default = "default_true")]
     pub use_default_excludes: bool,
     /// Search file contents (default true).

--- a/shell/src/code/functions/tree.rs
+++ b/shell/src/code/functions/tree.rs
@@ -30,11 +30,7 @@ use crate::code::path::PathResolver;
 #[derive(Debug, Deserialize, JsonSchema)]
 #[schemars(example = "example_tree_input")]
 pub struct TreeInput {
-    /// Base folder for the snapshot. Relative to the primary allowed root,
-    /// or an absolute path inside any allowed root. Defaults to `.` (the
-    /// primary root itself). Call `coder::info` to see the allowed roots.
-    /// Paths outside every allowed root are rejected — use the shell
-    /// worker's `shell::fs::*` for host paths outside the jail.
+    /// Base folder for the snapshot (default `.`).
     #[serde(default = "default_path")]
     pub path: String,
     /// Maximum depth to descend; the root node is depth 0.
@@ -44,19 +40,12 @@ pub struct TreeInput {
     /// flagged `truncated` and callers should switch to `coder::list-folder`.
     #[serde(default)]
     pub per_folder_limit: Option<u32>,
-    /// Apply the worker's `default_exclude_globs` config (noise folders
-    /// like .git/node_modules/target — call `coder::info` for the active
-    /// list). Excluded directories still appear as childless nodes
-    /// flagged `truncated` with reason "default_exclude"; excluded files
-    /// are omitted and their containing directory carries the same
-    /// truncation reason. Pass `false` to list everything.
+    /// Prune directories matching default_exclude_globs (see coder::info) into
+    /// childless `truncated` stubs; false lists everything.
     #[serde(default = "default_true")]
     pub use_default_excludes: bool,
-    /// List hidden (dot-prefixed) entries. Pass `false` to omit them —
-    /// files and folders alike — at every level; omitted entries do not
-    /// count toward `per_folder_limit`, so the cap serves visible names.
-    /// The requested root itself is exempt: explicitly naming a hidden
-    /// folder still lists its contents.
+    /// List dot-prefixed entries; false omits them at every level (they then
+    /// don't count toward per_folder_limit). The requested root is exempt.
     #[serde(default = "default_true")]
     pub include_hidden: bool,
     /// Internal harness filesystem scope; omitted from published schema.

--- a/shell/src/code/functions/update_file.rs
+++ b/shell/src/code/functions/update_file.rs
@@ -56,10 +56,7 @@ impl<'de> Deserialize<'de> for UpdateFileInput {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct UpdateFileSpec {
-    /// Path relative to the primary allowed root, or an absolute path inside
-    /// any allowed root. Call `coder::info` to see the allowed roots. Paths
-    /// outside every allowed root are rejected — use the shell worker's
-    /// `shell::fs::*` for host paths outside the jail.
+    /// File to edit.
     pub path: String,
     pub ops: Vec<UpdateOp>,
 }
@@ -82,37 +79,19 @@ pub enum UpdateOp {
     /// Replace all regex matches in the file body (after line ops).
     Replace {
         pattern: String,
-        /// Substitution text for each match. Capture references expand:
-        /// `$1`/`${1}` by index (`$0` is the whole match) and
-        /// `$name`/`${name}` by name. A literal `$` MUST be written `$$`
-        /// — JS/TS template literals in a replacement are the classic
-        /// collision: write `Hello, $${name}!` to output `Hello, ${name}!`.
-        /// Unbraced references consume the longest `[0-9A-Za-z_]` run,
-        /// so `$1a` means a group named "1a", NOT group 1 then "a" (use
-        /// `${1}a`). A reference to a group the pattern does not define
-        /// fails pre-write with C210 — nothing is written. References
-        /// are validated even when the replacement goes unused (e.g.
-        /// `expect_matches: 0`): the replacement must be well-formed
-        /// even when unused.
+        /// Substitution text; $1/${1}/$name/${name} expand captures ($0 = whole
+        /// match), a literal $ is written $$ (`$${name}`). Unknown references
+        /// fail C210.
         replacement: String,
         #[serde(default)]
         ignore_case: bool,
-        /// When true, `.` in `pattern` also matches `\n`, so a short
-        /// anchored pattern like `"fn parse_config\\(.*?\\n\\}"` replaces a
-        /// whole multi-line region without quoting it — prefer two short
-        /// anchors joined by `.*?` over pasting the block into the pattern.
-        /// Without this flag (the default), `.` does not cross newlines and
-        /// a multi-line pattern silently matches nothing.
+        /// When true `.` also matches newline, so a short pattern like
+        /// `start.*?end` spans lines; by default a multi-line pattern matches
+        /// nothing.
         #[serde(default)]
         dot_matches_newline: bool,
-        /// Expected number of matches for this op. When set and the actual
-        /// count differs, this FILE fails with C210 and nothing is written
-        /// to it (other files in the batch still apply). Set
-        /// `expect_matches: 1` to make a targeted read-free edit safe — a
-        /// mismatch means the pattern is anchored too loosely or matches
-        /// nothing. Set `expect_matches: 0` to assert ABSENCE: the op
-        /// succeeds only when nothing matches (the replacement is unused).
-        /// Omit to replace all matches unconditionally.
+        /// Expected match count; a mismatch fails this file with C210 and
+        /// writes nothing (0 asserts absence). Omit to replace all matches.
         #[serde(default)]
         expect_matches: Option<u64>,
     },

--- a/shell/src/fs/mod.rs
+++ b/shell/src/fs/mod.rs
@@ -263,8 +263,9 @@ pub struct ReadArgs {
 // Registration-boundary requests — each carries `target` plus the matching
 // `*Args` fields and derives `JsonSchema` for the SDK.
 
-/// `fs_scope` is accepted at deserialization time for trusted harness metadata,
-/// but is omitted from every published `shell::fs::*` request schema.
+/// Request for `shell::fs::ls`.
+// `fs_scope` is accepted at deserialization time for trusted harness metadata,
+// but is omitted from every published `shell::fs::*` request schema.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct LsRequest {
     /// host (default) or { kind: "sandbox", sandbox_id }.
@@ -553,10 +554,9 @@ impl SedRequest {
     }
 }
 
-/// Wire form of write content. A plain JSON **string** is written inline (host
-/// target only); a JSON **object** is a streaming `ContentRef` (host or sandbox,
-/// for large/streamed payloads). Untagged, so callers just pass `"content":
-/// "text"` or `"content": { channel_id, access_key, direction }`.
+/// Write content: a plain string is written inline (host target only); an
+/// object is a streaming ContentRef { channel_id, access_key, direction }.
+// Untagged, so callers just pass `"content": "text"` or the object.
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[serde(untagged)]
 pub enum WriteContentWire {
@@ -599,21 +599,22 @@ pub struct WriteRequest {
     /// set, else absolute. Omit when using `files`.
     #[serde(default)]
     pub path: Option<String>,
-    /// Single-file content: a plain string written inline (host target only),
-    /// OR a ContentRef { channel_id, access_key, direction } for an open write
-    /// stream channel. Omit when using `files`.
+    /// Single-file content: an inline string (host only) or a ContentRef {
+    /// channel_id, access_key, direction } for an open write stream; omit with
+    /// `files`.
     #[serde(default)]
     pub content: Option<WriteContentWire>,
-    /// Octal permission string for the single-file form, e.g. "0644".
-    /// `Option` (not a defaulted `String`) so the batch-form check can tell
-    /// "caller omitted mode" from "caller sent a mode" and reject the latter
-    /// instead of silently dropping it. Defaults to "0644" in the single-file
-    /// path. Omit when using `files` (each entry carries its own `mode`).
+    /// Octal permission string for the single-file form, e.g. "0644" (the
+    /// default); omit when using `files`.
+    // `Option` (not a defaulted `String`) so the batch-form check can tell
+    // "caller omitted mode" from "caller sent a mode" and reject the latter
+    // instead of silently dropping it.
     #[serde(default)]
     pub mode: Option<String>,
-    /// Create missing parent directories (single-file form). `Option` for the
-    /// same reason as `mode` — so a top-level `parents` sent alongside `files`
-    /// is rejected, not ignored. Defaults to `false`. Omit when using `files`.
+    /// Create missing parent directories (single-file form, default false);
+    /// omit when using `files`.
+    // `Option` for the same reason as `mode` — a top-level `parents` sent
+    // alongside `files` is rejected, not ignored.
     #[serde(default)]
     pub parents: Option<bool>,
     /// Batch form: write several files in one call. When present, the

--- a/shell/src/functions/types.rs
+++ b/shell/src/functions/types.rs
@@ -84,56 +84,42 @@ fn deserialize_timeout_ms<'de, D: Deserializer<'de>>(d: D) -> Result<Option<u64>
     Ok(v.as_u64())
 }
 
-/// Wire request for `shell::exec`. The schema is published to the engine's
-/// tool listing so callers see field types up front instead of guessing
-/// from the description.
+/// Wire request for `shell::exec`.
+// The schema is published to the engine's tool listing so callers see field
+// types up front instead of guessing from the description.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ExecRequest {
-    /// Program name (bare, PATH-resolved) or a path to an executable.
-    /// Must be a string — split arguments into `args`, do not pass argv as
-    /// an array here.
+    /// Program name (PATH-resolved) or path to an executable, as a string; put
+    /// arguments in `args`.
     #[serde(deserialize_with = "deserialize_command")]
     pub command: String,
-    /// Arguments passed to the program, in order. Every element must be a
-    /// string; non-string elements are rejected by index.
-    /// `None` (or `args: null` / absent) means "tokenize `command` via
-    /// shell-words"; `Some(_)` (including the empty vec) means "use args
-    /// verbatim, no shell-words." See `parse_argv` in `crate::exec::host`.
+    /// Arguments, in order (all strings). Omit/null to tokenize `command`
+    /// shell-words style; pass an array (even empty) to use it verbatim.
+    // See `parse_argv` in `crate::exec::host`.
     #[serde(default, deserialize_with = "deserialize_args")]
     pub args: Option<Vec<String>>,
-    /// Per-call timeout override, milliseconds. Capped at `cfg.max_timeout_ms`.
-    /// Negative or fractional values silently fall back to
-    /// `cfg.default_timeout_ms` (loose wire semantic, preserved on purpose).
+    /// Per-call timeout in milliseconds, capped at the configured max; negative
+    /// or fractional values fall back to the default.
+    // Caps at `cfg.max_timeout_ms`, falls back to `cfg.default_timeout_ms`
+    // (loose wire semantic, preserved on purpose).
     #[serde(default, deserialize_with = "deserialize_timeout_ms")]
     pub timeout_ms: Option<u64>,
-    /// Optional working directory for this call (host target only). Confined to
-    /// the fs jail exactly like `shell::fs::*` paths: jail-relative when
-    /// `fs.host_roots` are set (else absolute), canonicalized, and must resolve
-    /// inside a jail root and miss the denylist — a path that escapes returns
-    /// S215. Must already exist and be a directory. Omit to use the configured
-    /// `working_dir` (unchanged default). Rejected (S210) on a sandbox target.
+    /// Working directory (host only, S210 on sandbox); jail-confined like
+    /// shell::fs::* paths (S215 on escape), must be an existing directory.
     #[serde(default)]
     pub cwd: Option<String>,
     /// Internal harness filesystem scope; omitted from published schema.
     #[serde(default)]
     #[schemars(skip)]
     pub fs_scope: Option<FsScope>,
-    /// Optional per-call environment values (host target only). Deny-only: a
-    /// key may be set to ANY value except an exec-hijacking key (PATH, IFS,
-    /// HOME, LD_*/DYLD_*, and other loader/lookup and interpreter-startup
-    /// keys — see DANGEROUS_ENV_KEYS), which is rejected unconditionally
-    /// (`env.allow` plays no role here — that list only gates which vars get
-    /// forwarded from the worker's own environment). Supplying a dangerous
-    /// key rejects the WHOLE call (S210) naming the offending key; the env is
-    /// never silently dropped. Values override what would otherwise be
-    /// forwarded for that key. Rejected (S210) on a sandbox target.
+    /// Per-call env values (host only, S210 on sandbox); exec-hijacking keys
+    /// (PATH, IFS, HOME, LD_*/DYLD_*, …) reject the whole call S210.
+    // Deny-only: see DANGEROUS_ENV_KEYS; values override forwarded ones, and
+    // `env.allow` only gates forwarding from the worker's own environment.
     #[serde(default)]
     pub env: Option<BTreeMap<String, String>>,
-    /// Optional bytes written to the program's standard input, followed by EOF.
-    /// Use this to pipe content to a command that reads stdin (`tee`, `patch`,
-    /// `cat`, a filter) instead of wrapping it in a shell heredoc. Omit to leave
-    /// stdin closed (`/dev/null`, the default). HOST target only — rejected
-    /// (S210) on a sandbox target, like cwd/env.
+    /// Bytes written to the program's stdin, then EOF (host only, S210 on
+    /// sandbox); omit to leave stdin at /dev/null.
     #[serde(default)]
     pub stdin: Option<String>,
     /// Where to run the command. Defaults to the host worker; pass
@@ -142,46 +128,44 @@ pub struct ExecRequest {
     pub target: Target,
 }
 
-/// Wire request for `shell::exec_bg`. Same shape as [`ExecRequest`]; documented
-/// separately so the engine publishes a distinct schema per function.
+/// Wire request for `shell::exec_bg`.
+// Same shape as `ExecRequest`; documented separately so the engine publishes a
+// distinct schema per function.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ExecBgRequest {
-    /// Program name. See [`ExecRequest::command`].
+    /// Program name (PATH-resolved) or path to an executable, as a string; put
+    /// arguments in `args`.
     #[serde(deserialize_with = "deserialize_command")]
     pub command: String,
-    /// Arguments passed to the program. See [`ExecRequest::args`].
-    /// `None` (or `args: null` / absent) means "tokenize `command` via
-    /// shell-words"; `Some(_)` (including the empty vec) means "use args
-    /// verbatim, no shell-words." See `parse_argv` in `crate::exec::host`.
+    /// Arguments, in order (all strings). Omit/null to tokenize `command`
+    /// shell-words style; pass an array (even empty) to use it verbatim.
+    // See `parse_argv` in `crate::exec::host`.
     #[serde(default, deserialize_with = "deserialize_args")]
     pub args: Option<Vec<String>>,
-    /// Per-call timeout. Host-targeted background jobs IGNORE `timeout_ms`;
-    /// sandbox-targeted ones forward it through `cfg.resolve_timeout`.
+    /// Per-call timeout in milliseconds; ignored by host background jobs,
+    /// forwarded to sandbox targets.
+    // Sandbox targets go through `cfg.resolve_timeout`.
     #[serde(default, deserialize_with = "deserialize_timeout_ms")]
     pub timeout_ms: Option<u64>,
-    /// Optional working directory for this job (host target only). Same jail
-    /// confinement and rules as [`ExecRequest::cwd`]: canonicalized, must
-    /// resolve inside a jail root (S215 on escape) and be an existing
-    /// directory. Rejected (S210) on a sandbox target.
+    /// Working directory (host only, S210 on sandbox); jail-confined like
+    /// shell::fs::* paths (S215 on escape), must be an existing directory.
     #[serde(default)]
     pub cwd: Option<String>,
     /// Internal harness filesystem scope; omitted from published schema.
     #[serde(default)]
     #[schemars(skip)]
     pub fs_scope: Option<FsScope>,
-    /// Optional per-call environment values (host target only). Same gating as
-    /// [`ExecRequest::env`]: deny-only, rejecting only an exec-hijacking key
-    /// (PATH, IFS, HOME, LD_*/DYLD_*, and other loader/lookup and
-    /// interpreter-startup keys — see DANGEROUS_ENV_KEYS); any violation
-    /// rejects the whole call (S210). Rejected (S210) on a sandbox target.
+    /// Per-call env values (host only, S210 on sandbox); exec-hijacking keys
+    /// (PATH, IFS, HOME, LD_*/DYLD_*, …) reject the whole call S210.
+    // Deny-only: see DANGEROUS_ENV_KEYS; values override forwarded ones, and
+    // `env.allow` only gates forwarding from the worker's own environment.
     #[serde(default)]
     pub env: Option<BTreeMap<String, String>>,
-    /// Optional bytes written to the job's standard input, then EOF. See
-    /// [`ExecRequest::stdin`]. HOST target only — rejected (S210) on a sandbox
-    /// target.
+    /// Bytes written to the program's stdin, then EOF (host only, S210 on
+    /// sandbox); omit to leave stdin at /dev/null.
     #[serde(default)]
     pub stdin: Option<String>,
-    /// Where to run. See [`ExecRequest::target`].
+    /// Where to run: the host (default) or { kind: "sandbox", sandbox_id }.
     #[serde(default)]
     pub target: Target,
 }
@@ -277,13 +261,12 @@ impl From<&JobRecord> for JobSummary {
     }
 }
 
-/// `shell::list` takes no arguments; this empty struct publishes an accurate
-/// (empty-object) request schema.
-///
-/// NOTE: deliberately NOT `#[serde(deny_unknown_fields)]`. The engine injects
-/// a `_caller_worker_id` field into every call's payload, so a strict no-arg
-/// struct would reject EVERY call. The handler ignores the payload entirely
-/// (`move |_req: Value|` in main.rs) for the same reason.
+/// `shell::list` takes no arguments.
+// Empty struct publishes an accurate (empty-object) request schema.
+// Deliberately NOT `#[serde(deny_unknown_fields)]`: the engine injects a
+// `_caller_worker_id` field into every call's payload, so a strict no-arg
+// struct would reject EVERY call. The handler ignores the payload entirely
+// (`move |_req: Value|` in main.rs) for the same reason.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ListRequest {}
 
@@ -293,10 +276,10 @@ pub struct ListResponse {
     pub count: usize,
 }
 
-/// `shell::config-status` takes no arguments; this empty struct publishes an
-/// accurate (empty-object) request schema, mirroring [`ListRequest`]. The
-/// response is `configuration::ReloadStatus`. Like [`ListRequest`], it is NOT
-/// `deny_unknown_fields` — the engine-injected `_caller_worker_id` would
-/// otherwise be rejected; the handler ignores the payload.
+/// `shell::config-status` takes no arguments.
+// Empty struct publishes an accurate (empty-object) request schema, mirroring
+// `ListRequest`. The response is `configuration::ReloadStatus`. NOT
+// `deny_unknown_fields` — the engine-injected `_caller_worker_id` would
+// otherwise be rejected; the handler ignores the payload.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ConfigStatusRequest {}

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -289,21 +289,11 @@ async fn main() -> Result<()> {
                 })
             })
             .description(
-                "Run a command in the foreground and return its full output. \
-                 Put the program name in `command` (string) and arguments in `args` (string[]) — \
-                 do NOT pass argv as an array in `command`. `timeout_ms` is capped at the \
-                 configured max; negative/fractional values fall back to the default. `target` \
-                 defaults to the host; pass { kind: \"sandbox\", sandbox_id } to run in a microVM. \
-                 Optional host-only `cwd` scopes this call to a directory (jail-confined exactly \
-                 like shell::fs::* paths; escaping it is S215), optional `env` (object) sets \
-                 per-call values for ANY key except PATH/IFS/HOME/LD_*/DYLD_* or other \
-                 loader/lookup and interpreter-startup keys \
-                 (those reject S210 unconditionally) — and optional host-only `stdin` (string) is written to the \
-                 program's standard input (use it for `tee`, `patch`, or any stdin filter instead \
-                 of a shell heredoc). cwd/env/stdin on a sandbox target reject S210. \
-                 Backend errors return { code, message }; common: S216 host exec error, S300 VM \
-                 boot failed, S200 in-VM failure. argv-parse and denylist rejections are \
-                 plain-string messages naming the violation.",
+                "Run a command in the foreground and return its full output. Put the program in \
+                 `command` (string) and arguments in `args` (string[]), never argv in \
+                 `command`. Host-only cwd/env/stdin reject S210 on a sandbox target. Errors \
+                 return { code, message }; common: S216 host exec error, S300 VM boot failed, \
+                 S200 in-VM failure.",
             ),
         );
     }
@@ -321,20 +311,10 @@ async fn main() -> Result<()> {
                 })
             })
             .description(
-                "Spawn a command as a background job; returns { job_id, argv } \
-                 immediately. Same payload as shell::exec (command + args, do NOT pass argv as an \
-                 array), including the optional host-only `cwd` (jail-confined; escape is S215), \
-                 `env` (any key except PATH/IFS/HOME/LD_*/DYLD_* or other loader/lookup \
-                 and interpreter-startup keys, rejected unconditionally), and `stdin` (string written to the job's stdin); \
-                 violations and cwd/env/stdin on a sandbox target reject with an S210 message. Poll \
-                 with shell::status, terminate with shell::kill, list with shell::list. \
-                 Host background jobs ignore the per-call timeout_ms and run until they exit or \
-                 shell::kill terminates them; set the operator config `max_bg_timeout_ms` (0 = \
-                 unbounded, the default) to force-kill a runaway job after that long. \
-                 Spawn-time failures (argv-parse, denylist, cwd/env gating, spawn, \
-                 concurrency cap) are plain-string messages naming the violation; once spawned, \
-                 per-job failures surface through shell::status (the job record's status/stderr), \
-                 not this call's return.",
+                "Spawn a background job; returns { job_id, argv } immediately. Same payload as \
+                 shell::exec. Host jobs ignore timeout_ms and run until exit or shell::kill; \
+                 poll with shell::status, list with shell::list. Spawn-time failures are \
+                 plain-string messages; later failures surface in shell::status, not here.",
             ),
         );
     }
@@ -406,10 +386,9 @@ async fn main() -> Result<()> {
             .response_format(schema_value::<configuration::ReloadStatus>())
             .description(
                 "Report the last configuration hot-reload outcome: last_outcome \
-                 (applied|rejected), last_error, and rejected_reloads (count since \
-                 boot). A rejected outcome or non-zero count means a stored config \
-                 was refused and shell is enforcing an older policy than the central \
-                 store. Takes no arguments.",
+                 (applied|rejected), last_error, and rejected_reloads since boot. A rejected \
+                 outcome means shell is enforcing an older policy than the central store. Takes \
+                 no arguments.",
             )
             .metadata(serde_json::json!({ "internal": true })),
         );
@@ -598,13 +577,15 @@ fn register_fs(iii: &iii_sdk::IIIClient, state: &AppState) {
         }};
     }
 
-    fs_fn!("shell::fs::ls", fs_ls, fs::LsRequest, fs::LsResponse,
-        "List directory contents. `path` is relative to the primary fs jail root (the first \
-         fs.host_roots entry) when set, otherwise absolute. `target` defaults to host; pass \
-         { kind: \"sandbox\", sandbox_id } \
-         to run in a microVM. Errors return { code, message }; common: S210 bad path, S211 not found \
-         or not accessible, S212 not a directory, S215 jail escape. For paginated or recursive \
-         listings with noise filtering, prefer coder::list-folder / coder::tree.");
+    fs_fn!(
+        "shell::fs::ls",
+        fs_ls,
+        fs::LsRequest,
+        fs::LsResponse,
+        "List directory contents. Errors return { code, message }; common: S210 bad path, \
+         S211 not found or not accessible, S212 not a directory, S215 jail escape. For \
+         paginated or recursive listings prefer coder::list-folder / coder::tree."
+    );
     fs_fn!("shell::fs::stat", fs_stat, fs::StatRequest, fs::StatResponse,
         "Stat a single path (jail-relative when fs.host_roots are set). Returns the entry's type, size, \
          mode, and mtime. Errors return { code, message }; common: S211 not found or not accessible, \
@@ -618,10 +599,10 @@ fn register_fs(iii: &iii_sdk::IIIClient, state: &AppState) {
         fs_rm,
         fs::RmRequest,
         fs::RmResponse,
-        "Remove a path. `recursive: true` is required to delete a non-empty directory. Returns \
-         { removed, path, was_present }. Errors return { code, message }; common: S211 not found or \
-         not accessible, S214 dir not empty (pass recursive), S215 jail escape. To remove several \
-         paths in one call, use coder::delete-file (batched, per-entry errors)."
+        "Remove a path. `recursive: true` is required to delete a non-empty directory. \
+         Returns { removed, path, was_present }. Errors return { code, message }; common: \
+         S211 not found or not accessible, S214 dir not empty, S215 jail escape. \
+         coder::delete-file removes several paths per call."
     );
     fs_fn!("shell::fs::chmod", fs_chmod, fs::ChmodRequest, fs::ChmodResponse,
         "Change permissions. `mode` is an octal string like \"0644\". `uid`/`gid` optionally chown. \
@@ -634,50 +615,52 @@ fn register_fs(iii: &iii_sdk::IIIClient, state: &AppState) {
         fs::MvRequest,
         fs::MvResponse,
         "Move/rename a path. `overwrite: true` allows replacing an existing dst. Returns \
-         { moved, src, dst, overwrote }. Errors return { code, message }; common: S211 src not found \
-         or not accessible, S213 dst exists, S215 jail escape. To move several paths in one call, \
-         use coder::move (batched, per-entry errors)."
+         { moved, src, dst, overwrote }. Errors return { code, message }; common: S211 \
+         src not found or not accessible, S213 dst exists, S215 jail escape. coder::move \
+         moves several paths per call."
     );
     fs_fn!(
         "shell::fs::grep",
         fs_grep,
         fs::GrepRequest,
         fs::GrepResponse,
-        "Search file contents. `pattern` is a Rust regex (RE2-like). `recursive` defaults true. \
-         `include_glob`/`exclude_glob` filter paths. Returns { matches, truncated }. Errors return \
-         { code, message }; common: S217 bad regex, S215 jail escape. For token-budgeted search with \
-         context lines and noise filtering, prefer coder::search."
+        "Search file contents. `pattern` is a Rust regex (RE2-like); \
+         `include_glob`/`exclude_glob` filter paths. Returns { matches, truncated }. \
+         Errors return { code, message }; common: S217 bad regex, S215 jail escape. \
+         coder::search adds context lines and noise filtering."
     );
-    fs_fn!("shell::fs::sed", fs_sed, fs::SedRequest, fs::SedResponse,
-        "Find-and-replace across files. `pattern` is a Rust regex by default (set regex:false for a \
-         literal). Provide either `files` (explicit list) or `path` (+ recursive). Returns \
-         { results, total_replacements }. Errors return { code, message }; common: S217 bad regex, \
-         S211 not found or not accessible, S215 jail escape. For line-oriented edits with post-apply \
-         echoes (no re-read needed), prefer coder::update-file.");
+    fs_fn!(
+        "shell::fs::sed",
+        fs_sed,
+        fs::SedRequest,
+        fs::SedResponse,
+        "Find-and-replace across files. `pattern` is a Rust regex (regex: false for a \
+         literal). Provide either `files` or `path` (+ recursive). Returns { results, \
+         total_replacements }. Errors return { code, message }; common: S217 bad regex, \
+         S211 not found, S215 jail escape."
+    );
     fs_fn!(
         "shell::fs::write",
         fs_write,
         fs::WriteRequest,
         fs::WriteResponse,
-        "Write a file. Simplest form: { path, content: \"text\" } — `content` as a plain STRING is \
-         written inline (host target only), no streaming channel needed. For large/streamed payloads \
-         or a sandbox target, pass `content` as a ContentRef { channel_id, access_key, direction } \
-         from a write stream channel you opened through the engine's streaming layer (inline strings \
-         reject S210 on a sandbox target). To write several files at once, pass `files: [{ path, \
-         content, mode?, parents? }, ...]` instead of the single-file fields (host target, inline \
-         content) — the response then carries per-file results in `files`. `mode` is octal \
-         (default \"0644\"); `parents: true` creates missing parents. Errors return { code, message }; \
-         common: S210 bad mode/payload or inline-on-sandbox, S211 not accessible, S215 jail escape, \
-         S218 payload exceeds max_write_bytes, S216 channel/IO error. For plain text files, \
-         coder::create-file (batched) avoids the streaming channel."
+        "Write a file. A string `content` is written inline (host only); large payloads \
+         or a sandbox target need a ContentRef { channel_id, access_key, direction } from \
+         a write stream channel. `files: [...]` writes several files (host, inline). \
+         Errors return { code, message }; common: S210 bad mode or inline-on-sandbox, \
+         S218 over max_write_bytes."
     );
-    fs_fn!("shell::fs::read", fs_read, fs::ReadRequest, fs::ReadResponseWire,
-        "Stream a file from a path — returns a ContentRef HANDLE (channel_id/access_key), NOT the \
-         file text. For reading TEXT files use coder::read-file instead: it returns the content \
-         inline (windowed, batched) with no channel. This function is for binary/streamed payloads; \
-         the response carries the ContentRef plus size/mode/mtime. Errors return { code, message }; \
-         common: S211 not found or not accessible, S212 path is a directory, S215 jail escape, \
-         S218 file exceeds max_read_bytes, S216 channel/IO error.");
+    fs_fn!(
+        "shell::fs::read",
+        fs_read,
+        fs::ReadRequest,
+        fs::ReadResponseWire,
+        "Stream a file: returns a ContentRef handle (channel_id/access_key) plus \
+         size/mode/mtime, NOT the text — for text use coder::read-file, which returns \
+         content inline. Errors return { code, message }; common: S211 not found or not \
+         accessible, S212 is a directory, S218 over max_read_bytes, S216 channel/IO \
+         error."
+    );
 }
 
 /// Wait for SIGINT or, on Unix, SIGTERM so `docker stop` / `kubectl delete`

--- a/shell/src/pty/protocol.rs
+++ b/shell/src/pty/protocol.rs
@@ -14,21 +14,19 @@ pub struct OpenRequest {
     pub cols: u16,
     pub rows: u16,
     pub output_function_id: String,
-    /// Program to run instead of the user's login shell — an agent CLI, a
-    /// REPL, a TUI. Resolved on the worker's PATH. A caller that can open a
-    /// login shell can already run any program by typing it, so this adds
-    /// reach, not privilege; it is what lets a session BE one program with
-    /// no shell around it.
+    /// Program to run instead of the user's login shell (an agent CLI, REPL,
+    /// TUI), resolved on the worker's PATH.
+    // A caller that can open a login shell can already run any program by
+    // typing it, so this adds reach, not privilege; it is what lets a session
+    // BE one program with no shell around it.
     #[serde(default)]
     pub program: Option<String>,
     /// argv for `program`. Ignored without `program` (a login shell takes no
     /// arguments here).
     #[serde(default)]
     pub args: Option<Vec<String>>,
-    /// Extra environment for this session, on top of what the worker
-    /// forwards. Deny-only, like `shell::exec`'s per-call env: every key is
-    /// allowed except the exec-hijacking keys (`PATH`, `LD_*`, `DYLD_*`,
-    /// `BASH_ENV`, ...), which fail the call.
+    /// Extra environment on top of what the worker forwards; exec-hijacking
+    /// keys (PATH, LD_*, DYLD_*, BASH_ENV, …) fail the call.
     #[serde(default)]
     pub env: Option<BTreeMap<String, String>>,
     #[serde(rename = "_caller_worker_id", default)]
@@ -120,17 +118,15 @@ pub struct AttachResponse {
 }
 
 /// Take back a session whose reconnect token is gone.
-///
-/// The token is what proves a caller opened a session, and a browser that
-/// loses its storage loses the token while the program keeps running: an agent
-/// still working in a workspace nobody can reach. Adoption is the way back,
-/// and it is deliberately narrow — see `PtyManager::adopt`.
+// The token is what proves a caller opened a session, and a browser that loses
+// its storage loses the token while the program keeps running: an agent still
+// working in a workspace nobody can reach. Adoption is the way back, and it is
+// deliberately narrow — see `PtyManager::adopt`.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct AdoptRequest {
     pub session_id: String,
-    /// Where output goes next. Must belong to the same console page family as
-    /// the target it replaces, which is what keeps one page's sessions out of
-    /// another page's reach.
+    /// Where output goes next; must belong to the same console page family as
+    /// the target it replaces.
     pub output_function_id: String,
     pub cols: u16,
     pub rows: u16,

--- a/shell/tests/golden/schemas/coder.create-file.json
+++ b/shell/tests/golden/schemas/coder.create-file.json
@@ -1,5 +1,5 @@
 {
-  "description": "Create one or more files. Request shape: {\"files\": [{\"path\": \"...\", \"content\": \"...\"}]}. Per-file `overwrite` and `parents` flags; writes publish atomically. For a conflict-safe overwrite, pass the `revision` returned by coder::read-file as `expected_revision`; stale revisions return C221 without writing. Non-accessible paths return C211. Paths are relative to the primary allowed root or absolute inside any allowed root (coder::info lists them); for host paths outside the jail use shell::fs::*.",
+  "description": "Create one or more files atomically; per-file overwrite and parents flags. For a conflict-safe overwrite pass the revision from coder::read-file as expected_revision (stale revision: C221, nothing written). Paths: relative to the primary root or absolute inside an allowed root (see coder::info).",
   "function_id": "coder::create-file",
   "request_schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -11,7 +11,7 @@
           },
           "expected_revision": {
             "default": null,
-            "description": "Optional optimistic concurrency precondition for an overwrite. Pass the opaque `revision` returned by `coder::read-file`; if the file no longer has that exact content, the entry fails with C221 and is not written. Omit for backward-compatible unconditional overwrite.",
+            "description": "Optimistic-concurrency guard for an overwrite: the `revision` from coder::read-file; if the content changed the entry fails C221 unwritten.",
             "type": [
               "string",
               "null"
@@ -33,7 +33,7 @@
             "type": "boolean"
           },
           "path": {
-            "description": "Path relative to the primary allowed root, or an absolute path inside any allowed root. Call `coder::info` to see the allowed roots. Paths outside every allowed root are rejected — use the shell worker's `shell::fs::*` for host paths outside the jail.",
+            "description": "File to create.",
             "type": "string"
           }
         },

--- a/shell/tests/golden/schemas/coder.delete-file.json
+++ b/shell/tests/golden/schemas/coder.delete-file.json
@@ -1,5 +1,5 @@
 {
-  "description": "Remove one or more paths. Request shape: {\"paths\": [\"...\"]}. Directories need `recursive: true`; missing paths are idempotent successes; recursive removal refuses to descend through non-accessible entries. Paths are relative to the primary allowed root or absolute inside any allowed root (coder::info lists them); for host paths outside the jail use shell::fs::*.",
+  "description": "Remove one or more paths. Directories need recursive: true; missing paths succeed; recursion refuses to descend through non-accessible entries. Paths: relative to the primary root or absolute inside an allowed root (see coder::info).",
   "function_id": "coder::delete-file",
   "request_schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -14,7 +14,7 @@
     ],
     "properties": {
       "paths": {
-        "description": "Paths to remove. Each entry is relative to the primary allowed root, or an absolute path inside any allowed root. Call `coder::info` to see the allowed roots. Paths outside every allowed root are rejected — use the shell worker's `shell::fs::*` for host paths outside the jail.",
+        "description": "Paths to remove.",
         "items": {
           "type": "string"
         },

--- a/shell/tests/golden/schemas/coder.info.json
+++ b/shell/tests/golden/schemas/coder.info.json
@@ -1,5 +1,5 @@
 {
-  "description": "Report the coder access contract: the effective mode (jailed = paths confined to the allowed roots; unjailed = deny-only, absolute paths anywhere on the host, roots anchor relative paths only), canonical allowed roots (primary first), the session_root that relative paths actually anchor against when the session is scoped (it overrides primary_root and may sit outside every allowed root), per-file size caps, response budgets (max_output_bytes, batch_read_budget_bytes, search_response_budget_bytes), listing/search limits, the non-accessible glob patterns, and the default_exclude_globs noise filter applied by tree/search. Call this FIRST when unsure where coder may read or write, or when a path was rejected — in jailed mode, paths outside every allowed root need the shell worker's shell::fs::* instead.",
+  "description": "Report the coder access contract: mode (jailed | unjailed), allowed roots (primary first), the session_root relative paths anchor against, size caps, response budgets, listing/search limits, non-accessible globs and default_exclude_globs. Call it first when a path is rejected.",
   "function_id": "coder::info",
   "request_schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/shell/tests/golden/schemas/coder.list-folder.json
+++ b/shell/tests/golden/schemas/coder.list-folder.json
@@ -1,5 +1,5 @@
 {
-  "description": "Paginated single-folder listing, sorted by name. Entries carry only `name`; derive an entry's absolute path as the response's `path` + '/' + name. Non-accessible entries are still listed with a `non_accessible: true` flag. Paths are relative to the primary allowed root or absolute inside any allowed root (coder::info lists them); for host paths outside the jail use shell::fs::*.",
+  "description": "Paginated single-folder listing sorted by name. Entries carry only name; entry path = response path + '/' + name. Non-accessible entries are listed with non_accessible: true. Paths: relative to the primary root or absolute inside an allowed root (see coder::info).",
   "function_id": "coder::list-folder",
   "request_schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -19,7 +19,7 @@
       },
       "page_size": {
         "default": null,
-        "description": "Capped by `config.list_max_page_size`; falls back to `config.list_default_page_size` when omitted.",
+        "description": "Capped at list_max_page_size; defaults to list_default_page_size (see coder::info).",
         "format": "uint32",
         "minimum": 0.0,
         "type": [
@@ -29,7 +29,7 @@
       },
       "path": {
         "default": ".",
-        "description": "Folder to list. Relative to the primary allowed root, or an absolute path inside any allowed root. Defaults to `.` (the primary root itself). Call `coder::info` to see the allowed roots. Paths outside every allowed root are rejected — use the shell worker's `shell::fs::*` for host paths outside the jail.",
+        "description": "Folder to list (default `.`).",
         "type": "string"
       }
     },

--- a/shell/tests/golden/schemas/coder.move.json
+++ b/shell/tests/golden/schemas/coder.move.json
@@ -1,5 +1,5 @@
 {
-  "description": "Move or rename one or more paths inside the jail. Request shape: {\"files\": [{\"from\": \"...\", \"to\": \"...\"}]}. Paths are relative to the primary allowed root or absolute inside any allowed root (coder::info lists them); for host paths outside the jail use shell::fs::*. Per-entry `overwrite` and `parents` flags. Same-root moves use a per-file-atomic rename; cross-root moves use copy+delete (files only — cross-root directory moves are unsupported, move files individually). Copy+delete is rollback-safe: if source deletion fails after a successful copy the copy is removed and the error names the failure; if rollback also fails the error names both states for manual cleanup.",
+  "description": "Move or rename one or more paths; per-entry overwrite and parents flags. Same-root moves rename atomically; cross-root moves copy+delete files only (move directory contents individually) and remove the copy if the delete fails. Paths: relative to the primary root or absolute inside an allowed root (see coder::info).",
   "function_id": "coder::move",
   "request_schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -7,7 +7,7 @@
       "MoveFileSpec": {
         "properties": {
           "from": {
-            "description": "Source path: relative to the primary allowed root, or an absolute path inside any allowed root. Call `coder::info` to see the allowed roots. Paths outside every allowed root are rejected — use the shell worker's `shell::fs::*` for host paths outside the jail.",
+            "description": "Source path.",
             "type": "string"
           },
           "overwrite": {
@@ -21,7 +21,7 @@
             "type": "boolean"
           },
           "to": {
-            "description": "Destination path: relative to the primary allowed root, or an absolute path inside any allowed root. Call `coder::info` to see the allowed roots. Paths outside every allowed root are rejected — use the shell worker's `shell::fs::*` for host paths outside the jail.",
+            "description": "Destination path.",
             "type": "string"
           }
         },

--- a/shell/tests/golden/schemas/coder.read-file.json
+++ b/shell/tests/golden/schemas/coder.read-file.json
@@ -1,5 +1,5 @@
 {
-  "description": "Read a file window-first: probe with stat: true (size/mtime/mode plus total_lines, no content), then fetch just the lines you need with line_from/line_to (1-based, inclusive) — windows keep files larger than max_read_bytes readable window by window, with more_lines/total_lines reporting what remains. numbered: true prefixes each line with its absolute 1-based file line number, matching coder::update-file's line ops exactly. Full reads are budgeted by max_output_bytes (default 128 KiB; per-call override clamped to max_read_bytes) — an over-budget full read fails with a C218 carrying the file's size, line count, and the window/stat recovery calls. encoding: base64 (single-path full reads only) returns the file's exact bytes base64-encoded — the binary-aware read for images and other non-text payloads. Batch mode: pass paths[] (XOR path) to read multiple files in one call — entries are processed in request order against batch_read_budget_bytes, measured in bytes of returned content (after UTF-8 sanitization); per-entry errors (C211/C218) leave other entries unaffected. Paths are relative to the primary allowed root or absolute inside any allowed root (coder::info lists them); for host paths outside the jail use shell::fs::*. Non-accessible paths return C211.",
+  "description": "Read a file. stat: true probes size/mtime/total_lines without content; line_from/line_to (1-based, inclusive) read a window of a file of any size; numbered: true prefixes absolute line numbers; paths[] (XOR path) batch-reads. Paths: relative to the primary root or absolute inside an allowed root (see coder::info).",
   "function_id": "coder::read-file",
   "request_schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -26,15 +26,15 @@
       "ReadTarget": {
         "anyOf": [
           {
-            "description": "Bare path string: read the whole file (within remaining batch budget and `max_read_bytes`).",
+            "description": "Bare path string: read the whole file.",
             "type": "string"
           },
           {
-            "description": "Object form: path plus optional 1-based window parameters. Omit `line_from` to start from line 1; omit `line_to` to read to EOF.",
+            "description": "Object form: path plus optional window and flags.",
             "properties": {
               "line_from": {
                 "default": null,
-                "description": "First line of the window, 1-based inclusive (must be >= 1; 0 is rejected with C210 for this entry). Defaults to 1 when only `line_to` is set.",
+                "description": "First line of the window, 1-based inclusive (>= 1); defaults to 1 when only `line_to` is set.",
                 "format": "uint64",
                 "minimum": 1.0,
                 "type": [
@@ -44,7 +44,7 @@
               },
               "line_to": {
                 "default": null,
-                "description": "Last line of the window, 1-based inclusive. Must be >= `line_from` (C210 for this entry otherwise). Omit to read from `line_from` to EOF.",
+                "description": "Last line of the window, 1-based inclusive, >= `line_from`; omit to read to EOF.",
                 "format": "uint64",
                 "minimum": 1.0,
                 "type": [
@@ -54,16 +54,16 @@
               },
               "numbered": {
                 "default": false,
-                "description": "Prefix this entry's content lines with their absolute 1-based file line numbers (`N→`) — same semantics as the top-level `numbered` field. Prefix bytes are charged against `batch_read_budget_bytes`.",
+                "description": "Prefix this entry's lines with their absolute 1-based line numbers (`N→`); prefix bytes count toward the batch budget.",
                 "type": "boolean"
               },
               "path": {
-                "description": "File to read. Same jail rules as the top-level `path` field.",
+                "description": "File to read.",
                 "type": "string"
               },
               "stat": {
                 "default": false,
-                "description": "Per-entry metadata probe: same semantics as the top-level `stat` field — size/mode/mtime always, `total_lines`/`is_utf8` when the file fits `max_read_bytes`, content null, no batch budget consumed. C210 when combined with this entry's `line_from`/`line_to` or `numbered`.",
+                "description": "Metadata probe for this entry: size/mode/mtime plus total_lines, content null, no budget consumed; C210 with a window or `numbered`.",
                 "type": "boolean"
               }
             },
@@ -73,7 +73,7 @@
             "type": "object"
           }
         ],
-        "description": "A single entry in a `paths[]` batch request. Pass either a bare file path string (whole-file read, same cap as `max_read_bytes`) or an object with optional per-entry `line_from`/`line_to` window parameters (1-based, inclusive — same rules as the top-level `path` mode)."
+        "description": "One batch entry: a bare path string (whole-file read) or an object with a per-entry window, stat or numbered flag."
       }
     },
     "examples": [
@@ -100,11 +100,11 @@
             "$ref": "#/definitions/ReadEncoding"
           }
         ],
-        "description": "Content encoding for single-path FULL reads. Default `text` returns UTF-8 (binary bytes replaced by U+FFFD); `base64` returns the file's exact bytes base64-encoded (standard alphabet, padded) — for binary payloads like images that a caller needs to reconstruct. The ENCODED length is what's charged against `max_output_bytes`. C210 combined with `stat`, `line_from`/`line_to`, or `numbered` (text-shaping fields); ignored when `paths` is set."
+        "description": "Content encoding for full reads; `base64` returns the exact file bytes (encoded length is budgeted). C210 with stat/window/numbered."
       },
       "line_from": {
         "default": null,
-        "description": "First line of the window, 1-based inclusive (must be >= 1; 0 is rejected with C210). Setting `line_from` and/or `line_to` switches to windowed mode: the file is streamed and only the requested lines are returned, so files larger than `max_read_bytes` stay readable slice by slice — the byte cap then applies to the returned window, never the file size. Defaults to 1 when only `line_to` is set. A window starting past EOF succeeds with empty content and reports the file's `total_lines`. Only valid in single-path mode (`path`); ignored when `paths` is set. Lines are 0x0A- or EOF-terminated segments; a trailing newline does not create a phantom line (same convention as `coder::update-file`).",
+        "description": "First line (1-based, >= 1) of a windowed read; windows keep files over max_read_bytes readable slice by slice. `path` mode only.",
         "format": "uint64",
         "minimum": 1.0,
         "type": [
@@ -114,7 +114,7 @@
       },
       "line_to": {
         "default": null,
-        "description": "Last line of the window, 1-based inclusive. Must be >= `line_from` (C210 otherwise). Omit to read from `line_from` to end-of-file (still bounded by `max_read_bytes` on the returned bytes). Only valid in single-path mode (`path`); ignored when `paths` is set.",
+        "description": "Last line of the window, 1-based inclusive, >= `line_from`; omit to read from `line_from` to EOF. `path` mode only.",
         "format": "uint64",
         "minimum": 1.0,
         "type": [
@@ -124,7 +124,7 @@
       },
       "max_output_bytes": {
         "default": null,
-        "description": "Per-call override of the `max_output_bytes` config (default 131072) that budgets single-path FULL reads, measured in returned content bytes after UTF-8 conversion (numbered prefixes included). Values above `max_read_bytes` are silently clamped to it. When the full content would exceed the effective budget the call fails with a C218 naming the file's size and `total_lines` — recover by windowing with `line_from`/`line_to`, probing with `stat: true`, or raising this field. Full reads only: combining it with `line_from`/`line_to` is C210 (windows are bounded by `max_read_bytes` instead); ignored when `paths` is set (batch mode is governed by `batch_read_budget_bytes`).",
+        "description": "Full-read byte budget (returned bytes, clamped to max_read_bytes); over budget fails C218 naming size/total_lines. C210 with a window.",
         "format": "uint64",
         "minimum": 0.0,
         "type": [
@@ -134,19 +134,19 @@
       },
       "numbered": {
         "default": false,
-        "description": "When true every returned content line is prefixed `N→`, where N is the line's ABSOLUTE 1-based number in the file — a window starting at `line_from: 40` is numbered from 40, not 1. Numbers match `coder::update-file`'s 1-based line ops exactly, so you can go from a numbered read straight to a line edit. Prefix bytes count toward all byte caps and budgets (no hidden bypass). C210 with `stat: true` (no content to number). Batch entries take a per-entry `numbered` field instead; this top-level flag is ignored when `paths` is set.",
+        "description": "Prefix each line with its absolute 1-based file line number (`N→`), matching coder::update-file line ops; C210 with `stat`. `path` mode only.",
         "type": "boolean"
       },
       "path": {
         "default": null,
-        "description": "Single file to read. Relative to the primary allowed root, or an absolute path inside any allowed root. Call `coder::info` to see the allowed roots. Paths outside every allowed root are rejected — use the shell worker's `shell::fs::*` for host paths outside the jail. Mutually exclusive with `paths` (XOR): pass either `path` or `paths`, not both — C210 if both or neither is set.",
+        "description": "Single file to read; XOR with `paths` (C210 if both or neither is set).",
         "type": [
           "string",
           "null"
         ]
       },
       "paths": {
-        "description": "Batch of files (or windowed slices) to read in a single call. Each entry is either a plain path string (whole-file read) or an object `{path, line_from?, line_to?}` with per-entry window parameters. Entries are processed in request order against a shared `batch_read_budget_bytes` cap, measured in bytes of returned content (after UTF-8 sanitization) — see `coder::info` for the configured value. Results are returned in the `results` field; top-level fields are null. Mutually exclusive with `path` (XOR): pass either `path` or `paths`, not both — C210 if both or neither is set.",
+        "description": "Batch of files to read in one call (bare path strings or window objects), processed in order against batch_read_budget_bytes; XOR with `path`.",
         "items": {
           "$ref": "#/definitions/ReadTarget"
         },
@@ -157,7 +157,7 @@
       },
       "stat": {
         "default": false,
-        "description": "Metadata probe — the cheap \"how big is it\" call. When true the response carries size/mode/mtime plus `total_lines` and `is_utf8` (both null when the file exceeds `max_read_bytes` — size/mode/mtime still populate, so stat on a huge file SUCCEEDS); `content` is null, `lines_returned` 0, `more_lines` false. Probe BEFORE reading an unknown file, then fetch just the slice you need with `line_from`/`line_to`. Mutually exclusive with `line_from`, `line_to`, `numbered`, and `max_output_bytes` (C210 — stat returns no content for them to act on). Batch entries take a per-entry `stat` field instead; this top-level flag is ignored when `paths` is set.",
+        "description": "Metadata probe: size/mode/mtime plus total_lines/is_utf8, no content; C210 with line_from/line_to/numbered/max_output_bytes.",
         "type": "boolean"
       }
     },

--- a/shell/tests/golden/schemas/coder.search.json
+++ b/shell/tests/golden/schemas/coder.search.json
@@ -1,5 +1,5 @@
 {
-  "description": "Search file contents and/or paths. Path search matches files AND directories (each path_match carries kind: file|dir); content search reads files only. Supports literal or regex queries with include/exclude globs; non-accessible files are excluded from both content and path results. Only the FIRST match on each line is reported (one content match per matching line). Optional context_lines_before/context_lines_after (max 10) attach surrounding lines to each content match so many edits can go straight to coder::update-file with no read in between. Noise paths matching default_exclude_globs (.git, node_modules, target, … — coder::info lists them) are skipped by default; pass use_default_excludes: false to search inside them. Files larger than max_read_bytes are silently skipped during content scanning. Results are capped by max_matches AND a response byte budget (search_response_budget_bytes); when truncated is true, refine the query or add include_globs rather than paginate. Paths are relative to the primary allowed root or absolute inside any allowed root (coder::info lists them); for host paths outside the jail use shell::fs::*.",
+  "description": "Search file contents (literal or regex) and/or paths (files and dirs); first match per line only. default_exclude_globs noise is skipped unless use_default_excludes: false. truncated: true means refine the query, not paginate. Paths: relative to the primary root or absolute inside an allowed root (see coder::info).",
   "function_id": "coder::search",
   "request_schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -19,7 +19,7 @@
     "properties": {
       "context_lines_after": {
         "default": null,
-        "description": "Lines of context to return AFTER each content match. Same max (10), truncation, and budget rules as `context_lines_before`; unset = 0.",
+        "description": "Lines of context after each content match; same rules as `context_lines_before`.",
         "format": "uint32",
         "minimum": 0.0,
         "type": [
@@ -29,7 +29,7 @@
       },
       "context_lines_before": {
         "default": null,
-        "description": "Lines of context to return BEFORE each content match (same file only, in file order), max 10 — larger values are rejected with C210. With context lines many edit tasks can go straight from search output to coder::update-file with no read in between. Context lines are truncated to `max_line_bytes` like the matched text and count toward the response byte budget. Unset = 0.",
+        "description": "Lines of context before each content match (max 10, C210 above); truncated to max_line_bytes and counted in the budget. Default 0.",
         "format": "uint32",
         "minimum": 0.0,
         "type": [
@@ -51,7 +51,7 @@
       },
       "include_globs": {
         "default": [],
-        "description": "Glob patterns (matched against the path relative to its containing root — or, for a walk root outside every configured root, relative to the session directory `coder::info` reports as `session_root`) that paths must match to be considered. Empty = include everything.",
+        "description": "Root-relative glob patterns paths must match; empty = everything.",
         "items": {
           "type": "string"
         },
@@ -79,7 +79,7 @@
       },
       "path": {
         "default": ".",
-        "description": "Folder scoping the walk. Relative to the primary allowed root, or an absolute path inside any allowed root. Defaults to `.` (the primary root itself). Globs are matched relative to the containing root; result paths are absolute regardless of this value. Call `coder::info` to see the allowed roots. Paths outside every allowed root are rejected — use the shell worker's `shell::fs::*` for host paths outside the jail.",
+        "description": "Folder to search (default `.`); globs match relative to its root, result paths are absolute.",
         "type": "string"
       },
       "query": {
@@ -102,7 +102,7 @@
       },
       "use_default_excludes": {
         "default": true,
-        "description": "Apply the worker's `default_exclude_globs` config (noise paths like .git, node_modules, target, dist — call coder::info for the active list): the walk does not descend into matching directories and matching files are omitted from BOTH content and path results. Pass `false` to search inside them.",
+        "description": "Skip paths matching default_exclude_globs (.git, node_modules, …; see coder::info) in content and path results; false searches inside them.",
         "type": "boolean"
       }
     },

--- a/shell/tests/golden/schemas/coder.tree.json
+++ b/shell/tests/golden/schemas/coder.tree.json
@@ -1,5 +1,5 @@
 {
-  "description": "Recursive directory snapshot bounded by `max_depth` and a `per_folder_limit`. Slim wire shape: nodes carry only `name` — the root node's path IS the response's top-level `path`; derive any child's path as parent path + '/' + name. Folders that hit the limit are flagged `truncated` and the caller is pointed at coder::list-folder for pagination. Noise directories matching default_exclude_globs (.git, node_modules, target, … — coder::info lists them) appear as childless `truncated` stubs; pass use_default_excludes: false to descend into them. Pass include_hidden: false to omit dot-prefixed entries (they then don't count toward per_folder_limit). A total node budget bounds every snapshot; folders past it are stubs with reason max_nodes — re-root there or paginate with coder::list-folder. Paths are relative to the primary allowed root or absolute inside any allowed root (coder::info lists them); for host paths outside the jail use shell::fs::*.",
+  "description": "Recursive directory snapshot bounded by max_depth, per_folder_limit and a node budget. Nodes carry only name (child path = parent path + '/' + name); over-limit folders are truncated stubs to paginate with coder::list-folder. Paths: relative to the primary root or absolute inside an allowed root (see coder::info).",
   "function_id": "coder::tree",
   "request_schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -12,7 +12,7 @@
     "properties": {
       "include_hidden": {
         "default": true,
-        "description": "List hidden (dot-prefixed) entries. Pass `false` to omit them — files and folders alike — at every level; omitted entries do not count toward `per_folder_limit`, so the cap serves visible names. The requested root itself is exempt: explicitly naming a hidden folder still lists its contents.",
+        "description": "List dot-prefixed entries; false omits them at every level (they then don't count toward per_folder_limit). The requested root is exempt.",
         "type": "boolean"
       },
       "max_depth": {
@@ -27,7 +27,7 @@
       },
       "path": {
         "default": ".",
-        "description": "Base folder for the snapshot. Relative to the primary allowed root, or an absolute path inside any allowed root. Defaults to `.` (the primary root itself). Call `coder::info` to see the allowed roots. Paths outside every allowed root are rejected — use the shell worker's `shell::fs::*` for host paths outside the jail.",
+        "description": "Base folder for the snapshot (default `.`).",
         "type": "string"
       },
       "per_folder_limit": {
@@ -42,7 +42,7 @@
       },
       "use_default_excludes": {
         "default": true,
-        "description": "Apply the worker's `default_exclude_globs` config (noise folders like .git/node_modules/target — call `coder::info` for the active list). Excluded directories still appear as childless nodes flagged `truncated` with reason \"default_exclude\"; excluded files are omitted and their containing directory carries the same truncation reason. Pass `false` to list everything.",
+        "description": "Prune directories matching default_exclude_globs (see coder::info) into childless `truncated` stubs; false lists everything.",
         "type": "boolean"
       }
     },

--- a/shell/tests/golden/schemas/coder.update-file.json
+++ b/shell/tests/golden/schemas/coder.update-file.json
@@ -1,5 +1,5 @@
 {
-  "description": "Apply batched line-oriented and regex edits across one or more files. Request shape: {\"files\": [{\"path\": \"...\", \"ops\": [...]}]}. Line ops: { op: 'insert', at_line, content } | { op: 'remove', from_line, to_line } | { op: 'update_lines', from_line, to_line, content } — 1-based, inclusive, applied bottom-up. Regex op: { op: 'replace', pattern, replacement, ignore_case?, dot_matches_newline?, expect_matches? } runs on the file body after line ops. Replace large regions WITHOUT quoting them: two short anchors joined by .*? with dot_matches_newline: true — always prefer wildcards over pasting the block into the pattern. expect_matches: 1 turns a silent multi-site clobber into a safe pre-write C210; expect_matches: 0 asserts absence. In `replacement`, $1/${name} are capture references and a literal $ must be written $$ (JS/TS template literals: `Hello, $${name}!`); undefined references fail pre-write with C210. Each file commits atomically via temp + rename. On success each applied line op returns a bounded post-apply echo (±2 context lines); regex replace ops return up to 5 per-match-site echoes (first + last line of each replaced region, inner lines elided) — verify from the echoes instead of re-reading the file. Paths are relative to the primary allowed root or absolute inside any allowed root (coder::info lists them); for host paths outside the jail use shell::fs::*.",
+  "description": "Apply batched line ops (1-based, inclusive, applied bottom-up) then regex replace ops to one or more files; each file commits atomically. To replace a large region use two short anchors joined by .*? with dot_matches_newline: true instead of quoting it. Paths: relative to the primary root or absolute inside an allowed root (see coder::info).",
   "function_id": "coder::update-file",
   "request_schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -13,7 +13,7 @@
             "type": "array"
           },
           "path": {
-            "description": "Path relative to the primary allowed root, or an absolute path inside any allowed root. Call `coder::info` to see the allowed roots. Paths outside every allowed root are rejected — use the shell worker's `shell::fs::*` for host paths outside the jail.",
+            "description": "File to edit.",
             "type": "string"
           }
         },
@@ -113,12 +113,12 @@
             "properties": {
               "dot_matches_newline": {
                 "default": false,
-                "description": "When true, `.` in `pattern` also matches `\\n`, so a short anchored pattern like `\"fn parse_config\\\\(.*?\\\\n\\\\}\"` replaces a whole multi-line region without quoting it — prefer two short anchors joined by `.*?` over pasting the block into the pattern. Without this flag (the default), `.` does not cross newlines and a multi-line pattern silently matches nothing.",
+                "description": "When true `.` also matches newline, so a short pattern like `start.*?end` spans lines; by default a multi-line pattern matches nothing.",
                 "type": "boolean"
               },
               "expect_matches": {
                 "default": null,
-                "description": "Expected number of matches for this op. When set and the actual count differs, this FILE fails with C210 and nothing is written to it (other files in the batch still apply). Set `expect_matches: 1` to make a targeted read-free edit safe — a mismatch means the pattern is anchored too loosely or matches nothing. Set `expect_matches: 0` to assert ABSENCE: the op succeeds only when nothing matches (the replacement is unused). Omit to replace all matches unconditionally.",
+                "description": "Expected match count; a mismatch fails this file with C210 and writes nothing (0 asserts absence). Omit to replace all matches.",
                 "format": "uint64",
                 "minimum": 0.0,
                 "type": [
@@ -140,7 +140,7 @@
                 "type": "string"
               },
               "replacement": {
-                "description": "Substitution text for each match. Capture references expand: `$1`/`${1}` by index (`$0` is the whole match) and `$name`/`${name}` by name. A literal `$` MUST be written `$$` — JS/TS template literals in a replacement are the classic collision: write `Hello, $${name}!` to output `Hello, ${name}!`. Unbraced references consume the longest `[0-9A-Za-z_]` run, so `$1a` means a group named \"1a\", NOT group 1 then \"a\" (use `${1}a`). A reference to a group the pattern does not define fails pre-write with C210 — nothing is written. References are validated even when the replacement goes unused (e.g. `expect_matches: 0`): the replacement must be well-formed even when unused.",
+                "description": "Substitution text; $1/${1}/$name/${name} expand captures ($0 = whole match), a literal $ is written $$ (`$${name}`). Unknown references fail C210.",
                 "type": "string"
               }
             },


### PR DESCRIPTION
Closes [MOT-4639](https://linear.app/motia/issue/MOT-4639). Sub-issue of MOT-4636; follows #1047 (structural compaction) and #1053 (`MessageInput`).

## Why

After #1047, what a `functions::info` contract costs the model is 79% prose: schemars `description` strings from Rust doc comments plus the function-level registration descriptions. The prose is the contract — in `agent_trigger` exposure the model has no other source of argument semantics — but it was sized for a README: median property description 193 chars, p90 531, max 694, carrying procedural guidance, recovery advice, config-default narration, and the same jail sentence repeated in every coder function *and* every path field.

## Change (editorial, at the source, no truncation logic)

- **Property description = one sentence, ~140 chars max**: what the field is and, where the schema cannot express it, the valid values / format / unit.
- **Function description ~300 chars max**: what it does plus the one non-obvious calling rule. The coder jail clause now appears once per function description and never in field docs.
- **Internal notes** (Rust symbols, postmortems, serde rationale) moved from `///` to `//` — still in the source, off the wire.
- **No type, field, or serde attribute changed.** No enum conversions were warranted: every closed set already was an enum (`ReadEncoding`, `Target`, `SubagentIcon`/`Color`, `SystemPromptStrategy`, `Mode`).

Touched: `harness/src/functions/{spawn,send,subscribe,triggers_list,system_prompt,mod}.rs`, `harness/src/prompt/mode.rs`, `harness/src/turn_loop.rs`; `shell/src/code/functions/*.rs`, `shell/src/functions/types.rs`, `shell/src/main.rs`, `shell/src/fs/mod.rs`, `shell/src/pty/protocol.rs`. The regenerated goldens (`harness/tests/golden/schemas/*.json`, `shell/tests/golden/schemas/coder.*.json`) are the reviewable deliverable.

## Measured

Request-schema prose across the harness + shell goldens: **23,173 → 10,350 chars (−55%)**. Four fields sit at 141–147 chars on purpose (`replacement`'s `$$` escape rule, the `paths`/`path` XOR, spawn `agent`).

The 31 real `functions::info` payloads of the MOT-4636 corpus, model-visible copy (compaction applied), rebuilt contracts fetched from a local engine running this branch's harness + shell:

| function | fetches | before | after |
| -- | -- | -- | -- |
| `harness::spawn` | 7 | 80,387 | 35,924 |
| `coder::read-file` | 6 | 50,484 | 20,910 |
| `shell::exec` | 6 | 25,752 | 12,414 |
| `engine::register_trigger` (harness overlay) | 4 | 17,788 | 13,136 |
| `coder::create-file` | 4 | 8,004 | 5,676 |
| `coder::update-file` | 1 | 5,331 | 2,888 |
| **all 31 payloads** | | **202,538** | **104,931 (−48%)** |

Per fetch: `harness::spawn` 11.5k → 5.1k, `coder::read-file` 8.4k → 3.5k, `shell::exec` 4.3k → 2.1k.

## Guards

- 96 real corpus payloads for the touched functions validated against the rebuilt schemas: no payload lost validity. The 14 that fail are `engine::register_trigger` calls carrying `lifecycle.expires_at`, a field `main` already rejects (retired before this branch; only its doc comment moved).
- `cargo fmt`, `cargo clippy --all-features --all-targets -D warnings`, full `cargo test` green in both crates; goldens regenerated with `UPDATE_GOLDENS=1`.
- INT-025 pins a synthetic contract and is unaffected.

**Not yet done:** the live spot-check turn (spawn with `display`/`options` + `register_trigger` with `lifecycle` under the short prose). The compose stack was restarted mid-run and holds the `my-project` harness namespace; I will run it once the stack's harness can be swapped for this build.

https://claude.ai/code/session_01EUoLR66baA2QL7x6fH72bT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Simplified descriptions for agent controls, triggers, lifecycle requests, system prompts, turn handling, and operating modes.
  - Condensed documentation for coding and shell tools, including file operations, searches, folder listings, execution, and configuration.
  - Clarified select file-writing rules and request behavior while retaining existing functionality.
  - Updated published schema descriptions to match the streamlined guidance without changing fields, types, defaults, or validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->