### PR TITLE
(MOT-4656) perf(browser): trim the nine contract texts still over the prose limits

### DIFF
--- a/browser/src/functions/attach.rs
+++ b/browser/src/functions/attach.rs
@@ -9,14 +9,11 @@ use crate::session::TabInfo;
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct AttachInput {
-    /// CDP endpoint of the running browser: `http://127.0.0.1:9222` (the
-    /// worker resolves the WebSocket URL from `/json/version`) or a
-    /// `ws://` debugger URL directly. Start Chrome with
-    /// `--remote-debugging-port=9222` to expose one.
+    /// CDP endpoint of the running browser: `http://127.0.0.1:9222` (resolved
+    /// via `/json/version`) or a `ws://` debugger URL.
     pub cdp_url: String,
-    /// Adopt the existing tab whose URL contains this substring, exclusively,
-    /// and release it untouched on stop. Omit to open a fresh tab the
-    /// session owns and closes on stop. Must match exactly one open tab.
+    /// Adopt the one open tab whose URL contains this substring (released
+    /// untouched on stop); omit to open a fresh tab the session owns.
     #[serde(default)]
     pub adopt_url_substring: Option<String>,
     /// URL to open in the fresh tab (ignored when adopting). Omit for

--- a/browser/src/functions/execute.rs
+++ b/browser/src/functions/execute.rs
@@ -13,10 +13,8 @@ pub const MAX_ENVELOPE_BYTES: usize = 1_000_000;
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ExecuteInput {
     pub session_id: String,
-    /// Async JavaScript body run in the page. Top-level `await` and `return`
-    /// work. In scope: `state` (JSON object persisted across execute calls
-    /// for the session), `log(...)` (collected into the response), `sleep(ms)`,
-    /// and `waitFor(selector, { timeout })`. Return plain JSON.
+    /// Async JavaScript body run in the page; `state`, `log(...)`, `sleep(ms)`
+    /// and `waitFor(selector, { timeout })` are in scope. Return plain JSON.
     pub code: String,
     /// Upper bound on the run; clamped to `max_timeout_ms`.
     #[serde(default)]

--- a/browser/src/functions/frame.rs
+++ b/browser/src/functions/frame.rs
@@ -23,9 +23,8 @@ pub struct ScreencastStopInput {
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct FrameInput {
     pub session_id: String,
-    /// Frame cursor from the previous read; when the newest frame still has
-    /// this seq the response omits `frame` (nothing changed, nothing to
-    /// redraw).
+    /// Frame cursor from the previous read; the response omits `frame` while
+    /// the newest frame still has this seq.
     #[serde(default)]
     pub since_frame: Option<u64>,
 }

--- a/browser/src/functions/handoff.rs
+++ b/browser/src/functions/handoff.rs
@@ -15,9 +15,8 @@ pub struct HandoffInput {
     /// What the human must do before the call continues. Shown in the
     /// in-page banner and the handoff-requested event.
     pub instructions: String,
-    /// Give up after this long and return with `via: "timeout"`. Defaults to
-    /// the config default; clamped to `max_timeout_ms`. Set generously; a
-    /// human is slow.
+    /// Give up after this many ms and return `via: "timeout"` (clamped to
+    /// `max_timeout_ms`); set generously, a human is slow.
     #[serde(default)]
     pub timeout_ms: Option<u64>,
 }

--- a/browser/src/functions/mod.rs
+++ b/browser/src/functions/mod.rs
@@ -71,10 +71,10 @@ pub const SESSIONS_STOP_DESC: &str =
      already-stopped session succeeds with was_running=false.";
 pub const SESSIONS_ATTACH_ID: &str = "browser::sessions::attach";
 pub const SESSIONS_ATTACH_DESC: &str =
-    "Attach a session to an already-running browser over CDP (start Chrome with \
-     --remote-debugging-port). Opens a fresh tab the session owns, or adopts an existing user \
-     tab by URL substring and releases it untouched on stop. Reaches the real profile with its \
-     logins; disabled unless allow_attach is set in config.";
+    "Attach a session to an already-running browser over CDP (Chrome started with \
+     --remote-debugging-port): opens a fresh tab the session owns, or adopts a user tab by URL \
+     substring and releases it untouched on stop. Reaches the real profile and its logins; \
+     requires allow_attach in config.";
 pub const TABS_LIST_ID: &str = "browser::tabs::list";
 pub const TABS_LIST_DESC: &str =
     "List the open tabs of a running browser reachable at a CDP endpoint (url, title, and \

--- a/browser/src/functions/resize.rs
+++ b/browser/src/functions/resize.rs
@@ -25,10 +25,10 @@ pub struct ResizeInput {
     /// Default false. The device toolbar sets this for phone presets.
     #[serde(default)]
     pub mobile: Option<bool>,
-    /// This resize is a pane auto-fit, not an explicit choice. A fit is
-    /// refused (current size returned) while more than one viewer watches
-    /// the session, so two open panes do not fight over the shared
-    /// viewport; explicit resizes (device toolbar, agents) always apply.
+    /// Mark this resize as a pane auto-fit; a fit is refused (current size
+    /// returned) while more than one viewer watches the session.
+    // Keeps two open panes from fighting over the shared viewport; explicit
+    // resizes (device toolbar, agents) always apply.
     #[serde(default)]
     pub fit: Option<bool>,
 }

--- a/browser/src/functions/sessions.rs
+++ b/browser/src/functions/sessions.rs
@@ -14,9 +14,8 @@ pub struct StartInput {
     /// `headless` default.
     #[serde(default)]
     pub headful: Option<bool>,
-    /// Inspection-only session: act, evaluate, execute, and styles::write
-    /// are rejected while navigation, snapshots, reads, and screenshots
-    /// work. Immutable for the session's lifetime.
+    /// Inspection-only session for its whole lifetime: act, evaluate, execute
+    /// and styles::write are rejected; navigation and reads work.
     #[serde(default)]
     pub read_only: Option<bool>,
 }

--- a/browser/src/functions/snapshot.rs
+++ b/browser/src/functions/snapshot.rs
@@ -6,9 +6,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct SnapshotInput {
     pub session_id: String,
-    /// Return only what changed since this session's previous snapshot
-    /// instead of the full outline. Falls back to a full snapshot when
-    /// there is no baseline (first snapshot, or first after a navigation).
+    /// Return only what changed since the previous snapshot; a full outline
+    /// when there is no baseline (first snapshot or after a navigation).
     #[serde(default)]
     pub diff: Option<bool>,
 }

--- a/browser/tests/golden/schemas/browser.execute.json
+++ b/browser/tests/golden/schemas/browser.execute.json
@@ -11,7 +11,7 @@
     ],
     "properties": {
       "code": {
-        "description": "Async JavaScript body run in the page. Top-level `await` and `return` work. In scope: `state` (JSON object persisted across execute calls for the session), `log(...)` (collected into the response), `sleep(ms)`, and `waitFor(selector, { timeout })`. Return plain JSON.",
+        "description": "Async JavaScript body run in the page; `state`, `log(...)`, `sleep(ms)` and `waitFor(selector, { timeout })` are in scope. Return plain JSON.",
         "type": "string"
       },
       "session_id": {

--- a/browser/tests/golden/schemas/browser.frame.json
+++ b/browser/tests/golden/schemas/browser.frame.json
@@ -13,7 +13,7 @@
         "type": "string"
       },
       "since_frame": {
-        "description": "Frame cursor from the previous read; when the newest frame still has this seq the response omits `frame` (nothing changed, nothing to redraw).",
+        "description": "Frame cursor from the previous read; the response omits `frame` while the newest frame still has this seq.",
         "default": null,
         "type": [
           "integer",

--- a/browser/tests/golden/schemas/browser.handoff.json
+++ b/browser/tests/golden/schemas/browser.handoff.json
@@ -18,7 +18,7 @@
         "type": "string"
       },
       "timeout_ms": {
-        "description": "Give up after this long and return with `via: \"timeout\"`. Defaults to the config default; clamped to `max_timeout_ms`. Set generously; a human is slow.",
+        "description": "Give up after this many ms and return `via: \"timeout\"` (clamped to `max_timeout_ms`); set generously, a human is slow.",
         "default": null,
         "type": [
           "integer",

--- a/browser/tests/golden/schemas/browser.resize.json
+++ b/browser/tests/golden/schemas/browser.resize.json
@@ -21,7 +21,7 @@
         "format": "double"
       },
       "fit": {
-        "description": "This resize is a pane auto-fit, not an explicit choice. A fit is refused (current size returned) while more than one viewer watches the session, so two open panes do not fight over the shared viewport; explicit resizes (device toolbar, agents) always apply.",
+        "description": "Mark this resize as a pane auto-fit; a fit is refused (current size returned) while more than one viewer watches the session.",
         "default": null,
         "type": [
           "boolean",

--- a/browser/tests/golden/schemas/browser.sessions.attach.json
+++ b/browser/tests/golden/schemas/browser.sessions.attach.json
@@ -1,6 +1,6 @@
 {
   "function_id": "browser::sessions::attach",
-  "description": "Attach a session to an already-running browser over CDP (start Chrome with --remote-debugging-port). Opens a fresh tab the session owns, or adopts an existing user tab by URL substring and releases it untouched on stop. Reaches the real profile with its logins; disabled unless allow_attach is set in config.",
+  "description": "Attach a session to an already-running browser over CDP (Chrome started with --remote-debugging-port): opens a fresh tab the session owns, or adopts a user tab by URL substring and releases it untouched on stop. Reaches the real profile and its logins; requires allow_attach in config.",
   "request_schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "AttachInput",
@@ -10,7 +10,7 @@
     ],
     "properties": {
       "adopt_url_substring": {
-        "description": "Adopt the existing tab whose URL contains this substring, exclusively, and release it untouched on stop. Omit to open a fresh tab the session owns and closes on stop. Must match exactly one open tab.",
+        "description": "Adopt the one open tab whose URL contains this substring (released untouched on stop); omit to open a fresh tab the session owns.",
         "default": null,
         "type": [
           "string",
@@ -18,7 +18,7 @@
         ]
       },
       "cdp_url": {
-        "description": "CDP endpoint of the running browser: `http://127.0.0.1:9222` (the worker resolves the WebSocket URL from `/json/version`) or a `ws://` debugger URL directly. Start Chrome with `--remote-debugging-port=9222` to expose one.",
+        "description": "CDP endpoint of the running browser: `http://127.0.0.1:9222` (resolved via `/json/version`) or a `ws://` debugger URL.",
         "type": "string"
       },
       "read_only": {

--- a/browser/tests/golden/schemas/browser.sessions.start.json
+++ b/browser/tests/golden/schemas/browser.sessions.start.json
@@ -15,7 +15,7 @@
         ]
       },
       "read_only": {
-        "description": "Inspection-only session: act, evaluate, execute, and styles::write are rejected while navigation, snapshots, reads, and screenshots work. Immutable for the session's lifetime.",
+        "description": "Inspection-only session for its whole lifetime: act, evaluate, execute and styles::write are rejected; navigation and reads work.",
         "default": null,
         "type": [
           "boolean",

--- a/browser/tests/golden/schemas/browser.snapshot.json
+++ b/browser/tests/golden/schemas/browser.snapshot.json
@@ -10,7 +10,7 @@
     ],
     "properties": {
       "diff": {
-        "description": "Return only what changed since this session's previous snapshot instead of the full outline. Falls back to a full snapshot when there is no baseline (first snapshot, or first after a navigation).",
+        "description": "Return only what changed since the previous snapshot; a full outline when there is no baseline (first snapshot or after a navigation).",
         "default": null,
         "type": [
           "boolean",


### PR DESCRIPTION
Closes [MOT-4656](https://linear.app/motia/issue/MOT-4656). Sub-issue of MOT-4636; same rule as #1056 (harness/shell), #1058 (iii-directory) and #1060 (state/console), applied to the browser worker.

## Survey

The browser worker was already close to the rule: 46 registered functions, 6,833 chars of descriptions in total (avg 148), one over 300 chars, eight request property docs between 142 and 267. The 19 scrapling-derived functions (`browser::fetch`, `css`, `xpath`, `to-markdown`, `session-*`, `crawl`, …) are all ≤ 221 chars; their read-only Python-parity goldens show no diff.

## Change

| text | before | after |
| -- | -- | -- |
| `browser::sessions::attach` description | 308 | 295 |
| `ExecuteInput.code` | 267 | 138 |
| `ResizeInput.fit` | 257 | 122 (viewer-fight rationale moved to `//`) |
| `AttachInput.cdp_url` | 221 | 105 |
| `AttachInput.adopt_url_substring` | 199 | 124 |
| `SnapshotInput.diff` | 195 | 137 |
| `StartInput.read_only` | 175 | 130 |
| `HandoffInput.timeout_ms` | 151 | 114 |
| `FrameInput.since_frame` | 142 | 107 |

No type, field, or serde change. Goldens regenerated with `UPDATE_GOLDENS=1`: 7 `browser.*.json` files, description lines only. Response-type docs (`SnapshotOutput.truncated`, `.diff`) and `config.rs` are out of scope as in the sibling PRs.

## Gates

`cargo fmt`, `cargo test` (13 suites green), `cargo clippy --all-targets -D warnings` green. `clippy --all-features` could not be run locally: the `scrapling-compat` feature builds the vendored `curl_impersonate_sys` natively and that toolchain is not on this machine — CI's per-worker job covers it.

https://claude.ai/code/session_01EUoLR66baA2QL7x6fH72bT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified browser session attachment requirements, including configuration prerequisites and access to existing profiles and logins.
  - Updated guidance for read-only sessions, resizing behavior, handoff timeouts, frame updates, snapshot diffs, and browser execution.
  - Refined descriptions for tab adoption and browser connection options.
- **Schema Updates**
  - Synchronized request property descriptions with the revised browser API documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->