### PR TITLE
(MOT-4661) perf(pdf,canvas,a2ui,tailscale,bridge,pubsub,web,worktree,provider-llamacpp): trim request docs over 140 chars

### DIFF
--- a/a2ui/src/protocol.rs
+++ b/a2ui/src/protocol.rs
@@ -63,9 +63,9 @@ pub struct Component {
     pub id: String,
     /// Component name from the negotiated catalog.
     pub component: String,
-    /// Catalog-defined properties. The protocol stays catalog-agnostic; the
-    /// worker validates these against its supported component names and safe
-    /// relationship rules before persistence.
+    /// Catalog-defined properties, validated against the worker's supported
+    /// component names and relationship rules before persistence.
+    // The protocol type stays catalog-agnostic; validation lives in the worker.
     #[serde(flatten)]
     pub properties: BTreeMap<String, Value>,
 }

--- a/bridge/src/functions.rs
+++ b/bridge/src/functions.rs
@@ -66,8 +66,8 @@ pub struct InvokeInput {
     /// Payload passed to the remote function, forwarded verbatim.
     #[serde(default)]
     pub data: Value,
-    /// Milliseconds to wait for the result. `bridge.invoke` defaults to 30s
-    /// when omitted; `bridge.invoke_async` ignores this field (fire-and-forget).
+    /// Milliseconds to wait for the result; `bridge.invoke` defaults to 30s,
+    /// `bridge.invoke_async` ignores it.
     #[serde(default)]
     pub timeout_ms: Option<u64>,
 }

--- a/canvas/src/functions/syntax.rs
+++ b/canvas/src/functions/syntax.rs
@@ -21,9 +21,8 @@ pub const DESC: &str = "Return the mermaid syntax reference: every supported dia
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 pub struct Request {
-    /// Only return this diagram family (`flowchart`, `sequenceDiagram`, …;
-    /// aliases like `graph`, `sequence` or `state` are accepted). Omit for
-    /// the one-line overview of every family.
+    /// Diagram family to return (`flowchart`, `sequenceDiagram`, …; aliases
+    /// like `graph` accepted); omit for the overview of every family.
     #[serde(default)]
     pub family: Option<String>,
 }

--- a/canvas/src/functions/validate.rs
+++ b/canvas/src/functions/validate.rs
@@ -26,9 +26,8 @@ pub const DESC: &str = "Validate canvas source without storing it: detect the me
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct Request {
-    /// Format the source claims to be: `mermaid` or `freeform`. Omit to
-    /// auto-detect — a source whose first character is `{` is treated as an
-    /// excalidraw scene, anything else as mermaid text.
+    /// Source format, `mermaid` or `freeform`; omit to auto-detect (a source
+    /// starting with `{` is an excalidraw scene, anything else mermaid).
     #[serde(default)]
     pub format: Option<CanvasFormat>,
 

--- a/canvas/tests/golden/schemas/canvas.syntax.json
+++ b/canvas/tests/golden/schemas/canvas.syntax.json
@@ -6,7 +6,7 @@
     "properties": {
       "family": {
         "default": null,
-        "description": "Only return this diagram family (`flowchart`, `sequenceDiagram`, …; aliases like `graph`, `sequence` or `state` are accepted). Omit for the one-line overview of every family.",
+        "description": "Diagram family to return (`flowchart`, `sequenceDiagram`, …; aliases like `graph` accepted); omit for the overview of every family.",
         "type": [
           "string",
           "null"

--- a/canvas/tests/golden/schemas/canvas.validate.json
+++ b/canvas/tests/golden/schemas/canvas.validate.json
@@ -35,7 +35,7 @@
           }
         ],
         "default": null,
-        "description": "Format the source claims to be: `mermaid` or `freeform`. Omit to auto-detect — a source whose first character is `{` is treated as an excalidraw scene, anything else as mermaid text."
+        "description": "Source format, `mermaid` or `freeform`; omit to auto-detect (a source starting with `{` is an excalidraw scene, anything else mermaid)."
       },
       "source": {
         "description": "The source to validate: mermaid text, or an excalidraw scene JSON string.",

--- a/pdf/src/functions/classify.rs
+++ b/pdf/src/functions/classify.rs
@@ -31,9 +31,8 @@ pub struct Request {
     #[serde(default)]
     pub password: Option<String>,
 
-    /// Pages sampled for the verdict, overriding the configured default. `0`
-    /// scans every page, which is slower but settles a borderline mixed
-    /// document.
+    /// Pages sampled for the verdict, overriding the worker default; `0` scans
+    /// every page (slower, settles a borderline mixed document).
     #[serde(default)]
     pub sample_pages: Option<usize>,
 }

--- a/pdf/src/functions/items.rs
+++ b/pdf/src/functions/items.rs
@@ -37,8 +37,8 @@ pub struct Request {
     #[serde(default)]
     pub pages: Option<Vec<u32>>,
 
-    /// Items to return before truncating. Omit for the configured default; `0`
-    /// returns every item, which on a dense document is a very large response.
+    /// Items to return before truncating; omit for the worker default, `0`
+    /// returns every item (very large on a dense document).
     #[serde(default)]
     pub max_items: Option<usize>,
 }

--- a/pdf/src/functions/markdown.rs
+++ b/pdf/src/functions/markdown.rs
@@ -57,9 +57,8 @@ pub struct Request {
     #[serde(default)]
     pub password: Option<String>,
 
-    /// 1-indexed pages to convert. Omit for the whole document. A page filter
-    /// is the cheap way to read a long report: take the pages you need rather
-    /// than the whole thing truncated.
+    /// 1-indexed pages to convert; omit for the whole document (a page filter
+    /// is the cheap way to read a long report).
     #[serde(default)]
     pub pages: Option<Vec<u32>>,
 

--- a/pdf/src/source.rs
+++ b/pdf/src/source.rs
@@ -47,9 +47,10 @@ pub struct PdfSource {
     #[serde(default)]
     pub bytes_base64: Option<String>,
 
-    /// The filesystem jail this call runs under. Stamped by the harness on an
-    /// agent's call; absent on an operator or console call, which is already
-    /// user-initiated and not subject to the agent's scope.
+    /// Filesystem jail this call runs under; stamped by the harness on agent
+    /// calls, absent on operator or console calls.
+    // Operator/console calls are user-initiated and not subject to the agent's
+    // scope.
     #[serde(default)]
     pub fs_scope: Option<FsScope>,
 }

--- a/pdf/tests/golden/schemas/pdf.classify.json
+++ b/pdf/tests/golden/schemas/pdf.classify.json
@@ -45,7 +45,7 @@
             "type": "null"
           }
         ],
-        "description": "The filesystem jail this call runs under. Stamped by the harness on an agent's call; absent on an operator or console call, which is already user-initiated and not subject to the agent's scope."
+        "description": "Filesystem jail this call runs under; stamped by the harness on agent calls, absent on operator or console calls."
       },
       "password": {
         "default": null,
@@ -65,7 +65,7 @@
       },
       "sample_pages": {
         "default": null,
-        "description": "Pages sampled for the verdict, overriding the configured default. `0` scans every page, which is slower but settles a borderline mixed document.",
+        "description": "Pages sampled for the verdict, overriding the worker default; `0` scans every page (slower, settles a borderline mixed document).",
         "format": "uint",
         "minimum": 0.0,
         "type": [

--- a/pdf/tests/golden/schemas/pdf.extract-items.json
+++ b/pdf/tests/golden/schemas/pdf.extract-items.json
@@ -45,11 +45,11 @@
             "type": "null"
           }
         ],
-        "description": "The filesystem jail this call runs under. Stamped by the harness on an agent's call; absent on an operator or console call, which is already user-initiated and not subject to the agent's scope."
+        "description": "Filesystem jail this call runs under; stamped by the harness on agent calls, absent on operator or console calls."
       },
       "max_items": {
         "default": null,
-        "description": "Items to return before truncating. Omit for the configured default; `0` returns every item, which on a dense document is a very large response.",
+        "description": "Items to return before truncating; omit for the worker default, `0` returns every item (very large on a dense document).",
         "format": "uint",
         "minimum": 0.0,
         "type": [

--- a/pdf/tests/golden/schemas/pdf.extract-regions.json
+++ b/pdf/tests/golden/schemas/pdf.extract-regions.json
@@ -93,7 +93,7 @@
             "type": "null"
           }
         ],
-        "description": "The filesystem jail this call runs under. Stamped by the harness on an agent's call; absent on an operator or console call, which is already user-initiated and not subject to the agent's scope."
+        "description": "Filesystem jail this call runs under; stamped by the harness on agent calls, absent on operator or console calls."
       },
       "mode": {
         "allOf": [

--- a/pdf/tests/golden/schemas/pdf.extract-text.json
+++ b/pdf/tests/golden/schemas/pdf.extract-text.json
@@ -45,7 +45,7 @@
             "type": "null"
           }
         ],
-        "description": "The filesystem jail this call runs under. Stamped by the harness on an agent's call; absent on an operator or console call, which is already user-initiated and not subject to the agent's scope."
+        "description": "Filesystem jail this call runs under; stamped by the harness on agent calls, absent on operator or console calls."
       },
       "max_chars": {
         "default": null,

--- a/pdf/tests/golden/schemas/pdf.to-markdown.json
+++ b/pdf/tests/golden/schemas/pdf.to-markdown.json
@@ -64,7 +64,7 @@
             "type": "null"
           }
         ],
-        "description": "The filesystem jail this call runs under. Stamped by the harness on an agent's call; absent on an operator or console call, which is already user-initiated and not subject to the agent's scope."
+        "description": "Filesystem jail this call runs under; stamped by the harness on agent calls, absent on operator or console calls."
       },
       "include_images": {
         "default": false,
@@ -83,7 +83,7 @@
       },
       "pages": {
         "default": null,
-        "description": "1-indexed pages to convert. Omit for the whole document. A page filter is the cheap way to read a long report: take the pages you need rather than the whole thing truncated.",
+        "description": "1-indexed pages to convert; omit for the whole document (a page filter is the cheap way to read a long report).",
         "items": {
           "format": "uint32",
           "minimum": 0.0,

--- a/provider-llamacpp/src/count_tokens.rs
+++ b/provider-llamacpp/src/count_tokens.rs
@@ -45,9 +45,8 @@ fn count_tokens_url(api_url: &str) -> String {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct CountTokensRequest {
-    /// Model id the prompt targets. `llama-server` serves one model at a
-    /// time and counts with whichever it loaded, so this is carried for the
-    /// reply rather than to select a tokenizer.
+    /// Model id the prompt targets; echoed in the reply, since `llama-server`
+    /// counts with whichever model it has loaded.
     pub model: String,
     /// System prompt counted as the leading wire message when present.
     #[serde(default)]

--- a/provider-llamacpp/src/embed.rs
+++ b/provider-llamacpp/src/embed.rs
@@ -23,9 +23,8 @@ const EMBED_TIMEOUT_SECS: u64 = 20;
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct EmbedRequest {
-    /// Model name passed through to the server. llama-server embeds with
-    /// its loaded model regardless; the field is echoed for parity with
-    /// the other providers.
+    /// Model name echoed for parity with the other providers; llama-server
+    /// embeds with its loaded model regardless.
     #[serde(default)]
     pub model: Option<String>,
     /// Texts to embed, one vector returned per input, order preserved.

--- a/provider-llamacpp/tests/golden/schemas/provider.llamacpp.count_tokens.json
+++ b/provider-llamacpp/tests/golden/schemas/provider.llamacpp.count_tokens.json
@@ -471,7 +471,7 @@
         "type": "array"
       },
       "model": {
-        "description": "Model id the prompt targets. `llama-server` serves one model at a time and counts with whichever it loaded, so this is carried for the reply rather than to select a tokenizer.",
+        "description": "Model id the prompt targets; echoed in the reply, since `llama-server` counts with whichever model it has loaded.",
         "type": "string"
       },
       "system_prompt": {

--- a/provider-llamacpp/tests/golden/schemas/provider.llamacpp.embed.json
+++ b/provider-llamacpp/tests/golden/schemas/provider.llamacpp.embed.json
@@ -15,7 +15,7 @@
       },
       "model": {
         "default": null,
-        "description": "Model name passed through to the server. llama-server embeds with its loaded model regardless; the field is echoed for parity with the other providers.",
+        "description": "Model name echoed for parity with the other providers; llama-server embeds with its loaded model regardless.",
         "type": [
           "string",
           "null"

--- a/pubsub/src/trigger.rs
+++ b/pubsub/src/trigger.rs
@@ -19,9 +19,9 @@ use crate::hub::Hub;
 pub struct SubscribeTriggerSpec {
     /// Topic to subscribe to
     pub topic: String,
-    /// Optional function ID to evaluate before invoking handler.
-    /// Accepted for schema parity; the builtin never evaluated it and neither
-    /// does this worker.
+    /// Condition function ID accepted for schema parity with the builtin
+    /// trigger; never evaluated.
+    // The engine builtin never evaluated it and neither does this worker.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub condition_function_id: Option<String>,
 }

--- a/tailscale/src/functions/share.rs
+++ b/tailscale/src/functions/share.rs
@@ -137,7 +137,9 @@ pub struct ServeAddInput {
     /// URL path prefix to publish under; defaults to `/`.
     #[serde(default = "default_path")]
     pub path: String,
-    /// What to publish: a local port (`3000`), a loopback URL (`http://127.0.0.1:3000`, `https+insecure://localhost:8443`), or an absolute file or directory path.
+    /// Local port (`3000`), loopback URL (`http://127.0.0.1:3000`,
+    /// `https+insecure://localhost:8443`), or absolute file/directory path to
+    /// publish.
     pub target: String,
     /// Required `true` for Funnel: acknowledges that the target becomes reachable by anyone with the link.
     #[serde(default)]

--- a/tailscale/tests/golden/schemas/tailscale.serve.add.json
+++ b/tailscale/tests/golden/schemas/tailscale.serve.add.json
@@ -42,7 +42,7 @@
         "type": "string"
       },
       "target": {
-        "description": "What to publish: a local port (`3000`), a loopback URL (`http://127.0.0.1:3000`, `https+insecure://localhost:8443`), or an absolute file or directory path.",
+        "description": "Local port (`3000`), loopback URL (`http://127.0.0.1:3000`, `https+insecure://localhost:8443`), or absolute file/directory path to publish.",
         "type": "string"
       }
     },

--- a/web/src/schemas.rs
+++ b/web/src/schemas.rs
@@ -89,9 +89,9 @@ pub struct FetchPayload {
     /// How to return the body: "text" (default), "base64", or "json".
     #[serde(default)]
     pub response_format: Option<ResponseFormat>,
-    /// Page-reading mode: "markdown" | "text" | "html". When set, a browser
-    /// UA + format Accept header are used, HTML is transformed, and
-    /// response_format is ignored (treated as "text").
+    /// Page-reading mode; when set, HTML is transformed and `response_format`
+    /// is treated as `text`.
+    // Also switches to a browser UA and a format-specific Accept header.
     #[serde(default)]
     pub format: Option<PageFormat>,
     /// Content filter: prunes boilerplate. When set, `body` holds the filtered

--- a/worktree/src/functions/create.rs
+++ b/worktree/src/functions/create.rs
@@ -24,9 +24,8 @@ pub struct Request {
     /// codename when `branch_naming: codename`).
     #[serde(default)]
     pub branch: Option<String>,
-    /// Create the worktree at a GitHub pull request head: fetches
-    /// `refs/pull/<n>/head` from `origin` and branches `<prefix>pr-<n>` at
-    /// it. Mutually exclusive with `base_ref` and `branch`.
+    /// Pull request to branch from (fetches `refs/pull/<n>/head` from `origin`
+    /// as `<prefix>pr-<n>`); excludes `base_ref` and `branch`.
     #[serde(default)]
     pub pr: Option<u64>,
     /// Session to auto-claim the worktree for.

--- a/worktree/tests/golden/schemas/worktree.create.json
+++ b/worktree/tests/golden/schemas/worktree.create.json
@@ -21,7 +21,7 @@
       },
       "pr": {
         "default": null,
-        "description": "Create the worktree at a GitHub pull request head: fetches `refs/pull/<n>/head` from `origin` and branches `<prefix>pr-<n>` at it. Mutually exclusive with `base_ref` and `branch`.",
+        "description": "Pull request to branch from (fetches `refs/pull/<n>/head` from `origin` as `<prefix>pr-<n>`); excludes `base_ref` and `branch`.",
         "format": "uint64",
         "minimum": 0.0,
         "type": [


### PR DESCRIPTION
Closes [MOT-4661](https://linear.app/motia/issue/MOT-4661). Sub-issue of MOT-4636; the long tail of the prose survey after #1056, #1058, #1060, #1061, #1063, #1065, #1066.

## Change

No function description in these crates was over 300 chars; 14 request property docs were over 140 and are now one sentence each. Internal notes moved from `///` to `//`. No type, field, or serde change. 11 goldens regenerated with `UPDATE_GOLDENS=1`, description lines only.

| crate | field | before | after |
| -- | -- | -- | -- |
| pdf | `PdfSource.fs_scope` (flattened into all 5 requests) | 193 | 113 |
| pdf | `items::Request.max_items` / `markdown::Request.pages` / `classify::Request.sample_pages` | 143 / 173 / 144 | 120 / 111 / 129 |
| worktree | `create::Request.pr` | 179 | 127 |
| canvas | `syntax::Request.family` / `validate::Request.format` | 174 / 182 | 131 / 135 |
| a2ui | `Component.properties` | 177 | 127 |
| bridge | `InvokeInput.timeout_ms` | 142 | 103 |
| pubsub | `SubscribeTriggerSpec.condition_function_id` | 146 | 91 |
| tailscale | `ServeAddInput.target` | 155 | 139 |
| web | `FetchPayload.format` | 177 | 92 (value list dropped, `PageFormat` is a schema enum) |
| provider-llamacpp | `CountTokensRequest.model` / `EmbedRequest.model` | 175 / 151 | 113 / 108 |

memory, approval-gate and rbac-proxy were on the survey list but only had response, config or internal docs over the limit (`Memory.tags`, `PendingKind`, `RbacConfig`), so they are untouched.

## Gates

All nine touched crates: `cargo fmt`, `cargo clippy --all-features --all-targets -D warnings` green; `cargo test` green for pdf (103), canvas (78), a2ui (38), tailscale (34), bridge (37), pubsub (30), web (105). worktree and provider-llamacpp: every target green except `tests/integration.rs`, which spawns a local `iii` engine and fails identically on an untouched `main` checkout on this machine ("engine did not become ready in 15s"); CI runs them with its own engine.

https://claude.ai/code/session_01EUoLR66baA2QL7x6fH72bT