### PR TITLE
fix: collect trigger schemas from worker namespaces

### DIFF
--- a/.github/scripts/collect_worker_interface.py
+++ b/.github/scripts/collect_worker_interface.py
@@ -136,16 +136,23 @@ def enrich_functions_with_schemas(
     return functions
 
 
-def _fetch_trigger_detail(trigger_id: str) -> dict[str, object] | None:
+def _fetch_trigger_detail(
+    trigger_id: str, namespace: str | None = None
+) -> dict[str, object] | None:
     """`engine::triggers::info` for one trigger type, or None on any failure.
 
-    `engine::triggers::list` returns a `TriggerTypeSummary` (id + worker_name +
-    description only); only `::info` returns the `TriggerTypeDetail` carrying the
-    typed `configuration_schema`/`request_schema`/`response_schema`. Best-effort:
-    a failed lookup leaves the row schema-less, which publishes the empty
-    ("unknown") schema."""
+    `engine::triggers::list` returns a `TriggerTypeSummary` (id + namespace +
+    worker_name + description only); only `::info` returns the
+    `TriggerTypeDetail` carrying the typed `configuration_schema`/
+    `request_schema`/`response_schema`. The namespace must be passed in the
+    payload because `::info` otherwise looks in `default`. Best-effort: a failed
+    lookup leaves the row schema-less, which publishes the empty ("unknown")
+    schema."""
+    payload: dict[str, object] = {"id": trigger_id}
+    if namespace:
+        payload["namespace"] = namespace
     try:
-        return run_iii("engine::triggers::info", {"id": trigger_id})
+        return run_iii("engine::triggers::info", payload)
     except (
         subprocess.CalledProcessError,
         subprocess.TimeoutExpired,
@@ -171,12 +178,17 @@ def enrich_trigger_types_with_schemas(
     Without this enrichment every collected trigger schema normalizes to the
     empty `{}` that surfaces as 'unknown' in the registry. Mirrors
     `enrich_functions_with_schemas` for the trigger-type surface."""
-    rows_by_id = {t.get("id"): t for t in trigger_types if isinstance(t, dict)}
-    for trigger_id in target_trigger_ids:
-        row = rows_by_id.get(trigger_id)
-        if row is None:
+    target_ids = set(target_trigger_ids)
+    for row in trigger_types:
+        if not isinstance(row, dict):
             continue
-        detail = fetch_detail(trigger_id)
+        trigger_id = row.get("id")
+        if not isinstance(trigger_id, str) or trigger_id not in target_ids:
+            continue
+        namespace = row.get("namespace")
+        detail = fetch_detail(
+            trigger_id, namespace if isinstance(namespace, str) else None
+        )
         if not isinstance(detail, dict):
             continue
         for key in (

--- a/.github/scripts/tests/test_enrich_trigger_schemas.py
+++ b/.github/scripts/tests/test_enrich_trigger_schemas.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+import collect_worker_interface  # noqa: E402
 from collect_worker_interface import enrich_trigger_types_with_schemas  # noqa: E402
 
 CFG = {"type": "object", "properties": {"session_id": {"type": "string"}}}
@@ -23,7 +24,46 @@ REQ = {"type": "object", "properties": {"entry_id": {"type": "string"}}}
 
 def _details(mapping):
     """Return a fetch_detail stub backed by a {trigger_id: detail} mapping."""
-    return lambda trigger_id: mapping.get(trigger_id)
+    return lambda trigger_id, _namespace=None: mapping.get(trigger_id)
+
+
+def test_fetches_info_in_the_namespace_reported_by_list(monkeypatch) -> None:
+    calls = []
+
+    def fake_run_iii(function_path, payload):
+        calls.append((function_path, payload))
+        return {"id": "browser::console-event", "namespace": "api-ref-repair"}
+
+    monkeypatch.setattr(collect_worker_interface, "run_iii", fake_run_iii)
+
+    detail = collect_worker_interface._fetch_trigger_detail(
+        "browser::console-event", "api-ref-repair"
+    )
+
+    assert detail == {
+        "id": "browser::console-event",
+        "namespace": "api-ref-repair",
+    }
+    assert calls == [
+        (
+            "engine::triggers::info",
+            {"id": "browser::console-event", "namespace": "api-ref-repair"},
+        )
+    ]
+
+
+def test_fetches_info_without_namespace_for_legacy_list_rows(monkeypatch) -> None:
+    calls = []
+
+    def fake_run_iii(function_path, payload):
+        calls.append((function_path, payload))
+        return {"id": "session::created"}
+
+    monkeypatch.setattr(collect_worker_interface, "run_iii", fake_run_iii)
+
+    collect_worker_interface._fetch_trigger_detail("session::created")
+
+    assert calls == [("engine::triggers::info", {"id": "session::created"})]
 
 
 def test_merges_info_schemas_into_target_rows() -> None:
@@ -80,7 +120,39 @@ def test_tolerates_missing_info_detail() -> None:
     ]
 
     enrich_trigger_types_with_schemas(
-        triggers, ["session::created"], fetch_detail=lambda _id: None
+        triggers, ["session::created"], fetch_detail=lambda _id, _namespace: None
     )
 
     assert "configuration_schema" not in triggers[0]
+
+
+def test_enrichment_passes_each_list_rows_namespace_to_info() -> None:
+    triggers = [
+        {
+            "id": "browser::console-event",
+            "namespace": "api-ref-repair",
+            "worker_name": "browser",
+            "description": "x",
+        },
+        {
+            "id": "browser::console-event",
+            "worker_name": "browser",
+            "description": "legacy default row",
+        },
+    ]
+    calls = []
+
+    def fetch_detail(trigger_id, namespace):
+        calls.append((trigger_id, namespace))
+        return {"configuration_schema": CFG}
+
+    enrich_trigger_types_with_schemas(
+        triggers, ["browser::console-event"], fetch_detail=fetch_detail
+    )
+
+    assert calls == [
+        ("browser::console-event", "api-ref-repair"),
+        ("browser::console-event", None),
+    ]
+    assert triggers[0]["configuration_schema"] == CFG
+    assert triggers[1]["configuration_schema"] == CFG


### PR DESCRIPTION
## Summary
- pass the namespace returned by `engine::triggers::list` into each `engine::triggers::info` lookup
- preserve the legacy default-namespace fallback
- handle duplicate trigger IDs across namespaces without collapsing rows

## Validation
- `python3 -m pytest -q .github/scripts/tests`
- 318 passed, 3 subtests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trigger schema enrichment for namespaced triggers.
  * Preserved compatibility with trigger records that do not specify a namespace.
  * Improved handling of incomplete or invalid trigger records.

* **Tests**
  * Added coverage for namespaced and legacy trigger lookups.
  * Added validation for detail-fetching payloads and missing trigger details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->