### PR TITLE
fix: disable interface setup-node package cache

### DIFF
--- a/.github/workflows/deploy-prepare.yml
+++ b/.github/workflows/deploy-prepare.yml
@@ -305,6 +305,9 @@ jobs:
         if: steps.interface.outputs.kind == 'javascript-bundle' && steps.interface.outputs.interface_capture == 'required'
         with:
           node-version: ${{ steps.interface.outputs.runtime_version }}
+          # The interface job does not install pnpm; avoid setup-node's
+          # package-manager cache lookup before the runtime is available.
+          package-manager-cache: false
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         if: steps.interface.outputs.kind == 'python-bundle' && steps.interface.outputs.interface_capture == 'required'


### PR DESCRIPTION
The deployment interface-capture job invokes setup-node before installing pnpm. With the repository packageManager set to pnpm, setup-node attempts its automatic package-manager cache lookup and fails with "Unable to locate executable file: pnpm".

Disable that cache lookup for this job; dependency caching remains handled by the existing descriptor-specific cache steps.

Tests: pytest -q .github/scripts/tests/test_deployment_workflows.py .github/scripts/tests/test_deployment_train.py

This is CI/deployment maintenance with no linked ticket.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment preparation to skip unnecessary package-manager cache checks for interface builds.
  * No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->