### PR TITLE
refactor: narrow Registry interface publication checks

### DIFF
--- a/.github/scripts/_lib.py
+++ b/.github/scripts/_lib.py
@@ -486,7 +486,7 @@ def read_worker_catalog(path: Path | None = None) -> dict[str, WorkerSpec]:
             raise ValueError(f"{catalog_path}: workers.{catalog_id} must be a mapping")
         raw = dict(value)
         expected_sections = {"source", "artifact", "publish"}
-        legacy = {"language", "deploy", "manifest", "bin", "scripts", "interface_smoke"} & set(raw)
+        legacy = {"language", "deploy", "manifest", "bin", "scripts", "interface_smoke", "registry_interface"} & set(raw)
         if legacy:
             raise ValueError(f"{catalog_path}: workers.{catalog_id} uses legacy fields: {sorted(legacy)}")
         unknown_sections = set(raw) - expected_sections
@@ -562,7 +562,7 @@ def read_worker_catalog(path: Path | None = None) -> dict[str, WorkerSpec]:
             artifact=artifact,
             runtime=runtime,
             registry=registry,
-            validation={"interface": "skipped" if public.raw.get("interface_smoke") is False else "required"},
+            validation={"interface": "skipped" if public.raw.get("registry_interface") is False else "required"},
             raw=raw,
         )
     return parsed

--- a/.github/scripts/deployment_compiler.py
+++ b/.github/scripts/deployment_compiler.py
@@ -432,9 +432,11 @@ def compile_worker(root: Path, worker: str, value: Any, source_sha: str, compile
         fail(f"{public_path}: name must be {worker!r}")
     if manifest.get("manifest") != manifest_name:
         fail(f"{public_path}: manifest must match the private package_manifest")
-    interface_smoke = manifest.get("interface_smoke", True)
-    if not isinstance(interface_smoke, bool):
-        fail(f"{public_path}: interface_smoke must be a boolean when present")
+    if "interface_smoke" in manifest:
+        fail(f"{public_path}: interface_smoke was replaced by registry_interface")
+    registry_interface = manifest.get("registry_interface", True)
+    if not isinstance(registry_interface, bool):
+        fail(f"{public_path}: registry_interface must be a boolean when present")
     publish = value["publish"]
     if not isinstance(publish, bool):
         fail(f"workers.{worker}.publish must be a boolean")
@@ -469,10 +471,9 @@ def compile_worker(root: Path, worker: str, value: Any, source_sha: str, compile
         "source": source,
         "artifact": artifact,
         "runtime": normalize_runtime(worker, worker_dir, manifest, str(artifact["kind"])),
-        # Keep the legacy public-manifest spelling at the source boundary only.
-        # Inside the immutable deployment contract this is interface capture:
-        # registration metadata is collected, but no worker function is called.
-        "interface_capture": "required" if interface_smoke else "skipped",
+        # The public flag controls whether Registry functions and trigger types
+        # are collected. No worker function or product behavior is exercised.
+        "interface_capture": "required" if registry_interface else "skipped",
         "publish": publish,
         "build_units": build_units(worker, artifact),
         "registry_projection": projection,

--- a/.github/scripts/tests/test_deployment_compiler.py
+++ b/.github/scripts/tests/test_deployment_compiler.py
@@ -26,7 +26,7 @@ def test_canonical_numbers_reject_non_json_values():
         deployment_compiler.canonical_bytes({"budget": float("nan")})
 
 
-def test_compiler_derives_explicit_interface_capture_policy_for_every_worker():
+def test_compiler_derives_registry_interface_capture_policy_for_every_worker():
     catalog = deployment_compiler.read_yaml(ROOT / ".deploy" / "workers.yaml")["workers"]
     descriptors = {
         worker: deployment_compiler.compile_worker(

--- a/.github/scripts/tests/test_deployment_workflows.py
+++ b/.github/scripts/tests/test_deployment_workflows.py
@@ -228,15 +228,24 @@ def test_prepare_upload_requires_interface_evidence():
     assert "deployment-interface.json" in uploaded_path or uploaded_path.rstrip("/").endswith("deploy-prepared")
 
 
-def test_publish_finalize_and_verify_consume_interface_evidence():
+def test_registry_publishers_consume_interface_evidence():
     for name in ("_deploy-registry.yml", "_deploy-registry-finalize.yml"):
         text = body(name)
         assert "deployment_interface.py verify-evidence" in text, name
         assert "deployment-evidence.json" in text, name
         assert "deployment-interface.json" in text, name
+
+
+def test_public_surface_verification_does_not_repeat_registry_interface_readback():
     verify = body("deploy-verify.yml")
-    assert "deployment_interface.py verify-evidence" in verify
-    assert "deployment-evidence.json" in verify
+    assert "deployment_interface.py verify-evidence" not in verify
+    assert "deployment_interface.py compare" not in verify
+    assert "registry-interface.json" not in verify
+
+
+def test_github_asset_publication_leaves_interface_validation_to_registry_publication():
+    publish = body("deploy-publish.yml")
+    assert "deployment_interface.py verify-evidence" not in publish
 
 
 def test_registry_publishers_never_synthesize_an_empty_interface():

--- a/.github/scripts/tests/test_deployment_workflows.py
+++ b/.github/scripts/tests/test_deployment_workflows.py
@@ -236,18 +236,6 @@ def test_registry_publishers_consume_interface_evidence():
         assert "deployment-interface.json" in text, name
 
 
-def test_public_surface_verification_does_not_repeat_registry_interface_readback():
-    verify = body("deploy-verify.yml")
-    assert "deployment_interface.py verify-evidence" not in verify
-    assert "deployment_interface.py compare" not in verify
-    assert "registry-interface.json" not in verify
-
-
-def test_github_asset_publication_leaves_interface_validation_to_registry_publication():
-    publish = body("deploy-publish.yml")
-    assert "deployment_interface.py verify-evidence" not in publish
-
-
 def test_registry_publishers_never_synthesize_an_empty_interface():
     for name in ("_deploy-registry.yml", "_deploy-registry-finalize.yml"):
         text = body(name)

--- a/.github/scripts/tests/test_worker_compose.py
+++ b/.github/scripts/tests/test_worker_compose.py
@@ -21,7 +21,7 @@ def test_private_catalog_has_exact_first_party_and_fixture_counts():
 
 def test_catalog_has_only_release_build_contract_and_explicit_bundle_files():
     workers = _lib.read_worker_catalog(CATALOG)
-    legacy = {"language", "deploy", "manifest", "bin", "scripts", "interface_smoke", "name"}
+    legacy = {"language", "deploy", "manifest", "bin", "scripts", "interface_smoke", "registry_interface", "name"}
     for worker_id, worker in workers.items():
         assert set(worker.raw) == {"source", "artifact", "publish"}
         assert not legacy.intersection(worker.raw), worker_id

--- a/.github/scripts/tests/test_worker_compose.py
+++ b/.github/scripts/tests/test_worker_compose.py
@@ -12,13 +12,6 @@ ROOT = Path(__file__).resolve().parents[3]
 CATALOG = ROOT / ".deploy" / "workers.yaml"
 
 
-def test_private_catalog_has_exact_first_party_and_fixture_counts():
-    workers = _lib.read_worker_catalog(CATALOG)
-    assert len(workers) == 76
-    assert sum(worker.publish for worker in workers.values()) == 70
-    assert sum(not worker.publish for worker in workers.values()) == 6
-
-
 def test_catalog_has_only_release_build_contract_and_explicit_bundle_files():
     workers = _lib.read_worker_catalog(CATALOG)
     legacy = {"language", "deploy", "manifest", "bin", "scripts", "interface_smoke", "registry_interface", "name"}

--- a/.github/scripts/validate_worker.py
+++ b/.github/scripts/validate_worker.py
@@ -63,14 +63,18 @@ def validate_public_manifest(worker: str, spec: _lib.WorkerSpec, hard) -> None:
     ):
         hard(f"{worker}/iii.worker.yaml dependencies must be a string-to-string mapping")
 
-    manifest_skips_interface = manifest.raw.get("interface_smoke") is False
+    if "interface_smoke" in manifest.raw:
+        hard(f"{worker}/iii.worker.yaml interface_smoke was replaced by registry_interface")
+    registry_interface = manifest.raw.get("registry_interface", True)
+    if not isinstance(registry_interface, bool):
+        hard(f"{worker}/iii.worker.yaml registry_interface must be a boolean when present")
     tags = manifest.raw.get("tags")
     if tags is not None and (
         not isinstance(tags, list) or not all(isinstance(tag, str) for tag in tags)
     ):
         hard(f"{worker}/iii.worker.yaml tags must be a string array")
-    elif not manifest_skips_interface and not tags:
-        hard(f"{worker}/iii.worker.yaml tags must be non-empty when interface smoke is enabled")
+    elif registry_interface and not tags:
+        hard(f"{worker}/iii.worker.yaml tags must be non-empty when Registry interface publication is enabled")
 
     if manifest.deploy == "binary":
         executable = manifest.bin or manifest.name

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -600,12 +600,12 @@ jobs:
 
       - run: pip install --quiet pyyaml
 
-      # Some workers can't be interface-smoked: stdio servers (e.g. iii-lsp)
+      # Some workers have no static Registry interface: stdio servers (e.g. iii-lsp)
       # exit on stdin EOF while backgrounded, and pure discovery consumers
       # register no interface to collect. Their catalog validation is
       # `interface: skipped`; every downstream step is gated on this so the
       # rest of the matrix is unaffected.
-      - name: Check interface-smoke opt-out
+      - name: Check Registry interface opt-out
         id: optout
         env:
           WORKER: ${{ matrix.worker }}
@@ -614,7 +614,7 @@ jobs:
           skip=$(WORKER="$WORKER" python3 -c 'import os, sys; sys.path.insert(0, ".github/scripts"); import _lib; m = _lib.read_worker(os.environ["WORKER"]); print("true" if m.validation.get("interface") == "skipped" else "false")')
           echo "skip=$skip" >> "$GITHUB_OUTPUT"
           if [[ "$skip" == "true" ]]; then
-            echo "::notice::$WORKER opts out of the PR interface boot smoke (iii.worker.yaml interface_smoke: false)"
+            echo "::notice::$WORKER has no static Registry interface (iii.worker.yaml registry_interface: false)"
           fi
 
       - name: Rewrite SSH to HTTPS for public deps

--- a/.github/workflows/deploy-descriptor-index.yml
+++ b/.github/workflows/deploy-descriptor-index.yml
@@ -31,7 +31,7 @@ jobs:
           --compiler-repository '${{ github.repository }}'
           --output-dir deployment-descriptor-index
 
-      - name: Validate descriptor schema, identities, and counts
+      - name: Validate descriptor schema and identities
         env:
           SOURCE_SHA: ${{ github.sha }}
         run: |
@@ -49,8 +49,6 @@ jobs:
           assert index["source_sha"] == os.environ["SOURCE_SHA"]
           assert index["compiler"]["repository"] == os.environ["GITHUB_REPOSITORY"]
           assert index["compiler"]["commit"] == os.environ["SOURCE_SHA"]
-          assert len(index["workers"]) == 70
-          assert all(entry["publish"] is True for entry in index["workers"].values())
           validator = Draft202012Validator(schema)
           for worker, entry in index["workers"].items():
               descriptor = json.loads((root / entry["path"]).read_text())

--- a/.github/workflows/deploy-prepare.yml
+++ b/.github/workflows/deploy-prepare.yml
@@ -395,7 +395,7 @@ jobs:
             --trigger-types-baseline interface-work/triggers-baseline.json \
             --workers-baseline interface-work/workers-baseline.json
           python3 .github/scripts/collect_worker_interface.py \
-            --assert-non-empty --assert-typed-schemas \
+            --assert-typed-schemas \
             --assert-file interface-work/worker-interface.json
           python3 .github/scripts/deployment_interface.py snapshot \
             --descriptor deploy-prepared/deployment-descriptor.json \

--- a/.github/workflows/deploy-publish.yml
+++ b/.github/workflows/deploy-publish.yml
@@ -81,9 +81,6 @@ jobs:
           python3 .github/scripts/deployment_train.py verify-prepared \
             --descriptor deploy-prepared/deployment-descriptor.json \
             --prepared deploy-prepared/prepared-artifacts.json
-          python3 .github/scripts/deployment_interface.py verify-evidence \
-            --descriptor deploy-prepared/deployment-descriptor.json \
-            --evidence deploy-prepared/deployment-evidence.json
           [[ -n "$EXPECTED_MIRROR_VERSION" ]]
           python3 .github/scripts/deployment_control_contract.py validate-identity --identity "$DEPLOYMENT_IDENTITY"
           python3 .github/scripts/deployment_control_contract.py validate-dispatch --step-id "$STEP_ID" --dispatch-nonce "$DISPATCH_NONCE" --descriptor-sha256 "$DESCRIPTOR_SHA256" --plan-hash "$PLAN_HASH" --source-sha "$SOURCE_SHA" --prepared-sha "$PREPARED_SHA" --mutating

--- a/.github/workflows/deploy-verify.yml
+++ b/.github/workflows/deploy-verify.yml
@@ -62,7 +62,6 @@ jobs:
           set -euo pipefail
           test "$(jq -r .descriptor_sha256 deploy-prepared/deployment-descriptor.json)" = "$DESCRIPTOR_SHA256"
           python3 .github/scripts/deployment_train.py verify-prepared --descriptor deploy-prepared/deployment-descriptor.json --prepared deploy-prepared/prepared-artifacts.json
-          python3 .github/scripts/deployment_interface.py verify-evidence --descriptor deploy-prepared/deployment-descriptor.json --evidence deploy-prepared/deployment-evidence.json
           python3 .github/scripts/deployment_control_contract.py validate-identity --identity "$DEPLOYMENT_IDENTITY"
           python3 .github/scripts/deployment_control_contract.py validate-dispatch --step-id "$STEP_ID" --dispatch-nonce "$DISPATCH_NONCE" --descriptor-sha256 "$DESCRIPTOR_SHA256" --plan-hash "$PLAN_HASH" --source-sha "$SOURCE_SHA"
           python3 .github/scripts/deployment_control_contract.py authorize-dispatch --api-url "$RELEASE_CONTROL_API_URL" --repository '${{ github.repository }}' --step-id "$STEP_ID" --run-id '${{ github.run_id }}' --run-attempt '${{ github.run_attempt }}' --workflow 'deploy-verify.yml' --event '${{ github.event_name }}' --sha '${{ github.sha }}' --deployment-batch-id "$DEPLOYMENT_BATCH_ID" --deployment-target-id "$DEPLOYMENT_TARGET_ID" --attempt-id "$ATTEMPT_ID" --dispatch-nonce "$DISPATCH_NONCE" --plan-hash "$PLAN_HASH" --worker "$WORKER" --source-sha "$SOURCE_SHA" --target-version "$TARGET_VERSION" --channel "$RELEASE_CHANNEL" --descriptor-sha256 "$DESCRIPTOR_SHA256"
@@ -85,21 +84,6 @@ jobs:
           body=$(jq -nc --arg worker "$WORKER" --arg channel "$RELEASE_CHANNEL" '{worker:$worker,version:$channel}')
           actual=$(curl -fsS -H 'Content-Type: application/json' -X POST 'https://api.workers.iii.dev/resolve' --data "$body" | jq -r .root.version)
           test "$actual" = "$TARGET_VERSION"
-          if [[ "$(jq -r .interface_capture deploy-prepared/deployment-descriptor.json)" == required ]]; then
-            curl -fsS "https://api.workers.iii.dev/w/$WORKER?version=$TARGET_VERSION" > registry-worker.json
-            jq -e --arg worker "$WORKER" --arg version "$TARGET_VERSION" \
-              '.worker.name == $worker and .worker.version == $version' registry-worker.json >/dev/null
-            jq '.worker | {functions:(.functions // []),triggers:(.triggers // [])}' \
-              registry-worker.json > registry-interface.json
-            python3 .github/scripts/deployment_interface.py compare \
-              --descriptor deploy-prepared/deployment-descriptor.json \
-              --expected deploy-prepared/deployment-interface.json \
-              --actual registry-interface.json
-          else
-            python3 .github/scripts/deployment_interface.py compare \
-              --descriptor deploy-prepared/deployment-descriptor.json \
-              --expected deploy-prepared/deployment-interface.json
-          fi
           if [[ "$EXPECTED_IMAGE_DIGEST" != none ]]; then
             [[ "$EXPECTED_IMAGE_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]
             docker buildx imagetools inspect "ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/$WORKER:$RELEASE_CHANNEL" --format '{{json .Manifest}}' > image-manifest.json

--- a/acp/iii.worker.yaml
+++ b/acp/iii.worker.yaml
@@ -6,7 +6,7 @@ manifest: Cargo.toml
 license: Apache-2.0
 bin: iii-acp
 description: Agent Client Protocol surface — stdio JSON-RPC, exposes iii agents as ACP sessions
-# Opt out of the interface boot smoke: acp is a stdio JSON-RPC worker that exits
+# Opt out of Registry interface publication: acp is a stdio JSON-RPC worker that exits
 # on stdin EOF and registers only dynamic per-connection functions, so there is
 # no static interface to collect (mirrors lsp).
-interface_smoke: false
+registry_interface: false

--- a/docs/architecture/iii-worker-yaml.md
+++ b/docs/architecture/iii-worker-yaml.md
@@ -32,14 +32,14 @@ public field is present the compiler requires the two lists to match.
 
 | Field | Purpose | Consumer |
 |---|---|---|
-| `interface_smoke: false` | Declare that interface capture is skipped | `validate_worker.py`, `ci.yml`, release compiler |
+| `registry_interface: false` | Declare that Registry interface publication is skipped | `validate_worker.py`, `ci.yml`, release compiler |
 | `runtime` / `scripts.start` | Public local and installed runtime definition | `iii worker`, Compose, release compiler |
 | `scripts.install` | Build command for local install | `compose::add` (local source) |
 | `tags` | Discovery aliases included in the compiled Registry projection | release compiler |
 
 `tags` must be a list of strings. The publish pipeline trims values, converts them to lowercase,
 removes duplicates, and omits the field when no non-empty tags remain.
-`interface_smoke: false` compiles to `interface_capture: skipped` in the
+`registry_interface: false` compiles to `interface_capture: skipped` in the
 immutable deployment descriptor. Otherwise release prepare boots the prepared
 artifact against an isolated engine only long enough to capture registered
 functions and triggers. It does not invoke worker functions or validate an

--- a/docs/architecture/skills-and-permissions.md
+++ b/docs/architecture/skills-and-permissions.md
@@ -20,7 +20,7 @@ canonical `skills/SKILL.md` entrypoint.
 
 ### Publish
 
-On every successful release (when `interface_smoke != false`):
+On every successful release (when `registry_interface != false`):
 
 1. `build_skills_payload.py` collects any non-empty markdown under `skills/`
 2. `POST /w/<worker>/skills` — skipped cleanly when no markdown found

--- a/docs/architecture/testing-and-ci.md
+++ b/docs/architecture/testing-and-ci.md
@@ -80,7 +80,7 @@ metadata is present or typed.
 3. Start worker from `./target/debug/<bin>` (with `--config config.collect.yaml` when shipped)
 4. `collect_worker_interface.py` — 120 s wait, assert non-empty interface
 
-**Opt-out:** `interface_smoke: false` in `iii.worker.yaml` (for example `lsp`).
+**Opt-out:** `registry_interface: false` in `iii.worker.yaml` (for example `lsp`).
 The release compiler records this as `interface_capture: skipped`; only that
 explicit immutable policy permits empty `functions` and `triggers` in Registry.
 

--- a/docs/sops/binary-worker.md
+++ b/docs/sops/binary-worker.md
@@ -95,7 +95,7 @@ cargo test --locked --all-features
 ```
 
 CI builds changed Rust workers and checks interface registration unless
-`iii.worker.yaml` sets `interface_smoke: false`. Release prepare also boots one
+`iii.worker.yaml` sets `registry_interface: false`. Release prepare also boots one
 immutable Linux artifact in an isolated engine to capture Registry metadata.
 That capture invokes no worker function or external backend and is not a
 deployment smoke test.

--- a/docs/sops/new-worker.md
+++ b/docs/sops/new-worker.md
@@ -34,7 +34,7 @@ immutable Registry projection.
 Interface capture is enabled by default. CI checks it from source, and release
 prepare captures it again from the immutable prepared artifact for Registry
 publication. Set
-`interface_smoke: false` in `iii.worker.yaml` only for a worker that cannot
+`registry_interface: false` in `iii.worker.yaml` only for a worker that cannot
 expose a collectable interface, such as a stdio-only process. This setting does
 not skip behavior tests: it compiles to `interface_capture: skipped` in the
 immutable descriptor and explicitly permits an empty Registry interface.

--- a/lsp/iii.worker.yaml
+++ b/lsp/iii.worker.yaml
@@ -6,8 +6,8 @@ manifest: Cargo.toml
 license: Apache-2.0
 bin: lsp
 description: III Language Server — autocompletion and hover for III engine functions and triggers
-# Opt out of the interface boot smoke. lsp is a stdio language server:
+# Opt out of Registry interface publication. lsp is a stdio language server:
 # it exits on stdin EOF (so it cannot stay alive while backgrounded) and it
 # only consumes engine discovery — it registers no functions or trigger
 # types, so there is no interface to collect.
-interface_smoke: false
+registry_interface: false


### PR DESCRIPTION
## Summary

- keep runtime interface capture as the source of Registry functions and triggers
- validate captured interface evidence only in the Registry publication workflows
- remove the duplicate interface comparison from final public-surface verification
- keep the snapshot as the single empty-interface guard during deployment preparation
- remove fixed worker-count assertions from descriptor checkpoint validation
- rename the public `interface_smoke` opt-out to `registry_interface`
- preserve `acp` and `lsp` as explicit workers without a static Registry interface

## Why

Registry version publication already performs an exact readback of the worker detail, including functions and triggers. Repeating the same comparison in the later verification phase adds another failure point without strengthening the publication proof. The new option name reflects that the capture exists to populate Registry API reference metadata, not to exercise product behavior.

## Tests

`PYTHONDONTWRITEBYTECODE=1 pytest -p no:cacheprovider -q .github/scripts/tests`

318 passed, 3 subtests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Changes**
  - Renamed the worker configuration option from `interface_smoke` to `registry_interface`.
  - Worker manifests validate the new Boolean option and reject the legacy field.
  - Registry interface capture now follows `registry_interface`, including explicit opt-out support.
  - Deployment verification checks prepared artifacts directly; redundant interface evidence comparisons were removed.
  - Publishing no longer performs separate deployment-evidence verification.

- **Documentation**
  - Updated worker configuration, CI, deployment, and publishing guidance.

- **Tests**
  - Updated validation and workflow coverage for Registry interface publication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->