### PR TITLE
refactor: simplify descriptor checkpoint trust

### DIFF
--- a/.github/DEPLOYMENT_CUTOVER.md
+++ b/.github/DEPLOYMENT_CUTOVER.md
@@ -1,6 +1,6 @@
 # Deployment executor cutover
 
-`.deploy/workers.yaml` is the deployment catalog. The pinned compiler emits
+`.deploy/workers.yaml` is the deployment catalog. The Workers-owned compiler emits
 `deployment-descriptor` snapshots whose package-manifest version is
 informational; Release Control supplies one exact target version and channel.
 

--- a/.github/contracts/deployment-descriptor.schema.json
+++ b/.github/contracts/deployment-descriptor.schema.json
@@ -6,6 +6,7 @@
   "additionalProperties": false,
   "required": [
     "contract",
+    "contract_version",
     "worker",
     "package_manifest_version",
     "source_sha",
@@ -24,6 +25,7 @@
   ],
   "properties": {
     "contract": {"const": "deployment-descriptor"},
+    "contract_version": {"const": 1},
     "worker": {"type": "string", "pattern": "^[a-z0-9][a-z0-9_-]*$"},
     "package_manifest_version": {"type": "string", "minLength": 1},
     "source_sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},

--- a/.github/scripts/deployment_compiler.py
+++ b/.github/scripts/deployment_compiler.py
@@ -459,6 +459,7 @@ def compile_worker(root: Path, worker: str, value: Any, source_sha: str, compile
     }
     descriptor: dict[str, Any] = {
         "contract": "deployment-descriptor",
+        "contract_version": 1,
         "worker": worker,
         "package_manifest_version": package_manifest_version,
         "source_sha": source_sha,
@@ -492,8 +493,6 @@ def compile_index(args: argparse.Namespace) -> int:
     schema = args.schema.resolve()
     if not SHA_RE.fullmatch(args.source_sha):
         fail("source_sha must be a full lowercase commit SHA")
-    if not SHA_RE.fullmatch(args.compiler_commit):
-        fail("compiler_commit must be a full lowercase commit SHA")
     if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", args.compiler_repository):
         fail("compiler_repository must be an owner/name pair")
     document = read_yaml(deployment_spec)
@@ -525,10 +524,11 @@ def compile_index(args: argparse.Namespace) -> int:
         }
     index = {
         "contract": "deployment-descriptor-index",
+        "contract_version": 1,
         "source_sha": args.source_sha,
         "compiler": {
             "repository": args.compiler_repository,
-            "commit": args.compiler_commit,
+            "commit": args.source_sha,
             "digest": digest,
         },
         "workers": entries,
@@ -557,7 +557,6 @@ def parser() -> argparse.ArgumentParser:
     compile_command.add_argument("--deployment-spec", type=Path, default=Path(".deploy/workers.yaml"))
     compile_command.add_argument("--source-sha", required=True)
     compile_command.add_argument("--compiler-repository", required=True)
-    compile_command.add_argument("--compiler-commit", required=True)
     compile_command.add_argument("--schema", type=Path, default=schema)
     compile_command.add_argument("--output-dir", type=Path, required=True)
     compile_command.set_defaults(handler=compile_index)

--- a/.github/scripts/tests/test_deployment_compiler.py
+++ b/.github/scripts/tests/test_deployment_compiler.py
@@ -62,6 +62,8 @@ def test_descriptor_schema_requires_explicit_interface_capture_policy():
     )
 
     assert "interface_capture" in schema["required"]
+    assert "contract_version" in schema["required"]
+    assert schema["properties"]["contract_version"] == {"const": 1}
     assert schema["properties"]["interface_capture"] == {
         "enum": ["required", "skipped"]
     }

--- a/.github/scripts/tests/test_deployment_workflows.py
+++ b/.github/scripts/tests/test_deployment_workflows.py
@@ -133,18 +133,17 @@ def test_deployment_train_never_reads_public_worker_manifests():
         assert "iii.worker.yaml" not in path.read_text(encoding="utf-8"), path
 
 
-def test_descriptor_index_independently_verifies_approved_compiler_bytes():
+def test_descriptor_index_is_automatic_and_bound_to_the_exact_main_commit():
     text = body("deploy-descriptor-index.yml")
-    assert "Verify approved compiler bytes" in text
-    assert (
-        "APPROVED_COMPILER_DIGEST: "
-        "a01e716bee39d98afe46dd57bdc26b6b21f15a9341313f20dceed2fe87bd5084"
-    ) in text
-    assert 'digest.update(b"iii-workers-deployment-compiler\\0")' in text
-    assert 'Path(".github/scripts/deployment_compiler.py").read_bytes()' in text
-    assert 'digest.update(b"\\0deployment-descriptor-schema\\0")' in text
-    assert 'Path(".github/contracts/deployment-descriptor.schema.json").read_bytes()' in text
-    assert "unapproved deployment compiler bytes" in text
+    workflow = yaml.safe_load(text)
+    assert workflow[True] == {"push": {"branches": ["main"]}}
+    assert "workflow_dispatch" not in text
+    assert "APPROVED_COMPILER_DIGEST" not in text
+    assert "Verify approved compiler bytes" not in text
+    assert "ref: ${{ github.sha }}" in text
+    assert "--source-sha '${{ github.sha }}'" in text
+    assert "--compiler-commit" not in text
+    assert "name: deployment-descriptor-index-${{ github.sha }}" in text
 
 
 def test_release_prepare_fans_one_job_per_compiled_build_unit():

--- a/.github/workflows/deploy-descriptor-index.yml
+++ b/.github/workflows/deploy-descriptor-index.yml
@@ -3,12 +3,6 @@ name: Deployment Descriptor Index
 on:
   push:
     branches: [main]
-  workflow_dispatch:
-    inputs:
-      source_sha:
-        description: Full Workers source commit; defaults to the workflow SHA
-        required: false
-        type: string
 
 permissions: {}
 
@@ -18,45 +12,14 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Resolve immutable source
-        id: source
-        env:
-          REQUESTED_SOURCE_SHA: ${{ inputs.source_sha }}
-        run: |
-          set -euo pipefail
-          source_sha="${REQUESTED_SOURCE_SHA:-${GITHUB_SHA}}"
-          [[ "$source_sha" =~ ^[0-9a-f]{40}$ ]]
-          echo "sha=$source_sha" >> "$GITHUB_OUTPUT"
-
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
-          ref: ${{ steps.source.outputs.sha }}
+          ref: ${{ github.sha }}
           persist-credentials: false
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.12'
-
-      - name: Verify approved compiler bytes
-        env:
-          APPROVED_COMPILER_DIGEST: a01e716bee39d98afe46dd57bdc26b6b21f15a9341313f20dceed2fe87bd5084
-        run: |
-          set -euo pipefail
-          python3 - <<'PY'
-          import hashlib
-          import os
-          from pathlib import Path
-
-          digest = hashlib.sha256()
-          digest.update(b"iii-workers-deployment-compiler\0")
-          digest.update(Path(".github/scripts/deployment_compiler.py").read_bytes())
-          digest.update(b"\0deployment-descriptor-schema\0")
-          digest.update(Path(".github/contracts/deployment-descriptor.schema.json").read_bytes())
-          actual = digest.hexdigest()
-          expected = os.environ["APPROVED_COMPILER_DIGEST"]
-          if actual != expected:
-              raise SystemExit(f"unapproved deployment compiler bytes: expected {expected}, got {actual}")
-          PY
 
       - name: Install descriptor validators
         run: python -m pip install --disable-pip-version-check --quiet pyyaml jsonschema
@@ -64,14 +27,13 @@ jobs:
       - name: Compile all public release workers exactly once
         run: >-
           python3 .github/scripts/deployment_compiler.py compile-index
-          --source-sha '${{ steps.source.outputs.sha }}'
+          --source-sha '${{ github.sha }}'
           --compiler-repository '${{ github.repository }}'
-          --compiler-commit '${{ steps.source.outputs.sha }}'
           --output-dir deployment-descriptor-index
 
       - name: Validate descriptor schema, identities, and counts
         env:
-          SOURCE_SHA: ${{ steps.source.outputs.sha }}
+          SOURCE_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
           python3 - <<'PY'
@@ -84,6 +46,7 @@ jobs:
           schema = json.loads(Path(".github/contracts/deployment-descriptor.schema.json").read_text())
           index = json.loads((root / "deployment-descriptor-index.json").read_text())
           assert index["contract"] == "deployment-descriptor-index"
+          assert index["contract_version"] == 1
           assert index["source_sha"] == os.environ["SOURCE_SHA"]
           assert index["compiler"]["repository"] == os.environ["GITHUB_REPOSITORY"]
           assert index["compiler"]["commit"] == os.environ["SOURCE_SHA"]
@@ -100,7 +63,7 @@ jobs:
 
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
-          name: deployment-descriptor-index-${{ steps.source.outputs.sha }}
+          name: deployment-descriptor-index-${{ github.sha }}
           path: deployment-descriptor-index/
           if-no-files-found: error
           retention-days: 30

--- a/docs/sops/new-worker.md
+++ b/docs/sops/new-worker.md
@@ -48,7 +48,6 @@ python3 .github/scripts/validate_worker.py \
 python3 .github/scripts/deployment_compiler.py compile-index \
   --source-sha "$(git rev-parse HEAD)" \
   --compiler-repository iii-hq/workers \
-  --compiler-commit "$(git rev-parse HEAD)" \
   --output-dir /tmp/deployment-descriptor-index
 ```
 


### PR DESCRIPTION
## Summary

- generate deployment descriptors automatically from the exact commit pushed to main
- remove the manual dispatch path, hardcoded compiler digest approval, and duplicate compiler commit input
- version the descriptor contract explicitly while retaining compiler digest audit evidence
- update operator documentation and regression coverage

## Validation

- 315 script tests and 3 subtests passed
- actionlint passed
- compiled and schema-validated all 70 deployment descriptors

## Merge dependency

Merge iii-hq/release-control#132 first. It removes the cross-repository digest allowlist while retaining source and artifact integrity checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployment descriptors and indexes now include contract version `1`.
  * Descriptor index artifacts are tied to the exact commit on the main branch.

* **Updates**
  * Descriptor index generation now runs automatically on pushes to the main branch.
  * Deployment compiler examples and workflows no longer require a separate compiler commit argument.

* **Documentation**
  * Updated deployment cutover terminology and compiler usage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->