### PR TITLE
(MOT-4663) fix(workers): update SDK and bundle entrypoints

### DIFF
--- a/.github/scripts/tests/test_released_worker_sdk_runtime.py
+++ b/.github/scripts/tests/test_released_worker_sdk_runtime.py
@@ -15,7 +15,7 @@ def test_opengantry_uses_current_sdk_release() -> None:
         (REPO_ROOT / "opengantry" / "package.json").read_text(encoding="utf-8")
     )
 
-    assert package["dependencies"]["iii-sdk"] == "0.22.1-alpha.25"
+    assert package["dependencies"]["iii-sdk"] == "0.23.0"
 
 
 def test_scrapling_install_does_not_replace_current_sdk_with_vendor_copy() -> None:

--- a/.github/scripts/tests/test_worker_compose.py
+++ b/.github/scripts/tests/test_worker_compose.py
@@ -122,6 +122,22 @@ def test_claude_code_release_installs_its_shared_ui_workspace():
     }
 
 
+def test_worker_bundle_start_commands_target_packaged_entrypoints():
+    document = yaml.safe_load(CATALOG.read_text(encoding="utf-8"))
+
+    for worker_id in ("claude-code", "opencode", "opengantry", "openwiki"):
+        worker = document["workers"][worker_id]
+        manifest = yaml.safe_load(
+            (ROOT / worker["source"]["path"] / "iii.worker.yaml").read_text(
+                encoding="utf-8"
+            )
+        )
+        start = manifest["scripts"]["start"]
+
+        assert start.startswith("node ./"), worker_id
+        assert start.removeprefix("node ./") in worker["artifact"]["include"], worker_id
+
+
 def test_scrapling_release_bundle_vendors_dependencies():
     document = yaml.safe_load(CATALOG.read_text(encoding="utf-8"))
     scrapling = document["workers"]["scrapling"]

--- a/a2ui/Cargo.lock
+++ b/a2ui/Cargo.lock
@@ -673,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0342a8980e12e9bb994d9221637914a719a156cee73705b595d6588e45c9cfca"
+checksum = "e654538584cf6feec82f4f9e773d4b9f8c84bba5085e49a585aebe7227f8af8c"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -694,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.22.1-alpha.25"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb1167081b82a1aa9f12b05ad9e093fdf1cd2a3ed282bb66451a26e37f4a459"
+checksum = "3952d1ac84c88304fa27fef8ce0a9350585abe9e9b9f7513730497e72918186f"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/a2ui/Cargo.toml
+++ b/a2ui/Cargo.toml
@@ -18,7 +18,7 @@ name = "a2ui"
 path = "src/main.rs"
 
 [dependencies]
-iii-sdk = "=0.22.1-alpha.25"
+iii-sdk = "=0.23.0"
 iii-console-ui = { path = "../crates/console-ui" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time"] }
 serde = { version = "1", features = ["derive"] }

--- a/acp/Cargo.lock
+++ b/acp/Cargo.lock
@@ -685,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0342a8980e12e9bb994d9221637914a719a156cee73705b595d6588e45c9cfca"
+checksum = "e654538584cf6feec82f4f9e773d4b9f8c84bba5085e49a585aebe7227f8af8c"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -706,9 +706,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.22.1-alpha.25"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb1167081b82a1aa9f12b05ad9e093fdf1cd2a3ed282bb66451a26e37f4a459"
+checksum = "3952d1ac84c88304fa27fef8ce0a9350585abe9e9b9f7513730497e72918186f"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/acp/Cargo.toml
+++ b/acp/Cargo.toml
@@ -23,7 +23,7 @@ name = "iii-acp"
 path = "src/main.rs"
 
 [dependencies]
-iii-sdk = "=0.22.1-alpha.25"
+iii-sdk = "=0.23.0"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std", "io-util", "sync", "time", "signal"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/claude-code/iii.worker.yaml
+++ b/claude-code/iii.worker.yaml
@@ -11,7 +11,7 @@ runtime:
   kind: javascript
 
 scripts:
-  start: node ./index.mjs
+  start: node ./dist/bundle/index.mjs
 
 dependencies:
   state: "^0.22.2"

--- a/claude-code/index.mjs
+++ b/claude-code/index.mjs
@@ -1,12 +1,9 @@
 /**
- * The entry `iii.worker.yaml` names: `scripts.start` is `node ./index.mjs`.
+ * Source-checkout bootstrap for manual `node ./index.mjs` use.
  *
- * In a published bundle that path IS the bundle (`dist/bundle/index.mjs` ships
- * as the package root), so this file never runs there. From a source checkout
- * the same command lands here, and here it builds the worker if it has not been
- * built yet and then starts it — so a supervisor that reads the manifest starts
- * this worker either way, and a `worker-compose.yaml` needs no `run` or
- * `pre_run` line of its own.
+ * A published worker starts `dist/bundle/index.mjs` directly because the
+ * release archive preserves that path. From a source checkout this bootstrap
+ * builds the worker if needed and then starts it.
  *
  * TODO(iii-mono): remove the build step below once `iii compose` honours a
  * manifest's `scripts.install` as a container's default `pre_run`. The build

--- a/claude-code/package.json
+++ b/claude-code/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.173",
     "@opentelemetry/api": "^1.9.1",
-    "iii-sdk": "0.22.1-alpha.25",
+    "iii-sdk": "0.23.0",
     "yaml": "^2.6.0",
     "zod": "^4.0.0"
   },

--- a/claude-code/pnpm-lock.yaml
+++ b/claude-code/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^1.9.1
         version: 1.9.1
       iii-sdk:
-        specifier: 0.22.1-alpha.25
-        version: 0.22.1-alpha.25
+        specifier: 0.23.0
+        version: 0.23.0
       yaml:
         specifier: ^2.6.0
         version: 2.9.0
@@ -704,8 +704,8 @@ packages:
     peerDependencies:
       hono: ^4
 
-  '@iii-dev/helpers@0.22.1-alpha.25':
-    resolution: {integrity: sha512-q3XQZ4i+eMA4mi1iRaNHlTcIGJVvhCYkmfiIPn0rvlFjLYU32vEqjbxKeNsy9YyRbAhGbjF+kzXp2cUpycVhJw==}
+  '@iii-dev/helpers@0.23.0':
+    resolution: {integrity: sha512-q5iG1zZ8QNo32OuPqgxsSV4VM6/OYD43m/CObPYNUW2+loZBLniaoKo4sR20odxvH+aBue0pDz2G1z+K9sOK7A==}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -1264,8 +1264,8 @@ packages:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
-  iii-sdk@0.22.1-alpha.25:
-    resolution: {integrity: sha512-WUDzAydJacutn5IQz3Tcx296fAn88UnUt8S5/2slRsZK7WCadMS9o3qXmkgKAUAmPHsdCOAwVolBWNnAz4imqQ==}
+  iii-sdk@0.23.0:
+    resolution: {integrity: sha512-qpz7801IVfzwBy4nA/jGmabwZnDvN3Lf39RE6o9CgfIT4QAzgyYudXOfhOZypngmLfBBV/LDX6qJbUzgTlkSig==}
 
   import-in-the-middle@1.15.0:
     resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
@@ -2009,7 +2009,7 @@ snapshots:
     dependencies:
       hono: 4.12.25
 
-  '@iii-dev/helpers@0.22.1-alpha.25':
+  '@iii-dev/helpers@0.23.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.57.2
@@ -2630,9 +2630,9 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  iii-sdk@0.22.1-alpha.25:
+  iii-sdk@0.23.0:
     dependencies:
-      '@iii-dev/helpers': 0.22.1-alpha.25
+      '@iii-dev/helpers': 0.23.0
       '@opentelemetry/api': 1.9.1
       ws: 8.21.0
     transitivePeerDependencies:

--- a/code-runner/Cargo.lock
+++ b/code-runner/Cargo.lock
@@ -292,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "cap-fs-ext"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78e5a3368ae89b7cb68186411452b4b9fac8b41be9c19bf3f47c2d2c8e36e6b"
+checksum = "56ff379b70af8e08307a8f65e7040c7301cb4a572538ade16b4984f0da77847f"
 dependencies = [
  "cap-primitives",
  "cap-std",
@@ -304,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "cap-primitives"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdadbd7c002d3a484b35243669abdae85a0ebaded5a61117169dc3400f9a7ff0"
+checksum = "8b5f74729fd2f44701d1a8eb47e906cdb3ccd9ec0f02baad85a744b791940b18"
 dependencies = [
  "ambient-authority",
  "fs-set-times",
@@ -322,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "cap-std"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7281235d6e96d3544ca18bba9049be92f4190f8d923e3caef1b5f66cfa752608"
+checksum = "c1ec78e242cfa2cfe276807ac2ecc00315a6c97786977414bcd1c3963b6c91b8"
 dependencies = [
  "cap-primitives",
  "io-extras",
@@ -579,27 +579,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d552bd33b7a56dc70aeb1e1c960e51a218fa0db50f23873b500a310379450b2d"
+checksum = "16c273ba1bfc3a1cb27cb4f83df27134f3cb638a61f5ed79ab22cf86eb13da0d"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078e80e4c222279e3330f6aa1a256ca77ddf156d4453166a9f09defedc4594dd"
+checksum = "cbf8909326a466739e83ffe11e74c0c8c6b4bfa911b612aece915daa746cff58"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "820ce15d4ad3562d613c31a67b6d0434d403e7091a68d1349903842f7d31737e"
+checksum = "3cb26b06b54d8b2f8cdf4d440a32fc3b3b91c71c162333a69a70a66fa265fc45"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -607,9 +607,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61bca563d4b86d285928d9e27f97f27039bb33a0fc524fa130d7d0c106bf8ab3"
+checksum = "7ce4e57dbb7f73d08011808a19787c3a03c3e7854b2a479ed0b788915fb671be"
 dependencies = [
  "serde",
  "serde_derive",
@@ -618,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709f4b7c0fb57d952658d5b5c07fbdc4149acd7b7f0de9678ae754b9c981949a"
+checksum = "74b0a8968f33d0bc13bc86fe70dd3947e93acc9f358ed9848e9988448972a9be"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -649,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "903dc8915af62aad1d9d0f39a5968d33fa80b9aa899ed6f56e47f40ca4512e1e"
+checksum = "f69e8e2fe9deb48ef7b8d0c61612f8c1e2277d0421c201e30a4c844a4ebac698"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -662,24 +662,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0522d74c227e49f3fd49ab055311486ae4f09083262b66705bed676952491469"
+checksum = "ad4db1e87a65e9c5a832e3ede160830d4e34df938ac38b5604819f8825687e73"
 
 [[package]]
 name = "cranelift-control"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66560ea1c5cef72e170b18e46d263dba2d3169c9d39e8cafdab2173c6362cc1a"
+checksum = "9248cd37bb6ec460981f57ead368e32b1eca7a207ad50e3e9c7adc3b161f20e9"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ef5b17cc814d27e96b66a5b46da0e4ce2b8ac55a6d478048bb99d04b05526"
+checksum = "26b8bc91c0a3530d132acbf118965dabe9a084029eb0fa74b64760360dec3316"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -689,9 +689,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a87e0aaa39dbf70693b348a221e45904111704ee8f9fef140498471005f9842d"
+checksum = "5086f2ebc084a98b387e522680f62ef65a512444d8382151e03088716d3a1714"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.17.1",
@@ -702,15 +702,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf79003ebfa1eed5e87f3b84446ad5236f540268289960e14f387dc9b28e40b7"
+checksum = "b6a658670f779afc2df083be201ebe54805f69b7b9ffa8dab04142b72ed751c9"
 
 [[package]]
 name = "cranelift-native"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05bf4f235743c81e67ee4db617c5a4a0b65d58d3f0cfc575ee0f1a4e0cd58273"
+checksum = "16a41083b1fd953debd6f32d21fcda765b258f323ce907fdd6b4715f2769c478"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -719,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6977c2a71ab1e0d1e62f966b411a498aa04c4dce47d93d52f8a360a06058922"
+checksum = "244d9cd0759b0a3ccdd587cafb13434f9ea43b5c9d07701d277daf5cd0f7b7c1"
 
 [[package]]
 name = "crc32fast"
@@ -2340,9 +2340,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5c8c21ea032e4efbdf2d067dc45171779dbe0c8ecf20ef4a57efa7474f2b0a"
+checksum = "ed2bd641cb6a3ec5bffe60405568933163e0ea619da0943e9d2a417ceaa7fe82"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -2352,9 +2352,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f10925455d5dde962e3604eade797ba5488644c8ee14a44191e2f2b58980574"
+checksum = "d3fd4024d1e559eaf5579bc8ad84a2b5915f34b47acc13a06ffba7dac401b166"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3906,9 +3906,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80ca6098e0d4d06886d91d7f2cc3cb6623eb583c4c0ab3c89cbfb6098c8586c"
+checksum = "4cdaf5b8af5713146e3a62d940c71e3eb2ad1ebacfa6b55f0c8509a5b4b87718"
 dependencies = [
  "addr2line",
  "async-trait",
@@ -3959,9 +3959,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134f9d136d29c76f6c1b4c9b468e97a2efc38c7d49fd188e39b64870b2fea701"
+checksum = "58793271eab7ec26bab99ca497131f8b37702e7dc39e2f2d18293e3e915b4964"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -3990,9 +3990,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65db2eb1bfc5371a3b4107dbf539d0b93d05016fc29625b1648146b47db02071"
+checksum = "ede02ba77442cab88a2ddd5d16373e8bc450b55e05de8be039b024987a53d5a7"
 dependencies = [
  "base64",
  "directories-next",
@@ -4010,9 +4010,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf7b91fed3fc34781d57f9c6654ea2513bf0a99f7b0b0523c00de1e6efebe1c"
+checksum = "c5bba4eff4804620bae04d7793308d97a0c5a8a97ea19e635452518f84560f84"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -4025,15 +4025,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc8a678149885cae00289f806fbe74c7863084cf74cace0b8dc73602279400e1"
+checksum = "3d7032ff6b4d7a45e05be1cb32ec1756df5f2669f08296dbe2c61c3789dead2c"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0092c4b9d070ac5e278b6d0db10f5e71214190f0347ca57502b4692f796321"
+checksum = "f41d3b2cb9c3de7b696690af070d408b5e357011832f8b8bb7fbb315dbb620ed"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -4043,9 +4043,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6851ebc9e03cab23d9821d2b2505d380bdfe38f35ccec945247b05274d85c98b"
+checksum = "1d5cda5b90247978dd2ba6ca4e309508da19e9244445671d2d0e6a34e5c3b847"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -4070,9 +4070,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b26da6d5f60d4c438da70bba3553fe810a840533a64156be287dca2081c6991"
+checksum = "4d126366176553e8f304e8ac2078a4cc37134fe8f19d4d4695a09c5a2f577f10"
 dependencies = [
  "cc",
  "cfg-if",
@@ -4085,9 +4085,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed621ba25d7bf78b7edd7b4749abbb27c2e5cdba836c9504a424ee74b6c23149"
+checksum = "c1d28ff131bc40e11d84bc3a9fa0d264506439ffbbc89f3562fbb529d1caa617"
 dependencies = [
  "cc",
  "object",
@@ -4097,9 +4097,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5684ba160951baad06a725696f3c590e2fb0e8067c2aebee27bf7f9259058e85"
+checksum = "4a52de8b6afbfcd618073f592c1450cb661574e7061f3f4a44f1f7ec0c7f7909"
 dependencies = [
  "cfg-if",
  "libc",
@@ -4109,9 +4109,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112eead527bffa8ff0646a11fb4339a9d52ddd1da2b9a6fce4aff84c815dd94f"
+checksum = "5524fbaaf3d2134dd6229164d7fc81e443cce06d1e0576524d5f4e86e747cb13"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -4122,9 +4122,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "153592e0bed824fc13c6696203fa1bd7bd20eb355316475e39a55f081ef80eca"
+checksum = "e93bb9ae112a80618510f938275a5d88637b656e7d0a021fc906f52206c708ad"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4133,9 +4133,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c456ad6e81e0f46abfeca43687d18ea15e289c395b262ea6e0023e2682e088be"
+checksum = "bfdbdd9d6fab1ecb67a7dc189e32c9e341444945fb709437bf8aab25d9a88459"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4146,9 +4146,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c1cf60cd6a565213af7074b4aad7bb5e110e3c6c6aae54425aa0500a0e15e86"
+checksum = "b373095a6dc8382da56882ad16d7ea16771dd6927dd480b1ce3fe7c4b816d2cf"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -4172,9 +4172,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb08e1d7755aaa467ce14080b7b01e33c914a920f6000696f1e42e40ea6387e"
+checksum = "51b3c9b39b1a1b3029f80e614623e182f165133dfaca8610f156450343f080a4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4257,9 +4257,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89091642df051b84a7e00bdff75e985e507f2298384e477cc9310b0ddd79f004"
+checksum = "8c08bd1d66a10c7d4deaeb746cb1c5b5c62fb631907f18dfe058ecba71c99002"
 dependencies = [
  "bitflags",
  "thiserror 2.0.20",
@@ -4271,9 +4271,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12247f46f31bb5e7593947f9bba07317d0c1978e0d02250b979dd08f56f46e9f"
+checksum = "19eb81a4ceda41cc6fa2adc8e865473fc2e85630149ed7f5d95356b0010f0ed3"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -4285,9 +4285,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e556a0880c9506fdcc662b1e226c7ced692f4977fed5b1ed40a3f3f0a48356f2"
+checksum = "c0e0d7c6d28846ffa438e421976734a2057f13a7e20af9f2a8607a6714e1e358"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/code-runner/Cargo.lock
+++ b/code-runner/Cargo.lock
@@ -1647,9 +1647,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.22.1-alpha.25"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d24f39bff5a54a18ad0dbe92fff0311fe7d12445ec26da12b8d6b09056166bc"
+checksum = "e654538584cf6feec82f4f9e773d4b9f8c84bba5085e49a585aebe7227f8af8c"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -1706,9 +1706,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.22.1-alpha.25"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb1167081b82a1aa9f12b05ad9e093fdf1cd2a3ed282bb66451a26e37f4a459"
+checksum = "3952d1ac84c88304fa27fef8ce0a9350585abe9e9b9f7513730497e72918186f"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/code-runner/Cargo.toml
+++ b/code-runner/Cargo.toml
@@ -14,8 +14,8 @@ path = "src/main.rs"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.22.1-alpha.25"
-iii-helpers = "=0.22.1-alpha.25"
+iii-sdk = "=0.23.0"
+iii-helpers = "=0.23.0"
 # The two engines, as libraries. Both are bus-free: this worker owns the only
 # connection and implements `iii_node_core::engine::Engine` against it.
 iii-node-core = { path = "../crates/node-core" }

--- a/compose-ui/Cargo.lock
+++ b/compose-ui/Cargo.lock
@@ -691,9 +691,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0342a8980e12e9bb994d9221637914a719a156cee73705b595d6588e45c9cfca"
+checksum = "e654538584cf6feec82f4f9e773d4b9f8c84bba5085e49a585aebe7227f8af8c"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -712,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.22.1-alpha.25"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb1167081b82a1aa9f12b05ad9e093fdf1cd2a3ed282bb66451a26e37f4a459"
+checksum = "3952d1ac84c88304fa27fef8ce0a9350585abe9e9b9f7513730497e72918186f"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/compose-ui/Cargo.toml
+++ b/compose-ui/Cargo.toml
@@ -18,7 +18,7 @@ name = "compose_ui"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.22.1-alpha.25"
+iii-sdk = "=0.23.0"
 iii-console-ui = { path = "../crates/console-ui" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time", "fs", "io-util", "process"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/config-client/Cargo.toml
+++ b/crates/config-client/Cargo.toml
@@ -13,10 +13,10 @@ repository = "https://github.com/iii-hq/workers"
 publish = false
 
 [dependencies]
-# Range, not an exact pin — same rationale as crates/console-ui: workers on
-# this repo's SDK line carry their own exact pins (0.21.6 for most, 0.21.8
-# for the harness) and cargo must be able to unify them with this crate.
-iii-sdk = "=0.22.1-alpha.25"
+# Workers carry their own exact SDK pins. Keep this shared crate compatible
+# with both the previous prerelease and the current stable SDK line so Cargo
+# can unify it with each worker.
+iii-sdk = ">=0.22.1-alpha.25, <0.24.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # Must stay on the same schemars major as iii-sdk so the derived schemas line up.

--- a/crates/python-core/Cargo.lock
+++ b/crates/python-core/Cargo.lock
@@ -120,9 +120,9 @@ dependencies = [
 
 [[package]]
 name = "cap-fs-ext"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78e5a3368ae89b7cb68186411452b4b9fac8b41be9c19bf3f47c2d2c8e36e6b"
+checksum = "56ff379b70af8e08307a8f65e7040c7301cb4a572538ade16b4984f0da77847f"
 dependencies = [
  "cap-primitives",
  "cap-std",
@@ -132,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "cap-primitives"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdadbd7c002d3a484b35243669abdae85a0ebaded5a61117169dc3400f9a7ff0"
+checksum = "8b5f74729fd2f44701d1a8eb47e906cdb3ccd9ec0f02baad85a744b791940b18"
 dependencies = [
  "ambient-authority",
  "fs-set-times",
@@ -150,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "cap-std"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7281235d6e96d3544ca18bba9049be92f4190f8d923e3caef1b5f66cfa752608"
+checksum = "c1ec78e242cfa2cfe276807ac2ecc00315a6c97786977414bcd1c3963b6c91b8"
 dependencies = [
  "cap-primitives",
  "io-extras",
@@ -261,27 +261,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d552bd33b7a56dc70aeb1e1c960e51a218fa0db50f23873b500a310379450b2d"
+checksum = "16c273ba1bfc3a1cb27cb4f83df27134f3cb638a61f5ed79ab22cf86eb13da0d"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078e80e4c222279e3330f6aa1a256ca77ddf156d4453166a9f09defedc4594dd"
+checksum = "cbf8909326a466739e83ffe11e74c0c8c6b4bfa911b612aece915daa746cff58"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "820ce15d4ad3562d613c31a67b6d0434d403e7091a68d1349903842f7d31737e"
+checksum = "3cb26b06b54d8b2f8cdf4d440a32fc3b3b91c71c162333a69a70a66fa265fc45"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -289,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61bca563d4b86d285928d9e27f97f27039bb33a0fc524fa130d7d0c106bf8ab3"
+checksum = "7ce4e57dbb7f73d08011808a19787c3a03c3e7854b2a479ed0b788915fb671be"
 dependencies = [
  "serde",
  "serde_derive",
@@ -300,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709f4b7c0fb57d952658d5b5c07fbdc4149acd7b7f0de9678ae754b9c981949a"
+checksum = "74b0a8968f33d0bc13bc86fe70dd3947e93acc9f358ed9848e9988448972a9be"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -331,9 +331,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "903dc8915af62aad1d9d0f39a5968d33fa80b9aa899ed6f56e47f40ca4512e1e"
+checksum = "f69e8e2fe9deb48ef7b8d0c61612f8c1e2277d0421c201e30a4c844a4ebac698"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -344,24 +344,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0522d74c227e49f3fd49ab055311486ae4f09083262b66705bed676952491469"
+checksum = "ad4db1e87a65e9c5a832e3ede160830d4e34df938ac38b5604819f8825687e73"
 
 [[package]]
 name = "cranelift-control"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66560ea1c5cef72e170b18e46d263dba2d3169c9d39e8cafdab2173c6362cc1a"
+checksum = "9248cd37bb6ec460981f57ead368e32b1eca7a207ad50e3e9c7adc3b161f20e9"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ef5b17cc814d27e96b66a5b46da0e4ce2b8ac55a6d478048bb99d04b05526"
+checksum = "26b8bc91c0a3530d132acbf118965dabe9a084029eb0fa74b64760360dec3316"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -371,9 +371,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a87e0aaa39dbf70693b348a221e45904111704ee8f9fef140498471005f9842d"
+checksum = "5086f2ebc084a98b387e522680f62ef65a512444d8382151e03088716d3a1714"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.17.1",
@@ -384,15 +384,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf79003ebfa1eed5e87f3b84446ad5236f540268289960e14f387dc9b28e40b7"
+checksum = "b6a658670f779afc2df083be201ebe54805f69b7b9ffa8dab04142b72ed751c9"
 
 [[package]]
 name = "cranelift-native"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05bf4f235743c81e67ee4db617c5a4a0b65d58d3f0cfc575ee0f1a4e0cd58273"
+checksum = "16a41083b1fd953debd6f32d21fcda765b258f323ce907fdd6b4715f2769c478"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -401,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6977c2a71ab1e0d1e62f966b411a498aa04c4dce47d93d52f8a360a06058922"
+checksum = "244d9cd0759b0a3ccdd587cafb13434f9ea43b5c9d07701d277daf5cd0f7b7c1"
 
 [[package]]
 name = "crc32fast"
@@ -1297,9 +1297,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5c8c21ea032e4efbdf2d067dc45171779dbe0c8ecf20ef4a57efa7474f2b0a"
+checksum = "ed2bd641cb6a3ec5bffe60405568933163e0ea619da0943e9d2a417ceaa7fe82"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -1309,9 +1309,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f10925455d5dde962e3604eade797ba5488644c8ee14a44191e2f2b58980574"
+checksum = "d3fd4024d1e559eaf5579bc8ad84a2b5915f34b47acc13a06ffba7dac401b166"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2021,9 +2021,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80ca6098e0d4d06886d91d7f2cc3cb6623eb583c4c0ab3c89cbfb6098c8586c"
+checksum = "4cdaf5b8af5713146e3a62d940c71e3eb2ad1ebacfa6b55f0c8509a5b4b87718"
 dependencies = [
  "addr2line",
  "async-trait",
@@ -2074,9 +2074,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134f9d136d29c76f6c1b4c9b468e97a2efc38c7d49fd188e39b64870b2fea701"
+checksum = "58793271eab7ec26bab99ca497131f8b37702e7dc39e2f2d18293e3e915b4964"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -2105,9 +2105,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65db2eb1bfc5371a3b4107dbf539d0b93d05016fc29625b1648146b47db02071"
+checksum = "ede02ba77442cab88a2ddd5d16373e8bc450b55e05de8be039b024987a53d5a7"
 dependencies = [
  "base64",
  "directories-next",
@@ -2125,9 +2125,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf7b91fed3fc34781d57f9c6654ea2513bf0a99f7b0b0523c00de1e6efebe1c"
+checksum = "c5bba4eff4804620bae04d7793308d97a0c5a8a97ea19e635452518f84560f84"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -2140,15 +2140,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc8a678149885cae00289f806fbe74c7863084cf74cace0b8dc73602279400e1"
+checksum = "3d7032ff6b4d7a45e05be1cb32ec1756df5f2669f08296dbe2c61c3789dead2c"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0092c4b9d070ac5e278b6d0db10f5e71214190f0347ca57502b4692f796321"
+checksum = "f41d3b2cb9c3de7b696690af070d408b5e357011832f8b8bb7fbb315dbb620ed"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -2158,9 +2158,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6851ebc9e03cab23d9821d2b2505d380bdfe38f35ccec945247b05274d85c98b"
+checksum = "1d5cda5b90247978dd2ba6ca4e309508da19e9244445671d2d0e6a34e5c3b847"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -2185,9 +2185,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b26da6d5f60d4c438da70bba3553fe810a840533a64156be287dca2081c6991"
+checksum = "4d126366176553e8f304e8ac2078a4cc37134fe8f19d4d4695a09c5a2f577f10"
 dependencies = [
  "cc",
  "cfg-if",
@@ -2200,9 +2200,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed621ba25d7bf78b7edd7b4749abbb27c2e5cdba836c9504a424ee74b6c23149"
+checksum = "c1d28ff131bc40e11d84bc3a9fa0d264506439ffbbc89f3562fbb529d1caa617"
 dependencies = [
  "cc",
  "object",
@@ -2212,9 +2212,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5684ba160951baad06a725696f3c590e2fb0e8067c2aebee27bf7f9259058e85"
+checksum = "4a52de8b6afbfcd618073f592c1450cb661574e7061f3f4a44f1f7ec0c7f7909"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2224,9 +2224,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112eead527bffa8ff0646a11fb4339a9d52ddd1da2b9a6fce4aff84c815dd94f"
+checksum = "5524fbaaf3d2134dd6229164d7fc81e443cce06d1e0576524d5f4e86e747cb13"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -2237,9 +2237,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "153592e0bed824fc13c6696203fa1bd7bd20eb355316475e39a55f081ef80eca"
+checksum = "e93bb9ae112a80618510f938275a5d88637b656e7d0a021fc906f52206c708ad"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2248,9 +2248,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c456ad6e81e0f46abfeca43687d18ea15e289c395b262ea6e0023e2682e088be"
+checksum = "bfdbdd9d6fab1ecb67a7dc189e32c9e341444945fb709437bf8aab25d9a88459"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -2261,9 +2261,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c1cf60cd6a565213af7074b4aad7bb5e110e3c6c6aae54425aa0500a0e15e86"
+checksum = "b373095a6dc8382da56882ad16d7ea16771dd6927dd480b1ce3fe7c4b816d2cf"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -2287,9 +2287,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb08e1d7755aaa467ce14080b7b01e33c914a920f6000696f1e42e40ea6387e"
+checksum = "51b3c9b39b1a1b3029f80e614623e182f165133dfaca8610f156450343f080a4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2340,9 +2340,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89091642df051b84a7e00bdff75e985e507f2298384e477cc9310b0ddd79f004"
+checksum = "8c08bd1d66a10c7d4deaeb746cb1c5b5c62fb631907f18dfe058ecba71c99002"
 dependencies = [
  "bitflags",
  "thiserror 2.0.20",
@@ -2354,9 +2354,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12247f46f31bb5e7593947f9bba07317d0c1978e0d02250b979dd08f56f46e9f"
+checksum = "19eb81a4ceda41cc6fa2adc8e865473fc2e85630149ed7f5d95356b0010f0ed3"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2368,9 +2368,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e556a0880c9506fdcc662b1e226c7ced692f4977fed5b1ed40a3f3f0a48356f2"
+checksum = "c0e0d7c6d28846ffa438e421976734a2057f13a7e20af9f2a8607a6714e1e358"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/python-core/Cargo.toml
+++ b/crates/python-core/Cargo.toml
@@ -32,8 +32,8 @@ tracing = "0.1"
 # The sandbox. Pinned exact like deno_core in node-core: wasmtime majors churn
 # monthly and the containment behaviour (epoch traps, limiter semantics) must
 # not move under us.
-wasmtime = "=47.0.3"
-wasmtime-wasi = "=47.0.3"
+wasmtime = "=47.0.4"
+wasmtime-wasi = "=47.0.4"
 # `OutputStream::write` takes `bytes::Bytes` and wasmtime-wasi does not
 # re-export the crate, so the trait cannot be implemented without naming it.
 bytes = "1"

--- a/editor/Cargo.lock
+++ b/editor/Cargo.lock
@@ -675,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.22.1-alpha.25"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d24f39bff5a54a18ad0dbe92fff0311fe7d12445ec26da12b8d6b09056166bc"
+checksum = "e654538584cf6feec82f4f9e773d4b9f8c84bba5085e49a585aebe7227f8af8c"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -696,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.22.1-alpha.25"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb1167081b82a1aa9f12b05ad9e093fdf1cd2a3ed282bb66451a26e37f4a459"
+checksum = "3952d1ac84c88304fa27fef8ce0a9350585abe9e9b9f7513730497e72918186f"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/editor/Cargo.toml
+++ b/editor/Cargo.toml
@@ -17,11 +17,11 @@ path = "src/lib.rs"
 # Lockstep with every other worker and with `crates/console-ui`, which this
 # binary links: two iii-sdk versions in one process means two incompatible
 # `IIIClient` types.
-iii-sdk = "=0.22.1-alpha.25"
+iii-sdk = "=0.23.0"
 iii-console-ui = { path = "../crates/console-ui" }
 # Shared observability: the observer fires inside a harness turn, so its span
 # has to hang off that turn rather than dangle as its own trace root.
-iii-helpers = "=0.22.1-alpha.25"
+iii-helpers = "=0.23.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/eval/Cargo.lock
+++ b/eval/Cargo.lock
@@ -792,9 +792,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.22.1-alpha.25"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d24f39bff5a54a18ad0dbe92fff0311fe7d12445ec26da12b8d6b09056166bc"
+checksum = "e654538584cf6feec82f4f9e773d4b9f8c84bba5085e49a585aebe7227f8af8c"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -813,9 +813,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.22.1-alpha.25"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb1167081b82a1aa9f12b05ad9e093fdf1cd2a3ed282bb66451a26e37f4a459"
+checksum = "3952d1ac84c88304fa27fef8ce0a9350585abe9e9b9f7513730497e72918186f"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/eval/Cargo.toml
+++ b/eval/Cargo.toml
@@ -16,8 +16,8 @@ path = "src/lib.rs"
 
 [dependencies]
 harness = { path = "../harness" }
-iii-sdk = "=0.22.1-alpha.25"
-iii-helpers = "=0.22.1-alpha.25"
+iii-sdk = "=0.23.0"
+iii-helpers = "=0.23.0"
 iii-console-ui = { path = "../crates/console-ui" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time"] }
 serde = { version = "1", features = ["derive"] }

--- a/eval/tests/golden/schemas/eval.result.json
+++ b/eval/tests/golden/schemas/eval.result.json
@@ -967,7 +967,7 @@
         "type": "object"
       },
       "Mode": {
-        "description": "Console / send operating mode — prepends a short paragraph before the shared identity prompt. `ask` is also structural: the turn's dispatch policy is capped at the configured default policy, never widened.",
+        "description": "Operating mode prepended to the identity prompt; `ask` also caps the dispatch policy at the configured default.",
         "enum": [
           "ask",
           "agent"

--- a/eval/tests/golden/schemas/eval.start.json
+++ b/eval/tests/golden/schemas/eval.start.json
@@ -241,7 +241,7 @@
         "type": "object"
       },
       "Mode": {
-        "description": "Console / send operating mode — prepends a short paragraph before the shared identity prompt. `ask` is also structural: the turn's dispatch policy is capped at the configured default policy, never widened.",
+        "description": "Operating mode prepended to the identity prompt; `ask` also caps the dispatch policy at the configured default.",
         "enum": [
           "ask",
           "agent"

--- a/harness/Cargo.lock
+++ b/harness/Cargo.lock
@@ -628,8 +628,8 @@ dependencies = [
  "clap",
  "globset",
  "iii-console-ui",
- "iii-helpers 0.22.1-alpha.25",
- "iii-sdk 0.22.1-alpha.25",
+ "iii-helpers 0.23.0",
+ "iii-sdk 0.23.0",
  "jsonschema",
  "opentelemetry_sdk",
  "schemars",
@@ -975,7 +975,7 @@ dependencies = [
 name = "iii-console-ui"
 version = "0.1.0"
 dependencies = [
- "iii-sdk 0.22.1-alpha.25",
+ "iii-sdk 0.23.0",
  "schemars",
  "serde",
  "serde_json",
@@ -1006,9 +1006,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.22.1-alpha.25"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d24f39bff5a54a18ad0dbe92fff0311fe7d12445ec26da12b8d6b09056166bc"
+checksum = "e654538584cf6feec82f4f9e773d4b9f8c84bba5085e49a585aebe7227f8af8c"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -1048,14 +1048,14 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.22.1-alpha.25"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb1167081b82a1aa9f12b05ad9e093fdf1cd2a3ed282bb66451a26e37f4a459"
+checksum = "3952d1ac84c88304fa27fef8ce0a9350585abe9e9b9f7513730497e72918186f"
 dependencies = [
  "async-trait",
  "futures-util",
  "hostname",
- "iii-helpers 0.22.1-alpha.25",
+ "iii-helpers 0.23.0",
  "reqwest",
  "schemars",
  "serde",

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -19,12 +19,12 @@ path = "src/lib.rs"
 [dependencies]
 # 0.21.8 adds the reconnect reattach handshake. Older SDKs can lose this
 # worker's registrations when the engine reloads another worker.
-iii-sdk = "=0.22.1-alpha.25"
+iii-sdk = "=0.23.0"
 # Re-exports the same `opentelemetry` the SDK uses, so we can carry the active
 # OTel context across `tokio::spawn` boundaries (shared `Context` global).
 # 0.21.5 adds the live span-start push (`LiveSpanStartProcessor`), so the
 # console renders `harness::turn step` while it runs instead of on close.
-iii-helpers = "=0.22.1-alpha.25"
+iii-helpers = "=0.23.0"
 # Worker-side injectable console UI (content function + console:script/style
 # triggers + hot-reload watcher) — direct link, never published.
 iii-console-ui = { path = "../crates/console-ui" }

--- a/hermes/pyproject.toml
+++ b/hermes/pyproject.toml
@@ -10,8 +10,8 @@ authors = [{ name = "iii" }]
 license = "Apache-2.0"
 requires-python = ">=3.11"
 dependencies = [
-    "iii-sdk==0.22.1a25",
-    "iii-helpers==0.22.1a25",
+    "iii-sdk==0.23.0",
+    "iii-helpers==0.23.0",
     "opentelemetry-api",
     "opentelemetry-sdk",
     "pyyaml",

--- a/hermes/uv.lock
+++ b/hermes/uv.lock
@@ -72,8 +72,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "iii-helpers", specifier = "==0.22.1a25" },
-    { name = "iii-sdk", specifier = "==0.22.1a25" },
+    { name = "iii-helpers", specifier = "==0.23.0" },
+    { name = "iii-sdk", specifier = "==0.23.0" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-sdk" },
     { name = "pytest", marker = "extra == 'dev'" },
@@ -122,7 +122,7 @@ wheels = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.22.1a25"
+version = "0.23.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -131,14 +131,14 @@ dependencies = [
     { name = "pydantic" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/50/32/80bda7e2f96d0681ebfe9b6afe3cefad23edbacc7a76ed6e3306b4fa7215/iii_helpers-0.22.1a25.tar.gz", hash = "sha256:e62b74340b48baa0a3e35e1e116f8195a6b7256db14e234f1011a4c96e44f064", size = 81173, upload-time = "2026-08-27T13:17:50.521Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/4e/86f8c14a33972371b0124ad5720ce346c52a47e7d801e95cb9efe3df8502/iii_helpers-0.23.0.tar.gz", hash = "sha256:6035086d8dbf7cecb9f92b7dc6cb9e9793c73d6eebdc286394f171fb71abe5f5", size = 81173, upload-time = "2026-09-01T17:33:13.815Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/b6/eb7b9abb7e3c009df121ba663d348468ef4c6269a3a995ea2c55cf4a4ab0/iii_helpers-0.22.1a25-py3-none-any.whl", hash = "sha256:1aa8186b16f38fd4d237064f1d8a078a0a4552d368ef0f3ee59298eb4c9f4e0c", size = 29467, upload-time = "2026-08-27T13:17:49.214Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/96/2d8e36a35b223ac31d8af7b8aa52aa44e49e3eb397d1b2cd6df02420bde4/iii_helpers-0.23.0-py3-none-any.whl", hash = "sha256:035332804bb8f585905a223057f63528000b1cce1ebe7a8bd319b6e9cbf9ccf1", size = 29444, upload-time = "2026-09-01T17:33:12.911Z" },
 ]
 
 [[package]]
 name = "iii-sdk"
-version = "0.22.1a25"
+version = "0.23.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "iii-helpers" },
@@ -146,9 +146,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/50/b05e645eed82f9a5f1c4abab30a8ce4d0e4346fb71032e33749852ce98a8/iii_sdk-0.22.1a25.tar.gz", hash = "sha256:2c32929af7882e95744e306314ab49032263218eb8c6fcea6618bac78610c7cf", size = 201917, upload-time = "2026-08-27T13:18:53.043Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/4a/f23543aa23f5bb0aed1334f2147a38520555809927faeb967295cd4c00aa/iii_sdk-0.23.0.tar.gz", hash = "sha256:40ec1de1193a8b5f1d7df2a42acb8084cfcbd8627863f8a412281918cd0d6d38", size = 201938, upload-time = "2026-09-01T17:34:44.812Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/92/15ef1ef3554190012d71aaba81c7756958064b095f03ed7b7befa8e15ef1/iii_sdk-0.22.1a25-py3-none-any.whl", hash = "sha256:8dee91047d198103af5534392ffee989aa74933f84fede282038651a211fb5a9", size = 42497, upload-time = "2026-08-27T13:18:51.874Z" },
+    { url = "https://files.pythonhosted.org/packages/25/a5/c6e50faff6ebe8025fb03f976128dade6f9bd2c05bb57f8c7a6f4a909da0/iii_sdk-0.23.0-py3-none-any.whl", hash = "sha256:382df8108c7f642768c8956dacba5cbbd9bb2db0b21c74ef3174c620011b717c", size = 42490, upload-time = "2026-09-01T17:34:43.646Z" },
 ]
 
 [[package]]

--- a/kanban/package.json
+++ b/kanban/package.json
@@ -19,7 +19,7 @@
     "start": "node dist/bundle/index.mjs"
   },
   "dependencies": {
-    "iii-sdk": "0.22.1-alpha.25"
+    "iii-sdk": "0.23.0"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.10",

--- a/kanban/pnpm-lock.yaml
+++ b/kanban/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       iii-sdk:
-        specifier: 0.22.1-alpha.25
-        version: 0.22.1-alpha.25
+        specifier: 0.23.0
+        version: 0.23.0
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.10
@@ -399,8 +399,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@iii-dev/helpers@0.22.1-alpha.25':
-    resolution: {integrity: sha512-q3XQZ4i+eMA4mi1iRaNHlTcIGJVvhCYkmfiIPn0rvlFjLYU32vEqjbxKeNsy9YyRbAhGbjF+kzXp2cUpycVhJw==}
+  '@iii-dev/helpers@0.23.0':
+    resolution: {integrity: sha512-q5iG1zZ8QNo32OuPqgxsSV4VM6/OYD43m/CObPYNUW2+loZBLniaoKo4sR20odxvH+aBue0pDz2G1z+K9sOK7A==}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -790,8 +790,8 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  iii-sdk@0.22.1-alpha.25:
-    resolution: {integrity: sha512-WUDzAydJacutn5IQz3Tcx296fAn88UnUt8S5/2slRsZK7WCadMS9o3qXmkgKAUAmPHsdCOAwVolBWNnAz4imqQ==}
+  iii-sdk@0.23.0:
+    resolution: {integrity: sha512-qpz7801IVfzwBy4nA/jGmabwZnDvN3Lf39RE6o9CgfIT4QAzgyYudXOfhOZypngmLfBBV/LDX6qJbUzgTlkSig==}
 
   import-in-the-middle@1.15.0:
     resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
@@ -1203,7 +1203,7 @@ snapshots:
   '@esbuild/win32-x64@0.28.2':
     optional: true
 
-  '@iii-dev/helpers@0.22.1-alpha.25':
+  '@iii-dev/helpers@0.23.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.57.2
@@ -1576,9 +1576,9 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  iii-sdk@0.22.1-alpha.25:
+  iii-sdk@0.23.0:
     dependencies:
-      '@iii-dev/helpers': 0.22.1-alpha.25
+      '@iii-dev/helpers': 0.23.0
       '@opentelemetry/api': 1.9.1
       ws: 8.21.3
     transitivePeerDependencies:

--- a/lsp/Cargo.lock
+++ b/lsp/Cargo.lock
@@ -712,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0342a8980e12e9bb994d9221637914a719a156cee73705b595d6588e45c9cfca"
+checksum = "e654538584cf6feec82f4f9e773d4b9f8c84bba5085e49a585aebe7227f8af8c"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -733,9 +733,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.22.1-alpha.25"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb1167081b82a1aa9f12b05ad9e093fdf1cd2a3ed282bb66451a26e37f4a459"
+checksum = "3952d1ac84c88304fa27fef8ce0a9350585abe9e9b9f7513730497e72918186f"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/lsp/Cargo.toml
+++ b/lsp/Cargo.toml
@@ -13,7 +13,7 @@ name = "lsp"
 path = "src/main.rs"
 
 [dependencies]
-iii-sdk = "=0.22.1-alpha.25"
+iii-sdk = "=0.23.0"
 tower-lsp-server = "0.23"
 tree-sitter = "0.24"
 tree-sitter-typescript = "0.23"

--- a/mcp/Cargo.lock
+++ b/mcp/Cargo.lock
@@ -887,9 +887,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.22.1-alpha.25"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d24f39bff5a54a18ad0dbe92fff0311fe7d12445ec26da12b8d6b09056166bc"
+checksum = "e654538584cf6feec82f4f9e773d4b9f8c84bba5085e49a585aebe7227f8af8c"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -908,9 +908,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.22.1-alpha.25"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb1167081b82a1aa9f12b05ad9e093fdf1cd2a3ed282bb66451a26e37f4a459"
+checksum = "3952d1ac84c88304fa27fef8ce0a9350585abe9e9b9f7513730497e72918186f"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -15,8 +15,8 @@ name = "iii_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.22.1-alpha.25"
-iii-helpers = "=0.22.1-alpha.25"
+iii-sdk = "=0.23.0"
+iii-helpers = "=0.23.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/opencode/iii.worker.yaml
+++ b/opencode/iii.worker.yaml
@@ -11,7 +11,7 @@ runtime:
   kind: javascript
 
 scripts:
-  start: node ./index.mjs
+  start: node ./dist/bundle/index.mjs
 
 dependencies:
   state: "^0.22.2"

--- a/opencode/package.json
+++ b/opencode/package.json
@@ -23,7 +23,7 @@
     "opencode-worker": "./dist/index.js"
   },
   "dependencies": {
-    "iii-sdk": "0.22.1-alpha.25",
+    "iii-sdk": "0.23.0",
     "yaml": "^2.6.0",
     "zod": "^4.0.0"
   },

--- a/opencode/pnpm-lock.yaml
+++ b/opencode/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       iii-sdk:
-        specifier: 0.22.1-alpha.25
-        version: 0.22.1-alpha.25
+        specifier: 0.23.0
+        version: 0.23.0
       yaml:
         specifier: ^2.6.0
         version: 2.9.0
@@ -560,8 +560,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@iii-dev/helpers@0.22.1-alpha.25':
-    resolution: {integrity: sha512-q3XQZ4i+eMA4mi1iRaNHlTcIGJVvhCYkmfiIPn0rvlFjLYU32vEqjbxKeNsy9YyRbAhGbjF+kzXp2cUpycVhJw==}
+  '@iii-dev/helpers@0.23.0':
+    resolution: {integrity: sha512-q5iG1zZ8QNo32OuPqgxsSV4VM6/OYD43m/CObPYNUW2+loZBLniaoKo4sR20odxvH+aBue0pDz2G1z+K9sOK7A==}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -936,8 +936,8 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  iii-sdk@0.22.1-alpha.25:
-    resolution: {integrity: sha512-WUDzAydJacutn5IQz3Tcx296fAn88UnUt8S5/2slRsZK7WCadMS9o3qXmkgKAUAmPHsdCOAwVolBWNnAz4imqQ==}
+  iii-sdk@0.23.0:
+    resolution: {integrity: sha512-qpz7801IVfzwBy4nA/jGmabwZnDvN3Lf39RE6o9CgfIT4QAzgyYudXOfhOZypngmLfBBV/LDX6qJbUzgTlkSig==}
 
   import-in-the-middle@1.15.0:
     resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
@@ -1440,7 +1440,7 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@iii-dev/helpers@0.22.1-alpha.25':
+  '@iii-dev/helpers@0.23.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.57.2
@@ -1839,9 +1839,9 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  iii-sdk@0.22.1-alpha.25:
+  iii-sdk@0.23.0:
     dependencies:
-      '@iii-dev/helpers': 0.22.1-alpha.25
+      '@iii-dev/helpers': 0.23.0
       '@opentelemetry/api': 1.9.1
       ws: 8.21.0
     transitivePeerDependencies:

--- a/opengantry/iii.worker.yaml
+++ b/opengantry/iii.worker.yaml
@@ -14,4 +14,4 @@ description: OpenGantry governance for iii. Kernel verify and middleware gate be
 runtime:
   kind: javascript
 scripts:
-  start: node ./index.mjs
+  start: node ./dist/bundle/index.mjs

--- a/opengantry/package.json
+++ b/opengantry/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@jeger-ai/opengantry": "^3.2.5",
-    "iii-sdk": "0.22.1-alpha.25",
+    "iii-sdk": "0.23.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/opengantry/pnpm-lock.yaml
+++ b/opengantry/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^3.2.5
         version: 3.2.5
       iii-sdk:
-        specifier: 0.22.1-alpha.25
-        version: 0.22.1-alpha.25
+        specifier: 0.23.0
+        version: 0.23.0
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -248,8 +248,8 @@ packages:
     peerDependencies:
       hono: ^4
 
-  '@iii-dev/helpers@0.22.1-alpha.25':
-    resolution: {integrity: sha512-q3XQZ4i+eMA4mi1iRaNHlTcIGJVvhCYkmfiIPn0rvlFjLYU32vEqjbxKeNsy9YyRbAhGbjF+kzXp2cUpycVhJw==}
+  '@iii-dev/helpers@0.23.0':
+    resolution: {integrity: sha512-q5iG1zZ8QNo32OuPqgxsSV4VM6/OYD43m/CObPYNUW2+loZBLniaoKo4sR20odxvH+aBue0pDz2G1z+K9sOK7A==}
 
   '@jeger-ai/opengantry@3.2.5':
     resolution: {integrity: sha512-mM9HjNUgbh1sm+q/fNrM2DTfspXyQOzHJg2ZOjjwNAGYbdF24CkOJZX6J7OOggLpB65O112pUT62XXjY9XJHzg==}
@@ -576,8 +576,8 @@ packages:
     resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
     engines: {node: '>=0.10.0'}
 
-  iii-sdk@0.22.1-alpha.25:
-    resolution: {integrity: sha512-WUDzAydJacutn5IQz3Tcx296fAn88UnUt8S5/2slRsZK7WCadMS9o3qXmkgKAUAmPHsdCOAwVolBWNnAz4imqQ==}
+  iii-sdk@0.23.0:
+    resolution: {integrity: sha512-qpz7801IVfzwBy4nA/jGmabwZnDvN3Lf39RE6o9CgfIT4QAzgyYudXOfhOZypngmLfBBV/LDX6qJbUzgTlkSig==}
 
   import-in-the-middle@1.15.0:
     resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
@@ -960,7 +960,7 @@ snapshots:
     dependencies:
       hono: 4.13.2
 
-  '@iii-dev/helpers@0.22.1-alpha.25':
+  '@iii-dev/helpers@0.23.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.57.2
@@ -1366,9 +1366,9 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  iii-sdk@0.22.1-alpha.25:
+  iii-sdk@0.23.0:
     dependencies:
-      '@iii-dev/helpers': 0.22.1-alpha.25
+      '@iii-dev/helpers': 0.23.0
       '@opentelemetry/api': 1.9.1
       ws: 8.21.3
     transitivePeerDependencies:

--- a/opengantry/scripts/build-bundle.mjs
+++ b/opengantry/scripts/build-bundle.mjs
@@ -52,6 +52,5 @@ await build({
   logLevel: 'info',
 });
 
-// dist/ is bind-mounted empty inside libkrun. Copy next to worker-compose.yaml so
-// `compose::add` can run `node ./index.mjs` after `cp sandbox.mjs index.mjs`.
+// Keep a separate copy for the sandbox boot verification script.
 await copyFile(join(root, 'dist/bundle/index.mjs'), join(root, 'sandbox.mjs'));

--- a/openwiki/iii.worker.yaml
+++ b/openwiki/iii.worker.yaml
@@ -11,7 +11,7 @@ runtime:
   kind: javascript
 
 scripts:
-  start: node ./index.mjs
+  start: node ./dist/bundle/index.mjs
 
 dependencies:
   state: "^0.22.2"

--- a/openwiki/package.json
+++ b/openwiki/package.json
@@ -18,7 +18,7 @@
     "start": "node src/index.mjs"
   },
   "dependencies": {
-    "iii-sdk": "0.22.1-alpha.25"
+    "iii-sdk": "0.23.0"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.10",

--- a/openwiki/pnpm-lock.yaml
+++ b/openwiki/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       iii-sdk:
-        specifier: 0.22.1-alpha.25
-        version: 0.22.1-alpha.25
+        specifier: 0.23.0
+        version: 0.23.0
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.10
@@ -230,8 +230,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@iii-dev/helpers@0.22.1-alpha.25':
-    resolution: {integrity: sha512-q3XQZ4i+eMA4mi1iRaNHlTcIGJVvhCYkmfiIPn0rvlFjLYU32vEqjbxKeNsy9YyRbAhGbjF+kzXp2cUpycVhJw==}
+  '@iii-dev/helpers@0.23.0':
+    resolution: {integrity: sha512-q5iG1zZ8QNo32OuPqgxsSV4VM6/OYD43m/CObPYNUW2+loZBLniaoKo4sR20odxvH+aBue0pDz2G1z+K9sOK7A==}
 
   '@opentelemetry/api-logs@0.57.2':
     resolution: {integrity: sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==}
@@ -386,8 +386,8 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  iii-sdk@0.22.1-alpha.25:
-    resolution: {integrity: sha512-WUDzAydJacutn5IQz3Tcx296fAn88UnUt8S5/2slRsZK7WCadMS9o3qXmkgKAUAmPHsdCOAwVolBWNnAz4imqQ==}
+  iii-sdk@0.23.0:
+    resolution: {integrity: sha512-qpz7801IVfzwBy4nA/jGmabwZnDvN3Lf39RE6o9CgfIT4QAzgyYudXOfhOZypngmLfBBV/LDX6qJbUzgTlkSig==}
 
   import-in-the-middle@1.15.0:
     resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
@@ -563,7 +563,7 @@ snapshots:
   '@esbuild/win32-x64@0.25.12':
     optional: true
 
-  '@iii-dev/helpers@0.22.1-alpha.25':
+  '@iii-dev/helpers@0.23.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.57.2
@@ -745,9 +745,9 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  iii-sdk@0.22.1-alpha.25:
+  iii-sdk@0.23.0:
     dependencies:
-      '@iii-dev/helpers': 0.22.1-alpha.25
+      '@iii-dev/helpers': 0.23.0
       '@opentelemetry/api': 1.9.1
       ws: 8.21.1
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -695,8 +695,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/console-ui
       iii-sdk:
-        specifier: 0.22.1-alpha.25
-        version: 0.22.1-alpha.25
+        specifier: 0.23.0
+        version: 0.23.0
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -1445,8 +1445,8 @@ packages:
   '@iconify/utils@3.1.4':
     resolution: {integrity: sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==}
 
-  '@iii-dev/helpers@0.22.1-alpha.25':
-    resolution: {integrity: sha512-q3XQZ4i+eMA4mi1iRaNHlTcIGJVvhCYkmfiIPn0rvlFjLYU32vEqjbxKeNsy9YyRbAhGbjF+kzXp2cUpycVhJw==}
+  '@iii-dev/helpers@0.23.0':
+    resolution: {integrity: sha512-q5iG1zZ8QNo32OuPqgxsSV4VM6/OYD43m/CObPYNUW2+loZBLniaoKo4sR20odxvH+aBue0pDz2G1z+K9sOK7A==}
 
   '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0':
     resolution: {integrity: sha512-qvsTEwEFefhdirGOPnu9Wp6ChfIwy2dBCRuETU3uE+4cC+PFoxMSiiEhxk4lOluA34eARHA0OxqsEUYDqRMgeQ==}
@@ -3951,8 +3951,8 @@ packages:
   iii-browser-sdk@0.23.0:
     resolution: {integrity: sha512-tnTi6Szu5NwtCJNpA9hcbfIJ0Kb9BjXbRdA4gwswRKiSyduhoVNUoHaK8XTMCgQs/6vWRqwhGn1CHeVYeJB2cg==}
 
-  iii-sdk@0.22.1-alpha.25:
-    resolution: {integrity: sha512-WUDzAydJacutn5IQz3Tcx296fAn88UnUt8S5/2slRsZK7WCadMS9o3qXmkgKAUAmPHsdCOAwVolBWNnAz4imqQ==}
+  iii-sdk@0.23.0:
+    resolution: {integrity: sha512-qpz7801IVfzwBy4nA/jGmabwZnDvN3Lf39RE6o9CgfIT4QAzgyYudXOfhOZypngmLfBBV/LDX6qJbUzgTlkSig==}
 
   image-blob-reduce@3.0.1:
     resolution: {integrity: sha512-/VmmWgIryG/wcn4TVrV7cC4mlfUC/oyiKIfSg5eVM3Ten/c1c34RJhMYKCWTnoSMHSqXLt3tsrBR4Q2HInvN+Q==}
@@ -5666,7 +5666,7 @@ snapshots:
       '@iconify/types': 2.0.0
       import-meta-resolve: 4.2.0
 
-  '@iii-dev/helpers@0.22.1-alpha.25':
+  '@iii-dev/helpers@0.23.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.57.2
@@ -8141,9 +8141,9 @@ snapshots:
 
   iii-browser-sdk@0.23.0: {}
 
-  iii-sdk@0.22.1-alpha.25:
+  iii-sdk@0.23.0:
     dependencies:
-      '@iii-dev/helpers': 0.22.1-alpha.25
+      '@iii-dev/helpers': 0.23.0
       '@opentelemetry/api': 1.9.1
       ws: 8.21.1
     transitivePeerDependencies:

--- a/pubsub/Cargo.lock
+++ b/pubsub/Cargo.lock
@@ -696,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0342a8980e12e9bb994d9221637914a719a156cee73705b595d6588e45c9cfca"
+checksum = "e654538584cf6feec82f4f9e773d4b9f8c84bba5085e49a585aebe7227f8af8c"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -737,9 +737,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.22.1-alpha.25"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb1167081b82a1aa9f12b05ad9e093fdf1cd2a3ed282bb66451a26e37f4a459"
+checksum = "3952d1ac84c88304fa27fef8ce0a9350585abe9e9b9f7513730497e72918186f"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/pubsub/Cargo.toml
+++ b/pubsub/Cargo.toml
@@ -18,7 +18,7 @@ name = "pubsub"
 path = "src/main.rs"
 
 [dependencies]
-iii-sdk = "=0.22.1-alpha.25"
+iii-sdk = "=0.23.0"
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time"] }
 serde = { version = "1", features = ["derive"] }

--- a/rbac-proxy/Cargo.lock
+++ b/rbac-proxy/Cargo.lock
@@ -692,9 +692,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0342a8980e12e9bb994d9221637914a719a156cee73705b595d6588e45c9cfca"
+checksum = "e654538584cf6feec82f4f9e773d4b9f8c84bba5085e49a585aebe7227f8af8c"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -713,9 +713,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.22.1-alpha.25"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb1167081b82a1aa9f12b05ad9e093fdf1cd2a3ed282bb66451a26e37f4a459"
+checksum = "3952d1ac84c88304fa27fef8ce0a9350585abe9e9b9f7513730497e72918186f"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/rbac-proxy/Cargo.toml
+++ b/rbac-proxy/Cargo.toml
@@ -15,7 +15,7 @@ name = "rbac_proxy"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.22.1-alpha.25"
+iii-sdk = "=0.23.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "net", "io-util", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/sandbox-code-runner/Cargo.lock
+++ b/sandbox-code-runner/Cargo.lock
@@ -691,9 +691,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.22.1-alpha.25"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d24f39bff5a54a18ad0dbe92fff0311fe7d12445ec26da12b8d6b09056166bc"
+checksum = "e654538584cf6feec82f4f9e773d4b9f8c84bba5085e49a585aebe7227f8af8c"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -712,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.22.1-alpha.25"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb1167081b82a1aa9f12b05ad9e093fdf1cd2a3ed282bb66451a26e37f4a459"
+checksum = "3952d1ac84c88304fa27fef8ce0a9350585abe9e9b9f7513730497e72918186f"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/sandbox-code-runner/Cargo.toml
+++ b/sandbox-code-runner/Cargo.toml
@@ -14,8 +14,8 @@ path = "src/main.rs"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.22.1-alpha.25"
-iii-helpers = "=0.22.1-alpha.25"
+iii-sdk = "=0.23.0"
+iii-helpers = "=0.23.0"
 # Worker-side injectable console UI (content function + console:script/style
 # triggers + hot-reload watcher) — direct link, never published.
 iii-console-ui = { path = "../crates/console-ui" }

--- a/sandbox-code-runner/ui/package.json
+++ b/sandbox-code-runner/ui/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@iii-dev/console-ui": "workspace:*",
-    "iii-sdk": "0.22.1-alpha.25",
+    "iii-sdk": "0.23.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/security-scan/Cargo.lock
+++ b/security-scan/Cargo.lock
@@ -715,9 +715,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.22.1-alpha.25"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d24f39bff5a54a18ad0dbe92fff0311fe7d12445ec26da12b8d6b09056166bc"
+checksum = "e654538584cf6feec82f4f9e773d4b9f8c84bba5085e49a585aebe7227f8af8c"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -736,9 +736,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.22.1-alpha.25"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb1167081b82a1aa9f12b05ad9e093fdf1cd2a3ed282bb66451a26e37f4a459"
+checksum = "3952d1ac84c88304fa27fef8ce0a9350585abe9e9b9f7513730497e72918186f"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/security-scan/Cargo.toml
+++ b/security-scan/Cargo.toml
@@ -20,9 +20,9 @@ async-trait = "0.1"
 base64 = "0.22"
 clap = { version = "4", features = ["derive", "env"] }
 cron = "0.12"
-iii-helpers = "=0.22.1-alpha.25"
+iii-helpers = "=0.23.0"
 iii-console-ui = { path = "../crates/console-ui" }
-iii-sdk = "=0.22.1-alpha.25"
+iii-sdk = "=0.23.0"
 schemars = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/slack/Cargo.lock
+++ b/slack/Cargo.lock
@@ -657,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0342a8980e12e9bb994d9221637914a719a156cee73705b595d6588e45c9cfca"
+checksum = "e654538584cf6feec82f4f9e773d4b9f8c84bba5085e49a585aebe7227f8af8c"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -678,9 +678,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.22.1-alpha.25"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb1167081b82a1aa9f12b05ad9e093fdf1cd2a3ed282bb66451a26e37f4a459"
+checksum = "3952d1ac84c88304fa27fef8ce0a9350585abe9e9b9f7513730497e72918186f"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/slack/Cargo.toml
+++ b/slack/Cargo.toml
@@ -15,7 +15,7 @@ name = "slack"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.22.1-alpha.25"
+iii-sdk = "=0.23.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/telegram-bot/Cargo.lock
+++ b/telegram-bot/Cargo.lock
@@ -679,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.22.1-alpha.25"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d24f39bff5a54a18ad0dbe92fff0311fe7d12445ec26da12b8d6b09056166bc"
+checksum = "e654538584cf6feec82f4f9e773d4b9f8c84bba5085e49a585aebe7227f8af8c"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -700,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.22.1-alpha.25"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb1167081b82a1aa9f12b05ad9e093fdf1cd2a3ed282bb66451a26e37f4a459"
+checksum = "3952d1ac84c88304fa27fef8ce0a9350585abe9e9b9f7513730497e72918186f"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/telegram-bot/Cargo.toml
+++ b/telegram-bot/Cargo.toml
@@ -15,8 +15,8 @@ name = "telegram_bot"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.22.1-alpha.25"
-iii-helpers = "=0.22.1-alpha.25"
+iii-sdk = "=0.23.0"
+iii-helpers = "=0.23.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/workflow/Cargo.lock
+++ b/workflow/Cargo.lock
@@ -633,9 +633,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.22.1-alpha.25"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d24f39bff5a54a18ad0dbe92fff0311fe7d12445ec26da12b8d6b09056166bc"
+checksum = "e654538584cf6feec82f4f9e773d4b9f8c84bba5085e49a585aebe7227f8af8c"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -654,9 +654,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.22.1-alpha.25"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb1167081b82a1aa9f12b05ad9e093fdf1cd2a3ed282bb66451a26e37f4a459"
+checksum = "3952d1ac84c88304fa27fef8ce0a9350585abe9e9b9f7513730497e72918186f"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/workflow/Cargo.toml
+++ b/workflow/Cargo.toml
@@ -15,8 +15,8 @@ name = "workflow"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.22.1-alpha.25"
-iii-helpers = "=0.22.1-alpha.25"
+iii-sdk = "=0.23.0"
+iii-helpers = "=0.23.0"
 # Shared plumbing for the builtin `configuration` worker (seeding, retries,
 # NOT_FOUND semantics, serialized hot-reload, guidance binding slot).
 iii-config-client = { path = "../crates/config-client" }

--- a/worktree/Cargo.lock
+++ b/worktree/Cargo.lock
@@ -683,9 +683,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0342a8980e12e9bb994d9221637914a719a156cee73705b595d6588e45c9cfca"
+checksum = "e654538584cf6feec82f4f9e773d4b9f8c84bba5085e49a585aebe7227f8af8c"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -704,9 +704,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.22.1-alpha.25"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb1167081b82a1aa9f12b05ad9e093fdf1cd2a3ed282bb66451a26e37f4a459"
+checksum = "3952d1ac84c88304fa27fef8ce0a9350585abe9e9b9f7513730497e72918186f"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/worktree/Cargo.toml
+++ b/worktree/Cargo.toml
@@ -15,7 +15,7 @@ name = "worktree"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.22.1-alpha.25"
+iii-sdk = "=0.23.0"
 iii-worker-paths = { path = "../crates/worker-paths" }
 # Worker-side injectable console UI (content function + console:script/style
 # triggers + hot-reload watcher) — direct path link, never published.


### PR DESCRIPTION
## Summary

- update workers that failed custom-namespace registration to `iii-sdk` 0.23.0 and align direct helper dependencies
- start bundled JavaScript workers from the packaged `dist/bundle/index.mjs` entry point
- keep the shared configuration client compatible with the previous prerelease and current stable SDK lines
- update the shared Python sandbox runtime to Wasmtime 47.0.4 for the current RustSec fixes
- refresh lockfiles and schema fixtures, and add release-artifact coverage for compose start commands

## Validation

- ran the published worker catalog under the `worker_update` namespace; 53 workers registered and the 17 failed source packages were updated in this change
- passed Cargo tests, formatting, and Clippy for the affected Rust workers, `config-client`, and `python-core`
- passed build, test, type-check, and CI-equivalent Biome checks for the affected catalog Node workers
- passed the sandbox UI build and 275 tests
- passed Hermes Ruff checks and 46 tests
- passed `.github/scripts/tests/test_worker_compose.py` and the updated SDK runtime regression tests
- passed all 95 current-head CI checks

Fixes MOT-4663