### PR TITLE
(MOT-4664) feat(console): composer toolbar slot for injected worker actions

### DIFF
--- a/.github/scripts/tests/test_worker_compose.py
+++ b/.github/scripts/tests/test_worker_compose.py
@@ -55,8 +55,8 @@ def test_rust_frontends_are_explicit_workspace_locked_builds():
         for worker in document["workers"].values()
         for frontend in worker["artifact"].get("frontends", [])
     ]
-    assert sum(bool(worker["artifact"].get("frontends")) for worker in document["workers"].values()) == 41
-    assert len(frontends) == 44
+    assert sum(bool(worker["artifact"].get("frontends")) for worker in document["workers"].values()) == 42
+    assert len(frontends) == 45
     for frontend in frontends:
         assert set(frontend) == {
             "workspace_root", "source_path", "runtime", "package_manager", "lockfile",

--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -63,7 +63,11 @@ import {
 } from '@/lib/trace-links'
 import { turnAnchorMessageId } from '@/lib/turn-anchor'
 import { SEND_FAILED_CODE } from '@/lib/turn-failure'
-import { useExtSessionChips, useExtSessionTurnSummaries } from '@/lib/ui-slots'
+import {
+  useExtComposerActions,
+  useExtSessionChips,
+  useExtSessionTurnSummaries,
+} from '@/lib/ui-slots'
 import {
   activateWorkingDir,
   fetchDefaultWorkingDir,
@@ -806,6 +810,21 @@ export function ChatView({
       )
     })
   }, [extSessionTurnSummaries, conversation.id, streamingIndicator])
+
+  const extComposerActions = useExtComposerActions()
+  const composerActions = useMemo(() => {
+    if (extComposerActions.length === 0) return null
+    return [...extComposerActions].sort(compareChips).map((action) => {
+      const Action = action.render
+      return (
+        <Action
+          key={action.id}
+          sessionId={conversation.id}
+          isStreaming={streamingIndicator}
+        />
+      )
+    })
+  }, [extComposerActions, conversation.id, streamingIndicator])
 
   /* Shared live region: SR announcements for auto-accept, stop-reason
    * notices, and compaction markers route through this hook. Sighted
@@ -2436,6 +2455,7 @@ export function ChatView({
             }
             initialText={composerInitialText}
             onTextChange={handleComposerTextChange}
+            composerActions={composerActions}
             onSubmit={handleSubmit}
             onStop={handleStop}
             stopping={stopping}

--- a/console/web/src/components/chat/Composer.tsx
+++ b/console/web/src/components/chat/Composer.tsx
@@ -20,6 +20,7 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
 } from 'react'
 import { PermissionModePicker } from '@/components/permissions/PermissionModePicker'
 import { MOBILE_LAYOUT_QUERY, useMediaQuery } from '@/hooks/use-media-query'
@@ -49,6 +50,43 @@ import { LexicalShell } from './LexicalShell'
 import { ModelPicker } from './ModelPicker'
 import { nextHistoryTarget } from './queue-history'
 import { useFileDrop } from './use-file-drop'
+
+const WIDE_TOOLBAR_QUERY = '(min-width: 640px)'
+
+function subscribeWideToolbar(onChange: () => void): () => void {
+  if (typeof window.matchMedia !== 'function') return () => {}
+  const query = window.matchMedia(WIDE_TOOLBAR_QUERY)
+  query.addEventListener('change', onChange)
+  return () => query.removeEventListener('change', onChange)
+}
+
+function readWideToolbar(): boolean {
+  if (typeof window.matchMedia !== 'function') return true
+  return window.matchMedia(WIDE_TOOLBAR_QUERY).matches
+}
+
+/**
+ * Injected composer actions are stateful components (a microphone holds a
+ * capture session), so they must mount once. The two toolbar layouts are
+ * both in the DOM and only CSS hides one, so this slot mounts its children
+ * in the layout that is currently visible and nothing in the other.
+ */
+function ComposerActionsSlot({
+  layout,
+  children,
+}: {
+  layout: 'narrow' | 'wide'
+  children: ReactNode
+}) {
+  const wide = useSyncExternalStore(
+    subscribeWideToolbar,
+    readWideToolbar,
+    () => true,
+  )
+  if (!children) return null
+  const visible = wide ? layout === 'wide' : layout === 'narrow'
+  return visible ? <>{children}</> : null
+}
 
 export interface ComposerSubmitPayload {
   text: string
@@ -567,7 +605,7 @@ export function Composer({
             disabled={inputDisabled}
             className={toolbarIconButtonClass}
           />
-          {composerActions}
+          <ComposerActionsSlot layout="narrow">{composerActions}</ComposerActionsSlot>
           <button
             type="button"
             onClick={() => setMobileSettingsOpen(true)}
@@ -606,7 +644,7 @@ export function Composer({
               disabled={inputDisabled}
               className={toolbarIconButtonClass}
             />
-            {composerActions}
+            <ComposerActionsSlot layout="wide">{composerActions}</ComposerActionsSlot>
             {showMemoryBank && onMemoryBankChange ? (
               <BankPicker
                 value={memoryBank ?? null}

--- a/console/web/src/components/chat/Composer.tsx
+++ b/console/web/src/components/chat/Composer.tsx
@@ -12,7 +12,15 @@ import {
   MoreHorizontal,
   Square,
 } from 'lucide-react'
-import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import { PermissionModePicker } from '@/components/permissions/PermissionModePicker'
 import { MOBILE_LAYOUT_QUERY, useMediaQuery } from '@/hooks/use-media-query'
 import { attachmentsFromFiles } from '@/lib/attachments/from-files'
@@ -155,6 +163,11 @@ interface ComposerProps {
   onTextChange?: (text: string) => void
   /** Initial attachment chips (applied once on mount). */
   initialAttachments?: Attachment[]
+  /**
+   * Injected toolbar actions rendered beside the attach button (the
+   * `host.chat.registerComposerAction` slot), already built by the host.
+   */
+  composerActions?: ReactNode
   functionEntries?: FunctionEntry[]
   /**
    * Queued messages the composer can browse+edit with ↑/↓, oldest→newest.
@@ -211,6 +224,7 @@ export function Composer({
   initialText,
   onTextChange,
   initialAttachments,
+  composerActions,
   functionEntries,
   queuedForEdit,
   onEditQueued,
@@ -553,6 +567,7 @@ export function Composer({
             disabled={inputDisabled}
             className={toolbarIconButtonClass}
           />
+          {composerActions}
           <button
             type="button"
             onClick={() => setMobileSettingsOpen(true)}
@@ -591,6 +606,7 @@ export function Composer({
               disabled={inputDisabled}
               className={toolbarIconButtonClass}
             />
+            {composerActions}
             {showMemoryBank && onMemoryBankChange ? (
               <BankPicker
                 value={memoryBank ?? null}

--- a/console/web/src/components/chat/Composer.tsx
+++ b/console/web/src/components/chat/Composer.tsx
@@ -605,7 +605,9 @@ export function Composer({
             disabled={inputDisabled}
             className={toolbarIconButtonClass}
           />
-          <ComposerActionsSlot layout="narrow">{composerActions}</ComposerActionsSlot>
+          <ComposerActionsSlot layout="narrow">
+            {composerActions}
+          </ComposerActionsSlot>
           <button
             type="button"
             onClick={() => setMobileSettingsOpen(true)}
@@ -644,7 +646,9 @@ export function Composer({
               disabled={inputDisabled}
               className={toolbarIconButtonClass}
             />
-            <ComposerActionsSlot layout="wide">{composerActions}</ComposerActionsSlot>
+            <ComposerActionsSlot layout="wide">
+              {composerActions}
+            </ComposerActionsSlot>
             {showMemoryBank && onMemoryBankChange ? (
               <BankPicker
                 value={memoryBank ?? null}

--- a/console/web/src/lib/ui-composer-action-slots.test.ts
+++ b/console/web/src/lib/ui-composer-action-slots.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import type { RegisteredComposerAction } from './ui-slots'
+import { getExtComposerActions, registerExtComposerAction } from './ui-slots'
+
+function action(id: string, path: string): RegisteredComposerAction {
+  return { id, path, scope: path.split('/')[0], render: () => null }
+}
+
+describe('composer action slot', () => {
+  it('dedupes by id and restores a shadowed registration', () => {
+    const offVoice = registerExtComposerAction(
+      action('dictate', 'voice/page.js'),
+    )
+    const offOther = registerExtComposerAction(
+      action('dictate', 'other/page.js'),
+    )
+
+    expect(getExtComposerActions().map((item) => item.path)).toEqual([
+      'other/page.js',
+    ])
+
+    offOther()
+    expect(getExtComposerActions().map((item) => item.path)).toEqual([
+      'voice/page.js',
+    ])
+
+    offVoice()
+    offVoice()
+    expect(getExtComposerActions()).toEqual([])
+  })
+
+  it('preserves registration order across distinct ids', () => {
+    const offA = registerExtComposerAction(action('dictate', 'voice/page.js'))
+    const offB = registerExtComposerAction(action('snippet', 'snip/page.js'))
+
+    expect(getExtComposerActions().map((item) => item.id)).toEqual([
+      'dictate',
+      'snippet',
+    ])
+
+    offA()
+    offB()
+  })
+})

--- a/console/web/src/lib/ui-loader.tsx
+++ b/console/web/src/lib/ui-loader.tsx
@@ -28,6 +28,7 @@ import { PaneConfigurationProvider } from '@/lib/pane-configuration'
 import { requestPanelOpen } from '@/lib/panel-context'
 import { ExtensionScopeProvider } from '@/lib/ui-scope'
 import {
+  registerExtComposerAction,
   registerExtConfigForm,
   registerExtPage,
   registerExtProviderConfigForm,
@@ -39,6 +40,7 @@ import {
 } from '@/lib/ui-slots'
 import { requestWorkingDirectoryChange } from '@/lib/working-directory-request'
 import type {
+  ComposerActionProps,
   ConfigFormProps,
   ConsoleApi,
   Host,
@@ -258,6 +260,21 @@ function makeHost(
             render: (props: SessionTurnSummaryProps) => (
               <ScopedExtension scope={scope} path={path}>
                 <Summary {...props} />
+              </ScopedExtension>
+            ),
+          }),
+        )
+      },
+      registerComposerAction(action) {
+        const Action = action.render
+        return track(
+          registerExtComposerAction({
+            ...action,
+            scope,
+            path,
+            render: (props: ComposerActionProps) => (
+              <ScopedExtension scope={scope} path={path}>
+                <Action {...props} />
               </ScopedExtension>
             ),
           }),

--- a/console/web/src/lib/ui-slots.ts
+++ b/console/web/src/lib/ui-slots.ts
@@ -8,6 +8,7 @@
 
 import { useMemo, useSyncExternalStore } from 'react'
 import type {
+  ComposerActionRegistration,
   ConfigFormLayout,
   ConfigFormProps,
   FunctionTriggerRenderer,
@@ -64,6 +65,11 @@ export interface RegisteredSessionChip extends SessionChipRegistration {
 
 export interface RegisteredSessionTurnSummary
   extends SessionTurnSummaryRegistration {
+  scope: string
+  path: string
+}
+
+export interface RegisteredComposerAction extends ComposerActionRegistration {
   scope: string
   path: string
 }
@@ -138,6 +144,7 @@ const configFormsStore = createStore<RegisteredConfigForm>()
 const providerConfigFormsStore = createStore<RegisteredProviderConfigForm>()
 const sessionChipsStore = createStore<RegisteredSessionChip>()
 const sessionTurnSummariesStore = createStore<RegisteredSessionTurnSummary>()
+const composerActionsStore = createStore<RegisteredComposerAction>()
 const uiAssetsStatusStore = createValueStore<UiAssetsStatus>('unavailable')
 
 /**
@@ -224,6 +231,22 @@ export function registerExtSessionTurnSummary(
     )
   }
   return sessionTurnSummariesStore.add(entry)
+}
+
+/** Duplicate action id: last registration wins in the composer toolbar. */
+export function registerExtComposerAction(
+  entry: RegisteredComposerAction,
+): () => void {
+  const duplicate = composerActionsStore
+    .get()
+    .find((action) => action.id === entry.id)
+  if (duplicate && duplicate.path !== entry.path) {
+    console.warn(
+      `[iii-ui] duplicate composer action id '${entry.id}' - ` +
+        `'${entry.path}' overrides '${duplicate.path}'`,
+    )
+  }
+  return composerActionsStore.add(entry)
 }
 
 export function getExtPages(): readonly RegisteredPage[] {
@@ -363,6 +386,28 @@ export function useExtSessionTurnSummaries(): readonly RegisteredSessionTurnSumm
     () => EMPTY,
   )
   return useMemo(() => dedupeSessionTurnSummaries(summaries), [summaries])
+}
+
+function dedupeComposerActions(
+  actions: readonly RegisteredComposerAction[],
+): readonly RegisteredComposerAction[] {
+  const byId = new Map<string, RegisteredComposerAction>()
+  for (const action of actions) byId.set(action.id, action)
+  return [...byId.values()]
+}
+
+/** Composer toolbar actions deduplicated by id; last registration wins. */
+export function getExtComposerActions(): readonly RegisteredComposerAction[] {
+  return dedupeComposerActions(composerActionsStore.get())
+}
+
+export function useExtComposerActions(): readonly RegisteredComposerAction[] {
+  const actions = useSyncExternalStore(
+    composerActionsStore.subscribe,
+    composerActionsStore.get,
+    () => EMPTY,
+  )
+  return useMemo(() => dedupeComposerActions(actions), [actions])
 }
 
 /** The injected form override for one configuration id (last wins). */

--- a/console/web/src/types/injectable-ui.ts
+++ b/console/web/src/types/injectable-ui.ts
@@ -450,6 +450,27 @@ export interface SessionTurnSummaryRegistration {
 }
 
 /**
+ * Props a composer action receives. The host supplies the active session
+ * and its live turn state; the action owns everything else and hands text
+ * back through `host.chat.compose`.
+ */
+export interface ComposerActionProps {
+  /** Active session id, or `null` while the conversation has none yet. */
+  sessionId: string | null
+  isStreaming: boolean
+}
+
+/**
+ * An icon-sized action rendered in the composer's toolbar, beside the
+ * attach button. Duplicate `id`: last registration wins.
+ */
+export interface ComposerActionRegistration {
+  /** kebab-case; convention `<worker>-<name>`. */
+  id: string
+  render: React.ComponentType<ComposerActionProps>
+}
+
+/**
  * What `setup(host)` receives. Every registrar returns an unregister fn AND
  * is auto-tracked: the loader runs all of them on dispose.
  */
@@ -511,6 +532,7 @@ export interface Host {
     compose(draft: { text?: string; files?: File[] }): void
     registerSessionChip(chip: SessionChipRegistration): () => void
     registerTurnSummary(summary: SessionTurnSummaryRegistration): () => void
+    registerComposerAction(action: ComposerActionRegistration): () => void
     /** Jump the sidebar to this session. Feature-detect on older consoles. */
     selectConversation?(sessionId: string): void
     /**

--- a/docs/sops/injectable-console-ui.md
+++ b/docs/sops/injectable-console-ui.md
@@ -1023,6 +1023,27 @@ fetch their own data over `host.iii` (subscribe to your worker's triggers,
 hydrate with a function call on mount); the host passes identity only.
 Feature-detect on older consoles: `host.chat?.registerSessionChip`.
 
+### `host.chat.registerComposerAction({ id, render })`
+
+An icon-sized action in the composer's toolbar, rendered just before the
+attach button on every composer layout (the narrow row and the wide right
+cluster). Use it for input affordances that belong next to the caret:
+dictation, a snippet picker, a template. Your component receives:
+
+```ts
+interface ComposerActionProps {
+  sessionId: string | null  // null while the conversation has no session yet
+  isStreaming: boolean      // the session is producing a turn
+}
+```
+
+Render a single `IconButton` (16 px glyph, `label` as the accessible name)
+sized to match the attach button; hand text back through
+`host.chat.compose({ text })` and never submit on the user's behalf.
+Duplicate ids: last registration wins. Feature-detect on older consoles:
+`host.chat?.registerComposerAction`, and fall back to a session chip when it
+is absent.
+
 ### `host.chat` conversation helpers
 
 Newer Consoles expose two optional, non-rendering helpers on the same
@@ -1244,10 +1265,10 @@ its own board: the registry refuses to disable it.
 ## Status: shipped vs spec
 
 The implementation covers the spec's protocol, loader, and runtime slot
-registry. The spec's composer slot (`host.composer`) shipped later as
-`host.chat.registerSessionChip` — chips render in the chat header's right
-cluster, not the composer toolbar. Not shipped yet (don't design against
-them):
+registry. The spec's composer slot (`host.composer`) shipped in two parts:
+`host.chat.registerSessionChip` for status chips in the chat header's right
+cluster, and `host.chat.registerComposerAction` for icon actions in the
+composer toolbar itself. Not shipped yet (don't design against them):
 
 | Spec item | Status |
 |---|---|

--- a/packages/console-ui/index.d.ts
+++ b/packages/console-ui/index.d.ts
@@ -388,6 +388,24 @@ export interface SessionTurnSummaryRegistration {
   render: React.ComponentType<SessionTurnSummaryProps>
 }
 
+/** Props a composer toolbar action receives. */
+export interface ComposerActionProps {
+  /** Active session id, or `null` while the conversation has none yet. */
+  sessionId: string | null
+  /** Whether this session is currently producing a turn. */
+  isStreaming: boolean
+}
+
+/**
+ * An icon-sized action rendered in the composer's toolbar, beside the
+ * attach button. Duplicate `id`: last registration wins.
+ */
+export interface ComposerActionRegistration {
+  /** kebab-case; convention `<worker>-<name>`. */
+  id: string
+  render: React.ComponentType<ComposerActionProps>
+}
+
 /** Props for a worker-owned annotation detail rendered in the transcript. */
 export interface TranscriptAnnotationProps {
   version: number
@@ -480,6 +498,8 @@ export interface Host {
     registerSessionChip(chip: SessionChipRegistration): () => void
     /** Optional on consoles that predate the footer turn-summary slot. */
     registerTurnSummary?(summary: SessionTurnSummaryRegistration): () => void
+    /** Optional on consoles that predate the composer toolbar slot. */
+    registerComposerAction?(action: ComposerActionRegistration): () => void
     registerTranscriptRenderer?(renderer: TranscriptRendererRegistration): () => void
     /** Optional on consoles that predate worker-driven conversation switching. */
     selectConversation?(sessionId: string): void


### PR DESCRIPTION
## What

Adds a composer toolbar slot that injected worker UIs can fill, next to the attachment button in both the desktop and phone composer layouts.

- `host.chat.registerComposerAction(id, Component)` in the injectable-UI host, mirroring the session chip and turn summary registrations. The component receives `{ sessionId, isStreaming }` and renders inside the composer toolbar.
- `Composer` takes an optional `composerActions` node; `ChatView` collects the registered actions and passes them in.
- Registry, loader plumbing and the `@iii-dev/console-ui` type declaration, plus the injectable-console-ui SOP section that documents the slot.

## Why

Workers that produce input for the chat (voice dictation, clipboard tools, templates) need a control where people type, not only a page or a header chip. The voice worker uses this slot for its push-to-talk microphone.

## Verification

- `tsc --noEmit`, biome on the touched files, vitest for the slot registry (`ui-composer-action-slots.test.ts`) and the chat components.
- Verified in a browser at desktop and phone widths with the voice worker registering a mic button: it renders between the refresh and attach controls on desktop and first in the bottom row on phone, and stays out of the way when no worker registers an action.

Refs MOT-4664


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an extension point for toolbar actions in the chat composer.
  * Registered actions appear beside the attachment control on desktop and mobile.
  * Actions receive the current session and streaming state and can insert text without submitting automatically.
  * Duplicate action IDs use the latest registration, with fallback support for older consoles.

* **Documentation**
  * Updated injectable console UI guidance and extension API declarations for composer actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->