### PR TITLE
(MOT-4660) perf(editor,database,computer,document,email,github,security-scan): trim function contract prose

### DIFF
--- a/computer/src/functions/mod.rs
+++ b/computer/src/functions/mod.rs
@@ -20,9 +20,8 @@ use crate::session::{Session, Sessions};
 pub const SESSIONS_START_ID: &str = "computer::sessions::start";
 pub const SESSIONS_START_DESC: &str =
     "Start a computer-use session and return its session_id. Pass `image` to boot a fresh desktop \
-     in an iii-sandbox microVM (fixed virtual display, no host setup), an `endpoint` to drive a \
-     desktop through its guest executor, or omit both to drive the local machine. Sessions are \
-     durable; stop them with computer::sessions::stop when done.";
+     in an iii-sandbox microVM, `endpoint` to drive a remote desktop's guest executor, or neither \
+     to drive the local machine. Stop it with computer::sessions::stop.";
 pub const SESSIONS_LIST_ID: &str = "computer::sessions::list";
 pub const SESSIONS_LIST_DESC: &str =
     "List live computer sessions with their endpoint, guest OS, and screen size.";

--- a/computer/src/functions/sessions.rs
+++ b/computer/src/functions/sessions.rs
@@ -7,31 +7,25 @@ use crate::driver::Screen;
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct StartInput {
-    /// Boot a fresh desktop inside an iii-sandbox microVM from this OCI image
-    /// (a sandbox preset name or `custom_images` key) and drive it through iii
-    /// primitives alone. A fixed virtual display means 1:1
-    /// coordinates, no HiDPI or multi-monitor ambiguity. Falls back to the
-    /// configured `sandbox_image` when omitted. Takes precedence over
-    /// `endpoint`.
+    /// OCI image (sandbox preset name or `custom_images` key) for a fresh
+    /// iii-sandbox microVM desktop; overrides `endpoint`.
+    // Falls back to the configured `sandbox_image`. Fixed virtual display:
+    // 1:1 coordinates, no HiDPI or multi-monitor ambiguity.
     #[serde(default)]
     pub image: Option<String>,
-    /// Desktop to drive when not using a sandbox `image`. Omit (and leave
-    /// `image` unset) to drive the local machine this worker runs on (native
-    /// driver, nothing else to run). Pass the endpoint of a desktop guest's
-    /// executor (a `ws`/`wss`/`http`/`https` url or a bare `host:port`) to
-    /// drive a remote desktop; falls back to the configured
-    /// `default_endpoint` when omitted.
+    /// Remote desktop guest executor (`ws`/`wss`/`http`/`https` url or
+    /// `host:port`). Omit this and `image` to drive the local machine.
+    // Falls back to the configured `default_endpoint` before going native.
     #[serde(default)]
     pub endpoint: Option<String>,
-    /// Guest OS label recorded on the session and surfaced in
-    /// `session-started` (`linux`, `macos`, `windows`, `android`). Omit and
-    /// each driver labels itself: a sandbox session is `linux`, a remote one
-    /// takes the configured `os`, and a native one takes this host's OS.
+    /// Guest OS label recorded on the session: `linux`, `macos`, `windows` or
+    /// `android`. Omit to let the driver label itself.
+    // Sandbox sessions are `linux`, remote ones take the configured `os`,
+    // native ones this host's OS. Not an enum: the configured `os` is free text.
     #[serde(default)]
     pub os: Option<String>,
-    /// Display index (from `computer::displays`) for a native session. Omit to
-    /// drive the display under the cursor. Ignored for a remote `endpoint`
-    /// or a sandbox `image`.
+    /// Display index from `computer::displays` for a native session; omit for
+    /// the display under the cursor. Ignored with `endpoint` or `image`.
     #[serde(default)]
     pub monitor: Option<u32>,
 }

--- a/computer/tests/golden/schemas/computer.sessions.start.json
+++ b/computer/tests/golden/schemas/computer.sessions.start.json
@@ -1,12 +1,12 @@
 {
-  "description": "Start a computer-use session and return its session_id. Pass `image` to boot a fresh desktop in an iii-sandbox microVM (fixed virtual display, no host setup), an `endpoint` to drive a desktop through its guest executor, or omit both to drive the local machine. Sessions are durable; stop them with computer::sessions::stop when done.",
+  "description": "Start a computer-use session and return its session_id. Pass `image` to boot a fresh desktop in an iii-sandbox microVM, `endpoint` to drive a remote desktop's guest executor, or neither to drive the local machine. Stop it with computer::sessions::stop.",
   "function_id": "computer::sessions::start",
   "request_schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "properties": {
       "endpoint": {
         "default": null,
-        "description": "Desktop to drive when not using a sandbox `image`. Omit (and leave `image` unset) to drive the local machine this worker runs on (native driver, nothing else to run). Pass the endpoint of a desktop guest's executor (a `ws`/`wss`/`http`/`https` url or a bare `host:port`) to drive a remote desktop; falls back to the configured `default_endpoint` when omitted.",
+        "description": "Remote desktop guest executor (`ws`/`wss`/`http`/`https` url or `host:port`). Omit this and `image` to drive the local machine.",
         "type": [
           "string",
           "null"
@@ -14,7 +14,7 @@
       },
       "image": {
         "default": null,
-        "description": "Boot a fresh desktop inside an iii-sandbox microVM from this OCI image (a sandbox preset name or `custom_images` key) and drive it through iii primitives alone. A fixed virtual display means 1:1 coordinates, no HiDPI or multi-monitor ambiguity. Falls back to the configured `sandbox_image` when omitted. Takes precedence over `endpoint`.",
+        "description": "OCI image (sandbox preset name or `custom_images` key) for a fresh iii-sandbox microVM desktop; overrides `endpoint`.",
         "type": [
           "string",
           "null"
@@ -22,7 +22,7 @@
       },
       "monitor": {
         "default": null,
-        "description": "Display index (from `computer::displays`) for a native session. Omit to drive the display under the cursor. Ignored for a remote `endpoint` or a sandbox `image`.",
+        "description": "Display index from `computer::displays` for a native session; omit for the display under the cursor. Ignored with `endpoint` or `image`.",
         "format": "uint32",
         "minimum": 0.0,
         "type": [
@@ -32,7 +32,7 @@
       },
       "os": {
         "default": null,
-        "description": "Guest OS label recorded on the session and surfaced in `session-started` (`linux`, `macos`, `windows`, `android`). Omit and each driver labels itself: a sandbox session is `linux`, a remote one takes the configured `os`, and a native one takes this host's OS.",
+        "description": "Guest OS label recorded on the session: `linux`, `macos`, `windows` or `android`. Omit to let the driver label itself.",
         "type": [
           "string",
           "null"

--- a/database/src/handlers/diagram.rs
+++ b/database/src/handlers/diagram.rs
@@ -115,12 +115,9 @@ pub struct SchemaDiagramReq {
     pub max_tables: usize,
     #[serde(default = "default_timeout")]
     pub timeout_ms: u64,
-    /// Lay out only the neighbourhood of this table.
-    ///
-    /// A whole schema drawn at once answers "what exists"; it does not answer
-    /// "what does this table touch", which is the question actually being
-    /// asked most of the time. With a focus the diagram becomes explorable
-    /// one hop at a time instead of a wall to be scanned.
+    /// Lay out only the neighbourhood of this table, `depth` hops out.
+    // A whole schema drawn at once answers "what exists", not "what does this
+    // table touch"; a focus makes the diagram explorable one hop at a time.
     #[serde(default)]
     pub focus: Option<String>,
     /// How many foreign-key hops out from `focus` to include. Ignored without

--- a/database/src/handlers/execute_batch.rs
+++ b/database/src/handlers/execute_batch.rs
@@ -17,9 +17,8 @@ pub struct ExecuteBatchReq {
     /// configured database, or `primary` when several are configured.
     #[serde(default)]
     pub db: Option<String>,
-    /// Statements to run in order inside one transaction. Each entry is
-    /// either a bare SQL string or `{ "sql": "...", "params": [...] }` —
-    /// use `params` for dynamic values instead of inlining them into the SQL.
+    /// Statements to run in order inside one transaction. Put dynamic values
+    /// in `params`, not inline in the SQL.
     #[serde(deserialize_with = "lenient_statements")]
     pub statements: Vec<BatchStatement>,
     /// Optional: `read_committed` | `repeatable_read` | `serializable`.

--- a/database/src/handlers/filter.rs
+++ b/database/src/handlers/filter.rs
@@ -46,10 +46,9 @@ pub enum FilterOp {
     IsNotNull,
     /// NULL or the empty string. Distinct from `is_null` on purpose.
     IsEmpty,
-    /// Set membership, over `values`. Expressing "status is one of open,
-    /// pending, held" as three OR'd equality filters is not possible here —
-    /// filters stack with AND — so without this the question cannot be asked
-    /// at all.
+    /// Set membership, over `values`.
+    // Filters stack with AND, so "status is one of open, pending, held" cannot
+    // be expressed as OR'd equality filters; without this it cannot be asked.
     In,
     NotIn,
 }
@@ -98,9 +97,9 @@ pub struct FilterSpec {
     /// Postgres only. Rejected elsewhere rather than silently ignored.
     #[serde(default)]
     pub case_sensitive: Option<bool>,
-    /// Kept in the list but not applied. A caller refining a query wants to
-    /// switch one condition off and back on without losing how it was built,
-    /// and a console that only offers delete makes that a retype.
+    /// Kept in the list but not applied.
+    // Lets a caller switch one condition off and back on without losing how
+    // it was built; a console that only offers delete makes that a retype.
     #[serde(default)]
     pub disabled: bool,
 }
@@ -119,9 +118,9 @@ pub enum NullsPosition {
     Last,
 }
 
-/// Type-aware sort modes. These exist server-side because the grid is paged:
-/// sorting the fetched page would order 50 rows out of N, which is a
-/// different answer from sorting the table.
+/// Type-aware sort modes, applied server-side over the whole table.
+// They exist here because the grid is paged: sorting the fetched page would
+// order 50 rows out of N, a different answer from sorting the table.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum SortMode {

--- a/database/src/handlers/query.rs
+++ b/database/src/handlers/query.rs
@@ -22,13 +22,12 @@ pub struct QueryReq {
     #[serde(default = "default_timeout")]
     pub timeout_ms: u64,
     /// Whether this run belongs in `database::history`.
-    ///
-    /// Internal only — never deserialized, so a statement arriving over the
-    /// wire always records. The catalog reads behind `describeSchema`,
-    /// `browseTable`, `columnStats`, `explain` and `schemaDiagram` all run
-    /// through this same path, and recording them would bury the statements a
-    /// person actually typed under `PRAGMA table_info(...)` and spawn a
-    /// `state::update` per internal read.
+    // Internal only — never deserialized, so a statement arriving over the
+    // wire always records. The catalog reads behind `describeSchema`,
+    // `browseTable`, `columnStats`, `explain` and `schemaDiagram` all run
+    // through this same path, and recording them would bury the statements a
+    // person actually typed under `PRAGMA table_info(...)` and spawn a
+    // `state::update` per internal read.
     #[serde(skip, default = "records_history")]
     pub record_history: bool,
 }

--- a/database/src/handlers/schema.rs
+++ b/database/src/handlers/schema.rs
@@ -109,9 +109,8 @@ pub struct TableDescription {
 pub struct DescribeTableReq {
     #[serde(default)]
     pub db: Option<String>,
-    /// Table or view name. May be schema-qualified (`analytics.events`) on
-    /// postgres; prefer the explicit `schema` field when the name itself
-    /// contains a dot.
+    /// Table or view name; may be schema-qualified (`analytics.events`) on
+    /// postgres. Use `schema` when the name itself contains a dot.
     pub table: String,
     #[serde(default)]
     pub schema: Option<String>,

--- a/database/src/handlers/table_view.rs
+++ b/database/src/handlers/table_view.rs
@@ -42,9 +42,8 @@ pub struct TableView {
     /// Columns the reader has hidden. Order is not meaningful.
     #[serde(default)]
     pub hidden: Vec<String>,
-    /// Column display order. Names not listed keep their natural position
-    /// after those that are, so adding a column to the table does not require
-    /// re-saving the view.
+    /// Column display order. Unlisted columns keep their natural position
+    /// after the listed ones.
     #[serde(default)]
     pub order: Vec<String>,
 }

--- a/database/src/triggers/bus.rs
+++ b/database/src/triggers/bus.rs
@@ -32,9 +32,9 @@ pub const ROW_CHANGED_TYPE: &str = "database::row-changed";
 #[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct RowChangedConfig {
-    /// Database handle, as named in the worker's config. Required — a binding
-    /// that watched every database would fire for traffic its owner never
-    /// asked about.
+    /// Database handle, as named in the worker's config.
+    // Required: a binding that watched every database would fire for traffic
+    // its owner never asked about.
     pub db: String,
     /// Table filter. Matched case-insensitively and ignoring a schema
     /// qualifier. Omit to hear every table in the database.

--- a/database/src/triggers/sql.rs
+++ b/database/src/triggers/sql.rs
@@ -20,9 +20,8 @@ pub enum Op {
     Insert,
     Update,
     Delete,
-    /// Recognisably a write, but not one of the three above (a CTE-wrapped
-    /// statement, `MERGE`, a driver-specific form). Subscribers still hear
-    /// about it.
+    /// A write that is none of the above: a CTE-wrapped statement, `MERGE`,
+    /// a driver-specific form.
     Other,
 }
 

--- a/document/src/format.rs
+++ b/document/src/format.rs
@@ -16,9 +16,8 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-/// A format this worker converts. The names are the wire vocabulary: stable,
-/// lowercase, and independent of the file extension that named them (`.docm`
-/// is `docx`, `.xlsb` is `excel`).
+/// A format this worker converts. Names are independent of the file extension
+/// that named them (`.docm` is `docx`, `.xlsb` is `excel`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum Format {

--- a/document/src/functions/markdown.rs
+++ b/document/src/functions/markdown.rs
@@ -27,10 +27,9 @@ use crate::source::{describe_error, Body, DocumentSource};
 
 pub const ID: &str = "document::to-markdown";
 pub const DESC: &str = "Convert a Word, PowerPoint, Excel, OpenDocument, RTF, EPUB, CSV or PDF \
-                        document to markdown, preserving headings, lists, links and tables. The \
-                        format is detected from the bytes. Responses are capped; pass max_chars 0 \
-                        to take the whole document. For a PDF prefer pdf::classify first, which \
-                        reports which pages need OCR.";
+                        document to markdown, preserving headings, lists, links and tables. \
+                        Responses are capped; pass max_chars 0 for the whole document. For a PDF \
+                        run pdf::classify first to find pages needing OCR.";
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct Request {

--- a/document/src/functions/ocr.rs
+++ b/document/src/functions/ocr.rs
@@ -31,11 +31,10 @@ use crate::format::{self, Format};
 use crate::source::{Body, DocumentSource};
 
 pub const ID: &str = "document::ocr";
-pub const DESC: &str = "Transcribe a document that holds no readable text: a scanned PDF, a \
-                        photographed page, or a deck whose content is pictures. Renders the pages \
-                        that need it and reads them with a vision model, so it costs money per \
-                        page — pass `pages` (pdf::classify names them) to narrow it. Needs the \
-                        browser worker for PDFs and a vision model through llm-router.";
+pub const DESC: &str = "Transcribe a document with no readable text (scanned PDF, photographed \
+                        page, picture-only deck) by rendering its pages and reading them with a \
+                        vision model. Costs money per page: pass `pages` (pdf::classify names \
+                        them) to narrow it.";
 
 /// The prompt every page is read with.
 ///
@@ -53,10 +52,8 @@ pub struct Request {
     #[serde(flatten)]
     pub source: DocumentSource,
 
-    /// 1-indexed pages to transcribe, for a PDF. Omit for every page up to the
-    /// configured ceiling. This is the cost control: `pdf::classify` reports
-    /// which pages are scans, and passing that list keeps a long report from
-    /// being read a page at a time when only its cover is an image.
+    /// 1-indexed PDF pages to transcribe; omit for every page up to the
+    /// configured ceiling. Pass the scan pages `pdf::classify` reports.
     #[serde(default)]
     pub pages: Option<Vec<u32>>,
 

--- a/document/src/source.rs
+++ b/document/src/source.rs
@@ -18,13 +18,11 @@ use std::path::Path;
 
 use crate::config::WorkerConfig;
 
-/// The filesystem jail a call runs under.
-///
-/// The harness stamps this onto every function it dispatches, so a `path` an
-/// agent supplies has to be checked against it. Without the check these
-/// functions would read any document on the machine and hand back its text,
-/// which is a way around the scope the session was granted. Mirrors the shape
-/// the shell and pdf workers take.
+/// The filesystem jail a call runs under; `path` is checked against it.
+// The harness stamps this onto every function it dispatches. Without the check
+// these functions would read any document on the machine, a way around the
+// scope the session was granted. Mirrors the shape the shell and pdf workers
+// take.
 #[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
 pub struct FsScope {
     /// The session's working directory.
@@ -48,15 +46,13 @@ pub struct DocumentSource {
     #[serde(default)]
     pub bytes_base64: Option<String>,
 
-    /// Original file name for inline bytes, used only to recognise a format
-    /// the content cannot name. A `.csv` needs this; nothing else does.
-    /// Ignored when `path` is set, which carries its own name.
+    /// Original file name for `bytes_base64`, used only to recognise a format
+    /// the content cannot name (`.csv`). Ignored when `path` is set.
     #[serde(default)]
     pub file_name: Option<String>,
 
-    /// The filesystem jail this call runs under. Stamped by the harness on an
-    /// agent's call; absent on an operator or console call, which is already
-    /// user-initiated and not subject to the agent's scope.
+    /// Filesystem jail for this call. Stamped by the harness on an agent's
+    /// call; absent on an operator or console call.
     #[serde(default)]
     pub fs_scope: Option<FsScope>,
 }

--- a/document/tests/golden/schemas/document.detect.json
+++ b/document/tests/golden/schemas/document.detect.json
@@ -5,7 +5,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
       "FsScope": {
-        "description": "The filesystem jail a call runs under.\n\nThe harness stamps this onto every function it dispatches, so a `path` an agent supplies has to be checked against it. Without the check these functions would read any document on the machine and hand back its text, which is a way around the scope the session was granted. Mirrors the shape the shell and pdf workers take.",
+        "description": "The filesystem jail a call runs under; `path` is checked against it.",
         "properties": {
           "grants": {
             "default": [],
@@ -38,7 +38,7 @@
       },
       "file_name": {
         "default": null,
-        "description": "Original file name for inline bytes, used only to recognise a format the content cannot name. A `.csv` needs this; nothing else does. Ignored when `path` is set, which carries its own name.",
+        "description": "Original file name for `bytes_base64`, used only to recognise a format the content cannot name (`.csv`). Ignored when `path` is set.",
         "type": [
           "string",
           "null"
@@ -53,7 +53,7 @@
             "type": "null"
           }
         ],
-        "description": "The filesystem jail this call runs under. Stamped by the harness on an agent's call; absent on an operator or console call, which is already user-initiated and not subject to the agent's scope."
+        "description": "Filesystem jail for this call. Stamped by the harness on an agent's call; absent on an operator or console call."
       },
       "path": {
         "default": null,
@@ -137,7 +137,7 @@
         ]
       },
       "Format": {
-        "description": "A format this worker converts. The names are the wire vocabulary: stable, lowercase, and independent of the file extension that named them (`.docm` is `docx`, `.xlsb` is `excel`).",
+        "description": "A format this worker converts. Names are independent of the file extension that named them (`.docm` is `docx`, `.xlsb` is `excel`).",
         "oneOf": [
           {
             "description": "Binary Word 97-2003 (`.doc`).",

--- a/document/tests/golden/schemas/document.extract-assets.json
+++ b/document/tests/golden/schemas/document.extract-assets.json
@@ -5,7 +5,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
       "Format": {
-        "description": "A format this worker converts. The names are the wire vocabulary: stable, lowercase, and independent of the file extension that named them (`.docm` is `docx`, `.xlsb` is `excel`).",
+        "description": "A format this worker converts. Names are independent of the file extension that named them (`.docm` is `docx`, `.xlsb` is `excel`).",
         "oneOf": [
           {
             "description": "Binary Word 97-2003 (`.doc`).",
@@ -94,7 +94,7 @@
         ]
       },
       "FsScope": {
-        "description": "The filesystem jail a call runs under.\n\nThe harness stamps this onto every function it dispatches, so a `path` an agent supplies has to be checked against it. Without the check these functions would read any document on the machine and hand back its text, which is a way around the scope the session was granted. Mirrors the shape the shell and pdf workers take.",
+        "description": "The filesystem jail a call runs under; `path` is checked against it.",
         "properties": {
           "grants": {
             "default": [],
@@ -127,7 +127,7 @@
       },
       "file_name": {
         "default": null,
-        "description": "Original file name for inline bytes, used only to recognise a format the content cannot name. A `.csv` needs this; nothing else does. Ignored when `path` is set, which carries its own name.",
+        "description": "Original file name for `bytes_base64`, used only to recognise a format the content cannot name (`.csv`). Ignored when `path` is set.",
         "type": [
           "string",
           "null"
@@ -154,7 +154,7 @@
             "type": "null"
           }
         ],
-        "description": "The filesystem jail this call runs under. Stamped by the harness on an agent's call; absent on an operator or console call, which is already user-initiated and not subject to the agent's scope."
+        "description": "Filesystem jail for this call. Stamped by the harness on an agent's call; absent on an operator or console call."
       },
       "include_bytes": {
         "default": true,
@@ -241,7 +241,7 @@
         "type": "object"
       },
       "Format": {
-        "description": "A format this worker converts. The names are the wire vocabulary: stable, lowercase, and independent of the file extension that named them (`.docm` is `docx`, `.xlsb` is `excel`).",
+        "description": "A format this worker converts. Names are independent of the file extension that named them (`.docm` is `docx`, `.xlsb` is `excel`).",
         "oneOf": [
           {
             "description": "Binary Word 97-2003 (`.doc`).",

--- a/document/tests/golden/schemas/document.ocr.json
+++ b/document/tests/golden/schemas/document.ocr.json
@@ -1,11 +1,11 @@
 {
-  "description": "Transcribe a document that holds no readable text: a scanned PDF, a photographed page, or a deck whose content is pictures. Renders the pages that need it and reads them with a vision model, so it costs money per page — pass `pages` (pdf::classify names them) to narrow it. Needs the browser worker for PDFs and a vision model through llm-router.",
+  "description": "Transcribe a document with no readable text (scanned PDF, photographed page, picture-only deck) by rendering its pages and reading them with a vision model. Costs money per page: pass `pages` (pdf::classify names them) to narrow it.",
   "function_id": "document::ocr",
   "request_schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
       "FsScope": {
-        "description": "The filesystem jail a call runs under.\n\nThe harness stamps this onto every function it dispatches, so a `path` an agent supplies has to be checked against it. Without the check these functions would read any document on the machine and hand back its text, which is a way around the scope the session was granted. Mirrors the shape the shell and pdf workers take.",
+        "description": "The filesystem jail a call runs under; `path` is checked against it.",
         "properties": {
           "grants": {
             "default": [],
@@ -38,7 +38,7 @@
       },
       "file_name": {
         "default": null,
-        "description": "Original file name for inline bytes, used only to recognise a format the content cannot name. A `.csv` needs this; nothing else does. Ignored when `path` is set, which carries its own name.",
+        "description": "Original file name for `bytes_base64`, used only to recognise a format the content cannot name (`.csv`). Ignored when `path` is set.",
         "type": [
           "string",
           "null"
@@ -53,7 +53,7 @@
             "type": "null"
           }
         ],
-        "description": "The filesystem jail this call runs under. Stamped by the harness on an agent's call; absent on an operator or console call, which is already user-initiated and not subject to the agent's scope."
+        "description": "Filesystem jail for this call. Stamped by the harness on an agent's call; absent on an operator or console call."
       },
       "max_chars": {
         "default": null,
@@ -75,7 +75,7 @@
       },
       "pages": {
         "default": null,
-        "description": "1-indexed pages to transcribe, for a PDF. Omit for every page up to the configured ceiling. This is the cost control: `pdf::classify` reports which pages are scans, and passing that list keeps a long report from being read a page at a time when only its cover is an image.",
+        "description": "1-indexed PDF pages to transcribe; omit for every page up to the configured ceiling. Pass the scan pages `pdf::classify` reports.",
         "items": {
           "format": "uint32",
           "minimum": 0.0,

--- a/document/tests/golden/schemas/document.to-markdown.json
+++ b/document/tests/golden/schemas/document.to-markdown.json
@@ -1,11 +1,11 @@
 {
-  "description": "Convert a Word, PowerPoint, Excel, OpenDocument, RTF, EPUB, CSV or PDF document to markdown, preserving headings, lists, links and tables. The format is detected from the bytes. Responses are capped; pass max_chars 0 to take the whole document. For a PDF prefer pdf::classify first, which reports which pages need OCR.",
+  "description": "Convert a Word, PowerPoint, Excel, OpenDocument, RTF, EPUB, CSV or PDF document to markdown, preserving headings, lists, links and tables. Responses are capped; pass max_chars 0 for the whole document. For a PDF run pdf::classify first to find pages needing OCR.",
   "function_id": "document::to-markdown",
   "request_schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
       "Format": {
-        "description": "A format this worker converts. The names are the wire vocabulary: stable, lowercase, and independent of the file extension that named them (`.docm` is `docx`, `.xlsb` is `excel`).",
+        "description": "A format this worker converts. Names are independent of the file extension that named them (`.docm` is `docx`, `.xlsb` is `excel`).",
         "oneOf": [
           {
             "description": "Binary Word 97-2003 (`.doc`).",
@@ -94,7 +94,7 @@
         ]
       },
       "FsScope": {
-        "description": "The filesystem jail a call runs under.\n\nThe harness stamps this onto every function it dispatches, so a `path` an agent supplies has to be checked against it. Without the check these functions would read any document on the machine and hand back its text, which is a way around the scope the session was granted. Mirrors the shape the shell and pdf workers take.",
+        "description": "The filesystem jail a call runs under; `path` is checked against it.",
         "properties": {
           "grants": {
             "default": [],
@@ -127,7 +127,7 @@
       },
       "file_name": {
         "default": null,
-        "description": "Original file name for inline bytes, used only to recognise a format the content cannot name. A `.csv` needs this; nothing else does. Ignored when `path` is set, which carries its own name.",
+        "description": "Original file name for `bytes_base64`, used only to recognise a format the content cannot name (`.csv`). Ignored when `path` is set.",
         "type": [
           "string",
           "null"
@@ -154,7 +154,7 @@
             "type": "null"
           }
         ],
-        "description": "The filesystem jail this call runs under. Stamped by the harness on an agent's call; absent on an operator or console call, which is already user-initiated and not subject to the agent's scope."
+        "description": "Filesystem jail for this call. Stamped by the harness on an agent's call; absent on an operator or console call."
       },
       "max_chars": {
         "default": null,
@@ -287,7 +287,7 @@
         ]
       },
       "Format": {
-        "description": "A format this worker converts. The names are the wire vocabulary: stable, lowercase, and independent of the file extension that named them (`.docm` is `docx`, `.xlsb` is `excel`).",
+        "description": "A format this worker converts. Names are independent of the file extension that named them (`.docm` is `docx`, `.xlsb` is `excel`).",
         "oneOf": [
           {
             "description": "Binary Word 97-2003 (`.doc`).",

--- a/editor/src/functions/mod.rs
+++ b/editor/src/functions/mod.rs
@@ -40,10 +40,9 @@ pub const DESC_WORKSPACE_GET: &str =
     "The active workspace: its root, the files open against it, and which folders are \
      expanded. Shared by every surface, so this is what the agent and the console both see.";
 pub const DESC_CHANGES: &str =
-    "Recent file changes in the workspace, newest first, one entry per path. Recorded by \
-     the observer for every change however it was made, so it answers what happened while \
-     nothing was watching. Each entry carries the patch, the line counts, the function that \
-     performed the write, and the harness session and turn it happened in.";
+    "Recent file changes in the workspace, newest first, one entry per path, recorded \
+     however the write was made. Each entry carries the patch, line counts, the function \
+     that wrote, and the harness session and turn.";
 pub const DESC_TREE: &str =
     "List a folder in the workspace, with the expansion state the workspace remembers. \
      The walk, the noise-folder excludes and the jail are the shell worker's.";

--- a/editor/src/functions/types.rs
+++ b/editor/src/functions/types.rs
@@ -15,9 +15,8 @@ use crate::workspace::Buffer;
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct WorkspaceOpenInput {
-    /// Directory to work in. Jail-relative when shell's `fs.host_roots` are
-    /// set, else absolute. A plain folder is enough — a git repository is an
-    /// overlay, never a requirement.
+    /// Directory to work in: jail-relative when shell's `fs.host_roots` are
+    /// set, else absolute. Need not be a git repository.
     pub root: String,
 }
 
@@ -235,8 +234,7 @@ pub struct TreeInput {
     #[serde(default)]
     pub max_depth: Option<u32>,
     /// Root-relative folders to mark expanded before listing. Expansion is
-    /// part of the shared workspace, so it survives a reload and both surfaces
-    /// agree on it.
+    /// shared workspace state, so it survives a reload.
     #[serde(default)]
     pub expand: Vec<String>,
     /// Root-relative folders to collapse. Collapsing takes its descendants
@@ -343,9 +341,8 @@ pub enum Against {
     Index,
     /// Everything since the last commit: working tree vs HEAD.
     Head,
-    /// Everything not yet pushed: working tree vs the branch's upstream
-    /// (`@{upstream}`). Fails when the branch has no upstream configured,
-    /// which is a real answer rather than an error to swallow.
+    /// Everything not yet pushed: working tree vs `@{upstream}`. Fails when
+    /// the branch has no upstream configured.
     Upstream,
 }
 
@@ -370,10 +367,8 @@ pub struct GitHunksInput {
     /// Which comparison to make. Defaults to `worktree`.
     #[serde(default)]
     pub against: Against,
-    /// Unchanged lines kept around each hunk in `patch`. Defaults to 0, which
-    /// keeps `hunks` exactly the lines that changed — the ranges a gutter
-    /// paints. Pass 3 or so for a patch a person will read, and note that the
-    /// reported ranges widen to include the context you asked for.
+    /// Context lines around each hunk. Default 0 keeps `hunks` to exactly the
+    /// changed lines; a non-zero value widens the reported ranges too.
     #[serde(default)]
     pub context_lines: Option<u32>,
 }
@@ -607,17 +602,15 @@ mod request_tests {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct FindInput {
-    /// Fuzzy query. Matched as a subsequence against every tracked path, with
-    /// basename and word-boundary hits ranked highest. Empty returns the first
-    /// `limit` paths unranked.
+    /// Fuzzy subsequence query over candidate paths; basename and
+    /// word-boundary hits rank highest. Empty returns the first `limit` paths
+    /// unranked.
     pub query: String,
     /// Rows to return. Defaults to the worker's `find_limit`.
     #[serde(default)]
     pub limit: Option<u32>,
-    /// Include files git does not track yet (still honouring `.gitignore`).
-    /// On by default — a file the agent just created is exactly the one you
-    /// are looking for. Ignored outside a repository, where the workspace
-    /// listing is the source of candidates.
+    /// Include files git does not track yet, still honouring `.gitignore`.
+    /// Ignored outside a repository.
     #[serde(default = "default_true")]
     pub include_untracked: bool,
 }
@@ -690,26 +683,19 @@ pub struct SaveInput {
     pub path: String,
     /// Full new contents. This is a whole-file write, not a patch.
     pub content: String,
-    /// The `mtime` from the `editor::open` this edit started from. When it no
-    /// longer matches the file on disk, the write is refused and the
-    /// divergence comes back as a patch. Omit only when deliberately
-    /// overwriting whatever is there.
-    ///
-    /// Resolution is one second, which is all the filesystem reports. Two
-    /// writes inside the same second are therefore indistinguishable to this
-    /// field, and the second one wins silently — send `expected_version`
-    /// instead to close that window.
+    /// `mtime` from the `editor::open` this edit started from (1s resolution).
+    /// A mismatch refuses the write and returns the divergence as a patch.
+    // Two writes inside the same filesystem second are indistinguishable here
+    // and the second wins silently; `expected_version` closes that window.
+    // Omit both guards only to deliberately overwrite whatever is there.
     #[serde(default)]
     pub expected_mtime: Option<i64>,
-    /// The `version` from the `editor::open` — or from the previous
-    /// `editor::save` — this edit started from. It is a version of the
-    /// *content*, so it catches a write that landed inside the same filesystem
-    /// second and it does not care whether a clock or a checkout moved the
-    /// mtime.
-    ///
-    /// When this is present it is the guard and `expected_mtime` is ignored.
-    /// When it is absent the `expected_mtime` comparison applies exactly as
-    /// before, so a caller that has never heard of a version is unaffected.
+    /// `version` from the `editor::open` or `editor::save` this edit started
+    /// from. When present it is the guard and `expected_mtime` is ignored.
+    // A version of the *content*: catches a write inside the same filesystem
+    // second and ignores a clock or checkout moving the mtime. Absent, the
+    // `expected_mtime` comparison applies as before, so version-unaware
+    // callers are unaffected.
     #[serde(default)]
     pub expected_version: Option<String>,
 }

--- a/editor/tests/golden/schemas/editor.changes.json
+++ b/editor/tests/golden/schemas/editor.changes.json
@@ -1,5 +1,5 @@
 {
-  "description": "Recent file changes in the workspace, newest first, one entry per path. Recorded by the observer for every change however it was made, so it answers what happened while nothing was watching. Each entry carries the patch, the line counts, the function that performed the write, and the harness session and turn it happened in.",
+  "description": "Recent file changes in the workspace, newest first, one entry per path, recorded however the write was made. Each entry carries the patch, line counts, the function that wrote, and the harness session and turn.",
   "function_id": "editor::changes",
   "request_schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/editor/tests/golden/schemas/editor.find.json
+++ b/editor/tests/golden/schemas/editor.find.json
@@ -6,7 +6,7 @@
     "properties": {
       "include_untracked": {
         "default": true,
-        "description": "Include files git does not track yet (still honouring `.gitignore`). On by default — a file the agent just created is exactly the one you are looking for. Ignored outside a repository, where the workspace listing is the source of candidates.",
+        "description": "Include files git does not track yet, still honouring `.gitignore`. Ignored outside a repository.",
         "type": "boolean"
       },
       "limit": {
@@ -20,7 +20,7 @@
         ]
       },
       "query": {
-        "description": "Fuzzy query. Matched as a subsequence against every tracked path, with basename and word-boundary hits ranked highest. Empty returns the first `limit` paths unranked.",
+        "description": "Fuzzy subsequence query over candidate paths; basename and word-boundary hits rank highest. Empty returns the first `limit` paths unranked.",
         "type": "string"
       }
     },

--- a/editor/tests/golden/schemas/editor.git.hunks.json
+++ b/editor/tests/golden/schemas/editor.git.hunks.json
@@ -29,7 +29,7 @@
             "type": "string"
           },
           {
-            "description": "Everything not yet pushed: working tree vs the branch's upstream (`@{upstream}`). Fails when the branch has no upstream configured, which is a real answer rather than an error to swallow.",
+            "description": "Everything not yet pushed: working tree vs `@{upstream}`. Fails when the branch has no upstream configured.",
             "enum": [
               "upstream"
             ],
@@ -50,7 +50,7 @@
       },
       "context_lines": {
         "default": null,
-        "description": "Unchanged lines kept around each hunk in `patch`. Defaults to 0, which keeps `hunks` exactly the lines that changed — the ranges a gutter paints. Pass 3 or so for a patch a person will read, and note that the reported ranges widen to include the context you asked for.",
+        "description": "Context lines around each hunk. Default 0 keeps `hunks` to exactly the changed lines; a non-zero value widens the reported ranges too.",
         "format": "uint32",
         "minimum": 0.0,
         "type": [
@@ -105,7 +105,7 @@
             "type": "string"
           },
           {
-            "description": "Everything not yet pushed: working tree vs the branch's upstream (`@{upstream}`). Fails when the branch has no upstream configured, which is a real answer rather than an error to swallow.",
+            "description": "Everything not yet pushed: working tree vs `@{upstream}`. Fails when the branch has no upstream configured.",
             "enum": [
               "upstream"
             ],

--- a/editor/tests/golden/schemas/editor.save.json
+++ b/editor/tests/golden/schemas/editor.save.json
@@ -10,7 +10,7 @@
       },
       "expected_mtime": {
         "default": null,
-        "description": "The `mtime` from the `editor::open` this edit started from. When it no longer matches the file on disk, the write is refused and the divergence comes back as a patch. Omit only when deliberately overwriting whatever is there.\n\nResolution is one second, which is all the filesystem reports. Two writes inside the same second are therefore indistinguishable to this field, and the second one wins silently — send `expected_version` instead to close that window.",
+        "description": "`mtime` from the `editor::open` this edit started from (1s resolution). A mismatch refuses the write and returns the divergence as a patch.",
         "format": "int64",
         "type": [
           "integer",
@@ -19,7 +19,7 @@
       },
       "expected_version": {
         "default": null,
-        "description": "The `version` from the `editor::open` — or from the previous `editor::save` — this edit started from. It is a version of the *content*, so it catches a write that landed inside the same filesystem second and it does not care whether a clock or a checkout moved the mtime.\n\nWhen this is present it is the guard and `expected_mtime` is ignored. When it is absent the `expected_mtime` comparison applies exactly as before, so a caller that has never heard of a version is unaffected.",
+        "description": "`version` from the `editor::open` or `editor::save` this edit started from. When present it is the guard and `expected_mtime` is ignored.",
         "type": [
           "string",
           "null"

--- a/editor/tests/golden/schemas/editor.tree.json
+++ b/editor/tests/golden/schemas/editor.tree.json
@@ -14,7 +14,7 @@
       },
       "expand": {
         "default": [],
-        "description": "Root-relative folders to mark expanded before listing. Expansion is part of the shared workspace, so it survives a reload and both surfaces agree on it.",
+        "description": "Root-relative folders to mark expanded before listing. Expansion is shared workspace state, so it survives a reload.",
         "items": {
           "type": "string"
         },

--- a/editor/tests/golden/schemas/editor.workspace.open.json
+++ b/editor/tests/golden/schemas/editor.workspace.open.json
@@ -5,7 +5,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "properties": {
       "root": {
-        "description": "Directory to work in. Jail-relative when shell's `fs.host_roots` are set, else absolute. A plain folder is enough — a git repository is an overlay, never a requirement.",
+        "description": "Directory to work in: jail-relative when shell's `fs.host_roots` are set, else absolute. Need not be a git repository.",
         "type": "string"
       }
     },

--- a/email/src/handlers/search.rs
+++ b/email/src/handlers/search.rs
@@ -88,13 +88,10 @@ pub fn register(iii: &Arc<IIIClient>, pool: &Arc<crate::provider::imap::ImapPool
             }
         })
         .description(
-            "Stream search results from an account's IMAP. Payload: \
-             { account, folder?='INBOX', query }. `query` is IMAP SEARCH syntax \
-             (RFC 9051), e.g. 'FROM alice@x SINCE 1-Jan-2026' or 'UNSEEN \
-             SUBJECT \"invoice\"'. Returns NDJSON frames on the response channel; \
-             each frame is { uid, message_id, from, subject, snippet, ts, seen, \
-             flagged }. Channel closes when search completes. No polling — frames \
-             stream as IMAP returns matches.",
+            "Stream search results from an account's IMAP folder. `query` is IMAP SEARCH \
+             syntax (RFC 9051), e.g. 'FROM alice@x SINCE 1-Jan-2026'. Frames \
+             { uid, message_id, from, subject, snippet, ts, seen, flagged } stream as NDJSON \
+             on the response channel, which closes when the search completes.",
         ),
     );
 }

--- a/email/src/handlers/send.rs
+++ b/email/src/handlers/send.rs
@@ -109,16 +109,9 @@ pub fn register(iii: &Arc<IIIClient>, cell: &ConfigCell) {
             }
         })
         .description(
-            "Send an email via the account's SMTP transport. Payload: \
-             { account: string (key from email worker config), to: string[], \
-             cc?: string[], bcc?: string[], subject: string, html?: string, \
-             text?: string, reply_to?: string, in_reply_to?: string (Message-ID), \
-             references?: string[], attachments?: [{ filename, content_type, \
-             source: { kind: 'base64', data } }] }. Returns { message_id }. \
+            "Send an email via the account's SMTP transport; provide `html`, `text` or both. \
              The SMTP login comes from the account's `smtp.username` / `smtp.password` \
-             configuration, or from `auth::get_token` under provider key `email::<account>` \
-             when the configuration carries none. Provide html OR text (or both); at least \
-             one body is required.",
+             configuration, else from `auth::get_token` under provider key `email::<account>`.",
         ),
     );
 }

--- a/email/src/provider/smtp.rs
+++ b/email/src/provider/smtp.rs
@@ -25,9 +25,9 @@ pub struct Attachment {
 #[derive(Debug, Deserialize, JsonSchema, Clone)]
 #[serde(tag = "kind", rename_all = "lowercase")]
 pub enum AttachmentSource {
-    /// Inline base64 bytes. Best for LLM tool-use; bounces the full payload
-    /// through the engine. For large files prefer a sidecar upload via the
-    /// `storage` worker followed by a future stream-source variant.
+    /// Inline base64 bytes.
+    // Bounces the full payload through the engine; a stream-source variant fed
+    // by a `storage` worker upload is the intended path for large files.
     Base64(String),
 }
 

--- a/github/src/functions/passthrough.rs
+++ b/github/src/functions/passthrough.rs
@@ -13,10 +13,10 @@ use crate::events::{self, CalledEmitter};
 use crate::gh;
 
 pub const EXEC_ID: &str = "github::exec";
-pub const EXEC_DESC: &str = "Run any gh command: { args: [\"pr\", \"list\", \"-R\", \"owner/name\"], stdin?, timeout_ms? } -> { stdout, stderr, exit_code, duration_ms, timed_out, stdout_truncated, stderr_truncated }. A non-zero exit or a timeout is DATA here, not an error. The escape hatch for everything without a typed github::* function.";
+pub const EXEC_DESC: &str = "Run any gh command; `args` is the argv without the leading `gh`. A non-zero exit or a timeout is returned as data, not an error. The escape hatch for everything without a typed github::* function.";
 
 pub const API_ID: &str = "github::api";
-pub const API_DESC: &str = "Call any GitHub REST endpoint via gh api: { path: \"repos/OWNER/REPO/issues\", method?, fields?, body?, jq?, paginate?, timeout_ms? } -> { value: <parsed JSON> }. fields become -f key=value form fields (default method flips to POST); body is sent verbatim as the JSON request body. Non-2xx responses are errors carrying gh's stderr.";
+pub const API_DESC: &str = "Call any GitHub REST endpoint via gh api and return the parsed JSON. `fields` become `-f key=value` form fields and flip the default method to POST; `body` is sent verbatim as JSON. Non-2xx responses are errors carrying gh's stderr.";
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ExecRequest {
@@ -30,9 +30,8 @@ pub struct ExecRequest {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ApiRequest {
-    /// Endpoint path, with concrete owner/repo values (e.g. "rate_limit" or
-    /// "repos/cli/cli/issues") — placeholder expansion needs a checkout the
-    /// worker does not have.
+    /// Endpoint path with concrete owner/repo values, e.g. "rate_limit" or
+    /// "repos/cli/cli/issues"; `{owner}` placeholders are not expanded.
     pub path: String,
     /// HTTP method. gh defaults to GET, or POST when fields/body are present.
     pub method: Option<String>,

--- a/github/tests/golden/schemas/github.api.json
+++ b/github/tests/golden/schemas/github.api.json
@@ -1,5 +1,5 @@
 {
-  "description": "Call any GitHub REST endpoint via gh api: { path: \"repos/OWNER/REPO/issues\", method?, fields?, body?, jq?, paginate?, timeout_ms? } -> { value: <parsed JSON> }. fields become -f key=value form fields (default method flips to POST); body is sent verbatim as the JSON request body. Non-2xx responses are errors carrying gh's stderr.",
+  "description": "Call any GitHub REST endpoint via gh api and return the parsed JSON. `fields` become `-f key=value` form fields and flip the default method to POST; `body` is sent verbatim as JSON. Non-2xx responses are errors carrying gh's stderr.",
   "function_id": "github::api",
   "request_schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -39,7 +39,7 @@
         ]
       },
       "path": {
-        "description": "Endpoint path, with concrete owner/repo values (e.g. \"rate_limit\" or \"repos/cli/cli/issues\") — placeholder expansion needs a checkout the worker does not have.",
+        "description": "Endpoint path with concrete owner/repo values, e.g. \"rate_limit\" or \"repos/cli/cli/issues\"; `{owner}` placeholders are not expanded.",
         "type": "string"
       },
       "timeout_ms": {

--- a/github/tests/golden/schemas/github.exec.json
+++ b/github/tests/golden/schemas/github.exec.json
@@ -1,5 +1,5 @@
 {
-  "description": "Run any gh command: { args: [\"pr\", \"list\", \"-R\", \"owner/name\"], stdin?, timeout_ms? } -> { stdout, stderr, exit_code, duration_ms, timed_out, stdout_truncated, stderr_truncated }. A non-zero exit or a timeout is DATA here, not an error. The escape hatch for everything without a typed github::* function.",
+  "description": "Run any gh command; `args` is the argv without the leading `gh`. A non-zero exit or a timeout is returned as data, not an error. The escape hatch for everything without a typed github::* function.",
   "function_id": "github::exec",
   "request_schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/security-scan/src/contract.rs
+++ b/security-scan/src/contract.rs
@@ -166,8 +166,8 @@ pub struct SecurityScanResponseV1 {
     pub deduplicated: bool,
 }
 
-/// Payload emitted by the iii cron trigger. Its values are observability data
-/// only; the handler resolves all scan inputs from operator configuration.
+/// Payload emitted by the iii cron trigger. Values are observability data
+/// only; scan inputs come from operator configuration.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct SecurityScanScheduleEventV1 {
     pub trigger: String,

--- a/security-scan/src/functions.rs
+++ b/security-scan/src/functions.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 pub const REQUEST_ID: &str = "security-scan::request";
-pub const REQUEST_DESC: &str = "Queue a report-only security review of the full tree at an exact 40-character Git commit SHA for an operator-configured repository. Omit target_sha to analyze the entire repository at HEAD. Optional model follows the Console composer catalog id. Duplicate repository, commit, mode, and model requests return the same run id.";
+pub const REQUEST_DESC: &str = "Queue a report-only security review of an operator-configured repository at an exact 40-character commit SHA; omit target_sha to review HEAD. Duplicate repository, commit, mode and model requests return the same run id.";
 pub const LIST_ID: &str = "security-scan::list";
 pub const LIST_DESC: &str = "List security-scan runs as sanitized lightweight summaries, newest update first. Optional repository and status filters are applied before the bounded result limit.";
 pub const READ_ID: &str = "security-scan::read";

--- a/security-scan/tests/golden/schemas/security-scan.on-schedule.json
+++ b/security-scan/tests/golden/schemas/security-scan.on-schedule.json
@@ -3,7 +3,7 @@
   "function_id": "security-scan::on-schedule",
   "request_schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "description": "Payload emitted by the iii cron trigger. Its values are observability data only; the handler resolves all scan inputs from operator configuration.",
+    "description": "Payload emitted by the iii cron trigger. Values are observability data only; scan inputs come from operator configuration.",
     "properties": {
       "actual_time": {
         "type": "string"

--- a/security-scan/tests/golden/schemas/security-scan.request.json
+++ b/security-scan/tests/golden/schemas/security-scan.request.json
@@ -1,5 +1,5 @@
 {
-  "description": "Queue a report-only security review of the full tree at an exact 40-character Git commit SHA for an operator-configured repository. Omit target_sha to analyze the entire repository at HEAD. Optional model follows the Console composer catalog id. Duplicate repository, commit, mode, and model requests return the same run id.",
+  "description": "Queue a report-only security review of an operator-configured repository at an exact 40-character commit SHA; omit target_sha to review HEAD. Duplicate repository, commit, mode and model requests return the same run id.",
   "function_id": "security-scan::request",
   "request_schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",


### PR DESCRIPTION
Closes [MOT-4660](https://linear.app/motia/issue/MOT-4660). Sub-issue of MOT-4636; same rule as #1056, #1058, #1060, #1061, #1063, applied to the medium batch of workers the survey flagged.

## Change (editorial, at the source)

Function description ≤ ~300 chars (what it does + the one non-obvious calling rule); request property one sentence ≤ ~140; internal notes moved from `///` to `//`; no type, field, or serde change. Response-only types (editor `Buffer`, document `Body`/`Asset`/`DetectedFrom`) and config structs untouched, per scope.

| crate | text | before | after |
| -- | -- | -- | -- |
| email | `email::send` | 632 | 235 (payload shape dropped, schema carries it; html/text rule + credential source kept) |
| email | `email::search` | 416 | 284 (IMAP SEARCH syntax + NDJSON frame shape kept, schema cannot express them) |
| editor | `SaveInput.expected_version` / `.expected_mtime` | 479 / 458 | 137 / 139 |
| editor | `editor::changes` | 325 | 210 |
| editor | `FindInput.include_untracked`, `GitHunksInput.context_lines`, `Against::Upstream`, … | 152–268 | 97–139 |
| database | `QueryReq.record_history` (serde-skipped, never in schema) | 420 | 48 |
| database | `SchemaDiagramReq.focus`, `FilterOp::In`, `FilterSpec.disabled`, `ExecuteBatchReq.statements`, `RowChangedConfig.db`, … | 145–302 | 30–127 |
| computer | `sessions::start` | 333 | 252 |
| computer | `StartInput.endpoint` / `.image` / `.os` / `.monitor` | 359 / 337 / 259 / 161 | 127 / 115 / 118 / 136 |
| document | `ocr` / `markdown` descriptions | 346 / 318 | 232 / 262 |
| document | `ocr::Request.pages`, `DocumentSource.file_name` / `.fs_scope`, `FsScope` | 189–361 | 68–132 |
| github | `api` / `exec` descriptions, `ApiRequest.path` | 330 / 304 / 159 | 232 / 196 / 132 |
| security-scan | `security-scan::request` | 324 | 219 |

No enum conversions: `StartInput.os` inherits a free-text configured value for remote sessions (not a closed set); `isolation` is validated at runtime and already under the limit.

## Gates

All seven crates: `cargo fmt`, `cargo clippy --all-features --all-targets -D warnings`, `cargo test` green (editor 178, database 386, computer 32, document 89, email 14, github 55, security-scan 108). 17 goldens regenerated with `UPDATE_GOLDENS=1`, description lines only. database's `tests/e2e/` is a TypeScript/docker harness outside `cargo test` and was not run.

https://claude.ai/code/session_01EUoLR66baA2QL7x6fH72bT