### PR TITLE
fix: remove incompatible deployment contract version field

### DIFF
--- a/.github/contracts/deployment-descriptor.schema.json
+++ b/.github/contracts/deployment-descriptor.schema.json
@@ -6,7 +6,6 @@
   "additionalProperties": false,
   "required": [
     "contract",
-    "contract_version",
     "worker",
     "package_manifest_version",
     "source_sha",
@@ -25,7 +24,6 @@
   ],
   "properties": {
     "contract": {"const": "deployment-descriptor"},
-    "contract_version": {"const": 1},
     "worker": {"type": "string", "pattern": "^[a-z0-9][a-z0-9_-]*$"},
     "package_manifest_version": {"type": "string", "minLength": 1},
     "source_sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},

--- a/.github/scripts/deployment_compiler.py
+++ b/.github/scripts/deployment_compiler.py
@@ -459,7 +459,6 @@ def compile_worker(root: Path, worker: str, value: Any, source_sha: str, compile
     }
     descriptor: dict[str, Any] = {
         "contract": "deployment-descriptor",
-        "contract_version": 1,
         "worker": worker,
         "package_manifest_version": package_manifest_version,
         "source_sha": source_sha,
@@ -524,7 +523,6 @@ def compile_index(args: argparse.Namespace) -> int:
         }
     index = {
         "contract": "deployment-descriptor-index",
-        "contract_version": 1,
         "source_sha": args.source_sha,
         "compiler": {
             "repository": args.compiler_repository,

--- a/.github/scripts/tests/test_deployment_compiler.py
+++ b/.github/scripts/tests/test_deployment_compiler.py
@@ -62,8 +62,6 @@ def test_descriptor_schema_requires_explicit_interface_capture_policy():
     )
 
     assert "interface_capture" in schema["required"]
-    assert "contract_version" in schema["required"]
-    assert schema["properties"]["contract_version"] == {"const": 1}
     assert schema["properties"]["interface_capture"] == {
         "enum": ["required", "skipped"]
     }

--- a/.github/workflows/deploy-descriptor-index.yml
+++ b/.github/workflows/deploy-descriptor-index.yml
@@ -46,7 +46,6 @@ jobs:
           schema = json.loads(Path(".github/contracts/deployment-descriptor.schema.json").read_text())
           index = json.loads((root / "deployment-descriptor-index.json").read_text())
           assert index["contract"] == "deployment-descriptor-index"
-          assert index["contract_version"] == 1
           assert index["source_sha"] == os.environ["SOURCE_SHA"]
           assert index["compiler"]["repository"] == os.environ["GITHUB_REPOSITORY"]
           assert index["compiler"]["commit"] == os.environ["SOURCE_SHA"]


### PR DESCRIPTION
Removes the incompatible `contract_version` field from the deployment descriptor/index producer and schema so `deploy-prepare` matches the Release Control contract.

Validation: `pytest -q .github/scripts/tests/test_deployment_compiler.py .github/scripts/tests/test_deployment_train.py .github/scripts/tests/test_deployment_workflows.py` (57 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Deployment descriptors and their indexes no longer include a contract version field.
  - Descriptor validation no longer requires or checks a contract version value.
  - The deployment contract remains identified by the fixed `deployment-descriptor` value.
  - Existing interface capture policy requirements and allowed values remain unchanged.
  - Automated checks continue validating the supported deployment descriptor contract and interface capture settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->