### PR TITLE
(MOT-4654) perf(iii-directory): trim function contract prose to what the model needs

### DIFF
--- a/iii-directory/src/functions/agents.rs
+++ b/iii-directory/src/functions/agents.rs
@@ -115,9 +115,8 @@ pub struct ListAgentsOutput {
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct AgentGetInput {
     pub id: String,
-    /// When `true`, the response includes the FULL on-disk file content
-    /// (frontmatter block included) as `raw` — the exact string to hand
-    /// back to `directory::agents::update`.
+    /// When true, also return the exact on-disk file (frontmatter included) as
+    /// `raw`, ready for directory::agents::update.
     #[serde(default)]
     pub raw: Option<bool>,
 }
@@ -176,17 +175,11 @@ pub struct AgentGetOutput {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct AgentCreateInput {
-    /// New agent profile id — becomes the file stem
-    /// (`<agents_folder>/<id>.md`). Lowercase ASCII, digits,
-    /// `-` and `_` only. Must not collide with an existing agent profile or an
-    /// on-disk file at the target path.
+    /// New profile id, used as the file stem; lowercase ASCII, digits, `-` and
+    /// `_` only, and not already taken.
     pub id: String,
-    /// FULL file content, frontmatter block included. Frontmatter must
-    /// carry a non-empty `name`; the body is the system prompt and may be
-    /// empty (the profile then contributes only its parent chain, if any,
-    /// and its non-prompt settings). An `extends:` that does not resolve
-    /// is reported by `list`/`get` as `inheritance_error`, never a write
-    /// error.
+    /// Full file content, frontmatter included; `name` is required, the body is
+    /// the system prompt and may be empty.
     pub content: String,
 }
 
@@ -247,15 +240,10 @@ fn register_list(iii: &Arc<IIIClient>, cfg: &SharedConfig) {
             async move { Ok::<_, Error>(list_agents(&cfg)) }
         })
         .description(
-            "List agent profiles (id, display name, description, emoji logo, icon, color, \
-             model, reasoning_effort, skill_count, extends, modified_at) from the configured \
-             agents folder plus the profiles bundled with this worker (`builtin: true` until a \
-             local file shadows one — `iii` is the base identity most profiles extend). An \
-             agent profile is a reusable session identity: its file body is the system \
-             prompt. model / reasoning_effort / skill_count are resolved through `extends` \
-             (a profile inherits what it omits from its parent chain); skill_count null = \
-             sessions using the profile can use every skill. A row whose `extends` chain \
-             does not resolve carries `inheritance_error`.",
+            "List agent profiles (id, name, description, logo, icon, color, model, \
+             reasoning_effort, skill_count, extends, modified_at) from the agents \
+             folder plus the bundled ones (`builtin: true`). Inherited fields resolve \
+             through `extends`; skill_count null means every skill.",
         ),
     );
 }
@@ -276,19 +264,10 @@ fn register_get(iii: &Arc<IIIClient>, cfg: &SharedConfig, cache: &Arc<Registered
             }
         })
         .description(
-            "Fetch one agent profile by id. Returns the RESOLVED system prompt (each \
-             ancestor's body root-first, then this file's body; blank bodies are \
-             skipped, so a profile with no prompt of its own serves its parent chain \
-             unchanged, and a prompt-less profile without `extends` serves an empty \
-             string), display name, \
-             description, emoji logo, the skill filter resolved \
-             through `extends` plus unknown_skills (filter entries matching no visible \
-             skill — warnings, the profile still loads), model, reasoning_effort, icon, \
-             color, extends, builtin, and modified_at. `inheritance_error` is set when the \
-             `extends` chain names an unknown profile, loops, or is deeper than 8 levels: \
-             the profile then serves from its own file only and the harness refuses to \
-             run it. Pass raw: true to also get the exact on-disk file (this profile's \
-             own, ancestors excluded) for editing with directory::agents::update.",
+            "Fetch one agent profile by id: the system prompt resolved through its \
+             `extends` chain, display fields, skill filter, model, reasoning_effort, \
+             and `inheritance_error` when the chain does not resolve. Pass raw: true \
+             for the exact on-disk file to edit with directory::agents::update.",
         ),
     );
 }
@@ -311,14 +290,10 @@ fn register_create(iii: &Arc<IIIClient>, cfg: &SharedConfig, subs: &trigger_type
             }
         })
         .description(
-            "Create a NEW agent profile at <agents_folder>/<id>.md from full-file \
-             markdown content (frontmatter block included; a non-empty `name` is \
-             required, `logo` is emoji-only, and the body — the system prompt — may be \
-             empty; an `extends: <id>` that does not resolve is reported by list/get \
-             as `inheritance_error`). Rejects ids that already exist in the \
-             configured agents folder, or a target path that already exists on disk; \
-             creating a bundled id shadows the bundled copy. The write is atomic and \
-             fans out directory::agents::on-change with { op: \"create\" }.",
+            "Create a new agent profile at <agents_folder>/<id>.md from full-file \
+             markdown (frontmatter with a non-empty `name`, emoji-only `logo`; the \
+             body is the system prompt and may be empty). Rejects ids or paths that \
+             already exist; a bundled id is shadowed.",
         )
         .metadata(json!({"tool": {"label": "Create agent profile"}})),
     );
@@ -342,14 +317,10 @@ fn register_update(iii: &Arc<IIIClient>, cfg: &SharedConfig, subs: &trigger_type
             }
         })
         .description(
-            "Overwrite one EXISTING agent profile with new full-file markdown content — \
-             the same rules the scanner enforces (required frontmatter with a non-empty \
-             `name`, emoji-only `logo`; the body — the system prompt — may be empty), so \
-             an update can never produce a file the next directory::agents::list would skip. \
-             The agent profile id stays the file stem; frontmatter `name` is only the \
-             display name. Updating a bundled profile (`builtin: true`) creates the local \
-             file, which then shadows the bundled copy. The write is atomic and fans out \
-             directory::agents::on-change with { op: \"update\" }.",
+            "Overwrite one existing agent profile with full-file markdown \
+             (frontmatter with a non-empty `name`, emoji-only `logo`; the body is the \
+             system prompt and may be empty). Updating a bundled profile creates a \
+             local file that shadows it.",
         )
         .metadata(json!({"tool": {"label": "Update agent profile"}})),
     );
@@ -373,13 +344,9 @@ fn register_delete(iii: &Arc<IIIClient>, cfg: &SharedConfig, subs: &trigger_type
             }
         })
         .description(
-            "Permanently delete one EXISTING agent profile by id. Resolves against the \
-             same merged scan as directory::agents::list, removes only that profile's \
-             markdown file, and fans out directory::agents::on-change with \
-             { op: \"delete\" }. Deleting the local shadow of a bundled profile falls \
-             back to the bundled copy; a bundled profile with no local file has nothing \
-             to delete. Sessions already using this profile are not affected; profiles \
-             that extend it stop resolving until their `extends` is fixed.",
+            "Delete one existing agent profile's markdown file by id. Deleting the \
+             local shadow of a bundled profile falls back to the bundled copy; \
+             profiles that extend it stop resolving until fixed.",
         )
         .metadata(json!({"tool": {"label": "Delete agent profile"}})),
     );

--- a/iii-directory/src/functions/download.rs
+++ b/iii-directory/src/functions/download.rs
@@ -42,9 +42,8 @@ pub struct DownloadInput {
     /// Source B: explicit semver to pull. Mutually exclusive with `tag`.
     #[serde(default)]
     pub version: Option<String>,
-    /// Source B: registry tag to pull (e.g. `latest`). Mutually
-    /// exclusive with `version`. Defaults to `"latest"` when neither
-    /// `version` nor `tag` is provided.
+    /// Registry tag to pull (default `latest`); mutually exclusive with
+    /// `version`.
     #[serde(default)]
     pub tag: Option<String>,
 }
@@ -148,13 +147,10 @@ fn register_download(iii: &Arc<IIIClient>, cfg: &SharedConfig, subscribers: &sup
             async move { run_and_fan_out(&iii, &cfg, &subs, req).await }
         })
         .description(
-            "Download skills into skills_folder from EITHER source. Prefer the \
-             explicit directory::skills::download_from_registry / \
-             directory::skills::download_from_repo, whose schemas can't be mixed up. \
-             Pass {repo, skill, branch?} to clone one skill folder from a GitHub repo \
-             (branch defaults to \"main\"), or {worker, version?|tag?} to pull from the \
-             workers registry (tag defaults to \"latest\"). Specify exactly ONE source \
-             set. Files in the destination namespace are overwritten file-by-file.",
+            "Download skills into skills_folder from exactly one source: {repo, \
+             skill, branch?} clones a GitHub skill folder; {worker, version?|tag?} \
+             pulls from the workers registry. Prefer the explicit \
+             download_from_registry / download_from_repo.",
         )
         .metadata(json!({"tool": {"label": "Download skills"}})),
     );
@@ -189,11 +185,9 @@ fn register_download_from_registry(
         })
         .description(
             "Download one worker's directory bundle from the workers registry into \
-             skills_folder. `worker` is required; pass either `version` (exact semver) \
-             OR `tag` (e.g. \"latest\", the default when both are omitted), not both. \
-             Files in the destination namespace are overwritten file-by-file. A missing \
-             worker returns a `D310 not_found` naming the next function to call. To pull \
-             from a GitHub repo instead, use directory::skills::download_from_repo.",
+             skills_folder. `worker` is required; pass `version` (exact semver) or \
+             `tag` (default \"latest\"), not both. Files are overwritten \
+             file-by-file.",
         )
         .metadata(json!({"tool": {"label": "Download skills (registry)"}})),
     );
@@ -227,11 +221,9 @@ fn register_download_from_repo(
             }
         })
         .description(
-            "Download one skill folder from a GitHub repo into skills_folder. `repo` (the \
-             repo URL) and `skill` (the subfolder under `skills/`, which also names the \
-             destination namespace) are required; `branch` defaults to \"main\". The repo \
-             URL is validated (https / ssh / git@ only). To pull a published worker \
-             instead, use directory::skills::download_from_registry.",
+            "Download one skill folder from a GitHub repo into skills_folder: `repo` \
+             (https/ssh/git@ URL) and `skill` (subfolder under `skills/`, also the \
+             destination namespace) are required; `branch` defaults to \"main\".",
         )
         .metadata(json!({"tool": {"label": "Download skills (repo)"}})),
     );

--- a/iii-directory/src/functions/prompts.rs
+++ b/iii-directory/src/functions/prompts.rs
@@ -97,7 +97,11 @@ pub fn register(iii: &Arc<IIIClient>, cfg: &SharedConfig) {
                 Ok::<_, Error>(ListSystemPromptsOutput { prompts: entries })
             }
         })
-        .description("List system prompts (name, description, modified_at): filesystem-backed entries from skills_folder (`system-prompts/` path segment) plus the prompts bundled with this worker. A bundled prompt with no local file carries `builtin: true` — editing it via directory::system-prompts::update creates the local file, which then shadows the bundled copy."),
+        .description(
+            "List system prompts (name, description, modified_at) from \
+             skills_folder's `system-prompts/` plus the ones bundled with this worker \
+             (`builtin: true` until a local file shadows one).",
+        ),
     );
 
     let cfg_inner = cfg.clone();

--- a/iii-directory/src/functions/registry.rs
+++ b/iii-directory/src/functions/registry.rs
@@ -71,15 +71,12 @@ enum FetchError {
 /// page size — the client cannot override it).
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 pub struct WorkerListInput {
-    /// Optional free-text query. Forwarded to the registry as
-    /// `?search=…`; the registry ranks results by `pg_trgm` similarity
-    /// against `lower(name)` and `lower(description)`. When omitted,
-    /// results are ordered by `total_downloads DESC`.
+    /// Optional free-text query, fuzzy-matched by the registry; omitted means
+    /// ordered by downloads.
     #[serde(default)]
     pub search: Option<String>,
-    /// Opaque cursor returned by a previous call's
-    /// `pagination.next_cursor`. Pass back verbatim to fetch the next
-    /// page; omit (or pass `null`) to fetch the first page.
+    /// Cursor from a previous call's `pagination.next_cursor`; omit for the
+    /// first page.
     #[serde(default)]
     pub cursor: Option<String>,
 }
@@ -312,14 +309,9 @@ fn register_worker_list(iii: &Arc<IIIClient>, cfg: &SharedConfig, cache: Registr
             async move { worker_list(&cfg, &cache, req).await.map_err(Error::Handler) }
         })
         .description(
-            "List workers from the public registry (api.workers.iii.dev). \
-             Optional free-text `search` is matched fuzzily by the registry; \
-             omit it to browse by `total_downloads DESC`. Pagination is \
-             cursor-based with a server-authored page size — pass back \
-             `pagination.next_cursor` as `cursor` to fetch the next page. \
-             Shares the core `name` / `description` / `version` fields with \
-             the engine's `engine::workers::list`. Results are cached for \
-             `registry_cache_ttl_ms` (default 60s).",
+            "List workers from the public registry, optionally filtered by fuzzy \
+             `search` (default order: downloads). Cursor-paginated: pass back \
+             `pagination.next_cursor` as `cursor`.",
         ),
     );
 }
@@ -335,15 +327,9 @@ fn register_worker_info(iii: &Arc<IIIClient>, cfg: &SharedConfig, cache: Registr
             async move { worker_info(&cfg, &cache, req).await.map_err(Error::Handler) }
         })
         .description(
-            "Fetch full registry metadata for one worker: worker envelope \
-             (same core fields as the engine's `engine::workers::list` row \
-             shape, plus registry-only `type` / `config` / `supported_targets` / \
-             `total_downloads` / `dependencies` / `image`), readme, full \
-             API reference (functions + triggers schemas), and the tree \
-             of skill file paths fetched from the registry's \
-             /w/{slug}/skills endpoint. Pass either `version` or `tag` \
-             (defaults to tag=\"latest\"). Results are cached for \
-             `registry_cache_ttl_ms`.",
+            "Fetch one registry worker's full metadata: envelope, readme, API \
+             reference (function and trigger schemas), and skill file paths. Pass \
+             `version` or `tag` (default tag \"latest\").",
         ),
     );
 }

--- a/iii-directory/src/functions/search.rs
+++ b/iii-directory/src/functions/search.rs
@@ -266,6 +266,8 @@ pub struct SearchFunctionsRequest {
     /// summarize provided text or content are ignored. Write every entry in English,
     /// translating non-English user requests while preserving proper names, URLs, and function
     /// IDs.
+    // MOT-4654: kept verbatim on purpose — this is a tuned search directive pinned
+    // phrase-by-phrase by tests/search_schemas.rs, not descriptive prose.
     #[schemars(
         with = "HashSet<String>",
         length(min = 1, max = 6),

--- a/iii-directory/src/functions/skills.rs
+++ b/iii-directory/src/functions/skills.rs
@@ -67,17 +67,10 @@ const URI_PREFIX: &str = "iii://";
 
 /// Description for the `directory::skills::get` registration.
 const GET_DESCRIPTION: &str =
-    "Fetch one filesystem-backed skill by id and return its raw markdown body plus \
-     id, title, type, function_id, and modified_at. A worker overview is addressed \
-     by the bare worker name (e.g. \"iii-sandbox\") — that is the id `list`/`index` \
-     hand back. Input is forgiving: \"iii-sandbox/index\", \"iii-sandbox/SKILL.md\", a \
-     trailing \".md\", and an iii:// prefix all resolve to the same overview; and if \
-     the exact id misses, the worker name is matched case-insensitively as a \
-     substring (\"sandbox\" finds \"iii-sandbox\"). `title` prefers frontmatter \
-     `title:` over the body H1; `type` is the frontmatter `type:`. There is no \
-     `description` field here (the body already opens with that paragraph) — use \
-     directory::skills::list for the teaser-only view. On a miss you get a \
-     `D110 not_found` message naming the closest ids and the next function to call.";
+    "Fetch one skill by id and return its raw markdown body plus id, title, \
+     type, function_id, and modified_at. A worker overview is addressed by \
+     the bare worker name; `<id>.md` and `iii://<id>` forms are accepted. On \
+     a miss, D110 names the closest ids.";
 
 /// Recovery pointers attached to every `directory::skills::*` not-found
 /// message: where the agent should look to find a valid id.
@@ -168,18 +161,13 @@ struct IndexSkillsOutput {
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 pub struct SkillGetInput {
-    /// Skill id (the same string returned by `directory::skills::list`,
-    /// e.g. `"directory/skills/list"`). Two ergonomic variants are also
-    /// accepted: the file-path form `<id>.md` (the trailing `.md` is
-    /// stripped) and the legacy `iii://{id}` URI form. Other URI
-    /// schemes are rejected. The filename `SKILLS.md` is aliased to
-    /// `index.md` to match the filesystem scanner.
+    /// Skill id as returned by directory::skills::list (e.g.
+    /// `directory/skills/list`); `<id>.md` and `iii://<id>` forms are accepted.
+    // `SKILLS.md` is aliased to `index.md` to match the filesystem scanner;
+    // other URI schemes are rejected.
     pub id: String,
-    /// When `true`, the response includes the FULL on-disk file content
-    /// (frontmatter block included) as `raw`. For editors that need to
-    /// round-trip the exact file (`directory::skills::update` takes the
-    /// same full-file form); agent readers should leave this unset and
-    /// use `body`.
+    /// When true, also return the exact on-disk file (frontmatter included) as
+    /// `raw`, ready for directory::skills::update.
     #[serde(default)]
     pub raw: Option<bool>,
 }
@@ -542,18 +530,11 @@ fn register_list_skills(
             }
         })
         .description(
-            "List skills as one row PER SKILL (id, title, type, function_id, disable_model_invocation, description, \
-             bytes, modified_at) from skills_folder — use this when you need individual \
-             skill ids. A worker overview row's `id` is the bare worker name (e.g. \
-             `iii-sandbox`); pass it straight to directory::skills::get. For a per-WORKER \
-             overview instead, call directory::skills::index. Filters: `search` \
-             (case-insens. substring vs id+title+description), `prefix` (worker-namespace \
-             prefix; matches the overview row and its sub-skills), `type` (exact \
-             frontmatter type match). Pass `include_description: false` for token-light \
-             id+title+type rows (default: descriptions included). `title` prefers \
-             frontmatter `title:` over the body H1. Each row's `function_id` is the \
-             callable bus id (e.g. `sandbox::create`) — pass THAT to agent_trigger, not \
-             the row's `id` (which is a documentation address).",
+            "List skills, one row per skill (id, title, type, function_id, \
+             description, bytes, modified_at). Filters: `search` (substring on \
+             id/title/description), `prefix` (worker namespace), `type`; \
+             `include_description: false` for lighter rows. Pass a row's \
+             `function_id`, not its `id`, to agent_trigger.",
         ),
     );
 }
@@ -678,13 +659,9 @@ fn register_index_skills(
             }
         })
         .description(
-            "Render a per-WORKER overview: one short markdown block per installed worker \
-             (each worker's root overview doc `<ns>/index`, whether or not it declares \
-             frontmatter `type: index`). Each block is a `## <worker title>` heading, the \
-             first paragraph of that worker's overview, and a `directory::skills::get` call \
-             to read the full reference. Token-light by design and intended for \
-             system-prompt injection; for individual per-SKILL rows call \
-             directory::skills::list.",
+            "Per-worker overview: one short markdown block per installed worker \
+             (title, first paragraph, and the directory::skills::get call for the \
+             full reference). For per-skill rows use directory::skills::list.",
         ),
     );
 }

--- a/iii-directory/src/functions/update.rs
+++ b/iii-directory/src/functions/update.rs
@@ -100,9 +100,8 @@ const SYSTEM_PROMPT_CREATE_CONFLICT_NEXT: &[NextAction] = &[
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct SkillUpdateInput {
-    /// Skill id to overwrite — the same forms `directory::skills::get`
-    /// accepts (bare id, `<id>.md`, `SKILL(S).md`, `iii://<id>`). The
-    /// target file must already exist; update never creates skills.
+    /// Skill id to overwrite (same forms directory::skills::get accepts); the
+    /// file must already exist.
     pub id: String,
     /// FULL new file content, frontmatter block included — the string
     /// `directory::skills::get { raw: true }` returns, edited.
@@ -129,15 +128,11 @@ pub struct SkillUpdateOutput {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct SkillCreateInput {
-    /// New skill id — becomes the file path
-    /// (`<skills_folder>/<id>.md`), so it may contain `/`-separated
-    /// segments (`[a-z0-9_-]` each). Must not collide with an existing
-    /// visible skill (including system-installed agents skills) or an
-    /// on-disk file at the target path.
+    /// New skill id, used as the file path under skills_folder (`/`-separated
+    /// segments of `[a-z0-9_-]`), not already taken.
     pub id: String,
-    /// FULL file content, frontmatter block included — the same form
-    /// `directory::skills::update` takes. Frontmatter is optional for
-    /// skills; only the size cap and a non-empty body are enforced.
+    /// Full file content, frontmatter optional; only the size cap and a
+    /// non-empty body are enforced.
     pub content: String,
 }
 
@@ -175,15 +170,11 @@ pub struct SkillDeleteOutput {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct SystemPromptUpdateInput {
-    /// System prompt name to overwrite, as returned by
-    /// `directory::system-prompts::list`. The target file must already
-    /// exist — except for a worker-bundled prompt (`builtin: true` in the
-    /// list), where the update copy-on-writes the local file that then
-    /// shadows the bundled copy.
+    /// System prompt name to overwrite, as listed; a bundled prompt (`builtin:
+    /// true`) is copied to a local file first.
     pub name: String,
-    /// FULL new file content, frontmatter block included. The
-    /// frontmatter must keep a non-empty `description` — a system prompt
-    /// without one would be skipped by the next scan.
+    /// Full file content, frontmatter included; `description` must stay
+    /// non-empty.
     pub content: String,
 }
 
@@ -203,14 +194,11 @@ pub struct SystemPromptUpdateOutput {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct SystemPromptCreateInput {
-    /// New system prompt name — becomes the file stem
-    /// `<skills_folder>/system-prompts/<name>.md`. Same charset rules as
-    /// list/get names; must not collide with an existing system prompt.
+    /// New system prompt name, used as the file stem; same charset as listed
+    /// names and not already taken.
     pub name: String,
-    /// FULL file content, frontmatter block included — the same form
-    /// `directory::system-prompts::update` takes. Frontmatter must carry a
-    /// non-empty `description`; a declared `name` must match the
-    /// requested name.
+    /// Full file content, frontmatter included; `description` is required and a
+    /// declared `name` must match.
     pub content: String,
 }
 
@@ -285,15 +273,9 @@ fn register_update_skill(
             }
         })
         .description(
-            "Overwrite one EXISTING filesystem-backed skill with new full-file markdown \
-             content (frontmatter block included — pass back the `raw` field from \
-             directory::skills::get { raw: true }, edited). Accepts the same id forms as \
-             `get`. Never creates files (use directory::skills::create to author one, or \
-             directory::skills::download to materialize a bundle). Refuses read-only \
-             system-installed skills under agents_skills_folder. Content is validated \
-             against the read invariants (size cap, non-empty body after frontmatter); \
-             the write is atomic and fans out directory::skills::on-change with \
-             { op: \"update\" }.",
+            "Overwrite one existing skill with full-file markdown (pass back the \
+             `raw` from directory::skills::get { raw: true }, edited). Never creates \
+             files; refuses read-only system-installed skills.",
         )
         .metadata(json!({"tool": {"label": "Update skill"}})),
     );
@@ -339,15 +321,9 @@ fn register_create_skill(
             }
         })
         .description(
-            "Create a NEW filesystem-backed skill at <skills_folder>/<id>.md from \
-             full-file markdown content (frontmatter optional; only the size cap and a \
-             non-empty body are enforced, same as directory::skills::update). Rejects ids \
-             that already exist anywhere in the visible skill set (including \
-             system-installed agents skills), a target path that already exists on disk \
-             (even one the scanner would skip), ids in a namespace reserved by a \
-             system-installed agents skill, and — when filter_unregistered is on — ids \
-             the visibility filter would immediately hide. The write is atomic and fans \
-             out directory::skills::on-change with { op: \"create\" }. Use \
+            "Create a new skill at <skills_folder>/<id>.md from full-file markdown \
+             (frontmatter optional, non-empty body). Rejects ids or paths that \
+             already exist, including system-installed skills. Use \
              directory::skills::update to edit existing skills.",
         )
         .metadata(json!({"tool": {"label": "Create skill"}})),
@@ -385,12 +361,8 @@ fn register_delete_skill(
             }
         })
         .description(
-            "Permanently delete one EXISTING filesystem-backed skill by id. Accepts the \
-             same id forms as directory::skills::get, resolves against the same visible \
-             set as directory::skills::list, refuses read-only system-installed skills \
-             under agents_skills_folder, removes only that skill's markdown file (plus \
-             any parent directories the removal left empty), and fans out \
-             directory::skills::on-change with { op: \"delete\" }.",
+            "Delete one existing skill's markdown file by id (same id forms as \
+             directory::skills::get); refuses read-only system-installed skills.",
         )
         .metadata(json!({"tool": {"label": "Delete skill"}})),
     );
@@ -418,16 +390,10 @@ fn register_update_system_prompt(
             }
         })
         .description(
-            "Overwrite one EXISTING filesystem-backed system prompt with new full-file \
-             markdown content. Updating a worker-bundled prompt (`builtin: true` in the \
-             list) that has no local file yet copy-on-writes that file, which then \
-             shadows the bundled copy. The frontmatter must keep a non-empty `description` (and \
-             a valid `name` when it declares one) — the same rules the scanner enforces, \
-             so an update can never produce a file the next \
-             directory::system-prompts::list would skip. The write is atomic and fans \
-             out directory::system-prompts::on-change with { op: \"update\" }. Returns \
-             the system prompt's effective name after the write (frontmatter `name:` \
-             wins over the file stem).",
+            "Overwrite one existing system prompt with full-file markdown; the \
+             frontmatter must keep a non-empty `description`. Updating a bundled \
+             prompt (`builtin: true`) creates a local file that shadows it. Returns \
+             the effective name (frontmatter `name:` wins over the file stem).",
         )
         .metadata(json!({"tool": {"label": "Update system prompt"}})),
     );
@@ -455,14 +421,9 @@ fn register_create_system_prompt(
             }
         })
         .description(
-            "Create a NEW system prompt at <skills_folder>/system-prompts/<name>.md from \
-             full-file markdown content (frontmatter block included; a non-empty \
-             `description` is required, and a declared frontmatter `name` must match the \
-             requested name). Rejects names that already exist anywhere in the merged \
-             system-prompt scan, or a target path that already exists on disk (even one \
-             the scanner would skip). The write is atomic and fans out \
-             directory::system-prompts::on-change with { op: \"create\" }. Use \
-             directory::system-prompts::update to edit existing system prompts.",
+            "Create a new system prompt at <skills_folder>/system-prompts/<name>.md \
+             from full-file markdown (non-empty frontmatter `description` required; a \
+             declared `name` must match). Rejects names or paths that already exist.",
         )
         .metadata(json!({"tool": {"label": "Create system prompt"}})),
     );


### PR DESCRIPTION
Closes [MOT-4654](https://linear.app/motia/issue/MOT-4654). Sub-issue of MOT-4636; same rule as #1056 (MOT-4639) applied to iii-directory.

## Why

Surveying every harness dependency worker after #1056, iii-directory was the only one whose contracts were still README-sized *and* that the model actually fetches (`directory::agents::list` 4× in the corpus; `skills::*` / `agents::*` are the tech-leader's working set): 19 of 28 function descriptions over 300 chars (max 877), 16 request-type property docs over 140 (max 354).

## Change (editorial, at the source)

- Function description ≤ ~300 chars: what it does + the one non-obvious calling rule. Scanner-rule narration, `on-change` fan-out notes and "use X instead" tails deleted.
- Request property description = one sentence ≤ ~140 chars.
- Internal notes moved from `///` to `//`.
- No type, field, or serde change. Files: `iii-directory/src/functions/{agents,skills,update,download,registry,prompts,search}.rs`.

**Deliberate exception:** `SearchFunctionsRequest.capabilities` keeps its 486-char text verbatim — it is a tuned search directive pinned phrase-by-phrase by `tests/search_schemas.rs`, not descriptive prose; a `//` note marks it. Response-type docs (`AgentGetOutput`, `SkillGetOutput`, …) and `config.rs` are out of scope: response schemas never reach the model after #1047, config docs feed the `configuration` worker.

## Measured (source survey)

| | before | after |
| -- | -- | -- |
| function descriptions (28) | 11,638 | 5,001 (−57%) |
| request property docs | 5,556 | 3,750 (−33%) |
| `directory::agents::list` | 667 | 266 |
| `directory::agents::get` | 877 | 280 |
| `directory::skills::list` | 877 | 294 |
| `directory::skills::get` | 830 | 248 |
| `directory::skills::create` | 686 | 240 |

## Gates

`cargo fmt`, `cargo clippy --all-features --all-targets -D warnings`, `cargo test --lib` (412 passed) and `tests/search_schemas.rs` green; the search golden is unchanged. The cucumber suite is pre-broken on `main` (stale assertions) and was not used as a gate.

Live check on the compose stack (swap of the iii-directory binary + `functions::info` on `directory::agents::list`) follows as a comment.

https://claude.ai/code/session_01EUoLR66baA2QL7x6fH72bT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated and streamlined descriptions for directory, agent, download, prompt, registry, search, skill, and update operations.
  * Clarified key input constraints and behavior while preserving existing functionality.
  * Added documentation noting that capability directive text must remain exact and is covered by schema tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->