### PR TITLE
(MOT-4655) perf(state,console): trim the six contract texts left over 300/140 chars

### DIFF
--- a/console/src/functions/working_directory.rs
+++ b/console/src/functions/working_directory.rs
@@ -220,10 +220,9 @@ pub fn register(iii: &Arc<IIIClient>) {
             async move { propose(&client, request).await }
         })
         .description(
-            "Propose changing the current Harness session's working directory after creating or \
-             cloning a project elsewhere. The path is validated, then Console asks the user to \
-             confirm before the chat and paired Shell switch together. Call this when the user \
-             explicitly asked to continue in the new directory; never use it merely to inspect a file.",
+            "Propose switching the current session's working directory to a project created or \
+             cloned elsewhere; the console asks the user to confirm. Only when the user asked to \
+             continue there, never just to inspect a file.",
         ),
     );
 

--- a/console/src/functions/workspace.rs
+++ b/console/src/functions/workspace.rs
@@ -704,13 +704,10 @@ pub fn register(iii: &Arc<IIIClient>) {
             }
         })
         .description(
-            "Show a screen to the human in the console workspace, next to the conversation. \
-             Reuses the tab that already shows it, else places it beside chat in the active \
-             tab, else opens a new tab. Every browser on this engine updates. Use \
-             `{\"screen\":\"chat\",\"session_id\":\"<id>\"}` to open a chat panel pinned \
-             to one conversation. \
-             Use `ext:shell` for the file explorer, `ext:browser` for browser sessions, \
-             `ext:editor` for the editor, `workers` for the worker catalog.",
+            "Show a screen in the console workspace next to the conversation (reusing the tab \
+             that already shows it). Screens: `ext:shell` (files), `ext:browser`, \
+             `ext:editor`, `workers`, or `{\"screen\":\"chat\",\"session_id\":\"<id>\"}` \
+             for a pinned chat.",
         ),
     );
 

--- a/state/src/barrier.rs
+++ b/state/src/barrier.rs
@@ -79,10 +79,10 @@ pub struct BarrierConfig {
     pub id: String,
     /// A count, or the exact set of arrival keys.
     pub expect: Expect,
-    /// JSON pointer into the event for the arrival key (default `/key`, the
-    /// state event's own key). A missing pointer is an error, not a silent
-    /// unnamed arrival: two arrivals that both resolve to nothing would
-    /// collapse into one and the barrier would never complete.
+    /// JSON pointer into the event for the arrival key (default `/key`); a
+    /// pointer that resolves to nothing is an error.
+    // Not a silent unnamed arrival: two arrivals that both resolve to nothing
+    // would collapse into one and the barrier would never complete.
     #[serde(default)]
     pub key_from: Option<String>,
     /// JSON pointer into the event for the value to accumulate (default: the

--- a/state/src/functions.rs
+++ b/state/src/functions.rs
@@ -421,9 +421,8 @@ pub fn register_functions(iii: &Arc<IIIClient>, ctx: Arc<StateCtx>) {
             })
             .description(
                 "Atomically set a value only if it currently equals `expected` (omit `expected` \
-                 to mean 'only if absent'). Returns { swapped, current } — on a miss, `current` \
-                 is what is actually there, so a caller can recompute and retry. The primitive \
-                 for counters, claims and any read-modify-write that two callers might race.",
+                 to mean 'only if absent'). Returns { swapped, current }; on a miss `current` is \
+                 the stored value, so the caller can recompute and retry.",
             ),
         );
     }
@@ -454,10 +453,9 @@ pub fn register_functions(iii: &Arc<IIIClient>, ctx: Arc<StateCtx>) {
                 }
             })
             .description(
-                "Fan-in gate: record one arrival against a barrier and answer the typed \
-                 condition decision — `skip` until the expected set has arrived, then `allow` \
-                 EXACTLY ONCE carrying every arrival's payload. Use as a binding condition so a \
-                 coordinator wakes once when N producers finish instead of once per producer.",
+                "Fan-in gate for a binding condition: record one arrival and answer `skip` until \
+                 the expected set has arrived, then `allow` exactly once carrying every \
+                 arrival's payload.",
             ),
         );
     }
@@ -766,11 +764,10 @@ fn register_claim_namespace(iii: &Arc<IIIClient>, ctx: &Arc<StateCtx>) {
             }
         })
         .description(
-            "Reserve a PRIVATE state namespace for the calling worker: its scopes become \
-             invisible to public state::* and to trigger fan-out, and internal accessors \
-             `<functions_prefix>::state::{get, list, compare-and-set}` are registered. A worker \
-             may only claim the namespace matching its own worker name (engine-stamped caller \
-             identity). Idempotent; claims survive a state restart.",
+            "Reserve a private state namespace for the calling worker (its own worker name \
+             only): its scopes leave public state::* and trigger fan-out, and \
+             `<prefix>::state::{get, list, compare-and-set}` accessors are registered. \
+             Idempotent.",
         ),
     );
 }


### PR DESCRIPTION
Closes [MOT-4655](https://linear.app/motia/issue/MOT-4655). Sub-issue of MOT-4636; companion to #1056 (harness/shell) and #1058 (iii-directory).

Surveying every harness dependency worker in the repo (state, queue, cron, iii-directory, llm-router, session-manager, context-manager, the three providers, console) after #1056, these six texts were the only model-visible leftovers outside iii-directory. queue, cron, llm-router, session-manager, context-manager and the providers are clean on the model-visible side: their long docs sit on config structs or on the shared transcript types the model never fetches.

Same rule as #1056: function description ≤ ~300 chars (what it does + the one non-obvious rule), request property one sentence ≤ ~140, internal notes to `//`, no type or serde change.

| text | before | after |
| -- | -- | -- |
| `state::claim-namespace` | 370 | 244 |
| `state::compare-and-set` | 311 | 210 |
| `state::barrier` | 303 | 197 |
| `barrier.key_from` (request property) | 257 | 107 |
| `workspace::show` | 453 | 244 |
| working-directory proposal | 336 | 205 |

`state::set` / `state::get` / `state::list` (13 / 7 / 3 fetches in the MOT-4636 corpus) were already under the limit and are untouched.

Gates: `cargo fmt`, `cargo clippy --all-features --all-targets -D warnings`, `cargo test` green in both crates (state's e2e tests skip without an engine, as designed; run locally against a live engine they only exercise the running state worker, not this change).

https://claude.ai/code/session_01EUoLR66baA2QL7x6fH72bT