### PR TITLE
fix: preserve Registry interfaces during releases

### DIFF
--- a/.github/contracts/deployment-descriptor.schema.json
+++ b/.github/contracts/deployment-descriptor.schema.json
@@ -17,6 +17,7 @@
     "source",
     "artifact",
     "runtime",
+    "interface_capture",
     "publish",
     "build_units",
     "registry_projection"
@@ -48,6 +49,7 @@
       ]
     },
     "runtime": {"type": "object"},
+    "interface_capture": {"enum": ["required", "skipped"]},
     "publish": {"type": "boolean"},
     "build_units": {
       "type": "array",

--- a/.github/scripts/build_publish_payload.py
+++ b/.github/scripts/build_publish_payload.py
@@ -289,6 +289,7 @@ def build_payload(
     published_version: str,
     repo_url: str,
     interface: dict[str, Any],
+    interface_capture: str,
     artifacts: dict[str, Any],
     readme: str | None = None,
 ) -> dict[str, Any]:
@@ -299,6 +300,18 @@ def build_payload(
     }
     if not isinstance(registry_projection, dict) or set(registry_projection) != required:
         raise ValueError("registry_projection differs from the current Registry metadata contract")
+    if interface_capture not in {"required", "skipped"}:
+        raise ValueError("interface_capture must be required or skipped")
+    if not isinstance(interface, dict) or set(interface) != {"functions", "triggers"}:
+        raise ValueError("interface must contain only functions and triggers")
+    for field in ("functions", "triggers"):
+        if not isinstance(interface[field], list) or any(not isinstance(row, dict) for row in interface[field]):
+            raise ValueError(f"interface {field} must be an array of objects")
+    interface_empty = not interface["functions"] and not interface["triggers"]
+    if interface_capture == "required" and interface_empty:
+        raise ValueError("required interface capture must contain a function or trigger")
+    if interface_capture == "skipped" and not interface_empty:
+        raise ValueError("skipped interface capture must publish an empty interface")
     _lib.validate_deployment_target_version(published_version)
     deploy = registry_projection["type"]
     kind = artifacts.get("kind")
@@ -364,6 +377,7 @@ def main() -> int:
         published_version=args.published_version,
         repo_url=args.repo_url,
         interface=interface,
+        interface_capture=descriptor["interface_capture"],
         artifacts=artifacts,
         readme=readme,
     )

--- a/.github/scripts/deployment_compiler.py
+++ b/.github/scripts/deployment_compiler.py
@@ -192,7 +192,9 @@ def normalize_config(worker_dir: Path, manifest: dict[str, Any]) -> dict[str, An
     return config
 
 
-def normalize_runtime(worker: str, manifest: dict[str, Any], kind: str) -> dict[str, Any]:
+def normalize_runtime(
+    worker: str, worker_dir: Path, manifest: dict[str, Any], kind: str
+) -> dict[str, Any]:
     env = manifest.get("env") or {}
     if not isinstance(env, dict) or any(not isinstance(key, str) or not isinstance(value, str) for key, value in env.items()):
         fail(f"{worker}/iii.worker.yaml: env must map strings to strings")
@@ -207,6 +209,18 @@ def normalize_runtime(worker: str, manifest: dict[str, Any], kind: str) -> dict[
         "environment": dict(sorted(env.items())),
         "resources": resources,
     }
+    capture_config = worker_dir / "config.collect.yaml"
+    if capture_config.exists():
+        if not capture_config.is_file() or capture_config.is_symlink():
+            fail(f"{worker}/config.collect.yaml must be a regular file")
+        if kind != "rust-binary":
+            fail(f"{worker}/config.collect.yaml is only supported for binary workers")
+        result["interface_config"] = {
+            "path": "config.collect.yaml",
+            "sha256": file_sha256(capture_config),
+        }
+    else:
+        result["interface_config"] = None
     if kind == "rust-binary":
         result["exec"] = [str(manifest.get("bin") or worker)]
     elif kind in {"javascript-bundle", "python-bundle"}:
@@ -418,6 +432,9 @@ def compile_worker(root: Path, worker: str, value: Any, source_sha: str, compile
         fail(f"{public_path}: name must be {worker!r}")
     if manifest.get("manifest") != manifest_name:
         fail(f"{public_path}: manifest must match the private package_manifest")
+    interface_smoke = manifest.get("interface_smoke", True)
+    if not isinstance(interface_smoke, bool):
+        fail(f"{public_path}: interface_smoke must be a boolean when present")
     publish = value["publish"]
     if not isinstance(publish, bool):
         fail(f"workers.{worker}.publish must be a boolean")
@@ -451,7 +468,11 @@ def compile_worker(root: Path, worker: str, value: Any, source_sha: str, compile
         "compiler_digest": compiler_sha,
         "source": source,
         "artifact": artifact,
-        "runtime": normalize_runtime(worker, manifest, str(artifact["kind"])),
+        "runtime": normalize_runtime(worker, worker_dir, manifest, str(artifact["kind"])),
+        # Keep the legacy public-manifest spelling at the source boundary only.
+        # Inside the immutable deployment contract this is interface capture:
+        # registration metadata is collected, but no worker function is called.
+        "interface_capture": "required" if interface_smoke else "skipped",
         "publish": publish,
         "build_units": build_units(worker, artifact),
         "registry_projection": projection,

--- a/.github/scripts/deployment_interface.py
+++ b/.github/scripts/deployment_interface.py
@@ -1,0 +1,489 @@
+#!/usr/bin/env python3
+"""Capture and verify Registry interfaces from immutable prepared artifacts.
+
+This is publication evidence, not a deployment smoke test: the prepared worker
+is only allowed to register its functions and trigger types with an isolated
+engine. No worker function, external backend, or product behavior is exercised.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import tarfile
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _read_object(path: Path, label: str) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise SystemExit(f"{label} must be an object")
+    return value
+
+
+def _safe_member(name: str) -> PurePosixPath:
+    member = PurePosixPath(name)
+    if member.is_absolute() or not member.parts or any(part in {"", ".", ".."} for part in member.parts):
+        raise SystemExit(f"unsafe prepared archive path: {name!r}")
+    return member
+
+
+def extract_regular_tar(archive_path: Path, destination: Path) -> None:
+    destination.mkdir(parents=True, exist_ok=False)
+    with tarfile.open(archive_path, mode="r:gz") as archive:
+        members = archive.getmembers()
+        if not members:
+            raise SystemExit("prepared archive is empty")
+        for member in members:
+            relative = _safe_member(member.name)
+            if not member.isfile():
+                raise SystemExit(f"prepared archive member is not a regular file: {member.name}")
+            target = destination.joinpath(*relative.parts)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            source = archive.extractfile(member)
+            if source is None:
+                raise SystemExit(f"cannot read prepared archive member: {member.name}")
+            with target.open("wb") as handle:
+                shutil.copyfileobj(source, handle)
+            target.chmod(0o755 if member.mode & 0o111 else 0o644)
+
+
+def _capture_policy(descriptor: dict[str, Any]) -> str:
+    policy = descriptor.get("interface_capture")
+    if policy not in {"required", "skipped"}:
+        raise SystemExit("descriptor interface_capture must be required or skipped")
+    return str(policy)
+
+
+def _verify_prepared(
+    descriptor: dict[str, Any], prepared: dict[str, Any], root: Path
+) -> list[dict[str, Any]]:
+    expected = {
+        "contract": "prepared-artifacts",
+        "worker": descriptor["worker"],
+        "source_sha": descriptor["source_sha"],
+        "descriptor_sha256": descriptor["descriptor_sha256"],
+    }
+    if not isinstance(prepared, dict) or set(prepared) != {*expected, "artifacts"}:
+        raise SystemExit("prepared artifact inventory fields differ from contract")
+    if any(prepared.get(key) != value for key, value in expected.items()):
+        raise SystemExit("prepared artifact identity differs from release descriptor")
+    artifacts = prepared.get("artifacts")
+    if not isinstance(artifacts, list) or not artifacts:
+        raise SystemExit("prepared artifacts must be a non-empty array")
+    names: set[str] = set()
+    for artifact in artifacts:
+        if not isinstance(artifact, dict) or set(artifact) != {"unit", "name", "role", "sha256", "size"}:
+            raise SystemExit("prepared artifact entry fields differ from contract")
+        name = artifact.get("name")
+        if not isinstance(name, str) or not name or Path(name).name != name or name in names:
+            raise SystemExit(f"prepared artifact name is invalid or duplicated: {name!r}")
+        names.add(name)
+        path = root / name
+        if not path.is_file() or path.is_symlink():
+            raise SystemExit(f"prepared artifact is not a regular file: {path}")
+        if path.stat().st_size != artifact.get("size") or sha256(path) != artifact.get("sha256"):
+            raise SystemExit(f"prepared artifact bytes differ from inventory: {path}")
+    return artifacts
+
+
+def _single_artifact(
+    artifacts: list[dict[str, Any]], role: str, *, unit: str | None = None
+) -> dict[str, Any]:
+    matches = [
+        artifact
+        for artifact in artifacts
+        if artifact.get("role") == role and (unit is None or artifact.get("unit") == unit)
+    ]
+    if len(matches) != 1:
+        suffix = f" for unit {unit}" if unit else ""
+        raise SystemExit(f"prepared release requires exactly one {role} artifact{suffix}")
+    return matches[0]
+
+
+def stage(args: argparse.Namespace) -> int:
+    descriptor = _read_object(args.descriptor, "release descriptor")
+    prepared = _read_object(args.prepared, "prepared artifact inventory")
+    policy = _capture_policy(descriptor)
+    artifact = descriptor.get("artifact")
+    runtime = descriptor.get("runtime")
+    if not isinstance(artifact, dict) or not isinstance(runtime, dict):
+        raise SystemExit("descriptor artifact and runtime must be objects")
+    artifacts = _verify_prepared(descriptor, prepared, args.prepared.parent)
+    kind = artifact.get("kind")
+    result: dict[str, Any] = {
+        "contract": "deployment-interface-stage",
+        "worker": descriptor["worker"],
+        "descriptor_sha256": descriptor["descriptor_sha256"],
+        "prepared_sha256": sha256(args.prepared),
+        "interface_capture": policy,
+        "kind": kind,
+        "cwd": None,
+        "prepare": [],
+        "command": [],
+        "oci_archive": None,
+        "runtime_name": None,
+        "runtime_version": None,
+        "package_manager_name": None,
+        "package_manager_version": None,
+        "environment": {},
+    }
+    environment = runtime.get("environment", {})
+    if not isinstance(environment, dict) or any(
+        not isinstance(key, str) or not key or not isinstance(value, str)
+        for key, value in environment.items()
+    ):
+        raise SystemExit("runtime.environment must map non-empty strings to strings")
+    result["environment"] = dict(sorted(environment.items()))
+    interface_config = runtime.get("interface_config")
+    config_argument: list[str] = []
+    if interface_config is not None:
+        if not isinstance(interface_config, dict) or set(interface_config) != {"path", "sha256"}:
+            raise SystemExit("runtime.interface_config must contain only path and sha256")
+        if args.source_root is None:
+            raise SystemExit("interface capture config requires an immutable source root")
+        source = descriptor.get("source")
+        if not isinstance(source, dict):
+            raise SystemExit("descriptor source must be an object")
+        relative = PurePosixPath(str(interface_config.get("path", "")))
+        source_path = PurePosixPath(str(source.get("path", "")))
+        if (
+            relative.is_absolute() or not relative.parts
+            or source_path.is_absolute() or not source_path.parts
+            or any(part in {"", ".", ".."} for part in (*source_path.parts, *relative.parts))
+        ):
+            raise SystemExit("runtime.interface_config path must remain within the worker source")
+        config_path = args.source_root.joinpath(*source_path.parts, *relative.parts)
+        if not config_path.is_file() or config_path.is_symlink():
+            raise SystemExit(f"interface capture config is missing: {config_path}")
+        if sha256(config_path) != interface_config.get("sha256"):
+            raise SystemExit("interface capture config bytes differ from the deployment descriptor")
+        config_argument = ["--config", str(config_path.resolve())]
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    if policy == "required":
+        if kind == "rust-binary":
+            target = "x86_64-unknown-linux-gnu"
+            units = [
+                unit
+                for unit in descriptor.get("build_units", [])
+                if isinstance(unit, dict) and unit.get("kind") == kind and unit.get("target") == target
+            ]
+            if len(units) != 1:
+                raise SystemExit(f"required interface capture needs exactly one {target} build unit")
+            selected = _single_artifact(artifacts, "binary", unit=str(units[0]["id"]))
+            stage_dir = (args.out.parent / "runtime").resolve()
+            extract_regular_tar(args.prepared.parent / str(selected["name"]), stage_dir)
+            command = runtime.get("exec")
+            if not isinstance(command, list) or not command or not all(isinstance(part, str) for part in command):
+                raise SystemExit("non-OCI runtime.exec must be a non-empty argv array")
+            executable = stage_dir / command[0]
+            if not executable.is_file() or executable.is_symlink():
+                raise SystemExit(f"prepared runtime executable is missing: {executable}")
+            executable.chmod(0o755)
+            result.update(cwd=str(stage_dir), command=[str(executable), *command[1:], *config_argument])
+        elif kind in {"javascript-bundle", "python-bundle"}:
+            selected = _single_artifact(artifacts, "bundle")
+            stage_dir = (args.out.parent / "runtime").resolve()
+            extract_regular_tar(args.prepared.parent / str(selected["name"]), stage_dir)
+            start = runtime.get("start")
+            install = runtime.get("install") or ""
+            if not isinstance(start, str) or not start.strip() or not isinstance(install, str):
+                raise SystemExit("bundle runtime install/start commands are invalid")
+            tool_runtime = artifact.get("runtime")
+            manager = artifact.get("package_manager")
+            if not isinstance(tool_runtime, dict) or not isinstance(manager, dict):
+                raise SystemExit("bundle build runtime and package manager must be explicit")
+            result.update(
+                cwd=str(stage_dir),
+                prepare=[["sh", "-c", install]] if install.strip() else [],
+                command=["sh", "-c", start],
+                runtime_name=tool_runtime.get("name"),
+                runtime_version=tool_runtime.get("version"),
+                package_manager_name=manager.get("name"),
+                package_manager_version=manager.get("version"),
+            )
+        elif kind == "oci-image":
+            units = [
+                unit
+                for unit in descriptor.get("build_units", [])
+                if isinstance(unit, dict) and unit.get("kind") == kind and unit.get("platform") == "linux/amd64"
+            ]
+            if len(units) != 1:
+                raise SystemExit("required OCI interface capture needs exactly one linux/amd64 build unit")
+            selected = _single_artifact(artifacts, "oci-platform", unit=str(units[0]["id"]))
+            archive = (args.out.parent / "image.oci.tar").resolve()
+            with gzip.open(args.prepared.parent / str(selected["name"]), "rb") as source:
+                with archive.open("wb") as destination:
+                    shutil.copyfileobj(source, destination)
+            if not tarfile.is_tarfile(archive):
+                raise SystemExit("prepared OCI artifact is not an OCI tar archive")
+            result["oci_archive"] = str(archive)
+        else:
+            raise SystemExit(f"unsupported release interface artifact kind {kind!r}")
+    args.out.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if args.github_output:
+        with args.github_output.open("a", encoding="utf-8") as handle:
+            for key in (
+                "interface_capture", "kind", "runtime_name", "runtime_version",
+                "package_manager_name", "package_manager_version",
+            ):
+                handle.write(f"{key}={result[key] or ''}\n")
+    return 0
+
+
+def _canonical_interface(value: object) -> dict[str, list[dict[str, Any]]]:
+    if not isinstance(value, dict) or set(value) != {"functions", "triggers"}:
+        raise SystemExit("worker interface must contain only functions and triggers")
+    result: dict[str, list[dict[str, Any]]] = {}
+    for key in ("functions", "triggers"):
+        rows = value[key]
+        if not isinstance(rows, list) or any(not isinstance(row, dict) for row in rows):
+            raise SystemExit(f"worker interface {key} must be an array of objects")
+        result[key] = sorted(rows, key=lambda row: (str(row.get("name", "")), json.dumps(row, sort_keys=True)))
+    return result
+
+
+def snapshot(args: argparse.Namespace) -> int:
+    descriptor = _read_object(args.descriptor, "release descriptor")
+    prepared = _read_object(args.prepared, "prepared artifact inventory")
+    _verify_prepared(descriptor, prepared, args.prepared.parent)
+    policy = _capture_policy(descriptor)
+    if policy == "required":
+        if args.interface is None:
+            raise SystemExit("required interface capture needs collected interface bytes")
+        interface: dict[str, Any] | None = _canonical_interface(
+            json.loads(args.interface.read_text(encoding="utf-8"))
+        )
+        if not interface["functions"] and not interface["triggers"]:
+            raise SystemExit("required interface capture must contain a function or trigger")
+    else:
+        if args.interface is not None:
+            raise SystemExit("skipped interface capture must not accept collected interface")
+        interface = None
+    result = {
+        "contract": "deployment-interface",
+        "worker": descriptor["worker"],
+        "source_sha": descriptor["source_sha"],
+        "descriptor_sha256": descriptor["descriptor_sha256"],
+        "prepared_sha256": sha256(args.prepared),
+        "interface_capture": policy,
+        "interface": interface,
+    }
+    args.out.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0
+
+
+def build_evidence(args: argparse.Namespace) -> int:
+    descriptor = _read_object(args.descriptor, "release descriptor")
+    prepared = _read_object(args.prepared, "prepared artifact inventory")
+    interface = _read_object(args.interface, "release interface")
+    artifacts = _verify_prepared(descriptor, prepared, args.prepared.parent)
+    identity = {
+        "worker": descriptor["worker"],
+        "source_sha": descriptor["source_sha"],
+        "descriptor_sha256": descriptor["descriptor_sha256"],
+        "prepared_sha256": sha256(args.prepared),
+        "interface_capture": _capture_policy(descriptor),
+    }
+    if any(interface.get(key) != value for key, value in identity.items()):
+        raise SystemExit("release interface identity differs from prepared release")
+    evidence = [dict(artifact) for artifact in artifacts]
+    for path, role in (
+        (args.descriptor, "descriptor"),
+        (args.prepared, "prepared-inventory"),
+        (args.interface, "interface"),
+    ):
+        if not path.is_file() or path.is_symlink():
+            raise SystemExit(f"release evidence is not a regular file: {path}")
+        evidence.append({"name": path.name, "role": role, "sha256": sha256(path), "size": path.stat().st_size})
+    evidence.sort(key=lambda artifact: (str(artifact["name"]), str(artifact["role"])))
+    document = {"contract": "deployment-evidence", **identity, "artifacts": evidence}
+    args.out.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0
+
+
+def verify_evidence(args: argparse.Namespace) -> int:
+    descriptor = _read_object(args.descriptor, "release descriptor")
+    evidence = _read_object(args.evidence, "release evidence inventory")
+    expected = {
+        "contract": "deployment-evidence",
+        "worker": descriptor["worker"],
+        "source_sha": descriptor["source_sha"],
+        "descriptor_sha256": descriptor["descriptor_sha256"],
+        "prepared_sha256": sha256(args.evidence.parent / "prepared-artifacts.json"),
+        "interface_capture": _capture_policy(descriptor),
+    }
+    if any(evidence.get(key) != value for key, value in expected.items()):
+        raise SystemExit("release evidence identity differs from release descriptor and prepared inventory")
+    artifacts = evidence.get("artifacts")
+    if not isinstance(artifacts, list) or not artifacts:
+        raise SystemExit("release evidence artifacts must be a non-empty array")
+    names: set[str] = set()
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            raise SystemExit("release evidence artifact must be an object")
+        name = str(artifact.get("name", ""))
+        safe_name = _safe_member(name)
+        if len(safe_name.parts) != 1 or name in names:
+            raise SystemExit(f"release evidence artifact name is invalid or duplicated: {name}")
+        names.add(name)
+        path = args.evidence.parent / name
+        if not path.is_file() or path.is_symlink():
+            raise SystemExit(f"release evidence file is missing: {path}")
+        if path.stat().st_size != artifact.get("size") or sha256(path) != artifact.get("sha256"):
+            raise SystemExit(f"release evidence bytes differ from inventory: {path}")
+    required = {args.descriptor.name, "prepared-artifacts.json", "deployment-interface.json"}
+    if not required.issubset(names):
+        raise SystemExit(f"release evidence is incomplete: missing {sorted(required - names)}")
+    prepared = _read_object(args.evidence.parent / "prepared-artifacts.json", "prepared artifact inventory")
+    prepared_artifacts = _verify_prepared(descriptor, prepared, args.evidence.parent)
+    expected_names = {
+        *(str(artifact["name"]) for artifact in prepared_artifacts),
+        args.descriptor.name,
+        "prepared-artifacts.json",
+        "deployment-interface.json",
+    }
+    if names != expected_names:
+        raise SystemExit(
+            "release evidence file set differs from prepared release: "
+            f"missing={sorted(expected_names - names)} unknown={sorted(names - expected_names)}"
+        )
+    interface = _read_object(args.evidence.parent / "deployment-interface.json", "release interface")
+    interface_fields = {
+        "contract", "worker", "source_sha", "descriptor_sha256",
+        "prepared_sha256", "interface_capture", "interface",
+    }
+    if set(interface) != interface_fields:
+        raise SystemExit("release interface fields differ from contract")
+    for key, value in expected.items():
+        if key != "contract" and interface.get(key) != value:
+            raise SystemExit("release interface identity differs from release evidence")
+    if interface.get("contract") != "deployment-interface":
+        raise SystemExit("release interface contract mismatch")
+    captured = interface.get("interface")
+    if expected["interface_capture"] == "required":
+        canonical = _canonical_interface(captured)
+        if not canonical["functions"] and not canonical["triggers"]:
+            raise SystemExit("required release interface is empty")
+    elif captured is not None:
+        raise SystemExit("skipped release interface must remain null")
+    return 0
+
+
+def export_interface(args: argparse.Namespace) -> int:
+    descriptor = _read_object(args.descriptor, "release descriptor")
+    snapshot_value = _read_object(args.snapshot, "release interface")
+    policy = _capture_policy(descriptor)
+    if snapshot_value.get("interface_capture") != policy:
+        raise SystemExit("release interface policy differs from descriptor")
+    captured = snapshot_value.get("interface")
+    if policy == "required":
+        interface = _canonical_interface(captured)
+        if not interface["functions"] and not interface["triggers"]:
+            raise SystemExit("required release interface is empty")
+    elif captured is not None:
+        raise SystemExit("skipped release interface must remain null")
+    else:
+        interface = {"functions": [], "triggers": []}
+    args.out.write_text(json.dumps(interface, sort_keys=True) + "\n", encoding="utf-8")
+    return 0
+
+
+def compare(args: argparse.Namespace) -> int:
+    descriptor = _read_object(args.descriptor, "release descriptor")
+    expected = _read_object(args.expected, "prepared release interface")
+    policy = _capture_policy(descriptor)
+    if expected.get("interface_capture") != policy:
+        raise SystemExit("prepared interface policy differs from release descriptor")
+    if policy == "skipped":
+        if expected.get("interface") is not None or args.actual is not None:
+            raise SystemExit("skipped interface capture must remain explicit and empty")
+        return 0
+    if args.actual is None:
+        raise SystemExit("required deployment verification must collect the published interface")
+    if expected.get("interface") != _canonical_interface(json.loads(args.actual.read_text(encoding="utf-8"))):
+        raise SystemExit("published target interface differs from prepared artifact capture")
+    return 0
+
+
+def run_worker(args: argparse.Namespace) -> int:
+    metadata = _read_object(args.metadata, "release interface stage")
+    if metadata.get("contract") != "deployment-interface-stage" or metadata.get("interface_capture") != "required":
+        raise SystemExit("only a required prepared interface stage can be executed")
+    if metadata.get("kind") == "oci-image":
+        raise SystemExit("OCI interface stages must run through the container path")
+    cwd = Path(str(metadata["cwd"]))
+    environment = os.environ.copy()
+    environment.update(metadata.get("environment") or {})
+    environment["III_URL"] = args.engine_url
+    for command in metadata["prepare"]:
+        subprocess.run(command, cwd=cwd, env=environment, check=True)
+    with args.log.open("wb") as log:
+        process = subprocess.Popen(
+            metadata["command"], cwd=cwd, env=environment,
+            stdin=subprocess.PIPE, stdout=log, stderr=subprocess.STDOUT,
+        )
+        return process.wait()
+
+
+def make_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command", required=True)
+    stage_parser = sub.add_parser("stage")
+    stage_parser.set_defaults(handler=stage)
+    stage_parser.add_argument("--descriptor", type=Path, required=True)
+    stage_parser.add_argument("--prepared", type=Path, required=True)
+    stage_parser.add_argument("--source-root", type=Path)
+    stage_parser.add_argument("--out", type=Path, required=True)
+    stage_parser.add_argument("--github-output", type=Path)
+    snapshot_parser = sub.add_parser("snapshot")
+    snapshot_parser.set_defaults(handler=snapshot)
+    snapshot_parser.add_argument("--descriptor", type=Path, required=True)
+    snapshot_parser.add_argument("--prepared", type=Path, required=True)
+    snapshot_parser.add_argument("--interface", type=Path)
+    snapshot_parser.add_argument("--out", type=Path, required=True)
+    evidence_parser = sub.add_parser("build-evidence")
+    evidence_parser.set_defaults(handler=build_evidence)
+    evidence_parser.add_argument("--descriptor", type=Path, required=True)
+    evidence_parser.add_argument("--prepared", type=Path, required=True)
+    evidence_parser.add_argument("--interface", type=Path, required=True)
+    evidence_parser.add_argument("--out", type=Path, required=True)
+    verify_parser = sub.add_parser("verify-evidence")
+    verify_parser.set_defaults(handler=verify_evidence)
+    verify_parser.add_argument("--descriptor", type=Path, required=True)
+    verify_parser.add_argument("--evidence", type=Path, required=True)
+    export_parser = sub.add_parser("export-interface")
+    export_parser.set_defaults(handler=export_interface)
+    export_parser.add_argument("--descriptor", type=Path, required=True)
+    export_parser.add_argument("--snapshot", type=Path, required=True)
+    export_parser.add_argument("--out", type=Path, required=True)
+    compare_parser = sub.add_parser("compare")
+    compare_parser.set_defaults(handler=compare)
+    compare_parser.add_argument("--descriptor", type=Path, required=True)
+    compare_parser.add_argument("--expected", type=Path, required=True)
+    compare_parser.add_argument("--actual", type=Path)
+    run_parser = sub.add_parser("run-worker")
+    run_parser.set_defaults(handler=run_worker)
+    run_parser.add_argument("--metadata", type=Path, required=True)
+    run_parser.add_argument("--engine-url", required=True)
+    run_parser.add_argument("--log", type=Path, required=True)
+    return parser
+
+
+if __name__ == "__main__":
+    arguments = make_parser().parse_args()
+    raise SystemExit(arguments.handler(arguments))

--- a/.github/scripts/deployment_train.py
+++ b/.github/scripts/deployment_train.py
@@ -60,7 +60,7 @@ def verify_descriptor(descriptor: object) -> dict[str, object]:
         "contract", "worker", "package_manifest_version", "source_sha", "deployment_spec_sha256",
         "public_manifest_sha256", "registry_projection_sha256", "compiler_digest",
         "descriptor_sha256", "source", "artifact", "runtime",
-        "publish", "build_units", "registry_projection",
+        "interface_capture", "publish", "build_units", "registry_projection",
     }
     if set(descriptor) != required:
         raise SystemExit(
@@ -76,6 +76,8 @@ def verify_descriptor(descriptor: object) -> dict[str, object]:
     for field in ("source", "artifact", "runtime", "registry_projection"):
         if not isinstance(descriptor[field], dict):
             raise SystemExit(f"deployment descriptor {field} must be an object")
+    if descriptor["interface_capture"] not in {"required", "skipped"}:
+        raise SystemExit("deployment descriptor interface_capture must be required or skipped")
     if not isinstance(descriptor["build_units"], list) or not descriptor["build_units"]:
         raise SystemExit("deployment descriptor build_units must be non-empty")
     return descriptor
@@ -683,7 +685,11 @@ def _verify_prepared_inventory(descriptor: dict, descriptor_path: Path, prepared
         path.name for path in prepared_path.parent.iterdir()
         if path.is_file() and not path.is_symlink()
     }
-    expected_files = names | {descriptor_path.name, prepared_path.name}
+    evidence_files = {"deployment-interface.json", "deployment-evidence.json"}
+    present_evidence = actual & evidence_files
+    if present_evidence and present_evidence != evidence_files:
+        raise SystemExit("prepared directory must contain both interface evidence files or neither")
+    expected_files = names | {descriptor_path.name, prepared_path.name} | present_evidence
     if actual != expected_files:
         raise SystemExit(
             f"prepared directory differs from inventory: missing={sorted(expected_files - actual)} "

--- a/.github/scripts/tests/test_build_publish_payload.py
+++ b/.github/scripts/tests/test_build_publish_payload.py
@@ -1,5 +1,19 @@
 """Tests for projecting prepared deployments onto the current Registry API."""
+import pytest
+
 from build_publish_payload import build_payload
+
+
+NON_EMPTY_INTERFACE = {
+    "functions": [{
+        "name": "smoke::run",
+        "description": "Run the smoke operation",
+        "request_schema": {"type": "object"},
+        "response_schema": {"type": "object"},
+        "metadata": {},
+    }],
+    "triggers": [],
+}
 
 
 def build_binary_payload() -> dict[str, object]:
@@ -18,7 +32,8 @@ def build_binary_payload() -> dict[str, object]:
         registry_projection=projection,
         published_version="1.0.0-beta",
         repo_url="https://github.com/iii-hq/workers",
-        interface={"functions": [], "triggers": []},
+        interface=NON_EMPTY_INTERFACE,
+        interface_capture="required",
         artifacts={"kind": "rust-binary", "binaries": {"x86_64-unknown-linux-gnu": {"url": "https://example.test/smoke.tgz", "sha256": "b" * 64}}},
     )
 
@@ -49,7 +64,8 @@ def test_target_version_is_independent_from_manifest_metadata_and_has_no_implici
         registry_projection=projection,
         published_version="2.0.0-alpha",
         repo_url="https://github.com/iii-hq/workers",
-        interface={"functions": [], "triggers": []},
+        interface=NON_EMPTY_INTERFACE,
+        interface_capture="required",
         artifacts={"kind": "rust-binary", "binaries": payload["binaries"]},
     )
     assert target["version"] == "2.0.0-alpha"
@@ -66,13 +82,69 @@ def test_publish_target_accepts_numbered_rc() -> None:
         registry_projection=projection,
         published_version="2.0.0-rc.4",
         repo_url="https://github.com/iii-hq/workers",
-        interface={"functions": [], "triggers": []},
+        interface=NON_EMPTY_INTERFACE,
+        interface_capture="required",
         artifacts={
             "kind": "rust-binary",
             "binaries": {"x86_64-unknown-linux-gnu": {"url": "https://example.test/smoke.tgz", "sha256": "b" * 64}},
         },
     )
     assert payload["version"] == "2.0.0-rc.4"
+
+
+def test_required_interface_capture_rejects_empty_registry_surface() -> None:
+    projection = {
+        "worker_name": "web", "type": "binary", "description": "web",
+        "license": "Apache-2.0", "tags": [], "dependencies": [], "config": {},
+        "experimental": False, "readme": "# Web\n",
+    }
+
+    with pytest.raises(ValueError, match="required.*function or trigger"):
+        build_payload(
+            registry_projection=projection,
+            published_version="1.2.13",
+            repo_url="https://github.com/iii-hq/workers",
+            interface={"functions": [], "triggers": []},
+            interface_capture="required",
+            artifacts={
+                "kind": "rust-binary",
+                "binaries": {
+                    "x86_64-unknown-linux-gnu": {
+                        "url": "https://example.test/web.tgz",
+                        "sha256": "b" * 64,
+                    }
+                },
+            },
+        )
+
+
+@pytest.mark.parametrize("worker_name", ["acp", "lsp"])
+def test_skipped_interface_capture_allows_explicit_empty_surface(worker_name: str) -> None:
+    projection = {
+        "worker_name": worker_name, "type": "binary", "description": worker_name,
+        "license": "Apache-2.0", "tags": [], "dependencies": [], "config": {},
+        "experimental": False, "readme": f"# {worker_name}\n",
+    }
+
+    payload = build_payload(
+        registry_projection=projection,
+        published_version="1.0.0",
+        repo_url="https://github.com/iii-hq/workers",
+        interface={"functions": [], "triggers": []},
+        interface_capture="skipped",
+        artifacts={
+            "kind": "rust-binary",
+            "binaries": {
+                "x86_64-unknown-linux-gnu": {
+                    "url": f"https://example.test/{worker_name}.tgz",
+                    "sha256": "b" * 64,
+                }
+            },
+        },
+    )
+
+    assert payload["functions"] == []
+    assert payload["triggers"] == []
 
 
 def test_engine_builtins_are_not_deployment_targets() -> None:

--- a/.github/scripts/tests/test_deployment_compiler.py
+++ b/.github/scripts/tests/test_deployment_compiler.py
@@ -1,6 +1,12 @@
+import json
+from pathlib import Path
+
 import pytest
 
 import deployment_compiler
+
+
+ROOT = Path(__file__).resolve().parents[3]
 
 
 def test_canonical_numbers_match_json_stringify_representation():
@@ -18,3 +24,44 @@ def test_canonical_numbers_match_json_stringify_representation():
 def test_canonical_numbers_reject_non_json_values():
     with pytest.raises(ValueError):
         deployment_compiler.canonical_bytes({"budget": float("nan")})
+
+
+def test_compiler_derives_explicit_interface_capture_policy_for_every_worker():
+    catalog = deployment_compiler.read_yaml(ROOT / ".deploy" / "workers.yaml")["workers"]
+    descriptors = {
+        worker: deployment_compiler.compile_worker(
+            ROOT,
+            worker,
+            value,
+            "a" * 40,
+            "b" * 64,
+        )
+        for worker, value in catalog.items()
+        if value.get("publish") is True
+    }
+
+    assert descriptors["acp"]["interface_capture"] == "skipped"
+    assert descriptors["lsp"]["interface_capture"] == "skipped"
+    assert {
+        worker
+        for worker, descriptor in descriptors.items()
+        if descriptor["interface_capture"] != "required"
+    } == {"acp", "lsp"}
+    assert descriptors["database"]["runtime"]["interface_config"] == {
+        "path": "config.collect.yaml",
+        "sha256": deployment_compiler.file_sha256(ROOT / "database" / "config.collect.yaml"),
+    }
+    assert descriptors["web"]["runtime"]["interface_config"] is None
+
+
+def test_descriptor_schema_requires_explicit_interface_capture_policy():
+    schema = json.loads(
+        (ROOT / ".github" / "contracts" / "deployment-descriptor.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert "interface_capture" in schema["required"]
+    assert schema["properties"]["interface_capture"] == {
+        "enum": ["required", "skipped"]
+    }

--- a/.github/scripts/tests/test_deployment_interface.py
+++ b/.github/scripts/tests/test_deployment_interface.py
@@ -1,0 +1,475 @@
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+import deployment_interface
+from deployment_train import normalized_tar
+
+
+def write_prepared_inputs(
+    tmp_path: Path,
+    *,
+    worker: str = "web",
+    interface_capture: str = "required",
+) -> tuple[Path, Path]:
+    descriptor_path = tmp_path / "deployment-descriptor.json"
+    descriptor_path.write_text(
+        json.dumps({
+            "worker": worker,
+            "source_sha": "a" * 40,
+            "descriptor_sha256": "b" * 64,
+            "interface_capture": interface_capture,
+        }),
+        encoding="utf-8",
+    )
+    artifact = tmp_path / f"{worker}.bin"
+    artifact.write_bytes(b"immutable prepared worker")
+    prepared_path = tmp_path / "prepared-artifacts.json"
+    prepared_path.write_text(
+        json.dumps({
+            "contract": "prepared-artifacts",
+            "worker": worker,
+            "source_sha": "a" * 40,
+            "descriptor_sha256": "b" * 64,
+            "artifacts": [{
+                "unit": "linux",
+                "name": artifact.name,
+                "role": "binary",
+                "size": artifact.stat().st_size,
+                "sha256": deployment_interface.sha256(artifact),
+            }],
+        }),
+        encoding="utf-8",
+    )
+    return descriptor_path, prepared_path
+
+
+def snapshot_args(
+    descriptor: Path,
+    prepared: Path,
+    interface: Path | None,
+    out: Path,
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        descriptor=descriptor,
+        prepared=prepared,
+        interface=interface,
+        out=out,
+    )
+
+
+def write_archive_prepared_inputs(
+    tmp_path: Path,
+    *,
+    selected: dict,
+    member_name: str,
+    member_bytes: bytes,
+    unit: str,
+    role: str,
+) -> tuple[Path, Path]:
+    descriptor_path = tmp_path / "deployment-descriptor.json"
+    descriptor_path.write_text(json.dumps(selected), encoding="utf-8")
+    member = tmp_path / "archive-member"
+    member.write_bytes(member_bytes)
+    member.chmod(0o755)
+    archive = tmp_path / f"{selected['worker']}-{unit}.tar.gz"
+    normalized_tar([(member, member_name)], archive)
+    prepared_path = tmp_path / "prepared-artifacts.json"
+    prepared_path.write_text(
+        json.dumps({
+            "contract": "prepared-artifacts",
+            "worker": selected["worker"],
+            "source_sha": selected["source_sha"],
+            "descriptor_sha256": selected["descriptor_sha256"],
+            "artifacts": [{
+                "unit": unit,
+                "name": archive.name,
+                "role": role,
+                "size": archive.stat().st_size,
+                "sha256": deployment_interface.sha256(archive),
+            }],
+        }),
+        encoding="utf-8",
+    )
+    return descriptor_path, prepared_path
+
+
+def test_required_rust_capture_stages_only_prepared_bytes_with_absolute_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    selected = {
+        "worker": "smoke",
+        "source_sha": "a" * 40,
+        "descriptor_sha256": "b" * 64,
+        "interface_capture": "required",
+        "source": {
+            "path": "source-must-not-be-read",
+            "package_manifest": "Cargo.toml",
+        },
+        "artifact": {
+            "kind": "rust-binary",
+            "binary": "smoke",
+            "targets": ["x86_64-unknown-linux-gnu"],
+            "toolchain": {"name": "rust", "version": "1.97.1"},
+        },
+        "runtime": {
+            "exec": ["smoke", "--capture-interface"],
+            "environment": {},
+            "resources": {},
+        },
+        "build_units": [{
+            "id": "rust-x86_64-unknown-linux-gnu",
+            "kind": "rust-binary",
+            "target": "x86_64-unknown-linux-gnu",
+        }],
+    }
+    descriptor, prepared = write_archive_prepared_inputs(
+        tmp_path,
+        selected=selected,
+        member_name="smoke",
+        member_bytes=b"prepared executable",
+        unit="rust-x86_64-unknown-linux-gnu",
+        role="binary",
+    )
+    monkeypatch.chdir(tmp_path)
+    stage_path = Path("interface") / "stage.json"
+
+    assert deployment_interface.stage(argparse.Namespace(
+        descriptor=descriptor,
+        prepared=prepared,
+        out=stage_path,
+        github_output=None,
+    )) == 0
+
+    stage = json.loads(stage_path.read_text(encoding="utf-8"))
+    runtime = Path(stage["cwd"])
+    executable = Path(stage["command"][0])
+    assert stage["interface_capture"] == "required"
+    assert stage["kind"] == "rust-binary"
+    assert runtime.is_absolute()
+    assert executable.is_absolute()
+    assert executable.is_relative_to(runtime)
+    assert stage["command"][1:] == ["--capture-interface"]
+    assert executable.read_bytes() == b"prepared executable"
+    assert not (tmp_path / "source-must-not-be-read").exists()
+
+
+@pytest.mark.parametrize(
+    ("kind", "member_name", "start", "runtime", "package_manager"),
+    [
+        (
+            "javascript-bundle",
+            "dist/index.mjs",
+            "node dist/index.mjs",
+            {"name": "node", "version": "22.20.0"},
+            {"name": "pnpm", "version": "11.13.1"},
+        ),
+        (
+            "python-bundle",
+            "worker.py",
+            "python worker.py",
+            {"name": "python", "version": "3.12.13"},
+            {"name": "uv", "version": "0.8.15"},
+        ),
+    ],
+)
+def test_required_bundle_capture_stages_prepared_archive(
+    tmp_path: Path,
+    kind: str,
+    member_name: str,
+    start: str,
+    runtime: dict[str, str],
+    package_manager: dict[str, str],
+) -> None:
+    selected = {
+        "worker": "bundle",
+        "source_sha": "a" * 40,
+        "descriptor_sha256": "b" * 64,
+        "interface_capture": "required",
+        "source": {
+            "path": "source-must-not-be-read",
+            "package_manifest": "package.json" if kind == "javascript-bundle" else "pyproject.toml",
+        },
+        "artifact": {
+            "kind": kind,
+            "runtime": runtime,
+            "package_manager": package_manager,
+        },
+        "runtime": {
+            "install": "echo install prepared dependencies",
+            "start": start,
+            "environment": {"BUNDLE_SETTING": "prepared"},
+            "resources": {},
+        },
+        "build_units": [{"id": "bundle", "kind": kind}],
+    }
+    descriptor, prepared = write_archive_prepared_inputs(
+        tmp_path,
+        selected=selected,
+        member_name=member_name,
+        member_bytes=b"prepared bundle",
+        unit="bundle",
+        role="bundle",
+    )
+    stage_path = tmp_path / "interface" / "stage.json"
+
+    assert deployment_interface.stage(argparse.Namespace(
+        descriptor=descriptor,
+        prepared=prepared,
+        out=stage_path,
+        github_output=None,
+    )) == 0
+
+    stage = json.loads(stage_path.read_text(encoding="utf-8"))
+    assert stage["kind"] == kind
+    assert stage["command"] == ["sh", "-c", start]
+    assert stage["prepare"] == [["sh", "-c", "echo install prepared dependencies"]]
+    assert stage["runtime_name"] == runtime["name"]
+    assert stage["runtime_version"] == runtime["version"]
+    assert stage["package_manager_name"] == package_manager["name"]
+    assert stage["package_manager_version"] == package_manager["version"]
+    assert (Path(stage["cwd"]) / member_name).read_bytes() == b"prepared bundle"
+    assert not (tmp_path / "source-must-not-be-read").exists()
+
+
+def test_required_capture_needs_present_non_empty_interface(tmp_path: Path) -> None:
+    descriptor, prepared = write_prepared_inputs(tmp_path)
+    snapshot = tmp_path / "deployment-interface.json"
+
+    with pytest.raises(SystemExit, match="needs collected interface bytes"):
+        deployment_interface.snapshot(
+            snapshot_args(descriptor, prepared, None, snapshot)
+        )
+
+    collected = tmp_path / "collected-interface.json"
+    collected.write_text('{"functions":[],"triggers":[]}', encoding="utf-8")
+    with pytest.raises(SystemExit, match="must contain a function or trigger"):
+        deployment_interface.snapshot(
+            snapshot_args(descriptor, prepared, collected, snapshot)
+        )
+
+    collected.write_text(
+        json.dumps({
+            "functions": [{"name": "web::fetch"}],
+            "triggers": [],
+        }),
+        encoding="utf-8",
+    )
+    assert deployment_interface.snapshot(
+        snapshot_args(descriptor, prepared, collected, snapshot)
+    ) == 0
+    captured = json.loads(snapshot.read_text(encoding="utf-8"))
+    assert captured["interface_capture"] == "required"
+    assert captured["prepared_sha256"] == deployment_interface.sha256(prepared)
+    assert captured["interface"]["functions"] == [{"name": "web::fetch"}]
+
+
+def test_required_capture_compares_canonical_published_surface(tmp_path: Path) -> None:
+    descriptor, prepared = write_prepared_inputs(tmp_path)
+    collected = tmp_path / "collected-interface.json"
+    collected.write_text(
+        json.dumps({
+            "functions": [
+                {"name": "web::z", "request_schema": {}, "response_schema": {}},
+                {"name": "web::a", "request_schema": {}, "response_schema": {}},
+            ],
+            "triggers": [],
+        }),
+        encoding="utf-8",
+    )
+    snapshot = tmp_path / "deployment-interface.json"
+    deployment_interface.snapshot(
+        snapshot_args(descriptor, prepared, collected, snapshot)
+    )
+    published = tmp_path / "published-interface.json"
+    published.write_text(
+        json.dumps({
+            "functions": list(reversed(json.loads(collected.read_text())["functions"])),
+            "triggers": [],
+        }),
+        encoding="utf-8",
+    )
+
+    assert deployment_interface.compare(argparse.Namespace(
+        descriptor=descriptor,
+        expected=snapshot,
+        actual=published,
+    )) == 0
+
+    published.write_text(
+        '{"functions":[{"name":"web::different"}],"triggers":[]}',
+        encoding="utf-8",
+    )
+    with pytest.raises(SystemExit, match="differs"):
+        deployment_interface.compare(argparse.Namespace(
+            descriptor=descriptor,
+            expected=snapshot,
+            actual=published,
+        ))
+
+
+def test_required_trigger_only_interface_is_valid(tmp_path: Path) -> None:
+    descriptor, prepared = write_prepared_inputs(tmp_path)
+    collected = tmp_path / "trigger-only.json"
+    collected.write_text(
+        json.dumps({
+            "functions": [],
+            "triggers": [{
+                "name": "web::on-event",
+                "invocation_schema": {"type": "object"},
+            }],
+        }),
+        encoding="utf-8",
+    )
+    snapshot = tmp_path / "deployment-interface.json"
+
+    assert deployment_interface.snapshot(
+        snapshot_args(descriptor, prepared, collected, snapshot)
+    ) == 0
+    captured = json.loads(snapshot.read_text(encoding="utf-8"))
+    assert captured["interface"]["functions"] == []
+    assert captured["interface"]["triggers"][0]["name"] == "web::on-event"
+
+
+@pytest.mark.parametrize("worker", ["acp", "lsp"])
+def test_skipped_capture_records_explicit_null_interface(
+    tmp_path: Path, worker: str
+) -> None:
+    descriptor, prepared = write_prepared_inputs(
+        tmp_path,
+        worker=worker,
+        interface_capture="skipped",
+    )
+    snapshot = tmp_path / "deployment-interface.json"
+
+    assert deployment_interface.snapshot(
+        snapshot_args(descriptor, prepared, None, snapshot)
+    ) == 0
+    captured = json.loads(snapshot.read_text(encoding="utf-8"))
+    assert captured["interface_capture"] == "skipped"
+    assert captured["interface"] is None
+
+
+def test_evidence_verification_rejects_missing_interface_artifact(tmp_path: Path) -> None:
+    descriptor, prepared = write_prepared_inputs(tmp_path)
+    collected = tmp_path / "collected-interface.json"
+    collected.write_text(
+        '{"functions":[{"name":"web::fetch"}],"triggers":[]}',
+        encoding="utf-8",
+    )
+    snapshot = tmp_path / "deployment-interface.json"
+    deployment_interface.snapshot(
+        snapshot_args(descriptor, prepared, collected, snapshot)
+    )
+    evidence = tmp_path / "deployment-evidence.json"
+    deployment_interface.build_evidence(argparse.Namespace(
+        descriptor=descriptor,
+        prepared=prepared,
+        interface=snapshot,
+        out=evidence,
+    ))
+    snapshot.unlink()
+
+    with pytest.raises(SystemExit, match="release evidence file is missing"):
+        deployment_interface.verify_evidence(argparse.Namespace(
+            descriptor=descriptor,
+            evidence=evidence,
+        ))
+
+
+def test_evidence_verification_rejects_required_empty_interface(tmp_path: Path) -> None:
+    descriptor, prepared = write_prepared_inputs(tmp_path)
+    snapshot = tmp_path / "deployment-interface.json"
+    snapshot.write_text(
+        json.dumps({
+            "contract": "deployment-interface",
+            "worker": "web",
+            "source_sha": "a" * 40,
+            "descriptor_sha256": "b" * 64,
+            "prepared_sha256": deployment_interface.sha256(prepared),
+            "interface_capture": "required",
+            "interface": {"functions": [], "triggers": []},
+        }),
+        encoding="utf-8",
+    )
+    evidence = tmp_path / "deployment-evidence.json"
+    deployment_interface.build_evidence(argparse.Namespace(
+        descriptor=descriptor,
+        prepared=prepared,
+        interface=snapshot,
+        out=evidence,
+    ))
+
+    with pytest.raises(SystemExit, match="required release interface is empty"):
+        deployment_interface.verify_evidence(argparse.Namespace(
+            descriptor=descriptor,
+            evidence=evidence,
+        ))
+
+
+def test_evidence_inventory_covers_interface_and_prepared_bytes_and_detects_tamper(
+    tmp_path: Path,
+) -> None:
+    descriptor, prepared = write_prepared_inputs(tmp_path)
+    collected = tmp_path / "collected-interface.json"
+    collected.write_text(
+        '{"functions":[{"name":"web::fetch"}],"triggers":[]}',
+        encoding="utf-8",
+    )
+    snapshot = tmp_path / "deployment-interface.json"
+    deployment_interface.snapshot(
+        snapshot_args(descriptor, prepared, collected, snapshot)
+    )
+    evidence = tmp_path / "deployment-evidence.json"
+    deployment_interface.build_evidence(argparse.Namespace(
+        descriptor=descriptor,
+        prepared=prepared,
+        interface=snapshot,
+        out=evidence,
+    ))
+
+    assert deployment_interface.verify_evidence(argparse.Namespace(
+        descriptor=descriptor,
+        evidence=evidence,
+    )) == 0
+    roles = {
+        artifact["role"]
+        for artifact in json.loads(evidence.read_text(encoding="utf-8"))["artifacts"]
+    }
+    assert {"binary", "descriptor", "prepared-inventory", "interface"}.issubset(roles)
+
+    snapshot.write_text("{}", encoding="utf-8")
+    with pytest.raises(SystemExit, match="bytes differ"):
+        deployment_interface.verify_evidence(argparse.Namespace(
+            descriptor=descriptor,
+            evidence=evidence,
+        ))
+
+
+def test_run_worker_applies_descriptor_environment_and_engine_url(tmp_path: Path) -> None:
+    metadata = tmp_path / "stage.json"
+    metadata.write_text(
+        json.dumps({
+            "contract": "deployment-interface-stage",
+            "interface_capture": "required",
+            "kind": "javascript-bundle",
+            "cwd": str(tmp_path),
+            "prepare": [],
+            "command": [
+                "python3",
+                "-c",
+                "import os; assert os.environ['WORKER_SETTING'] == 'prepared'; "
+                "assert os.environ['III_URL'] == 'ws://127.0.0.1:1234'",
+            ],
+            "environment": {"WORKER_SETTING": "prepared"},
+        }),
+        encoding="utf-8",
+    )
+
+    assert deployment_interface.run_worker(argparse.Namespace(
+        metadata=metadata,
+        engine_url="ws://127.0.0.1:1234",
+        log=tmp_path / "worker.log",
+    )) == 0

--- a/.github/scripts/tests/test_deployment_train.py
+++ b/.github/scripts/tests/test_deployment_train.py
@@ -54,6 +54,7 @@ def descriptor(worker: str, source_sha: str, package_manifest_version: str) -> d
             "include": ["dist/index.mjs"],
         },
         "runtime": {"environment": {}, "resources": {}, "install": "", "start": "node dist/index.mjs"},
+        "interface_capture": "required",
         "publish": True,
         "build_units": [{"id": "bundle", "kind": "javascript-bundle"}],
         "registry_projection": {

--- a/.github/scripts/tests/test_deployment_workflows.py
+++ b/.github/scripts/tests/test_deployment_workflows.py
@@ -138,7 +138,7 @@ def test_descriptor_index_independently_verifies_approved_compiler_bytes():
     assert "Verify approved compiler bytes" in text
     assert (
         "APPROVED_COMPILER_DIGEST: "
-        "8dca9bcf5f11dcf1982183b5570fd07a84c2cb87f633b1da4124a1464b35f861"
+        "a01e716bee39d98afe46dd57bdc26b6b21f15a9341313f20dceed2fe87bd5084"
     ) in text
     assert 'digest.update(b"iii-workers-deployment-compiler\\0")' in text
     assert 'Path(".github/scripts/deployment_compiler.py").read_bytes()' in text
@@ -193,25 +193,60 @@ def test_release_build_falls_back_when_optional_sccache_is_unavailable():
     assert "RUSTC_WRAPPER" not in workflow["env"]
 
 
-def test_prepare_uploads_inventory_without_booting_the_worker():
+def test_prepare_captures_interface_from_prepared_bytes():
     text = body("deploy-prepare.yml")
     workflow = yaml.safe_load(text)
-    assert "adapter" not in workflow["jobs"]
+    capture_jobs = [
+        job
+        for job in workflow["jobs"].values()
+        if "deployment_interface.py stage" in str(job)
+    ]
+    assert len(capture_jobs) == 1
+    capture_job = capture_jobs[0]
+    assert set(capture_job["needs"]) == {"prepare", "assemble"}
+    assert "deployment_interface.py stage" in text
+    assert "deployment_interface.py snapshot" in text
+    assert "deployment_interface.py build-evidence" in text
     assert "deployment-prepared-${{ env.DEPLOYMENT_TARGET_ID }}" in text
-    assert "deployment_interface.py" not in text
-    assert "collect_worker_interface.py" not in text
-    assert "install.iii.dev" not in text
+    interface_text = str(capture_job)
+    assert "inputs.source_sha" not in interface_text
+    assert "worker-compose.yaml" not in interface_text
 
 
-def test_all_post_prepare_phases_verify_prepared_bytes_and_report_them():
-    for name in set(ENTRYPOINTS) - {"deploy-prepare.yml"}:
+def test_prepare_upload_requires_interface_evidence():
+    workflow = yaml.safe_load(body("deploy-prepare.yml"))
+    uploads = [
+        step
+        for job in workflow["jobs"].values()
+        for step in job.get("steps", [])
+        if str(step.get("uses", "")).startswith("actions/upload-artifact@")
+        and str(step.get("with", {}).get("name", "")).startswith("deployment-prepared-")
+    ]
+    assert len(uploads) == 1
+    upload = uploads[0]
+    assert upload["with"]["if-no-files-found"] == "error"
+    uploaded_path = str(upload["with"]["path"])
+    assert "deployment-interface.json" in uploaded_path or uploaded_path.rstrip("/").endswith("deploy-prepared")
+
+
+def test_publish_finalize_and_verify_consume_interface_evidence():
+    for name in ("_deploy-registry.yml", "_deploy-registry-finalize.yml"):
         text = body(name)
-        assert "deployment_train.py verify-prepared" in text, name
-        assert "prepared-artifacts.json" in text, name
-        assert "deployment-evidence.json" not in text, name
-    registry = body("_deploy-registry.yml")
-    assert "deployment_train.py verify-prepared" in registry
-    assert "deployment_interface.py" not in registry
+        assert "deployment_interface.py verify-evidence" in text, name
+        assert "deployment-evidence.json" in text, name
+        assert "deployment-interface.json" in text, name
+    verify = body("deploy-verify.yml")
+    assert "deployment_interface.py verify-evidence" in verify
+    assert "deployment-evidence.json" in verify
+
+
+def test_registry_publishers_never_synthesize_an_empty_interface():
+    for name in ("_deploy-registry.yml", "_deploy-registry-finalize.yml"):
+        text = body(name)
+        assert '"functions": []' not in text, name
+        assert '"triggers": []' not in text, name
+        assert "deployment-interface.json" in text, name
+        assert "--interface-json interface.json" in text, name
 
 
 def test_publish_is_retry_safe_and_effect_states_are_probe_derived():
@@ -302,6 +337,24 @@ def test_finalize_promotes_the_rc_bytes_verbatim_with_no_supplemental_build():
     assert "assemble-stable" not in text
     assert "stable-delta" not in text
     assert "--profile" not in text
+
+
+def test_finalize_fallback_rebuilds_evidence_from_the_exact_candidate_interface():
+    workflow = yaml.safe_load(body("deploy-finalize.yml"))
+    fallback_steps = [
+        step
+        for job in workflow["jobs"].values()
+        for step in job.get("steps", [])
+        if step.get("if") == "steps.prepared.outcome != 'success'"
+        and "deployment_interface.py snapshot" in step.get("run", "")
+    ]
+    assert len(fallback_steps) == 1
+    command = fallback_steps[0]["run"]
+    assert "api.workers.iii.dev/w/$WORKER?version=$SOURCE_RC_VERSION" in command
+    assert "deployment_interface.py build-evidence" in command
+    assert "deployment_interface.py verify-evidence" in command
+    assert "deployment-interface.json" in command
+    assert "TARGET_VERSION" not in command
 
 
 def test_registry_finalize_is_atomic_and_never_moves_channels_piecewise():

--- a/.github/workflows/_deploy-registry-finalize.yml
+++ b/.github/workflows/_deploy-registry-finalize.yml
@@ -45,6 +45,13 @@ jobs:
           python3 .github/scripts/deployment_train.py verify-prepared \
             --descriptor deploy-prepared/deployment-descriptor.json \
             --prepared deploy-prepared/prepared-artifacts.json
+          python3 .github/scripts/deployment_interface.py verify-evidence \
+            --descriptor deploy-prepared/deployment-descriptor.json \
+            --evidence deploy-prepared/deployment-evidence.json
+          python3 .github/scripts/deployment_interface.py export-interface \
+            --descriptor deploy-prepared/deployment-descriptor.json \
+            --snapshot deploy-prepared/deployment-interface.json \
+            --out interface.json
           python3 - <<'PY'
           import json
           import os
@@ -87,7 +94,6 @@ jobs:
               artifact_payload = {"kind": kind, "image_tag": image_tag}
           else:
               raise SystemExit(f"unsupported artifact kind {kind}")
-          Path("interface.json").write_text(json.dumps({"functions": [], "triggers": []}, sort_keys=True) + "\n")
           Path("registry-artifacts.json").write_text(json.dumps(artifact_payload, sort_keys=True) + "\n")
           PY
           python3 .github/scripts/build_publish_payload.py \

--- a/.github/workflows/_deploy-registry.yml
+++ b/.github/workflows/_deploy-registry.yml
@@ -49,6 +49,13 @@ jobs:
           python3 .github/scripts/deployment_train.py verify-prepared \
             --descriptor deploy-prepared/deployment-descriptor.json \
             --prepared deploy-prepared/prepared-artifacts.json
+          python3 .github/scripts/deployment_interface.py verify-evidence \
+            --descriptor deploy-prepared/deployment-descriptor.json \
+            --evidence deploy-prepared/deployment-evidence.json
+          python3 .github/scripts/deployment_interface.py export-interface \
+            --descriptor deploy-prepared/deployment-descriptor.json \
+            --snapshot deploy-prepared/deployment-interface.json \
+            --out interface.json
           python3 - <<'PY'
           import json
           import os
@@ -91,7 +98,6 @@ jobs:
               artifact_payload = {"kind": kind, "image_tag": image_tag}
           else:
               raise SystemExit(f"unsupported artifact kind {kind}")
-          Path("interface.json").write_text(json.dumps({"functions": [], "triggers": []}, sort_keys=True) + "\n")
           Path("registry-artifacts.json").write_text(json.dumps(artifact_payload, sort_keys=True) + "\n")
           PY
           python3 .github/scripts/build_publish_payload.py \

--- a/.github/workflows/deploy-descriptor-index.yml
+++ b/.github/workflows/deploy-descriptor-index.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Verify approved compiler bytes
         env:
-          APPROVED_COMPILER_DIGEST: 8dca9bcf5f11dcf1982183b5570fd07a84c2cb87f633b1da4124a1464b35f861
+          APPROVED_COMPILER_DIGEST: a01e716bee39d98afe46dd57bdc26b6b21f15a9341313f20dceed2fe87bd5084
         run: |
           set -euo pipefail
           python3 - <<'PY'

--- a/.github/workflows/deploy-finalize.yml
+++ b/.github/workflows/deploy-finalize.yml
@@ -76,6 +76,9 @@ jobs:
           python3 .github/scripts/deployment_train.py verify-prepared \
             --descriptor deploy-prepared/deployment-descriptor.json \
             --prepared deploy-prepared/prepared-artifacts.json
+          python3 .github/scripts/deployment_interface.py verify-evidence \
+            --descriptor deploy-prepared/deployment-descriptor.json \
+            --evidence deploy-prepared/deployment-evidence.json
 
       - name: Reconstruct prepared rc bytes from immutable surfaces
         if: steps.prepared.outcome != 'success'
@@ -200,6 +203,31 @@ jobs:
           python3 .github/scripts/deployment_train.py verify-prepared \
             --descriptor deploy-prepared/deployment-descriptor.json \
             --prepared deploy-prepared/prepared-artifacts.json
+          if [[ "$(jq -r .interface_capture deploy-prepared/deployment-descriptor.json)" == required ]]; then
+            curl -fsS "https://api.workers.iii.dev/w/$WORKER?version=$SOURCE_RC_VERSION" > source-worker.json
+            jq -e --arg worker "$WORKER" --arg version "$SOURCE_RC_VERSION" \
+              '.worker.name == $worker and .worker.version == $version' source-worker.json >/dev/null
+            jq '.worker | {functions:(.functions // []),triggers:(.triggers // [])}' \
+              source-worker.json > source-interface.json
+            python3 .github/scripts/deployment_interface.py snapshot \
+              --descriptor deploy-prepared/deployment-descriptor.json \
+              --prepared deploy-prepared/prepared-artifacts.json \
+              --interface source-interface.json \
+              --out deploy-prepared/deployment-interface.json
+          else
+            python3 .github/scripts/deployment_interface.py snapshot \
+              --descriptor deploy-prepared/deployment-descriptor.json \
+              --prepared deploy-prepared/prepared-artifacts.json \
+              --out deploy-prepared/deployment-interface.json
+          fi
+          python3 .github/scripts/deployment_interface.py build-evidence \
+            --descriptor deploy-prepared/deployment-descriptor.json \
+            --prepared deploy-prepared/prepared-artifacts.json \
+            --interface deploy-prepared/deployment-interface.json \
+            --out deploy-prepared/deployment-evidence.json
+          python3 .github/scripts/deployment_interface.py verify-evidence \
+            --descriptor deploy-prepared/deployment-descriptor.json \
+            --evidence deploy-prepared/deployment-evidence.json
 
       - name: Authorize exact finalization dispatch
         env:
@@ -253,6 +281,9 @@ jobs:
           python3 .github/scripts/deployment_train.py verify-prepared \
             --descriptor deploy-prepared/deployment-descriptor.json \
             --prepared deploy-prepared/prepared-artifacts.json
+          python3 .github/scripts/deployment_interface.py verify-evidence \
+            --descriptor deploy-prepared/deployment-descriptor.json \
+            --evidence deploy-prepared/deployment-evidence.json
 
       - name: Resolve immutable tag
         id: identity
@@ -657,7 +688,7 @@ jobs:
           fi
           artifacts='[]'
           kind=unknown
-          if [[ -f deploy-prepared/prepared-artifacts.json ]]; then artifacts=$(jq -c '[.artifacts[] | del(.unit)]' deploy-prepared/prepared-artifacts.json); fi
+          if [[ -f deploy-prepared/deployment-evidence.json ]]; then artifacts=$(jq -c '[.artifacts[] | del(.unit)]' deploy-prepared/deployment-evidence.json); fi
           if [[ -f deploy-prepared/deployment-descriptor.json ]]; then kind=$(jq -r .artifact.kind deploy-prepared/deployment-descriptor.json); fi
           normalize_state() {
             python3 -c 'import sys; value=sys.argv[1].strip(); print(value if value in {"absent", "present", "unknown"} else "unknown")' "$1"

--- a/.github/workflows/deploy-prepare.yml
+++ b/.github/workflows/deploy-prepare.yml
@@ -234,17 +234,189 @@ jobs:
 
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
+          name: deployment-assembled-${{ env.DEPLOYMENT_TARGET_ID }}
+          path: deploy-prepared/
+          if-no-files-found: error
+          retention-days: 7
+
+  interface:
+    needs: [prepare, assemble]
+    runs-on: workers-release-linux-8core
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      # Use the workflow implementation selected by this run, while all worker
+      # bytes and their runtime contract come from the immutable prepared artifact.
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+          sparse-checkout: .github/scripts
+
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: deployment-assembled-${{ env.DEPLOYMENT_TARGET_ID }}
+          path: deploy-prepared
+
+      - name: Resolve descriptor-bound capture configuration
+        id: capture_source
+        run: |
+          set -euo pipefail
+          echo "required=$(jq -r '.runtime.interface_config != null' deploy-prepared/deployment-descriptor.json)" >> "$GITHUB_OUTPUT"
+          echo "path=$(jq -er '.source.path + "/config.collect.yaml"' deploy-prepared/deployment-descriptor.json)" >> "$GITHUB_OUTPUT"
+
+      # Capture-only configuration is hashed into the descriptor and read from
+      # the same immutable source SHA as the prepared artifact.
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        if: steps.capture_source.outputs.required == 'true'
+        with:
+          persist-credentials: false
+          ref: ${{ needs.prepare.outputs.prepared_sha }}
+          path: capture-source
+          sparse-checkout: ${{ steps.capture_source.outputs.path }}
+          sparse-checkout-cone-mode: false
+
+      - name: Stage immutable bytes for interface capture
+        id: interface
+        run: >-
+          python3 .github/scripts/deployment_interface.py stage
+          --descriptor deploy-prepared/deployment-descriptor.json
+          --prepared deploy-prepared/prepared-artifacts.json
+          --source-root capture-source
+          --out interface-work/stage.json
+          --github-output "$GITHUB_OUTPUT"
+
+      - name: Install current iii runtime
+        if: steps.interface.outputs.interface_capture == 'required'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          curl -fsSL --retry 3 --retry-all-errors --retry-delay 5 \
+            https://install.iii.dev/iii/main/install.sh -o /tmp/install-iii.sh
+          sh /tmp/install-iii.sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          echo "$HOME/.iii/bin" >> "$GITHUB_PATH"
+          export PATH="$HOME/.local/bin:$HOME/.iii/bin:$PATH"
+          iii --version
+
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        if: steps.interface.outputs.kind == 'javascript-bundle' && steps.interface.outputs.interface_capture == 'required'
+        with:
+          node-version: ${{ steps.interface.outputs.runtime_version }}
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        if: steps.interface.outputs.kind == 'python-bundle' && steps.interface.outputs.interface_capture == 'required'
+        with:
+          python-version: ${{ steps.interface.outputs.runtime_version }}
+
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        if: steps.interface.outputs.kind == 'python-bundle' && steps.interface.outputs.interface_capture == 'required'
+        with:
+          version: ${{ steps.interface.outputs.package_manager_version }}
+          enable-cache: false
+
+      - name: Install OCI capture tooling
+        if: steps.interface.outputs.kind == 'oci-image' && steps.interface.outputs.interface_capture == 'required'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y skopeo
+
+      - name: Collect interface registration from immutable artifact
+        env:
+          INTERFACE_CAPTURE: ${{ steps.interface.outputs.interface_capture }}
+          KIND: ${{ steps.interface.outputs.kind }}
+        run: |
+          set -euo pipefail
+          if [[ "$INTERFACE_CAPTURE" == skipped ]]; then
+            python3 .github/scripts/deployment_interface.py snapshot \
+              --descriptor deploy-prepared/deployment-descriptor.json \
+              --prepared deploy-prepared/prepared-artifacts.json \
+              --out deploy-prepared/deployment-interface.json
+            python3 .github/scripts/deployment_interface.py build-evidence \
+              --descriptor deploy-prepared/deployment-descriptor.json \
+              --prepared deploy-prepared/prepared-artifacts.json \
+              --interface deploy-prepared/deployment-interface.json \
+              --out deploy-prepared/deployment-evidence.json
+            exit 0
+          fi
+
+          engine_pid=''
+          worker_pid=''
+          container_name=''
+          image_name=''
+          cleanup() {
+            if [[ -n "$container_name" ]]; then docker rm -f "$container_name" >/dev/null 2>&1 || true; fi
+            if [[ -n "$image_name" ]]; then docker image rm "$image_name" >/dev/null 2>&1 || true; fi
+            if [[ -n "$worker_pid" ]]; then kill -- "-$worker_pid" >/dev/null 2>&1 || true; fi
+            if [[ -n "$engine_pid" ]]; then kill -- "-$engine_pid" >/dev/null 2>&1 || true; fi
+          }
+          trap cleanup EXIT
+          engine_port=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')
+          engine_url="ws://127.0.0.1:$engine_port"
+          printf 'workers:\n  - name: iii-worker-manager\n    config:\n      host: 127.0.0.1\n      port: %s\n' "$engine_port" >interface-work/engine.yaml
+          setsid iii --config interface-work/engine.yaml --no-update-check >interface-work/engine.log 2>&1 &
+          engine_pid=$!
+          for _ in $(seq 1 60); do
+            kill -0 "$engine_pid" 2>/dev/null || { cat interface-work/engine.log; exit 1; }
+            iii trigger --port "$engine_port" 'engine::workers::list' --json '{}' >/dev/null 2>&1 && break
+            sleep 1
+          done
+          iii trigger --port "$engine_port" 'engine::workers::list' --json '{}' >interface-work/workers-baseline.json
+          iii trigger --port "$engine_port" 'engine::triggers::list' --json '{"include_internal":false}' >interface-work/triggers-baseline.json
+
+          if [[ "$KIND" == oci-image ]]; then
+            container_name="deployment-interface-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+            image_name="$container_name:prepared"
+            oci_archive=$(jq -er .oci_archive interface-work/stage.json)
+            sudo skopeo copy "oci-archive:$oci_archive" "docker-daemon:$image_name"
+            docker_env=(--env "III_URL=$engine_url")
+            while IFS= read -r encoded; do
+              docker_env+=(--env "$(printf '%s' "$encoded" | base64 --decode)")
+            done < <(jq -r '.environment | to_entries[] | (.key + "=" + .value) | @base64' interface-work/stage.json)
+            docker run --rm --network host --name "$container_name" "${docker_env[@]}" "$image_name" \
+              >interface-work/worker.log 2>&1 &
+            worker_pid=$!
+          else
+            setsid python3 .github/scripts/deployment_interface.py run-worker \
+              --metadata interface-work/stage.json --engine-url "$engine_url" \
+              --log interface-work/worker.log &
+            worker_pid=$!
+          fi
+
+          export III_TRIGGER_PORT="$engine_port"
+          python3 .github/scripts/collect_worker_interface.py \
+            --worker "$WORKER" --out interface-work/worker-interface.json \
+            --wait-seconds 600 \
+            --trigger-types-baseline interface-work/triggers-baseline.json \
+            --workers-baseline interface-work/workers-baseline.json
+          python3 .github/scripts/collect_worker_interface.py \
+            --assert-non-empty --assert-typed-schemas \
+            --assert-file interface-work/worker-interface.json
+          python3 .github/scripts/deployment_interface.py snapshot \
+            --descriptor deploy-prepared/deployment-descriptor.json \
+            --prepared deploy-prepared/prepared-artifacts.json \
+            --interface interface-work/worker-interface.json \
+            --out deploy-prepared/deployment-interface.json
+          python3 .github/scripts/deployment_interface.py build-evidence \
+            --descriptor deploy-prepared/deployment-descriptor.json \
+            --prepared deploy-prepared/prepared-artifacts.json \
+            --interface deploy-prepared/deployment-interface.json \
+            --out deploy-prepared/deployment-evidence.json
+
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
           name: deployment-prepared-${{ env.DEPLOYMENT_TARGET_ID }}
           path: deploy-prepared/
           if-no-files-found: error
-          # Fast path for release finalization: verified rc bytes must outlive
-          # the soak window, so keep them long enough to promote without a
-          # rebuild.
+          # Prepared bytes and their captured Registry interface must outlive
+          # the candidate soak window so stable finalization reuses both.
           retention-days: 90
 
   report:
     if: always()
-    needs: [prepare, build, assemble]
+    needs: [prepare, build, assemble, interface]
     runs-on: workers-release-linux-8core
     permissions:
       actions: read
@@ -268,16 +440,17 @@ jobs:
           PREPARE_RESULT: ${{ needs.prepare.result }}
           BUILD_RESULT: ${{ needs.build.result }}
           ASSEMBLE_RESULT: ${{ needs.assemble.result }}
+          INTERFACE_RESULT: ${{ needs.interface.result }}
         run: |
           set -euo pipefail
           outcome=succeeded; error=null
-          if [[ "$PREPARE_RESULT" == cancelled || "$BUILD_RESULT" == cancelled || "$ASSEMBLE_RESULT" == cancelled ]]; then
+          if [[ "$PREPARE_RESULT" == cancelled || "$BUILD_RESULT" == cancelled || "$ASSEMBLE_RESULT" == cancelled || "$INTERFACE_RESULT" == cancelled ]]; then
             outcome=canceled; error='{"code":"prepare_canceled","category":"build","retryable":true,"message":"release preparation was canceled"}'
-          elif [[ "$PREPARE_RESULT" != success || "$BUILD_RESULT" != success || "$ASSEMBLE_RESULT" != success ]]; then
+          elif [[ "$PREPARE_RESULT" != success || "$BUILD_RESULT" != success || "$ASSEMBLE_RESULT" != success || "$INTERFACE_RESULT" != success ]]; then
             outcome=failed; error='{"code":"prepare_failed","category":"build","retryable":true,"message":"release preparation did not complete"}'
           fi
           artifacts='[]'
-          if [[ -f deploy-prepared/prepared-artifacts.json ]]; then artifacts=$(jq -c '[.artifacts[] | del(.unit)]' deploy-prepared/prepared-artifacts.json); fi
+          if [[ -f deploy-prepared/deployment-evidence.json ]]; then artifacts=$(jq -c '[.artifacts[] | del(.unit)]' deploy-prepared/deployment-evidence.json); fi
           state=absent; [[ "$outcome" == succeeded ]] && state=present
           effects=$(jq -nc --arg id "$SOURCE_SHA" --arg state "$state" '[{surface:"source-snapshot",state:$state,immutable_id:$id}]')
           python3 .github/scripts/deployment_control_contract.py write-result \

--- a/.github/workflows/deploy-publish.yml
+++ b/.github/workflows/deploy-publish.yml
@@ -81,6 +81,9 @@ jobs:
           python3 .github/scripts/deployment_train.py verify-prepared \
             --descriptor deploy-prepared/deployment-descriptor.json \
             --prepared deploy-prepared/prepared-artifacts.json
+          python3 .github/scripts/deployment_interface.py verify-evidence \
+            --descriptor deploy-prepared/deployment-descriptor.json \
+            --evidence deploy-prepared/deployment-evidence.json
           [[ -n "$EXPECTED_MIRROR_VERSION" ]]
           python3 .github/scripts/deployment_control_contract.py validate-identity --identity "$DEPLOYMENT_IDENTITY"
           python3 .github/scripts/deployment_control_contract.py validate-dispatch --step-id "$STEP_ID" --dispatch-nonce "$DISPATCH_NONCE" --descriptor-sha256 "$DESCRIPTOR_SHA256" --plan-hash "$PLAN_HASH" --source-sha "$SOURCE_SHA" --prepared-sha "$PREPARED_SHA" --mutating
@@ -488,7 +491,7 @@ jobs:
           fi
           artifacts='[]'
           kind=unknown
-          if [[ -f deploy-prepared/prepared-artifacts.json ]]; then artifacts=$(jq -c '[.artifacts[] | del(.unit)]' deploy-prepared/prepared-artifacts.json); fi
+          if [[ -f deploy-prepared/deployment-evidence.json ]]; then artifacts=$(jq -c '[.artifacts[] | del(.unit)]' deploy-prepared/deployment-evidence.json); fi
           if [[ -f deploy-prepared/deployment-descriptor.json ]]; then kind=$(jq -r .artifact.kind deploy-prepared/deployment-descriptor.json); fi
           normalize_state() {
             python3 -c 'import sys; value=sys.argv[1].strip(); print(value if value in {"absent", "present", "unknown"} else "unknown")' "$1"

--- a/.github/workflows/deploy-verify.yml
+++ b/.github/workflows/deploy-verify.yml
@@ -62,6 +62,7 @@ jobs:
           set -euo pipefail
           test "$(jq -r .descriptor_sha256 deploy-prepared/deployment-descriptor.json)" = "$DESCRIPTOR_SHA256"
           python3 .github/scripts/deployment_train.py verify-prepared --descriptor deploy-prepared/deployment-descriptor.json --prepared deploy-prepared/prepared-artifacts.json
+          python3 .github/scripts/deployment_interface.py verify-evidence --descriptor deploy-prepared/deployment-descriptor.json --evidence deploy-prepared/deployment-evidence.json
           python3 .github/scripts/deployment_control_contract.py validate-identity --identity "$DEPLOYMENT_IDENTITY"
           python3 .github/scripts/deployment_control_contract.py validate-dispatch --step-id "$STEP_ID" --dispatch-nonce "$DISPATCH_NONCE" --descriptor-sha256 "$DESCRIPTOR_SHA256" --plan-hash "$PLAN_HASH" --source-sha "$SOURCE_SHA"
           python3 .github/scripts/deployment_control_contract.py authorize-dispatch --api-url "$RELEASE_CONTROL_API_URL" --repository '${{ github.repository }}' --step-id "$STEP_ID" --run-id '${{ github.run_id }}' --run-attempt '${{ github.run_attempt }}' --workflow 'deploy-verify.yml' --event '${{ github.event_name }}' --sha '${{ github.sha }}' --deployment-batch-id "$DEPLOYMENT_BATCH_ID" --deployment-target-id "$DEPLOYMENT_TARGET_ID" --attempt-id "$ATTEMPT_ID" --dispatch-nonce "$DISPATCH_NONCE" --plan-hash "$PLAN_HASH" --worker "$WORKER" --source-sha "$SOURCE_SHA" --target-version "$TARGET_VERSION" --channel "$RELEASE_CHANNEL" --descriptor-sha256 "$DESCRIPTOR_SHA256"
@@ -84,6 +85,21 @@ jobs:
           body=$(jq -nc --arg worker "$WORKER" --arg channel "$RELEASE_CHANNEL" '{worker:$worker,version:$channel}')
           actual=$(curl -fsS -H 'Content-Type: application/json' -X POST 'https://api.workers.iii.dev/resolve' --data "$body" | jq -r .root.version)
           test "$actual" = "$TARGET_VERSION"
+          if [[ "$(jq -r .interface_capture deploy-prepared/deployment-descriptor.json)" == required ]]; then
+            curl -fsS "https://api.workers.iii.dev/w/$WORKER?version=$TARGET_VERSION" > registry-worker.json
+            jq -e --arg worker "$WORKER" --arg version "$TARGET_VERSION" \
+              '.worker.name == $worker and .worker.version == $version' registry-worker.json >/dev/null
+            jq '.worker | {functions:(.functions // []),triggers:(.triggers // [])}' \
+              registry-worker.json > registry-interface.json
+            python3 .github/scripts/deployment_interface.py compare \
+              --descriptor deploy-prepared/deployment-descriptor.json \
+              --expected deploy-prepared/deployment-interface.json \
+              --actual registry-interface.json
+          else
+            python3 .github/scripts/deployment_interface.py compare \
+              --descriptor deploy-prepared/deployment-descriptor.json \
+              --expected deploy-prepared/deployment-interface.json
+          fi
           if [[ "$EXPECTED_IMAGE_DIGEST" != none ]]; then
             [[ "$EXPECTED_IMAGE_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]
             docker buildx imagetools inspect "ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/$WORKER:$RELEASE_CHANNEL" --format '{{json .Manifest}}' > image-manifest.json
@@ -100,7 +116,7 @@ jobs:
           if [[ "$STATUS" == cancelled ]]; then outcome=canceled; error='{"code":"release_verify_canceled","category":"verification","retryable":true,"message":"release surface verification was canceled"}'
           elif [[ "$STATUS" != success ]]; then outcome=failed; error='{"code":"release_verify_failed","category":"verification","retryable":true,"message":"release surface verification did not complete"}'; fi
           artifacts='[]'
-          if [[ -f deploy-prepared/prepared-artifacts.json ]]; then artifacts=$(jq -c '[.artifacts[] | del(.unit)]' deploy-prepared/prepared-artifacts.json); fi
+          if [[ -f deploy-prepared/deployment-evidence.json ]]; then artifacts=$(jq -c '[.artifacts[] | del(.unit)]' deploy-prepared/deployment-evidence.json); fi
           python3 .github/scripts/deployment_control_contract.py write-result --repository '${{ github.repository }}' --step-id "$STEP_ID" --run-id '${{ github.run_id }}' --run-attempt '${{ github.run_attempt }}' --workflow 'deploy-verify.yml' --event '${{ github.event_name }}' --sha '${{ github.sha }}' --deployment-batch-id "$DEPLOYMENT_BATCH_ID" --deployment-target-id "$DEPLOYMENT_TARGET_ID" --attempt-id "$ATTEMPT_ID" --dispatch-nonce "$DISPATCH_NONCE" --plan-hash "$PLAN_HASH" --worker "$WORKER" --phase verify --source-sha "$SOURCE_SHA" --prepared-sha "$PREPARED_SHA" --target-version "$TARGET_VERSION" --channel "$RELEASE_CHANNEL" --descriptor-sha256 "$DESCRIPTOR_SHA256" --outcome "$outcome" --effects '[]' --artifacts-json "$artifacts" --error-json "$error" --output deployment-result.json
       - if: always()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6

--- a/README.md
+++ b/README.md
@@ -216,8 +216,8 @@ then routes:
 The `pr-checks` job additionally enforces, per changed worker: `README.md`
 present, the private build entry and public `iii.worker.yaml` valid,
 `tests/` non-empty, and the package version not behind the PR base. It also
-requires non-empty public discovery tags on workers whose public
-`interface_smoke` PR check is enabled — see the
+requires non-empty public discovery tags on workers whose interface capture is
+enabled — see the
 [Discovery tags step](docs/sops/new-worker.md#discovery-tags-required).
 
 Full reference (discovery buckets, interface boot smoke, e2e workflows):

--- a/docs/architecture/iii-worker-yaml.md
+++ b/docs/architecture/iii-worker-yaml.md
@@ -32,15 +32,18 @@ public field is present the compiler requires the two lists to match.
 
 | Field | Purpose | Consumer |
 |---|---|---|
-| `interface_smoke: false` | Opt out of the PR-only interface boot check | `validate_worker.py`, `ci.yml` |
+| `interface_smoke: false` | Declare that interface capture is skipped | `validate_worker.py`, `ci.yml`, release compiler |
 | `runtime` / `scripts.start` | Public local and installed runtime definition | `iii worker`, Compose, release compiler |
 | `scripts.install` | Build command for local install | `compose::add` (local source) |
 | `tags` | Discovery aliases included in the compiled Registry projection | release compiler |
 
 `tags` must be a list of strings. The publish pipeline trims values, converts them to lowercase,
 removes duplicates, and omits the field when no non-empty tags remain.
-`interface_smoke: false` skips only the PR check; deployments never boot a
-prepared worker. Private `publish` controls whether a worker appears in the
+`interface_smoke: false` compiles to `interface_capture: skipped` in the
+immutable deployment descriptor. Otherwise release prepare boots the prepared
+artifact against an isolated engine only long enough to capture registered
+functions and triggers. It does not invoke worker functions or validate an
+external backend. Private `publish` controls whether a worker appears in the
 deployment index.
 
 ```yaml

--- a/docs/architecture/testing-and-ci.md
+++ b/docs/architecture/testing-and-ci.md
@@ -67,11 +67,11 @@ in both `rust` and `interface-smoke` jobs.
   claimed minimum compiler; the repository does not infer an MSRV from the
   pinned CI version.
 
-## Interface boot smoke (Rust)
+## Interface registration checks and release capture (Rust)
 
-**Why it exists:** release publish boots the worker on a clean runner with no
-`data/` directory. A worker can compile and pass unit tests yet crash at publish
-when SQLite parent dirs or sidecars are missing (#104 / `database/v0.2.6`).
+**Why it exists:** Registry discovery is generated from the functions and
+trigger types a worker registers. A successful build cannot prove that this
+metadata is present or typed.
 
 **Flow:**
 
@@ -81,7 +81,16 @@ when SQLite parent dirs or sidecars are missing (#104 / `database/v0.2.6`).
 4. `collect_worker_interface.py` — 120 s wait, assert non-empty interface
 
 **Opt-out:** `interface_smoke: false` in `iii.worker.yaml` (for example `lsp`).
-This is a PR-only check and is not part of deployment prepare or publication.
+The release compiler records this as `interface_capture: skipped`; only that
+explicit immutable policy permits empty `functions` and `triggers` in Registry.
+
+Release prepare repeats registration collection from one immutable prepared
+artifact and binds `deployment-interface.json` to the descriptor and prepared
+inventory digests. This is publication evidence, not a deployment smoke: no
+worker function or external backend is invoked. Behavioral coverage remains in
+the dedicated E2E workflows below. When `config.collect.yaml` exists, its digest
+is part of the descriptor and prepare verifies the same-source bytes before
+using the file for capture-only startup defaults.
 
 ## Dedicated e2e workflows
 

--- a/docs/sops/binary-worker.md
+++ b/docs/sops/binary-worker.md
@@ -94,9 +94,11 @@ cargo clippy --locked --all-targets --all-features -- -D warnings
 cargo test --locked --all-features
 ```
 
-CI builds changed Rust workers and runs the PR-only interface boot smoke unless
-`iii.worker.yaml` sets `interface_smoke: false`. Deployment does not boot the
-prepared binary.
+CI builds changed Rust workers and checks interface registration unless
+`iii.worker.yaml` sets `interface_smoke: false`. Release prepare also boots one
+immutable Linux artifact in an isolated engine to capture Registry metadata.
+That capture invokes no worker function or external backend and is not a
+deployment smoke test.
 
 ## Release behavior
 

--- a/docs/sops/new-worker.md
+++ b/docs/sops/new-worker.md
@@ -14,8 +14,8 @@ details are in [`binary-worker.md`](binary-worker.md).
 - Add an entry to the private
   [`.deploy/workers.yaml`](../../.deploy/workers.yaml) build catalog.
 
-The private entry contains exactly `source`, `artifact`, `validation`, and
-`publish`. Public runtime and Registry metadata stay in `iii.worker.yaml`.
+The private entry contains exactly `source`, `artifact`, and `publish`. Public
+runtime and Registry metadata stay in `iii.worker.yaml`.
 See [`worker-compose.md`](../architecture/worker-compose.md) for the boundary.
 Release Control reads only the compiled descriptor index and never either
 source document.
@@ -31,10 +31,13 @@ Never put API keys, tokens, `III_*` connection settings, or mutable external
 references in public defaults; the compiler rejects them before producing the
 immutable Registry projection.
 
-The PR interface boot check is enabled by default. Set
+Interface capture is enabled by default. CI checks it from source, and release
+prepare captures it again from the immutable prepared artifact for Registry
+publication. Set
 `interface_smoke: false` in `iii.worker.yaml` only for a worker that cannot
 expose a collectable interface, such as a stdio-only process. This setting does
-not affect deployment or publication.
+not skip behavior tests: it compiles to `interface_capture: skipped` in the
+immutable descriptor and explicitly permits an empty Registry interface.
 
 ## Local checks
 
@@ -56,8 +59,15 @@ Run the language suite that CI will select:
 - Python: Ruff and pytest.
 
 Handlers published as interface metadata must have typed request and response
-schemas. Add a focused schema/catalog test for the worker and a dedicated E2E
-workflow when startup, sidecars, or external protocol behavior needs coverage.
+schemas. Capture only observes registration; it never invokes a worker function
+or external backend. Add a focused schema/catalog test for the worker and a
+dedicated E2E workflow when behavior, sidecars, or external protocols need
+coverage.
+
+If registration needs safe startup defaults, add `config.collect.yaml` beside
+`iii.worker.yaml`. The compiler records its SHA-256 in the immutable descriptor;
+release prepare reads those exact bytes from the selected source SHA and passes
+the file only to the isolated interface-capture process.
 
 ## Release readiness
 

--- a/docs/sops/release.md
+++ b/docs/sops/release.md
@@ -28,7 +28,9 @@ tested candidate.
 1. `deploy-prepare.yml` authorizes the dispatch, verifies descriptor identity,
    builds one job per **candidate-profile** target, and uploads the
    byte-unchanged descriptor, prepared inventory, and artifacts with their
-   SHA-256 and size (retained 90 days as the finalization fast path).
+   SHA-256 and size. It then captures registered functions and triggers from
+   one immutable artifact and binds that interface evidence to the descriptor
+   and prepared inventory (retained 90 days as the finalization fast path).
 2. `deploy-publish.yml` publishes or proves GitHub assets, the exact Registry
    version and a digest-pinned OCI image when applicable, then CASes the
    requested channel from the value captured in the plan.
@@ -41,7 +43,12 @@ tested candidate.
    version to the Registry **without a channel**, and then moves `next` and
    `latest` together through the Registry's transactional finalize primitive.
    It shares the `deployment-<worker>` concurrency group with publish.
-4. `deploy-verify.yml` verifies GitHub, Registry and optional GHCR surfaces.
+4. `deploy-verify.yml` verifies GitHub, the exact Registry interface captured
+   during prepare, and optional GHCR surfaces.
+
+Interface capture is a publication-integrity step. It starts the artifact only
+to observe registration against an isolated engine; it never calls a worker
+function or external backend and is not a deployment smoke test.
 
 Every entrypoint authorizes with GitHub OIDC audience
 `release-control-workers`. It uploads

--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -15,6 +15,8 @@ ignore=(
   'https://api.workers.iii.dev/w/$WORKER/tags/latest' # workflow action endpoint, PUT only
   'https://api.workers.iii.dev/w/$WORKER/tags/next' # workflow action endpoint, PUT only
   'https://api.workers.iii.dev/w/$WORKER/api-reference' # release API endpoint, not a documentation link
+  'https://api.workers.iii.dev/w/$WORKER?version=$SOURCE_RC_VERSION' # dynamic exact-version release API endpoint
+  'https://api.workers.iii.dev/w/$WORKER?version=$TARGET_VERSION' # dynamic exact-version verification API endpoint
   'https://release-control.iii.dev/contracts/deployment-execution.schema.json' # JSON Schema identifier; published at cutover
   'https://workers.iii.dev/workers/'       # URL prefix in a test assertion, not a link
   'https://workers.iii.dev/workers/skills' # published (badge.svg 200) but registry page missing


### PR DESCRIPTION
## Summary

- capture registered functions and triggers from the exact prepared artifact before Registry publication
- bind interface evidence to the source, descriptor, prepared inventory, and optional capture configuration digest
- reject empty interfaces unless the worker explicitly opts out, and verify the published readback against captured evidence
- preserve the evidence through candidate publication and stable finalization, including the recovery path for expired prepared artifacts

## Validation

- `python3 -m pytest .github/scripts/tests -q` — 315 passed, 3 subtests passed
- all deployment descriptors compiled and validated against the schema
- Python bytecode compilation and workflow YAML parsing passed
- `git diff --check` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deployment interface capture and evidence verification for prepared artifacts.
  * Added support for capturing registered functions and triggers, with explicit required or skipped policies.
  * Added optional runtime configuration tracking with file integrity checks.
  * Deployment workflows now validate captured interfaces before publishing and verification.

* **Documentation**
  * Updated release, worker onboarding, CI, and architecture guidance for interface capture and evidence validation.

* **Tests**
  * Expanded coverage for interface capture, evidence integrity, artifact verification, and workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->