### PR TITLE
(MOT-4665) feat(llm-router): transcribe and speak surfaces for speech providers

### DIFF
--- a/llm-router/README.md
+++ b/llm-router/README.md
@@ -54,10 +54,12 @@ partial content, so consumers never hang on a half-open stream.
 | `router::complete` | Non-streaming convenience over the same pipeline; returns the final message. |
 | `router::abort` | Cancel an in-flight turn by `request_id`. |
 | `router::route` | Read-only routing preview: `{model, provider?}` → `{provider, candidates}`, same rules and error codes as `router::chat`. Pin the result as the explicit `provider` on the chat call when you need the provider before streaming. |
-| `router::models::list` | List catalog models, filterable by `provider` / `capability`. |
+| `router::models::list` | List catalog models, filterable by `provider` / `capability` / `modality` (`chat` by default, `stt`, `tts`, `any`). |
 | `router::models::get` | Fetch one model record (`null` when unknown). |
 | `router::models::supports` | Check one capability flag for one model. |
 | `router::embed` | Batch text embeddings through the first embed-capable provider in the registry (`{model?, provider?, input[]}` → `{provider, model, embeddings[][]}`); providers without an embed surface are skipped. |
+| `router::transcribe` | Speech to text: `{model?, provider?, audio_base64, mime?, language?, prompt?}` → `{provider, model, text, segments[]?, language?, duration_secs?}`. The provider comes from the named `provider`, else from the catalog owner of the `stt` model, else the first provider that declared one. |
+| `router::speak` | Text to speech: `{model?, provider?, text, voice?, format?, language?, speed?}` → `{provider, model, audio_base64, mime, voice?, duration_secs?}`. Same resolution over `tts` models. |
 | `router::count_tokens` | Count prompt tokens: `{model, provider?, system_prompt?, tools?, messages}` → `{provider, model, tokens, estimator}`, resolved with the same routing rules as `router::chat` and forwarded to `provider::<id>::count_tokens`. Never runs the model and costs nothing; `estimator` is `provider` (metering API) or `tiktoken` (local tokenizer). A provider without the surface is a typed `router/no_token_counter` error, so callers can fall back to their own estimate. |
 | `router::provider::list` | Registered providers with `configured` / `available` status. |
 
@@ -92,8 +94,10 @@ registration token, and every later protocol call must present it.
 | `router::models::reconcile` | Replace the provider's catalog slice in one write. |
 
 The provider worker itself exposes `provider::<id>::stream` and, when
-capable, `provider::<id>::refresh_models` (model discovery) and
-`provider::<id>::count_tokens` (prompt token counting).
+capable, `provider::<id>::refresh_models` (model discovery),
+`provider::<id>::count_tokens` (prompt token counting),
+`provider::<id>::embed` (embeddings), and the speech pair
+`provider::<id>::transcribe` / `provider::<id>::speak`.
 
 ## Configuration
 
@@ -218,6 +222,30 @@ system_prompt?, tools?, messages}` → `{model, tokens, estimator}`) to serve
 (`estimator: "provider"`) or a local tokenizer estimate (`estimator:
 "tiktoken"`). Providers without it simply make `router::count_tokens` return
 a typed `router/no_token_counter` error for that provider.
+
+### Speech providers
+
+A speech provider is the same kind of worker with no chat stream: it
+declares its models with a `speech` block and serves one or both speech
+surfaces. `router::models::list` hides speech models from chat pickers
+unless asked (`modality: "stt" | "tts" | "any"`), and `router::chat`
+refuses them with a message that names the right door.
+
+```json
+{ "id": "scribe-v1", "provider": "elevenlabs", "context_window": 0, "max_output_tokens": 0,
+  "speech": { "modality": "stt", "languages": ["en", "hi"], "streaming": true } }
+```
+
+| Function | Request | Response |
+|---|---|---|
+| `provider::<id>::transcribe` | `{model?, audio_base64, mime, language?, prompt?}` | `{model, text, segments[{text, start_secs?, end_secs?}]?, language?, duration_secs?}` |
+| `provider::<id>::speak` | `{model?, text, voice?, format, language?, speed?}` | `{model, audio_base64, mime, voice?, duration_secs?}` |
+
+`model` arrives as the id the caller named, or `null` for the provider's
+default. `format` is what the caller asked for (`mp3`, `wav`, `pcm16`,
+`opus`); answer with the container you produced and say so in `mime`.
+Credentials resolve through `router::provider::resolve` exactly as for
+chat providers.
 
 The first real provider implementing this protocol is
 [`provider-anthropic/`](https://github.com/iii-hq/workers/tree/main/provider-anthropic) — useful as a reference

--- a/llm-router/src/catalog/handlers.rs
+++ b/llm-router/src/catalog/handlers.rs
@@ -28,8 +28,13 @@ pub fn make_models_list(
     move |req: ModelsListRequest| {
         let catalog = catalog.clone();
         Box::pin(async move {
-            let models =
-                models_list(&catalog, req.provider.as_deref(), req.capability.as_deref()).await;
+            let models = models_list(
+                &catalog,
+                req.provider.as_deref(),
+                req.capability.as_deref(),
+                req.modality.unwrap_or_default(),
+            )
+            .await;
             Ok(ModelsListResponse { models })
         })
     }

--- a/llm-router/src/catalog/queries.rs
+++ b/llm-router/src/catalog/queries.rs
@@ -1,5 +1,5 @@
 //! models::list / get / supports semantics (spec § Capability strings).
-use crate::types::model::Model;
+use crate::types::model::{ModalityFilter, Model, SpeechModality};
 
 use super::store::CatalogStore;
 
@@ -14,6 +14,9 @@ pub fn model_supports(model: &Model, capability: &str) -> bool {
             model.supports_thinking == Some(true)
         }
         "thinking:xhigh" => model.supports_xhigh == Some(true),
+        "stt" => model.speech_modality() == Some(SpeechModality::Stt),
+        "tts" => model.speech_modality() == Some(SpeechModality::Tts),
+        "streaming" => model.speech.as_ref().is_some_and(|s| s.streaming),
         _ => false,
     }
 }
@@ -22,6 +25,7 @@ pub async fn models_list(
     store: &CatalogStore,
     provider: Option<&str>,
     capability: Option<&str>,
+    modality: ModalityFilter,
 ) -> Vec<Model> {
     let mut models = match provider {
         Some(p) => {
@@ -41,6 +45,7 @@ pub async fn models_list(
     if let Some(cap) = capability {
         models.retain(|m| model_supports(m, cap));
     }
+    models.retain(|m| m.matches_modality(modality));
     models
 }
 
@@ -157,7 +162,46 @@ mod tests {
             supports_structured_output: None,
             thinking_budgets: None,
             pricing: None,
+            speech: None,
         }
+    }
+
+    fn scribe() -> Model {
+        Model {
+            id: "scribe".into(),
+            provider: "elevenlabs".into(),
+            context_window: 0,
+            max_output_tokens: 0,
+            supports_thinking: None,
+            supports_xhigh: None,
+            supports_tools: None,
+            supports_vision: None,
+            speech: Some(crate::types::model::SpeechModel {
+                modality: SpeechModality::Stt,
+                languages: vec!["en".into()],
+                streaming: true,
+            }),
+            ..sonnet()
+        }
+    }
+
+    #[test]
+    fn speech_capability_strings_and_modality_filters() {
+        let stt = scribe();
+        assert!(model_supports(&stt, "stt"));
+        assert!(!model_supports(&stt, "tts"));
+        assert!(model_supports(&stt, "streaming"));
+        assert!(!model_supports(&stt, "tools"));
+        assert!(stt.matches_modality(ModalityFilter::Stt));
+        assert!(stt.matches_modality(ModalityFilter::Any));
+        assert!(!stt.matches_modality(ModalityFilter::Chat));
+        assert!(!stt.matches_modality(ModalityFilter::Tts));
+        let chat = sonnet();
+        assert!(!model_supports(&chat, "stt"));
+        assert!(!model_supports(&chat, "streaming"));
+        assert!(chat.matches_modality(ModalityFilter::Chat));
+        assert!(!chat.matches_modality(ModalityFilter::Stt));
+        assert_eq!(ModalityFilter::default(), ModalityFilter::Chat);
     }
 
     // Provider-less models::get: unique ids resolve (context-manager budgets

--- a/llm-router/src/catalog/store.rs
+++ b/llm-router/src/catalog/store.rs
@@ -167,6 +167,7 @@ mod tests {
             supports_structured_output: None,
             thinking_budgets: None,
             pricing: None,
+            speech: None,
         }
     }
 

--- a/llm-router/src/chat/chat.rs
+++ b/llm-router/src/chat/chat.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 
 use crate::types::errors::{RouterCode, RouterError};
 use crate::types::events::{AssistantMessageEvent, ErrorKind, StopReason};
+use crate::types::model::SpeechModality;
 use crate::types::router::{ChatResponse, ErrorShape};
 use iii_helpers::observability::opentelemetry::trace::FutureExt as _;
 use iii_sdk::channel::StreamChannelRef;
@@ -21,7 +22,7 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 use uuid::Uuid;
 
-use crate::catalog::queries::{effective_model_ref, model_supports};
+use crate::catalog::queries::{effective_model_ref, model_supports, models_get};
 use crate::catalog::store::CatalogStore;
 use crate::channels::create_router_channel;
 use crate::config::state::{snapshot, ConfigCell};
@@ -374,6 +375,33 @@ impl ChatPipeline {
             call.model = model;
         }
         let call = call; // frozen: nothing below mutates the normalized pair
+
+        // Speech models live in the same catalog so callers can list and
+        // pick them, but they answer router::transcribe / router::speak, not
+        // chat. Refuse before routing so the message names the right door
+        // instead of a provider stream failing on an unknown model.
+        if let Some(modality) = models_get(&self.catalog, call.provider.as_deref(), &call.model)
+            .await
+            .and_then(|meta| meta.speech_modality())
+        {
+            let door = match modality {
+                SpeechModality::Stt => "router::transcribe",
+                SpeechModality::Tts => "router::speak",
+            };
+            return Err(fail_with_terminal(
+                sink.as_ref(),
+                None,
+                &call.model,
+                "",
+                RouterCode::InvalidRequest,
+                format!(
+                    "Model \"{}\" is a speech model; call {door} instead of chat.",
+                    call.model
+                ),
+                pre_stream_error_kind(RouterCode::InvalidRequest),
+                None,
+            ));
+        }
 
         // A pre-stream failure must still leave exactly one terminal frame on
         // the sink. Without it, `router::complete`'s drain blocks for its full

--- a/llm-router/src/lib.rs
+++ b/llm-router/src/lib.rs
@@ -14,6 +14,7 @@ pub mod register;
 pub mod registry;
 pub mod routing;
 pub mod settings;
+pub mod speech;
 pub mod state;
 pub mod surface;
 pub mod testkit;

--- a/llm-router/src/register.rs
+++ b/llm-router/src/register.rs
@@ -130,6 +130,26 @@ pub async fn register_router(iii: IIIClient) -> Result<RouterRefs, Error> {
             .metadata(internal_meta()),
     );
     iii.register_function(
+        surface::TRANSCRIBE_ID,
+        RegisterFunction::new_async(crate::speech::make_transcribe(
+            iii.clone(),
+            registry.clone(),
+            catalog.clone(),
+        ))
+        .description(surface::TRANSCRIBE_DESC)
+        .metadata(internal_meta()),
+    );
+    iii.register_function(
+        surface::SPEAK_ID,
+        RegisterFunction::new_async(crate::speech::make_speak(
+            iii.clone(),
+            registry.clone(),
+            catalog.clone(),
+        ))
+        .description(surface::SPEAK_DESC)
+        .metadata(internal_meta()),
+    );
+    iii.register_function(
         surface::COUNT_TOKENS_ID,
         RegisterFunction::new_async(crate::count_tokens::make_count_tokens(
             iii.clone(),

--- a/llm-router/src/speech.rs
+++ b/llm-router/src/speech.rs
@@ -162,13 +162,13 @@ fn surface_name(modality: SpeechModality) -> &'static str {
 ///
 /// 1. A composite `provider::model` id splits when its prefix names a
 ///    registered or catalog provider, as everywhere else in the router.
-/// 2. An explicit provider must be registered; its model is the caller's,
-///    or its first catalog model of this modality, or its default.
+/// 2. An explicit provider must be registered; it gets the caller's model
+///    or, with none named, its own default (`None` on the wire).
 /// 3. A model without a provider resolves through the catalog: exactly one
 ///    owner with this modality wins, a model of the other modality is a
 ///    caller error, several owners are ambiguous, none is unserved.
 /// 4. Neither: the first provider (by id) that declared a model of this
-///    modality, with its first such model.
+///    modality, which then uses its own default.
 pub fn resolve_speech_target(
     modality: SpeechModality,
     model: Option<&str>,
@@ -200,16 +200,7 @@ pub fn resolve_speech_target(
                 ),
             ));
         }
-        let model = model.map(str::to_string).or_else(|| {
-            let mut ids: Vec<&str> = catalog
-                .iter()
-                .filter(|m| m.provider == provider && of_modality(m))
-                .map(|m| m.id.as_str())
-                .collect();
-            ids.sort_unstable();
-            ids.first().map(|id| id.to_string())
-        });
-        return Ok((provider.to_string(), model));
+        return Ok((provider.to_string(), model.map(str::to_string)));
     }
 
     if let Some(model) = model {
@@ -257,14 +248,14 @@ pub fn resolve_speech_target(
         };
     }
 
-    let mut candidates: Vec<(&str, &str)> = catalog
+    let mut candidates: Vec<&str> = catalog
         .iter()
         .filter(|m| of_modality(m) && registered_has(&m.provider))
-        .map(|m| (m.provider.as_str(), m.id.as_str()))
+        .map(|m| m.provider.as_str())
         .collect();
     candidates.sort_unstable();
     match candidates.first() {
-        Some((provider, model)) => Ok((provider.to_string(), Some(model.to_string()))),
+        Some(provider) => Ok((provider.to_string(), None)),
         None => Err(RouterError::new(
             RouterCode::NoProviderForModel,
             format!(
@@ -569,7 +560,7 @@ mod tests {
         ];
         assert_eq!(
             resolve_speech_target(SpeechModality::Stt, None, Some("sarvam"), &reg, &catalog),
-            Ok(("sarvam".into(), Some("saarika-v1".into())))
+            Ok(("sarvam".into(), None))
         );
         let err = resolve_speech_target(SpeechModality::Stt, None, Some("ghost"), &reg, &catalog)
             .unwrap_err();
@@ -586,7 +577,7 @@ mod tests {
         let reg = registered(&["elevenlabs", "google-speech"]);
         assert_eq!(
             resolve_speech_target(SpeechModality::Stt, None, None, &reg, &catalog),
-            Ok(("elevenlabs".into(), Some("scribe".into())))
+            Ok(("elevenlabs".into(), None))
         );
         let err = resolve_speech_target(
             SpeechModality::Tts,

--- a/llm-router/src/speech.rs
+++ b/llm-router/src/speech.rs
@@ -1,0 +1,601 @@
+//! `router::transcribe` and `router::speak` — the speech front doors, shaped
+//! like `router::embed`: the router resolves a provider, forwards to
+//! `provider::<id>::transcribe` or `provider::<id>::speak`, and stamps the
+//! provider on the reply. Providers declare speech models with a `speech`
+//! block on the model record, so a caller can name a model and the router
+//! finds its owner, consoles can list them, and a chat picker never sees
+//! them. A provider named explicitly is called even when its catalog slice
+//! is cold; one without the surface answers function-not-found, which
+//! becomes a typed `router/no_speech_provider` error.
+
+use std::future::Future;
+use std::sync::Arc;
+
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::IIIClient;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use crate::catalog::queries::effective_model_ref;
+use crate::catalog::store::CatalogStore;
+use crate::registry::store::RegistryStore;
+use crate::types::errors::{is_function_not_found, RouterCode, RouterError};
+use crate::types::model::{Model, SpeechModality};
+
+/// Recordings can run long and providers decode at a fraction of real time.
+const TRANSCRIBE_TIMEOUT_MS: u64 = 300_000;
+/// Synthesis of a few paragraphs; providers stream nothing back here.
+const SPEAK_TIMEOUT_MS: u64 = 120_000;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct RouterTranscribeRequest {
+    /// Speech-to-text model id (an `stt` model from `router::models::list`);
+    /// the provider's default when omitted.
+    #[serde(default)]
+    pub model: Option<String>,
+    /// Provider id; resolved from the model's catalog owner when omitted.
+    #[serde(default)]
+    pub provider: Option<String>,
+    /// The audio, base64. WAV unless `mime` says otherwise.
+    pub audio_base64: String,
+    /// MIME type of the audio: `audio/wav` (default), `audio/mpeg`,
+    /// `audio/webm`, `audio/ogg`, `audio/flac`.
+    #[serde(default)]
+    pub mime: Option<String>,
+    /// BCP-47 language hint; the model detects the language when omitted.
+    #[serde(default)]
+    pub language: Option<String>,
+    /// Vocabulary or context hint for the recognizer, when the provider
+    /// takes one.
+    #[serde(default)]
+    pub prompt: Option<String>,
+}
+
+/// One timed span of a transcript; times are absent when the provider
+/// gives none.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct TranscriptSegment {
+    pub text: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_secs: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub end_secs: Option<f64>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct RouterTranscribeResponse {
+    pub provider: String,
+    pub model: String,
+    /// The whole transcript.
+    pub text: String,
+    /// Timed spans when the provider produces them.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub segments: Vec<TranscriptSegment>,
+    /// Language the provider detected or was told (BCP-47).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duration_secs: Option<f64>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct RouterSpeakRequest {
+    /// Text-to-speech model id (a `tts` model from `router::models::list`);
+    /// the provider's default when omitted.
+    #[serde(default)]
+    pub model: Option<String>,
+    /// Provider id; resolved from the model's catalog owner when omitted.
+    #[serde(default)]
+    pub provider: Option<String>,
+    /// Text to speak.
+    pub text: String,
+    /// Voice id or name as the provider knows it; the provider's default
+    /// when omitted.
+    #[serde(default)]
+    pub voice: Option<String>,
+    /// Audio container wanted: `mp3` (default), `wav`, `pcm16`, `opus`.
+    /// Providers answer with what they can and say so in `mime`.
+    #[serde(default)]
+    pub format: Option<String>,
+    /// BCP-47 language hint for multilingual voices.
+    #[serde(default)]
+    pub language: Option<String>,
+    /// Speaking-rate multiplier; 1.0 is the voice's own pace.
+    #[serde(default)]
+    pub speed: Option<f64>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct RouterSpeakResponse {
+    pub provider: String,
+    pub model: String,
+    /// The audio, base64.
+    pub audio_base64: String,
+    /// MIME type of the audio, e.g. `audio/mpeg`.
+    pub mime: String,
+    /// Voice the provider used.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub voice: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duration_secs: Option<f64>,
+}
+
+/// What `provider::<id>::transcribe` answers; `provider` is stamped on by
+/// the router.
+#[derive(Debug, Deserialize)]
+struct ProviderTranscribeReply {
+    model: String,
+    text: String,
+    #[serde(default)]
+    segments: Vec<TranscriptSegment>,
+    #[serde(default)]
+    language: Option<String>,
+    #[serde(default)]
+    duration_secs: Option<f64>,
+}
+
+/// What `provider::<id>::speak` answers; `provider` is stamped on by the
+/// router.
+#[derive(Debug, Deserialize)]
+struct ProviderSpeakReply {
+    model: String,
+    audio_base64: String,
+    #[serde(default)]
+    mime: Option<String>,
+    #[serde(default)]
+    voice: Option<String>,
+    #[serde(default)]
+    duration_secs: Option<f64>,
+}
+
+fn surface_name(modality: SpeechModality) -> &'static str {
+    match modality {
+        SpeechModality::Stt => "transcribe",
+        SpeechModality::Tts => "speak",
+    }
+}
+
+/// The provider a speech request goes to and the model id it carries
+/// (`None` = the provider's default). Pure so the rules are pinned in tests:
+///
+/// 1. A composite `provider::model` id splits when its prefix names a
+///    registered or catalog provider, as everywhere else in the router.
+/// 2. An explicit provider must be registered; its model is the caller's,
+///    or its first catalog model of this modality, or its default.
+/// 3. A model without a provider resolves through the catalog: exactly one
+///    owner with this modality wins, a model of the other modality is a
+///    caller error, several owners are ambiguous, none is unserved.
+/// 4. Neither: the first provider (by id) that declared a model of this
+///    modality, with its first such model.
+pub fn resolve_speech_target(
+    modality: SpeechModality,
+    model: Option<&str>,
+    provider: Option<&str>,
+    registered: &[String],
+    catalog: &[Model],
+) -> Result<(String, Option<String>), RouterError> {
+    let provider = provider.map(str::trim).filter(|p| !p.is_empty());
+    let model = model.map(str::trim).filter(|m| !m.is_empty());
+    let registered_has = |id: &str| registered.iter().any(|p| p == id);
+    let (provider, model) = match model {
+        Some(model) => {
+            let (p, m) = effective_model_ref(provider, model, |p| {
+                registered_has(p) || catalog.iter().any(|c| c.provider == p)
+            });
+            (p, Some(m))
+        }
+        None => (provider, None),
+    };
+    let of_modality = |m: &Model| m.speech_modality() == Some(modality);
+    let surface = surface_name(modality);
+
+    if let Some(provider) = provider {
+        if !registered_has(provider) {
+            return Err(RouterError::new(
+                RouterCode::UnknownProvider,
+                format!(
+                    "Provider \"{provider}\" is not registered. Choose a configured provider and try again."
+                ),
+            ));
+        }
+        let model = model.map(str::to_string).or_else(|| {
+            let mut ids: Vec<&str> = catalog
+                .iter()
+                .filter(|m| m.provider == provider && of_modality(m))
+                .map(|m| m.id.as_str())
+                .collect();
+            ids.sort_unstable();
+            ids.first().map(|id| id.to_string())
+        });
+        return Ok((provider.to_string(), model));
+    }
+
+    if let Some(model) = model {
+        let mut owners: Vec<&str> = catalog
+            .iter()
+            .filter(|m| m.id == model && of_modality(m))
+            .map(|m| m.provider.as_str())
+            .collect();
+        owners.sort_unstable();
+        owners.dedup();
+        return match owners.as_slice() {
+            [owner] => Ok((owner.to_string(), Some(model.to_string()))),
+            [] => {
+                if let Some(other) = catalog
+                    .iter()
+                    .find(|m| m.id == model && m.speech.is_some() && !of_modality(m))
+                {
+                    let kind = other.speech_modality().map(surface_name).unwrap_or("chat");
+                    return Err(RouterError::new(
+                        RouterCode::InvalidRequest,
+                        format!(
+                            "Model \"{model}\" is a {kind} model; router::{surface} needs a {surface} model."
+                        ),
+                    ));
+                }
+                Err(RouterError::new(
+                    RouterCode::NoProviderForModel,
+                    format!(
+                        "No registered provider serves the {surface} model \"{model}\". \
+                         router::models::list with modality \"{}\" names the choices.",
+                        match modality {
+                            SpeechModality::Stt => "stt",
+                            SpeechModality::Tts => "tts",
+                        }
+                    ),
+                ))
+            }
+            many => Err(RouterError::new(
+                RouterCode::AmbiguousModel,
+                format!(
+                    "Model \"{model}\" is served by {}; pass provider to choose one.",
+                    many.join(", ")
+                ),
+            )),
+        };
+    }
+
+    let mut candidates: Vec<(&str, &str)> = catalog
+        .iter()
+        .filter(|m| of_modality(m) && registered_has(&m.provider))
+        .map(|m| (m.provider.as_str(), m.id.as_str()))
+        .collect();
+    candidates.sort_unstable();
+    match candidates.first() {
+        Some((provider, model)) => Ok((provider.to_string(), Some(model.to_string()))),
+        None => Err(RouterError::new(
+            RouterCode::NoProviderForModel,
+            format!(
+                "No registered provider has declared a {surface} model. Add a speech provider \
+                 worker or pass provider explicitly."
+            ),
+        )),
+    }
+}
+
+async fn forward(
+    iii: &IIIClient,
+    provider: &str,
+    modality: SpeechModality,
+    payload: Value,
+    timeout_ms: u64,
+) -> Result<Value, Error> {
+    let surface = surface_name(modality);
+    let function_id = format!("provider::{provider}::{surface}");
+    match iii
+        .trigger(TriggerRequest {
+            function_id: function_id.clone(),
+            payload,
+            action: None,
+            timeout_ms: Some(timeout_ms),
+        })
+        .await
+    {
+        Ok(reply) => Ok(reply),
+        Err(e) if is_function_not_found(&e) => Err(Error::Handler(format!(
+            "router/no_speech_provider: provider \"{provider}\" has no {surface} surface \
+             ({function_id}); choose a speech provider or install one"
+        ))),
+        Err(e) => Err(e),
+    }
+}
+
+fn bad_reply(provider: &str, modality: SpeechModality, what: &str) -> Error {
+    Error::Handler(format!(
+        "router/bad_provider_response: provider::{provider}::{} {what}",
+        surface_name(modality)
+    ))
+}
+
+pub fn make_transcribe(
+    iii: IIIClient,
+    registry: Arc<RegistryStore>,
+    catalog: Arc<CatalogStore>,
+) -> impl Fn(RouterTranscribeRequest) -> BoxedTranscribeFuture + Send + Sync + 'static {
+    move |req: RouterTranscribeRequest| {
+        let (iii, registry, catalog) = (iii.clone(), registry.clone(), catalog.clone());
+        Box::pin(async move {
+            if req.audio_base64.trim().is_empty() {
+                return Err(RouterError::new(
+                    RouterCode::InvalidRequest,
+                    "audio_base64 must not be empty",
+                )
+                .into());
+            }
+            let registered = registry.ids().await;
+            let models = catalog.all().await;
+            let (provider, model) = resolve_speech_target(
+                SpeechModality::Stt,
+                req.model.as_deref(),
+                req.provider.as_deref(),
+                &registered,
+                &models,
+            )?;
+            let reply = forward(
+                &iii,
+                &provider,
+                SpeechModality::Stt,
+                json!({
+                    "model": model,
+                    "audio_base64": req.audio_base64,
+                    "mime": req.mime.unwrap_or_else(|| "audio/wav".to_string()),
+                    "language": req.language,
+                    "prompt": req.prompt,
+                }),
+                TRANSCRIBE_TIMEOUT_MS,
+            )
+            .await?;
+            let reply: ProviderTranscribeReply = serde_json::from_value(reply).map_err(|e| {
+                bad_reply(
+                    &provider,
+                    SpeechModality::Stt,
+                    &format!("returned no usable transcript: {e}"),
+                )
+            })?;
+            if reply.model.is_empty() {
+                return Err(bad_reply(
+                    &provider,
+                    SpeechModality::Stt,
+                    "returned no model",
+                ));
+            }
+            Ok(RouterTranscribeResponse {
+                provider,
+                model: reply.model,
+                text: reply.text,
+                segments: reply.segments,
+                language: reply.language,
+                duration_secs: reply.duration_secs,
+            })
+        })
+    }
+}
+
+pub fn make_speak(
+    iii: IIIClient,
+    registry: Arc<RegistryStore>,
+    catalog: Arc<CatalogStore>,
+) -> impl Fn(RouterSpeakRequest) -> BoxedSpeakFuture + Send + Sync + 'static {
+    move |req: RouterSpeakRequest| {
+        let (iii, registry, catalog) = (iii.clone(), registry.clone(), catalog.clone());
+        Box::pin(async move {
+            if req.text.trim().is_empty() {
+                return Err(
+                    RouterError::new(RouterCode::InvalidRequest, "text must not be empty").into(),
+                );
+            }
+            let registered = registry.ids().await;
+            let models = catalog.all().await;
+            let (provider, model) = resolve_speech_target(
+                SpeechModality::Tts,
+                req.model.as_deref(),
+                req.provider.as_deref(),
+                &registered,
+                &models,
+            )?;
+            let reply = forward(
+                &iii,
+                &provider,
+                SpeechModality::Tts,
+                json!({
+                    "model": model,
+                    "text": req.text,
+                    "voice": req.voice,
+                    "format": req.format.unwrap_or_else(|| "mp3".to_string()),
+                    "language": req.language,
+                    "speed": req.speed,
+                }),
+                SPEAK_TIMEOUT_MS,
+            )
+            .await?;
+            let reply: ProviderSpeakReply = serde_json::from_value(reply).map_err(|e| {
+                bad_reply(
+                    &provider,
+                    SpeechModality::Tts,
+                    &format!("returned no usable audio: {e}"),
+                )
+            })?;
+            if reply.model.is_empty() {
+                return Err(bad_reply(
+                    &provider,
+                    SpeechModality::Tts,
+                    "returned no model",
+                ));
+            }
+            if reply.audio_base64.is_empty() {
+                return Err(bad_reply(
+                    &provider,
+                    SpeechModality::Tts,
+                    "returned empty audio_base64",
+                ));
+            }
+            Ok(RouterSpeakResponse {
+                provider,
+                model: reply.model,
+                audio_base64: reply.audio_base64,
+                mime: reply.mime.unwrap_or_else(|| "audio/mpeg".to_string()),
+                voice: reply.voice,
+                duration_secs: reply.duration_secs,
+            })
+        })
+    }
+}
+
+type BoxedTranscribeFuture =
+    std::pin::Pin<Box<dyn Future<Output = Result<RouterTranscribeResponse, Error>> + Send>>;
+type BoxedSpeakFuture =
+    std::pin::Pin<Box<dyn Future<Output = Result<RouterSpeakResponse, Error>> + Send>>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::model::SpeechModel;
+
+    fn speech(id: &str, provider: &str, modality: SpeechModality) -> Model {
+        Model {
+            id: id.into(),
+            provider: provider.into(),
+            display_name: None,
+            context_window: 0,
+            max_output_tokens: 0,
+            input_limit: None,
+            supports_thinking: None,
+            supports_xhigh: None,
+            reasoning_efforts: None,
+            supports_tools: None,
+            supports_vision: None,
+            supports_cache: None,
+            supports_structured_output: None,
+            thinking_budgets: None,
+            pricing: None,
+            speech: Some(SpeechModel {
+                modality,
+                languages: vec!["en".into()],
+                streaming: false,
+            }),
+        }
+    }
+
+    fn chat(id: &str, provider: &str) -> Model {
+        Model {
+            speech: None,
+            context_window: 128_000,
+            max_output_tokens: 8_192,
+            ..speech(id, provider, SpeechModality::Stt)
+        }
+    }
+
+    fn registered(ids: &[&str]) -> Vec<String> {
+        ids.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn a_model_id_resolves_to_its_single_owner() {
+        let catalog = vec![
+            speech("scribe", "elevenlabs", SpeechModality::Stt),
+            speech("eleven-v3", "elevenlabs", SpeechModality::Tts),
+            chat("gpt-x", "openai"),
+        ];
+        let reg = registered(&["elevenlabs", "openai"]);
+        assert_eq!(
+            resolve_speech_target(SpeechModality::Stt, Some("scribe"), None, &reg, &catalog),
+            Ok(("elevenlabs".into(), Some("scribe".into())))
+        );
+        assert_eq!(
+            resolve_speech_target(SpeechModality::Tts, Some("eleven-v3"), None, &reg, &catalog),
+            Ok(("elevenlabs".into(), Some("eleven-v3".into())))
+        );
+    }
+
+    #[test]
+    fn the_wrong_modality_is_a_caller_error_and_unknown_ids_are_unserved() {
+        let catalog = vec![speech("eleven-v3", "elevenlabs", SpeechModality::Tts)];
+        let reg = registered(&["elevenlabs"]);
+        let err =
+            resolve_speech_target(SpeechModality::Stt, Some("eleven-v3"), None, &reg, &catalog)
+                .unwrap_err();
+        assert_eq!(err.code, RouterCode::InvalidRequest);
+        let err = resolve_speech_target(SpeechModality::Stt, Some("nope"), None, &reg, &catalog)
+            .unwrap_err();
+        assert_eq!(err.code, RouterCode::NoProviderForModel);
+    }
+
+    #[test]
+    fn two_owners_are_ambiguous_until_a_provider_is_named() {
+        let catalog = vec![
+            speech("whisper-1", "openai", SpeechModality::Stt),
+            speech("whisper-1", "groq", SpeechModality::Stt),
+        ];
+        let reg = registered(&["groq", "openai"]);
+        let err =
+            resolve_speech_target(SpeechModality::Stt, Some("whisper-1"), None, &reg, &catalog)
+                .unwrap_err();
+        assert_eq!(err.code, RouterCode::AmbiguousModel);
+        assert_eq!(
+            resolve_speech_target(
+                SpeechModality::Stt,
+                Some("whisper-1"),
+                Some("groq"),
+                &reg,
+                &catalog
+            ),
+            Ok(("groq".into(), Some("whisper-1".into())))
+        );
+        assert_eq!(
+            resolve_speech_target(
+                SpeechModality::Stt,
+                Some("groq::whisper-1"),
+                None,
+                &reg,
+                &catalog
+            ),
+            Ok(("groq".into(), Some("whisper-1".into())))
+        );
+    }
+
+    #[test]
+    fn an_explicit_provider_is_called_even_with_a_cold_catalog() {
+        let reg = registered(&["sarvam"]);
+        assert_eq!(
+            resolve_speech_target(SpeechModality::Stt, None, Some("sarvam"), &reg, &[]),
+            Ok(("sarvam".into(), None))
+        );
+        let catalog = vec![
+            speech("saarika-v2", "sarvam", SpeechModality::Stt),
+            speech("saarika-v1", "sarvam", SpeechModality::Stt),
+            speech("bulbul-v2", "sarvam", SpeechModality::Tts),
+        ];
+        assert_eq!(
+            resolve_speech_target(SpeechModality::Stt, None, Some("sarvam"), &reg, &catalog),
+            Ok(("sarvam".into(), Some("saarika-v1".into())))
+        );
+        let err = resolve_speech_target(SpeechModality::Stt, None, Some("ghost"), &reg, &catalog)
+            .unwrap_err();
+        assert_eq!(err.code, RouterCode::UnknownProvider);
+    }
+
+    #[test]
+    fn with_nothing_named_the_first_declaring_provider_wins() {
+        let catalog = vec![
+            speech("chirp-3", "google-speech", SpeechModality::Stt),
+            speech("scribe", "elevenlabs", SpeechModality::Stt),
+            speech("eleven-v3", "elevenlabs", SpeechModality::Tts),
+        ];
+        let reg = registered(&["elevenlabs", "google-speech"]);
+        assert_eq!(
+            resolve_speech_target(SpeechModality::Stt, None, None, &reg, &catalog),
+            Ok(("elevenlabs".into(), Some("scribe".into())))
+        );
+        let err = resolve_speech_target(
+            SpeechModality::Tts,
+            None,
+            None,
+            &registered(&["openai"]),
+            &catalog,
+        )
+        .unwrap_err();
+        assert_eq!(err.code, RouterCode::NoProviderForModel);
+    }
+}

--- a/llm-router/src/speech.rs
+++ b/llm-router/src/speech.rs
@@ -386,6 +386,7 @@ pub fn make_speak(
                 &registered,
                 &models,
             )?;
+            let format = req.format.unwrap_or_else(|| "mp3".to_string());
             let reply = forward(
                 &iii,
                 &provider,
@@ -394,7 +395,7 @@ pub fn make_speak(
                     "model": model,
                     "text": req.text,
                     "voice": req.voice,
-                    "format": req.format.unwrap_or_else(|| "mp3".to_string()),
+                    "format": format,
                     "language": req.language,
                     "speed": req.speed,
                 }),
@@ -426,11 +427,24 @@ pub fn make_speak(
                 provider,
                 model: reply.model,
                 audio_base64: reply.audio_base64,
-                mime: reply.mime.unwrap_or_else(|| "audio/mpeg".to_string()),
+                mime: reply
+                    .mime
+                    .unwrap_or_else(|| mime_for_format(&format).to_string()),
                 voice: reply.voice,
                 duration_secs: reply.duration_secs,
             })
         })
+    }
+}
+
+/// The MIME type a requested `format` implies when a provider answers
+/// without naming one.
+fn mime_for_format(format: &str) -> &'static str {
+    match format {
+        "wav" => "audio/wav",
+        "pcm16" => "audio/pcm",
+        "opus" => "audio/ogg",
+        _ => "audio/mpeg",
     }
 }
 
@@ -443,6 +457,14 @@ type BoxedSpeakFuture =
 mod tests {
     use super::*;
     use crate::types::model::SpeechModel;
+
+    #[test]
+    fn mime_fallback_follows_the_requested_format() {
+        assert_eq!(mime_for_format("mp3"), "audio/mpeg");
+        assert_eq!(mime_for_format("wav"), "audio/wav");
+        assert_eq!(mime_for_format("pcm16"), "audio/pcm");
+        assert_eq!(mime_for_format("opus"), "audio/ogg");
+    }
 
     fn speech(id: &str, provider: &str, modality: SpeechModality) -> Model {
         Model {

--- a/llm-router/src/surface.rs
+++ b/llm-router/src/surface.rs
@@ -43,6 +43,18 @@ pub const EMBED_DESC: &str =
      or discovers the first embed-capable one from the live registry; one vector per input, \
      order preserved.";
 
+pub const TRANSCRIBE_ID: &str = "router::transcribe";
+pub const TRANSCRIBE_DESC: &str =
+    "Speech to text through provider::<id>::transcribe: {model?, provider?, audio_base64, \
+     mime?, language?} to {provider, model, text, segments?}. Resolves the provider from the \
+     catalog's stt models when none is named.";
+
+pub const SPEAK_ID: &str = "router::speak";
+pub const SPEAK_DESC: &str =
+    "Text to speech through provider::<id>::speak: {model?, provider?, text, voice?, format?} \
+     to {provider, model, audio_base64, mime}. Resolves the provider from the catalog's tts \
+     models when none is named.";
+
 pub const COUNT_TOKENS_ID: &str = "router::count_tokens";
 pub const COUNT_TOKENS_DESC: &str =
     "Count prompt tokens for {model, provider?, system_prompt?, tools?, messages} through the \
@@ -51,7 +63,8 @@ pub const COUNT_TOKENS_DESC: &str =
 
 pub const MODELS_LIST_ID: &str = "router::models::list";
 pub const MODELS_LIST_DESC: &str =
-    "List catalog models, optionally filtered by provider and/or a capability flag.";
+    "List catalog models, optionally filtered by provider, a capability flag, and modality \
+     (chat by default; stt, tts, or any).";
 
 pub const MODELS_GET_ID: &str = "router::models::get";
 pub const MODELS_GET_DESC: &str =
@@ -137,6 +150,13 @@ pub fn catalog() -> Vec<FunctionSpec> {
         spec::<AbortRequest, AbortResponse>(ABORT_ID, ABORT_DESC),
         spec::<crate::embed::RouterEmbedRequest, crate::embed::RouterEmbedResponse>(
             EMBED_ID, EMBED_DESC,
+        ),
+        spec::<crate::speech::RouterTranscribeRequest, crate::speech::RouterTranscribeResponse>(
+            TRANSCRIBE_ID,
+            TRANSCRIBE_DESC,
+        ),
+        spec::<crate::speech::RouterSpeakRequest, crate::speech::RouterSpeakResponse>(
+            SPEAK_ID, SPEAK_DESC,
         ),
         spec::<
             crate::count_tokens::RouterCountTokensRequest,

--- a/llm-router/src/types/model.rs
+++ b/llm-router/src/types/model.rs
@@ -39,6 +39,44 @@ pub struct Pricing {
     pub cache_write: Option<f64>,
 }
 
+/// What a speech model does. Chat models carry no `speech` block.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum SpeechModality {
+    /// Speech to text, served through `router::transcribe`.
+    Stt,
+    /// Text to speech, served through `router::speak`.
+    Tts,
+}
+
+/// Facts about a speech model. Present only on models served through
+/// `router::transcribe` / `router::speak`; such models report
+/// `context_window` and `max_output_tokens` as 0.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct SpeechModel {
+    pub modality: SpeechModality,
+    /// BCP-47 tags of the languages the model handles; empty when the
+    /// provider does not say.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub languages: Vec<String>,
+    /// Realtime input (stt) or streamed audio output (tts) is available.
+    #[serde(default)]
+    pub streaming: bool,
+}
+
+/// Model family selector for `router::models::list`. `chat` is the default
+/// so pickers built before speech models existed keep listing only what
+/// `router::chat` can run.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum ModalityFilter {
+    #[default]
+    Chat,
+    Stt,
+    Tts,
+    Any,
+}
+
 /// The capability record (README § Model descriptor).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct Model {
@@ -68,6 +106,25 @@ pub struct Model {
     pub thinking_budgets: Option<BTreeMap<ThinkingLevel, u64>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pricing: Option<Pricing>,
+    /// Set on speech models only; see [`SpeechModel`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub speech: Option<SpeechModel>,
+}
+
+impl Model {
+    /// `None` for chat models.
+    pub fn speech_modality(&self) -> Option<SpeechModality> {
+        self.speech.as_ref().map(|s| s.modality)
+    }
+
+    pub fn matches_modality(&self, filter: ModalityFilter) -> bool {
+        match filter {
+            ModalityFilter::Any => true,
+            ModalityFilter::Chat => self.speech.is_none(),
+            ModalityFilter::Stt => self.speech_modality() == Some(SpeechModality::Stt),
+            ModalityFilter::Tts => self.speech_modality() == Some(SpeechModality::Tts),
+        }
+    }
 }
 
 /// Function invocation schema — what a provider sees as a `tools` array entry

--- a/llm-router/src/types/router.rs
+++ b/llm-router/src/types/router.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeMap;
 use crate::types::credential::Credential;
 use crate::types::events::{ErrorKind, StopReason, Usage};
 use crate::types::messages::{AgentMessage, AssistantMessage};
-use crate::types::model::{AgentFunction, Model, ThinkingLevel};
+use crate::types::model::{AgentFunction, ModalityFilter, Model, ThinkingLevel};
 use iii_sdk::channel::StreamChannelRef;
 
 // ── consumer surface ────────────────────────────────────────────────────────
@@ -294,6 +294,9 @@ pub struct ModelsListRequest {
     /// Keep only models that support this capability flag (optional).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub capability: Option<String>,
+    /// Model family: `chat` (default), `stt`, `tts`, or `any`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub modality: Option<ModalityFilter>,
 }
 
 /// Output of `router::models::list`.

--- a/llm-router/tests/golden/schemas/router.models.budget.json
+++ b/llm-router/tests/golden/schemas/router.models.budget.json
@@ -91,6 +91,17 @@
               "null"
             ]
           },
+          "speech": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/SpeechModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Set on speech models only; see [`SpeechModel`]."
+          },
           "supports_cache": {
             "type": [
               "boolean",
@@ -213,6 +224,49 @@
         },
         "required": [
           "effort"
+        ],
+        "type": "object"
+      },
+      "SpeechModality": {
+        "description": "What a speech model does. Chat models carry no `speech` block.",
+        "oneOf": [
+          {
+            "description": "Speech to text, served through `router::transcribe`.",
+            "enum": [
+              "stt"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Text to speech, served through `router::speak`.",
+            "enum": [
+              "tts"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "SpeechModel": {
+        "description": "Facts about a speech model. Present only on models served through `router::transcribe` / `router::speak`; such models report `context_window` and `max_output_tokens` as 0.",
+        "properties": {
+          "languages": {
+            "description": "BCP-47 tags of the languages the model handles; empty when the provider does not say.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "modality": {
+            "$ref": "#/definitions/SpeechModality"
+          },
+          "streaming": {
+            "default": false,
+            "description": "Realtime input (stt) or streamed audio output (tts) is available.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "modality"
         ],
         "type": "object"
       }

--- a/llm-router/tests/golden/schemas/router.models.get.json
+++ b/llm-router/tests/golden/schemas/router.models.get.json
@@ -82,6 +82,17 @@
               "null"
             ]
           },
+          "speech": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/SpeechModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Set on speech models only; see [`SpeechModel`]."
+          },
           "supports_cache": {
             "type": [
               "boolean",
@@ -198,6 +209,49 @@
         },
         "required": [
           "effort"
+        ],
+        "type": "object"
+      },
+      "SpeechModality": {
+        "description": "What a speech model does. Chat models carry no `speech` block.",
+        "oneOf": [
+          {
+            "description": "Speech to text, served through `router::transcribe`.",
+            "enum": [
+              "stt"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Text to speech, served through `router::speak`.",
+            "enum": [
+              "tts"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "SpeechModel": {
+        "description": "Facts about a speech model. Present only on models served through `router::transcribe` / `router::speak`; such models report `context_window` and `max_output_tokens` as 0.",
+        "properties": {
+          "languages": {
+            "description": "BCP-47 tags of the languages the model handles; empty when the provider does not say.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "modality": {
+            "$ref": "#/definitions/SpeechModality"
+          },
+          "streaming": {
+            "default": false,
+            "description": "Realtime input (stt) or streamed audio output (tts) is available.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "modality"
         ],
         "type": "object"
       }

--- a/llm-router/tests/golden/schemas/router.models.list.json
+++ b/llm-router/tests/golden/schemas/router.models.list.json
@@ -1,8 +1,20 @@
 {
-  "description": "List catalog models, optionally filtered by provider and/or a capability flag.",
+  "description": "List catalog models, optionally filtered by provider, a capability flag, and modality (chat by default; stt, tts, or any).",
   "function_id": "router::models::list",
   "request_schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+      "ModalityFilter": {
+        "description": "Model family selector for `router::models::list`. `chat` is the default so pickers built before speech models existed keep listing only what `router::chat` can run.",
+        "enum": [
+          "chat",
+          "stt",
+          "tts",
+          "any"
+        ],
+        "type": "string"
+      }
+    },
     "description": "Input of `router::models::list`.",
     "properties": {
       "capability": {
@@ -11,6 +23,17 @@
           "string",
           "null"
         ]
+      },
+      "modality": {
+        "anyOf": [
+          {
+            "$ref": "#/definitions/ModalityFilter"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "description": "Model family: `chat` (default), `stt`, `tts`, or `any`."
       },
       "provider": {
         "description": "Filter to a single provider id (optional).",
@@ -77,6 +100,17 @@
               "array",
               "null"
             ]
+          },
+          "speech": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/SpeechModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Set on speech models only; see [`SpeechModel`]."
           },
           "supports_cache": {
             "type": [
@@ -182,6 +216,49 @@
         },
         "required": [
           "effort"
+        ],
+        "type": "object"
+      },
+      "SpeechModality": {
+        "description": "What a speech model does. Chat models carry no `speech` block.",
+        "oneOf": [
+          {
+            "description": "Speech to text, served through `router::transcribe`.",
+            "enum": [
+              "stt"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Text to speech, served through `router::speak`.",
+            "enum": [
+              "tts"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "SpeechModel": {
+        "description": "Facts about a speech model. Present only on models served through `router::transcribe` / `router::speak`; such models report `context_window` and `max_output_tokens` as 0.",
+        "properties": {
+          "languages": {
+            "description": "BCP-47 tags of the languages the model handles; empty when the provider does not say.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "modality": {
+            "$ref": "#/definitions/SpeechModality"
+          },
+          "streaming": {
+            "default": false,
+            "description": "Realtime input (stt) or streamed audio output (tts) is available.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "modality"
         ],
         "type": "object"
       }

--- a/llm-router/tests/golden/schemas/router.models.reconcile.json
+++ b/llm-router/tests/golden/schemas/router.models.reconcile.json
@@ -56,6 +56,17 @@
               "null"
             ]
           },
+          "speech": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/SpeechModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Set on speech models only; see [`SpeechModel`]."
+          },
           "supports_cache": {
             "type": [
               "boolean",
@@ -160,6 +171,49 @@
         },
         "required": [
           "effort"
+        ],
+        "type": "object"
+      },
+      "SpeechModality": {
+        "description": "What a speech model does. Chat models carry no `speech` block.",
+        "oneOf": [
+          {
+            "description": "Speech to text, served through `router::transcribe`.",
+            "enum": [
+              "stt"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Text to speech, served through `router::speak`.",
+            "enum": [
+              "tts"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "SpeechModel": {
+        "description": "Facts about a speech model. Present only on models served through `router::transcribe` / `router::speak`; such models report `context_window` and `max_output_tokens` as 0.",
+        "properties": {
+          "languages": {
+            "description": "BCP-47 tags of the languages the model handles; empty when the provider does not say.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "modality": {
+            "$ref": "#/definitions/SpeechModality"
+          },
+          "streaming": {
+            "default": false,
+            "description": "Realtime input (stt) or streamed audio output (tts) is available.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "modality"
         ],
         "type": "object"
       }

--- a/llm-router/tests/golden/schemas/router.provider.register.json
+++ b/llm-router/tests/golden/schemas/router.provider.register.json
@@ -56,6 +56,17 @@
               "null"
             ]
           },
+          "speech": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/SpeechModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Set on speech models only; see [`SpeechModel`]."
+          },
           "supports_cache": {
             "type": [
               "boolean",
@@ -180,6 +191,49 @@
         },
         "required": [
           "effort"
+        ],
+        "type": "object"
+      },
+      "SpeechModality": {
+        "description": "What a speech model does. Chat models carry no `speech` block.",
+        "oneOf": [
+          {
+            "description": "Speech to text, served through `router::transcribe`.",
+            "enum": [
+              "stt"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Text to speech, served through `router::speak`.",
+            "enum": [
+              "tts"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "SpeechModel": {
+        "description": "Facts about a speech model. Present only on models served through `router::transcribe` / `router::speak`; such models report `context_window` and `max_output_tokens` as 0.",
+        "properties": {
+          "languages": {
+            "description": "BCP-47 tags of the languages the model handles; empty when the provider does not say.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "modality": {
+            "$ref": "#/definitions/SpeechModality"
+          },
+          "streaming": {
+            "default": false,
+            "description": "Realtime input (stt) or streamed audio output (tts) is available.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "modality"
         ],
         "type": "object"
       }

--- a/llm-router/tests/golden/schemas/router.speak.json
+++ b/llm-router/tests/golden/schemas/router.speak.json
@@ -1,0 +1,108 @@
+{
+  "description": "Text to speech through provider::<id>::speak: {model?, provider?, text, voice?, format?} to {provider, model, audio_base64, mime}. Resolves the provider from the catalog's tts models when none is named.",
+  "function_id": "router::speak",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "format": {
+        "default": null,
+        "description": "Audio container wanted: `mp3` (default), `wav`, `pcm16`, `opus`. Providers answer with what they can and say so in `mime`.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "language": {
+        "default": null,
+        "description": "BCP-47 language hint for multilingual voices.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "model": {
+        "default": null,
+        "description": "Text-to-speech model id (a `tts` model from `router::models::list`); the provider's default when omitted.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "provider": {
+        "default": null,
+        "description": "Provider id; resolved from the model's catalog owner when omitted.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "speed": {
+        "default": null,
+        "description": "Speaking-rate multiplier; 1.0 is the voice's own pace.",
+        "format": "double",
+        "type": [
+          "number",
+          "null"
+        ]
+      },
+      "text": {
+        "description": "Text to speak.",
+        "type": "string"
+      },
+      "voice": {
+        "default": null,
+        "description": "Voice id or name as the provider knows it; the provider's default when omitted.",
+        "type": [
+          "string",
+          "null"
+        ]
+      }
+    },
+    "required": [
+      "text"
+    ],
+    "title": "RouterSpeakRequest",
+    "type": "object"
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "audio_base64": {
+        "description": "The audio, base64.",
+        "type": "string"
+      },
+      "duration_secs": {
+        "format": "double",
+        "type": [
+          "number",
+          "null"
+        ]
+      },
+      "mime": {
+        "description": "MIME type of the audio, e.g. `audio/mpeg`.",
+        "type": "string"
+      },
+      "model": {
+        "type": "string"
+      },
+      "provider": {
+        "type": "string"
+      },
+      "voice": {
+        "description": "Voice the provider used.",
+        "type": [
+          "string",
+          "null"
+        ]
+      }
+    },
+    "required": [
+      "audio_base64",
+      "mime",
+      "model",
+      "provider"
+    ],
+    "title": "RouterSpeakResponse",
+    "type": "object"
+  }
+}

--- a/llm-router/tests/golden/schemas/router.transcribe.json
+++ b/llm-router/tests/golden/schemas/router.transcribe.json
@@ -1,0 +1,129 @@
+{
+  "description": "Speech to text through provider::<id>::transcribe: {model?, provider?, audio_base64, mime?, language?} to {provider, model, text, segments?}. Resolves the provider from the catalog's stt models when none is named.",
+  "function_id": "router::transcribe",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "audio_base64": {
+        "description": "The audio, base64. WAV unless `mime` says otherwise.",
+        "type": "string"
+      },
+      "language": {
+        "default": null,
+        "description": "BCP-47 language hint; the model detects the language when omitted.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "mime": {
+        "default": null,
+        "description": "MIME type of the audio: `audio/wav` (default), `audio/mpeg`, `audio/webm`, `audio/ogg`, `audio/flac`.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "model": {
+        "default": null,
+        "description": "Speech-to-text model id (an `stt` model from `router::models::list`); the provider's default when omitted.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "prompt": {
+        "default": null,
+        "description": "Vocabulary or context hint for the recognizer, when the provider takes one.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "provider": {
+        "default": null,
+        "description": "Provider id; resolved from the model's catalog owner when omitted.",
+        "type": [
+          "string",
+          "null"
+        ]
+      }
+    },
+    "required": [
+      "audio_base64"
+    ],
+    "title": "RouterTranscribeRequest",
+    "type": "object"
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+      "TranscriptSegment": {
+        "description": "One timed span of a transcript; times are absent when the provider gives none.",
+        "properties": {
+          "end_secs": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "start_secs": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "duration_secs": {
+        "format": "double",
+        "type": [
+          "number",
+          "null"
+        ]
+      },
+      "language": {
+        "description": "Language the provider detected or was told (BCP-47).",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "model": {
+        "type": "string"
+      },
+      "provider": {
+        "type": "string"
+      },
+      "segments": {
+        "description": "Timed spans when the provider produces them.",
+        "items": {
+          "$ref": "#/definitions/TranscriptSegment"
+        },
+        "type": "array"
+      },
+      "text": {
+        "description": "The whole transcript.",
+        "type": "string"
+      }
+    },
+    "required": [
+      "model",
+      "provider",
+      "text"
+    ],
+    "title": "RouterTranscribeResponse",
+    "type": "object"
+  }
+}

--- a/llm-router/tests/integration.rs
+++ b/llm-router/tests/integration.rs
@@ -2615,8 +2615,9 @@ async fn speech_surfaces_forward_to_the_provider_and_stay_out_of_the_chat_list()
     provider.register_function(
         "provider::speech::speak",
         RegisterFunction::new_async(|input: Value| async move {
+            let model = input["model"].as_str().unwrap_or("say-1");
             Ok::<Value, Error>(json!({
-                "model": input["model"],
+                "model": model,
                 "audio_base64": "AAAA",
                 "mime": if input["format"] == json!("wav") { "audio/wav" } else { "audio/mpeg" },
                 "voice": input["voice"],

--- a/llm-router/tests/integration.rs
+++ b/llm-router/tests/integration.rs
@@ -2588,3 +2588,147 @@ async fn complete_fails_fast_when_the_provider_worker_is_gone() {
     consumer.shutdown();
     router_iii.shutdown();
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn speech_surfaces_forward_to_the_provider_and_stay_out_of_the_chat_list() {
+    let engine = engine_or_skip!();
+    let router_iii = register_worker(&engine.url, test_init_options());
+    register_router(router_iii.clone())
+        .await
+        .expect("router boots");
+
+    // A speech provider on its own connection: one stt and one tts model,
+    // both surfaces, no chat stream at all.
+    let provider = register_worker(&engine.url, test_init_options());
+    provider.register_function(
+        "provider::speech::transcribe",
+        RegisterFunction::new_async(|input: Value| async move {
+            let heard = input["audio_base64"].as_str().map(str::len).unwrap_or(0);
+            Ok::<Value, Error>(json!({
+                "model": input["model"],
+                "text": format!("heard {heard} chars of {}", input["mime"].as_str().unwrap_or("?")),
+                "segments": [{ "text": "heard", "start_secs": 0.0, "end_secs": 1.0 }],
+                "language": input["language"],
+            }))
+        }),
+    );
+    provider.register_function(
+        "provider::speech::speak",
+        RegisterFunction::new_async(|input: Value| async move {
+            Ok::<Value, Error>(json!({
+                "model": input["model"],
+                "audio_base64": "AAAA",
+                "mime": if input["format"] == json!("wav") { "audio/wav" } else { "audio/mpeg" },
+                "voice": input["voice"],
+            }))
+        }),
+    );
+    let declared = call(
+        &provider,
+        "router::provider::register",
+        json!({
+            "id": "speech",
+            "models": [
+                { "id": "listen-1", "provider": "speech", "context_window": 0, "max_output_tokens": 0,
+                  "speech": { "modality": "stt", "languages": ["en"], "streaming": false } },
+                { "id": "say-1", "provider": "speech", "context_window": 0, "max_output_tokens": 0,
+                  "speech": { "modality": "tts", "languages": ["en"] } }
+            ]
+        }),
+    )
+    .await
+    .expect("speech provider declares");
+    assert_eq!(declared["ok"], json!(true));
+
+    // Default listing is chat only; the speech families list on request.
+    let chat = call(&router_iii, "router::models::list", json!({}))
+        .await
+        .expect("chat list");
+    assert_eq!(chat["models"], json!([]));
+    let stt = call(
+        &router_iii,
+        "router::models::list",
+        json!({ "modality": "stt" }),
+    )
+    .await
+    .expect("stt list");
+    assert_eq!(stt["models"][0]["id"], json!("listen-1"));
+    assert_eq!(stt["models"][0]["speech"]["modality"], json!("stt"));
+    let any = call(
+        &router_iii,
+        "router::models::list",
+        json!({ "modality": "any" }),
+    )
+    .await
+    .expect("any list");
+    assert_eq!(any["models"].as_array().map(Vec::len), Some(2));
+    let supports = call(
+        &router_iii,
+        "router::models::supports",
+        json!({ "id": "say-1", "capability": "tts" }),
+    )
+    .await
+    .expect("supports");
+    assert_eq!(supports["supported"], json!(true));
+
+    // transcribe finds the provider from the model id and forwards the audio.
+    let heard = call(
+        &router_iii,
+        "router::transcribe",
+        json!({ "model": "listen-1", "audio_base64": "UklGRg==", "language": "en" }),
+    )
+    .await
+    .expect("transcribe");
+    assert_eq!(heard["provider"], json!("speech"));
+    assert_eq!(heard["model"], json!("listen-1"));
+    assert_eq!(heard["text"], json!("heard 8 chars of audio/wav"));
+    assert_eq!(heard["segments"][0]["text"], json!("heard"));
+    assert_eq!(heard["language"], json!("en"));
+
+    // speak by provider alone picks that provider's tts model.
+    let said = call(
+        &router_iii,
+        "router::speak",
+        json!({ "provider": "speech", "text": "hello", "voice": "v1", "format": "wav" }),
+    )
+    .await
+    .expect("speak");
+    assert_eq!(said["provider"], json!("speech"));
+    assert_eq!(said["model"], json!("say-1"));
+    assert_eq!(said["mime"], json!("audio/wav"));
+    assert_eq!(said["voice"], json!("v1"));
+
+    // The wrong family and an absent surface are typed errors, not silence.
+    let wrong = call(
+        &router_iii,
+        "router::transcribe",
+        json!({ "model": "say-1", "audio_base64": "UklGRg==" }),
+    )
+    .await
+    .expect_err("a tts model cannot transcribe");
+    assert_eq!(remote_code(&wrong), "router/invalid_request");
+    let empty = call(
+        &router_iii,
+        "router::speak",
+        json!({ "provider": "speech", "text": "  " }),
+    )
+    .await
+    .expect_err("empty text is refused");
+    assert_eq!(remote_code(&empty), "router/invalid_request");
+
+    // A speech model is not a chat target.
+    let refused = call(
+        &router_iii,
+        "router::complete",
+        json!({
+            "model": "listen-1",
+            "messages": [{ "role": "user", "content": [{ "type": "text", "text": "hi" }] }]
+        }),
+    )
+    .await
+    .expect_err("speech models do not chat");
+    assert_eq!(remote_code(&refused), "router/invalid_request");
+
+    provider.shutdown();
+    router_iii.shutdown();
+}

--- a/llm-router/tests/schemas.rs
+++ b/llm-router/tests/schemas.rs
@@ -32,7 +32,7 @@ fn spec_to_pretty_json(spec: &FunctionSpec) -> String {
     pretty
 }
 
-/// The catalog must cover exactly the 17 registered functions, in registration
+/// The catalog must cover exactly the 19 registered functions, in registration
 /// order (kept in lockstep with `register::register_router`).
 #[test]
 fn catalog_lists_all_functions_in_registration_order() {
@@ -44,6 +44,8 @@ fn catalog_lists_all_functions_in_registration_order() {
             "router::complete",
             "router::abort",
             "router::embed",
+            "router::transcribe",
+            "router::speak",
             "router::count_tokens",
             "router::models::list",
             "router::models::get",

--- a/provider-anthropic/src/discovery.rs
+++ b/provider-anthropic/src/discovery.rs
@@ -93,6 +93,7 @@ fn model_from_live(row: &Value) -> Option<Model> {
         supports_structured_output: Some(false),
         thinking_budgets: None,
         pricing: pricing_for(id),
+        speech: None,
     })
 }
 

--- a/provider-anthropic/src/thinking.rs
+++ b/provider-anthropic/src/thinking.rs
@@ -102,6 +102,7 @@ mod tests {
             supports_structured_output: Some(false),
             thinking_budgets: None,
             pricing: None,
+            speech: None,
         }
     }
 

--- a/provider-anthropic/tests/golden/schemas/provider.anthropic.stream.json
+++ b/provider-anthropic/tests/golden/schemas/provider.anthropic.stream.json
@@ -428,6 +428,17 @@
               "null"
             ]
           },
+          "speech": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/SpeechModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Set on speech models only; see [`SpeechModel`]."
+          },
           "supports_cache": {
             "type": [
               "boolean",
@@ -544,6 +555,49 @@
         },
         "required": [
           "type"
+        ],
+        "type": "object"
+      },
+      "SpeechModality": {
+        "description": "What a speech model does. Chat models carry no `speech` block.",
+        "oneOf": [
+          {
+            "description": "Speech to text, served through `router::transcribe`.",
+            "enum": [
+              "stt"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Text to speech, served through `router::speak`.",
+            "enum": [
+              "tts"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "SpeechModel": {
+        "description": "Facts about a speech model. Present only on models served through `router::transcribe` / `router::speak`; such models report `context_window` and `max_output_tokens` as 0.",
+        "properties": {
+          "languages": {
+            "description": "BCP-47 tags of the languages the model handles; empty when the provider does not say.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "modality": {
+            "$ref": "#/definitions/SpeechModality"
+          },
+          "streaming": {
+            "default": false,
+            "description": "Realtime input (stt) or streamed audio output (tts) is available.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "modality"
         ],
         "type": "object"
       },

--- a/provider-claude-code/src/curated.rs
+++ b/provider-claude-code/src/curated.rs
@@ -35,6 +35,7 @@ fn fallback_model(base_id: &str, display_name: &str, adaptive: bool) -> Model {
         thinking_budgets: None,
         // Subscription billing: no per-token pricing to enrich with.
         pricing: None,
+        speech: None,
     }
 }
 

--- a/provider-claude-code/src/discovery.rs
+++ b/provider-claude-code/src/discovery.rs
@@ -95,6 +95,7 @@ fn model_from_live(row: &Value) -> Option<Model> {
         thinking_budgets: None,
         // Subscription billing: no per-token pricing.
         pricing: None,
+        speech: None,
     })
 }
 

--- a/provider-claude-code/src/thinking.rs
+++ b/provider-claude-code/src/thinking.rs
@@ -102,6 +102,7 @@ mod tests {
             supports_structured_output: Some(false),
             thinking_budgets: None,
             pricing: None,
+            speech: None,
         }
     }
 

--- a/provider-claude-code/tests/golden/schemas/provider.claude-code.stream.json
+++ b/provider-claude-code/tests/golden/schemas/provider.claude-code.stream.json
@@ -428,6 +428,17 @@
               "null"
             ]
           },
+          "speech": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/SpeechModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Set on speech models only; see [`SpeechModel`]."
+          },
           "supports_cache": {
             "type": [
               "boolean",
@@ -544,6 +555,49 @@
         },
         "required": [
           "type"
+        ],
+        "type": "object"
+      },
+      "SpeechModality": {
+        "description": "What a speech model does. Chat models carry no `speech` block.",
+        "oneOf": [
+          {
+            "description": "Speech to text, served through `router::transcribe`.",
+            "enum": [
+              "stt"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Text to speech, served through `router::speak`.",
+            "enum": [
+              "tts"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "SpeechModel": {
+        "description": "Facts about a speech model. Present only on models served through `router::transcribe` / `router::speak`; such models report `context_window` and `max_output_tokens` as 0.",
+        "properties": {
+          "languages": {
+            "description": "BCP-47 tags of the languages the model handles; empty when the provider does not say.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "modality": {
+            "$ref": "#/definitions/SpeechModality"
+          },
+          "streaming": {
+            "default": false,
+            "description": "Realtime input (stt) or streamed audio output (tts) is available.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "modality"
         ],
         "type": "object"
       },

--- a/provider-command-code/src/catalog.rs
+++ b/provider-command-code/src/catalog.rs
@@ -42,6 +42,7 @@ pub fn model_from_row(row: &Value) -> Option<Model> {
         supports_structured_output: None,
         thinking_budgets: None,
         pricing: None,
+        speech: None,
     })
 }
 

--- a/provider-command-code/tests/golden/schemas/provider.command-code.stream.json
+++ b/provider-command-code/tests/golden/schemas/provider.command-code.stream.json
@@ -428,6 +428,17 @@
               "null"
             ]
           },
+          "speech": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/SpeechModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Set on speech models only; see [`SpeechModel`]."
+          },
           "supports_cache": {
             "type": [
               "boolean",
@@ -544,6 +555,49 @@
         },
         "required": [
           "type"
+        ],
+        "type": "object"
+      },
+      "SpeechModality": {
+        "description": "What a speech model does. Chat models carry no `speech` block.",
+        "oneOf": [
+          {
+            "description": "Speech to text, served through `router::transcribe`.",
+            "enum": [
+              "stt"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Text to speech, served through `router::speak`.",
+            "enum": [
+              "tts"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "SpeechModel": {
+        "description": "Facts about a speech model. Present only on models served through `router::transcribe` / `router::speak`; such models report `context_window` and `max_output_tokens` as 0.",
+        "properties": {
+          "languages": {
+            "description": "BCP-47 tags of the languages the model handles; empty when the provider does not say.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "modality": {
+            "$ref": "#/definitions/SpeechModality"
+          },
+          "streaming": {
+            "default": false,
+            "description": "Realtime input (stt) or streamed audio output (tts) is available.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "modality"
         ],
         "type": "object"
       },

--- a/provider-deepseek/src/curated.rs
+++ b/provider-deepseek/src/curated.rs
@@ -70,6 +70,7 @@ pub fn enrich(id: &str) -> Model {
                     cache_read: Some(cached),
                     cache_write: None, // automatic caching, no write surcharge
                 }),
+                speech: None,
                 ..base(id)
             }
         }
@@ -100,6 +101,7 @@ fn base(id: &str) -> Model {
         supports_structured_output: Some(false),
         thinking_budgets: None, // toggle + effort enum, not token budgets
         pricing: None,
+        speech: None,
     }
 }
 

--- a/provider-deepseek/tests/golden/schemas/provider.deepseek.stream.json
+++ b/provider-deepseek/tests/golden/schemas/provider.deepseek.stream.json
@@ -428,6 +428,17 @@
               "null"
             ]
           },
+          "speech": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/SpeechModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Set on speech models only; see [`SpeechModel`]."
+          },
           "supports_cache": {
             "type": [
               "boolean",
@@ -544,6 +555,49 @@
         },
         "required": [
           "type"
+        ],
+        "type": "object"
+      },
+      "SpeechModality": {
+        "description": "What a speech model does. Chat models carry no `speech` block.",
+        "oneOf": [
+          {
+            "description": "Speech to text, served through `router::transcribe`.",
+            "enum": [
+              "stt"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Text to speech, served through `router::speak`.",
+            "enum": [
+              "tts"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "SpeechModel": {
+        "description": "Facts about a speech model. Present only on models served through `router::transcribe` / `router::speak`; such models report `context_window` and `max_output_tokens` as 0.",
+        "properties": {
+          "languages": {
+            "description": "BCP-47 tags of the languages the model handles; empty when the provider does not say.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "modality": {
+            "$ref": "#/definitions/SpeechModality"
+          },
+          "streaming": {
+            "default": false,
+            "description": "Realtime input (stt) or streamed audio output (tts) is available.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "modality"
         ],
         "type": "object"
       },

--- a/provider-github-copilot/src/catalog.rs
+++ b/provider-github-copilot/src/catalog.rs
@@ -80,6 +80,7 @@ pub fn model_from_row(row: &Value) -> Option<Model> {
         thinking_budgets: None,
         // Subscription metering (premium requests), not per-token pricing.
         pricing: None,
+        speech: None,
     })
 }
 

--- a/provider-github-copilot/tests/golden/schemas/provider.github-copilot.stream.json
+++ b/provider-github-copilot/tests/golden/schemas/provider.github-copilot.stream.json
@@ -428,6 +428,17 @@
               "null"
             ]
           },
+          "speech": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/SpeechModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Set on speech models only; see [`SpeechModel`]."
+          },
           "supports_cache": {
             "type": [
               "boolean",
@@ -544,6 +555,49 @@
         },
         "required": [
           "type"
+        ],
+        "type": "object"
+      },
+      "SpeechModality": {
+        "description": "What a speech model does. Chat models carry no `speech` block.",
+        "oneOf": [
+          {
+            "description": "Speech to text, served through `router::transcribe`.",
+            "enum": [
+              "stt"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Text to speech, served through `router::speak`.",
+            "enum": [
+              "tts"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "SpeechModel": {
+        "description": "Facts about a speech model. Present only on models served through `router::transcribe` / `router::speak`; such models report `context_window` and `max_output_tokens` as 0.",
+        "properties": {
+          "languages": {
+            "description": "BCP-47 tags of the languages the model handles; empty when the provider does not say.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "modality": {
+            "$ref": "#/definitions/SpeechModality"
+          },
+          "streaming": {
+            "default": false,
+            "description": "Realtime input (stt) or streamed audio output (tts) is available.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "modality"
         ],
         "type": "object"
       },

--- a/provider-kimi/src/curated.rs
+++ b/provider-kimi/src/curated.rs
@@ -167,6 +167,7 @@ pub fn enrich(id: &str) -> Model {
             supports_structured_output: Some(true), // json_object mode
             thinking_budgets: None,
             pricing: Some(meta.pricing),
+            speech: None,
         },
         None => Model {
             id: id.into(),
@@ -184,6 +185,7 @@ pub fn enrich(id: &str) -> Model {
             supports_structured_output: None,
             thinking_budgets: None,
             pricing: None,
+            speech: None,
         },
     }
 }

--- a/provider-kimi/tests/golden/schemas/provider.kimi.stream.json
+++ b/provider-kimi/tests/golden/schemas/provider.kimi.stream.json
@@ -428,6 +428,17 @@
               "null"
             ]
           },
+          "speech": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/SpeechModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Set on speech models only; see [`SpeechModel`]."
+          },
           "supports_cache": {
             "type": [
               "boolean",
@@ -544,6 +555,49 @@
         },
         "required": [
           "type"
+        ],
+        "type": "object"
+      },
+      "SpeechModality": {
+        "description": "What a speech model does. Chat models carry no `speech` block.",
+        "oneOf": [
+          {
+            "description": "Speech to text, served through `router::transcribe`.",
+            "enum": [
+              "stt"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Text to speech, served through `router::speak`.",
+            "enum": [
+              "tts"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "SpeechModel": {
+        "description": "Facts about a speech model. Present only on models served through `router::transcribe` / `router::speak`; such models report `context_window` and `max_output_tokens` as 0.",
+        "properties": {
+          "languages": {
+            "description": "BCP-47 tags of the languages the model handles; empty when the provider does not say.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "modality": {
+            "$ref": "#/definitions/SpeechModality"
+          },
+          "streaming": {
+            "default": false,
+            "description": "Realtime input (stt) or streamed audio output (tts) is available.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "modality"
         ],
         "type": "object"
       },

--- a/provider-llamacpp/src/discovery.rs
+++ b/provider-llamacpp/src/discovery.rs
@@ -91,6 +91,7 @@ fn enrich(id: &str, model_context_length: Option<u64>, props: &Props) -> Model {
         supports_structured_output: Some(true),
         thinking_budgets: None,
         pricing: None, // self-hosted
+        speech: None,
     }
 }
 

--- a/provider-llamacpp/tests/golden/schemas/provider.llamacpp.stream.json
+++ b/provider-llamacpp/tests/golden/schemas/provider.llamacpp.stream.json
@@ -428,6 +428,17 @@
               "null"
             ]
           },
+          "speech": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/SpeechModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Set on speech models only; see [`SpeechModel`]."
+          },
           "supports_cache": {
             "type": [
               "boolean",
@@ -544,6 +555,49 @@
         },
         "required": [
           "type"
+        ],
+        "type": "object"
+      },
+      "SpeechModality": {
+        "description": "What a speech model does. Chat models carry no `speech` block.",
+        "oneOf": [
+          {
+            "description": "Speech to text, served through `router::transcribe`.",
+            "enum": [
+              "stt"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Text to speech, served through `router::speak`.",
+            "enum": [
+              "tts"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "SpeechModel": {
+        "description": "Facts about a speech model. Present only on models served through `router::transcribe` / `router::speak`; such models report `context_window` and `max_output_tokens` as 0.",
+        "properties": {
+          "languages": {
+            "description": "BCP-47 tags of the languages the model handles; empty when the provider does not say.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "modality": {
+            "$ref": "#/definitions/SpeechModality"
+          },
+          "streaming": {
+            "default": false,
+            "description": "Realtime input (stt) or streamed audio output (tts) is available.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "modality"
         ],
         "type": "object"
       },

--- a/provider-openai-codex/src/discovery.rs
+++ b/provider-openai-codex/src/discovery.rs
@@ -157,6 +157,7 @@ fn map_models(mut remote: Vec<CodexModel>) -> Vec<Model> {
                 supports_structured_output: None,
                 thinking_budgets: None,
                 pricing: None,
+                speech: None,
             }
         })
         .collect()

--- a/provider-openai-codex/src/reasoning.rs
+++ b/provider-openai-codex/src/reasoning.rs
@@ -233,6 +233,7 @@ mod tests {
             supports_structured_output: None,
             thinking_budgets: None,
             pricing: None,
+            speech: None,
         };
         assert_eq!(
             native_reasoning_effort(

--- a/provider-openai-codex/tests/golden/schemas/provider.openai-codex.stream.json
+++ b/provider-openai-codex/tests/golden/schemas/provider.openai-codex.stream.json
@@ -428,6 +428,17 @@
               "null"
             ]
           },
+          "speech": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/SpeechModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Set on speech models only; see [`SpeechModel`]."
+          },
           "supports_cache": {
             "type": [
               "boolean",
@@ -544,6 +555,49 @@
         },
         "required": [
           "type"
+        ],
+        "type": "object"
+      },
+      "SpeechModality": {
+        "description": "What a speech model does. Chat models carry no `speech` block.",
+        "oneOf": [
+          {
+            "description": "Speech to text, served through `router::transcribe`.",
+            "enum": [
+              "stt"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Text to speech, served through `router::speak`.",
+            "enum": [
+              "tts"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "SpeechModel": {
+        "description": "Facts about a speech model. Present only on models served through `router::transcribe` / `router::speak`; such models report `context_window` and `max_output_tokens` as 0.",
+        "properties": {
+          "languages": {
+            "description": "BCP-47 tags of the languages the model handles; empty when the provider does not say.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "modality": {
+            "$ref": "#/definitions/SpeechModality"
+          },
+          "streaming": {
+            "default": false,
+            "description": "Realtime input (stt) or streamed audio output (tts) is available.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "modality"
         ],
         "type": "object"
       },

--- a/provider-openai/src/curated.rs
+++ b/provider-openai/src/curated.rs
@@ -84,6 +84,7 @@ pub fn enrich(id: &str) -> Model {
             supports_structured_output: Some(true), // native json_schema mode
             thinking_budgets: None,                 // effort enum, not token budgets
             pricing,
+            speech: None,
         },
         None => Model {
             id: id.into(),
@@ -101,6 +102,7 @@ pub fn enrich(id: &str) -> Model {
             supports_structured_output: None,
             thinking_budgets: None,
             pricing: None,
+            speech: None,
         },
     }
 }

--- a/provider-openai/tests/golden/schemas/provider.openai.stream.json
+++ b/provider-openai/tests/golden/schemas/provider.openai.stream.json
@@ -428,6 +428,17 @@
               "null"
             ]
           },
+          "speech": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/SpeechModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Set on speech models only; see [`SpeechModel`]."
+          },
           "supports_cache": {
             "type": [
               "boolean",
@@ -544,6 +555,49 @@
         },
         "required": [
           "type"
+        ],
+        "type": "object"
+      },
+      "SpeechModality": {
+        "description": "What a speech model does. Chat models carry no `speech` block.",
+        "oneOf": [
+          {
+            "description": "Speech to text, served through `router::transcribe`.",
+            "enum": [
+              "stt"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Text to speech, served through `router::speak`.",
+            "enum": [
+              "tts"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "SpeechModel": {
+        "description": "Facts about a speech model. Present only on models served through `router::transcribe` / `router::speak`; such models report `context_window` and `max_output_tokens` as 0.",
+        "properties": {
+          "languages": {
+            "description": "BCP-47 tags of the languages the model handles; empty when the provider does not say.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "modality": {
+            "$ref": "#/definitions/SpeechModality"
+          },
+          "streaming": {
+            "default": false,
+            "description": "Realtime input (stt) or streamed audio output (tts) is available.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "modality"
         ],
         "type": "object"
       },

--- a/provider-opencode-go/src/curated.rs
+++ b/provider-opencode-go/src/curated.rs
@@ -278,6 +278,7 @@ pub fn enrich(id: &str) -> Model {
             },
             thinking_budgets: None,
             pricing: None,
+            speech: None,
         },
         None => Model {
             id: id.into(),
@@ -295,6 +296,7 @@ pub fn enrich(id: &str) -> Model {
             supports_structured_output: None,
             thinking_budgets: None,
             pricing: None,
+            speech: None,
         },
     }
 }

--- a/provider-opencode-go/tests/golden/schemas/provider.opencode_go.stream.json
+++ b/provider-opencode-go/tests/golden/schemas/provider.opencode_go.stream.json
@@ -428,6 +428,17 @@
               "null"
             ]
           },
+          "speech": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/SpeechModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Set on speech models only; see [`SpeechModel`]."
+          },
           "supports_cache": {
             "type": [
               "boolean",
@@ -544,6 +555,49 @@
         },
         "required": [
           "type"
+        ],
+        "type": "object"
+      },
+      "SpeechModality": {
+        "description": "What a speech model does. Chat models carry no `speech` block.",
+        "oneOf": [
+          {
+            "description": "Speech to text, served through `router::transcribe`.",
+            "enum": [
+              "stt"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Text to speech, served through `router::speak`.",
+            "enum": [
+              "tts"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "SpeechModel": {
+        "description": "Facts about a speech model. Present only on models served through `router::transcribe` / `router::speak`; such models report `context_window` and `max_output_tokens` as 0.",
+        "properties": {
+          "languages": {
+            "description": "BCP-47 tags of the languages the model handles; empty when the provider does not say.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "modality": {
+            "$ref": "#/definitions/SpeechModality"
+          },
+          "streaming": {
+            "default": false,
+            "description": "Realtime input (stt) or streamed audio output (tts) is available.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "modality"
         ],
         "type": "object"
       },

--- a/provider-openrouter/src/catalog.rs
+++ b/provider-openrouter/src/catalog.rs
@@ -122,6 +122,7 @@ pub fn model_from_row(row: &Value) -> Option<Model> {
         supports_structured_output: Some(supports(row, "structured_outputs")),
         thinking_budgets: None,
         pricing: if has_pricing { Some(pricing) } else { None },
+        speech: None,
     })
 }
 

--- a/provider-openrouter/src/stream_fn.rs
+++ b/provider-openrouter/src/stream_fn.rs
@@ -312,6 +312,7 @@ mod tests {
             supports_structured_output: None,
             thinking_budgets: None,
             pricing: None,
+            speech: None,
         }
     }
 

--- a/provider-openrouter/tests/golden/schemas/provider.openrouter.stream.json
+++ b/provider-openrouter/tests/golden/schemas/provider.openrouter.stream.json
@@ -428,6 +428,17 @@
               "null"
             ]
           },
+          "speech": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/SpeechModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Set on speech models only; see [`SpeechModel`]."
+          },
           "supports_cache": {
             "type": [
               "boolean",
@@ -544,6 +555,49 @@
         },
         "required": [
           "type"
+        ],
+        "type": "object"
+      },
+      "SpeechModality": {
+        "description": "What a speech model does. Chat models carry no `speech` block.",
+        "oneOf": [
+          {
+            "description": "Speech to text, served through `router::transcribe`.",
+            "enum": [
+              "stt"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Text to speech, served through `router::speak`.",
+            "enum": [
+              "tts"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "SpeechModel": {
+        "description": "Facts about a speech model. Present only on models served through `router::transcribe` / `router::speak`; such models report `context_window` and `max_output_tokens` as 0.",
+        "properties": {
+          "languages": {
+            "description": "BCP-47 tags of the languages the model handles; empty when the provider does not say.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "modality": {
+            "$ref": "#/definitions/SpeechModality"
+          },
+          "streaming": {
+            "default": false,
+            "description": "Realtime input (stt) or streamed audio output (tts) is available.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "modality"
         ],
         "type": "object"
       },

--- a/provider-xai/src/curated.rs
+++ b/provider-xai/src/curated.rs
@@ -106,6 +106,7 @@ pub fn enrich(id: &str) -> Model {
             supports_structured_output: Some(true), // native json_schema response_format
             thinking_budgets: None,                 // effort enum, not token budgets
             pricing: Some(pricing),
+            speech: None,
         },
         None => Model {
             id: id.into(),
@@ -123,6 +124,7 @@ pub fn enrich(id: &str) -> Model {
             supports_structured_output: None,
             thinking_budgets: None,
             pricing: None,
+            speech: None,
         },
     }
 }

--- a/provider-xai/tests/golden/schemas/provider.xai.stream.json
+++ b/provider-xai/tests/golden/schemas/provider.xai.stream.json
@@ -428,6 +428,17 @@
               "null"
             ]
           },
+          "speech": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/SpeechModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Set on speech models only; see [`SpeechModel`]."
+          },
           "supports_cache": {
             "type": [
               "boolean",
@@ -544,6 +555,49 @@
         },
         "required": [
           "type"
+        ],
+        "type": "object"
+      },
+      "SpeechModality": {
+        "description": "What a speech model does. Chat models carry no `speech` block.",
+        "oneOf": [
+          {
+            "description": "Speech to text, served through `router::transcribe`.",
+            "enum": [
+              "stt"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Text to speech, served through `router::speak`.",
+            "enum": [
+              "tts"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "SpeechModel": {
+        "description": "Facts about a speech model. Present only on models served through `router::transcribe` / `router::speak`; such models report `context_window` and `max_output_tokens` as 0.",
+        "properties": {
+          "languages": {
+            "description": "BCP-47 tags of the languages the model handles; empty when the provider does not say.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "modality": {
+            "$ref": "#/definitions/SpeechModality"
+          },
+          "streaming": {
+            "default": false,
+            "description": "Realtime input (stt) or streamed audio output (tts) is available.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "modality"
         ],
         "type": "object"
       },

--- a/provider-zai/src/curated.rs
+++ b/provider-zai/src/curated.rs
@@ -205,6 +205,7 @@ fn glm_53_coding_model() -> Model {
         supports_structured_output: Some(false),
         thinking_budgets: None,
         pricing: None,
+        speech: None,
     }
 }
 
@@ -236,6 +237,7 @@ fn to_model(r: &Row) -> Model {
             cache_read: Some(cached),
             cache_write: None,
         }),
+        speech: None,
     }
 }
 

--- a/provider-zai/tests/golden/schemas/provider.zai.stream.json
+++ b/provider-zai/tests/golden/schemas/provider.zai.stream.json
@@ -428,6 +428,17 @@
               "null"
             ]
           },
+          "speech": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/SpeechModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Set on speech models only; see [`SpeechModel`]."
+          },
           "supports_cache": {
             "type": [
               "boolean",
@@ -544,6 +555,49 @@
         },
         "required": [
           "type"
+        ],
+        "type": "object"
+      },
+      "SpeechModality": {
+        "description": "What a speech model does. Chat models carry no `speech` block.",
+        "oneOf": [
+          {
+            "description": "Speech to text, served through `router::transcribe`.",
+            "enum": [
+              "stt"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Text to speech, served through `router::speak`.",
+            "enum": [
+              "tts"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "SpeechModel": {
+        "description": "Facts about a speech model. Present only on models served through `router::transcribe` / `router::speak`; such models report `context_window` and `max_output_tokens` as 0.",
+        "properties": {
+          "languages": {
+            "description": "BCP-47 tags of the languages the model handles; empty when the provider does not say.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "modality": {
+            "$ref": "#/definitions/SpeechModality"
+          },
+          "streaming": {
+            "default": false,
+            "description": "Realtime input (stt) or streamed audio output (tts) is available.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "modality"
         ],
         "type": "object"
       },


### PR DESCRIPTION
## What

Speech providers plug into llm-router the way chat providers do, so the voice worker and any agent can transcribe audio or synthesize speech through one call without knowing the vendor's API.

- **Model records** take an optional `speech` block: `{ modality: "stt" | "tts", languages: [...], streaming: bool }`. Chat models are untouched (one added `speech: None` per provider literal). Capability strings `stt`, `tts`, `streaming` work in `router::models::supports` and `router::models::list`.
- **`router::models::list`** takes `modality` (`chat` default, `stt`, `tts`, `any`). Existing pickers pass nothing and keep seeing chat models only. `router::chat` refuses a speech model with a message naming the right door.
- **`router::transcribe`** `{model?, provider?, audio_base64, mime?, language?, prompt?}` → `{provider, model, text, segments[]?, language?, duration_secs?}`.
- **`router::speak`** `{model?, provider?, text, voice?, format?, language?, speed?}` → `{provider, model, audio_base64, mime, voice?, duration_secs?}`.
- Both mirror `router::embed`: resolve a provider, forward to `provider::<id>::transcribe` / `provider::<id>::speak`, stamp the provider on the reply. Resolution: explicit provider wins (cold catalog tolerated); a bare model id resolves through its unique catalog owner (typed errors for the wrong family, ambiguous owners, unserved ids); nothing named picks the first provider that declared a model of that family. A provider without the surface answers function-not-found, surfaced as `router/no_speech_provider`.
- README documents the surfaces and the provider contract (declaration shape, request and reply per surface).

## Why

The voice worker (#1070) runs local models and OpenAI-shaped endpoints today. ElevenLabs, Google, Sarvam and self-hosted servers each speak their own wire format; that code belongs in one provider worker per vendor behind the router, with credentials and model discovery in one place, not inside the voice worker. This is the router half. Next: a `router` engine in the voice worker, then the first provider worker.

## Verification

- `cargo fmt`, `cargo clippy --all-targets --all-features -D warnings`, `cargo test` (160 unit, schemas with regenerated goldens, engine-backed integration).
- New integration test: a scripted speech provider declares one stt and one tts model; default `models::list` stays empty, `modality: "stt"` lists it, `transcribe` resolves the provider from the model id and forwards audio, `speak` by provider picks that provider's tts model, a tts model handed to `transcribe` and a speech model handed to `router::complete` both fail `router/invalid_request`.
- `cargo check --locked` in every provider crate whose `Model` literals changed.

Refs MOT-4664
Fixes MOT-4665


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added speech-to-text through `router::transcribe`, with transcripts and optional timing metadata.
  - Added text-to-speech through `router::speak`, returning audio and metadata.
  - Added speech model details, including modality, supported languages, and streaming capability.
  - Added `chat`, `stt`, `tts`, and `any` filters to model listings.
- **Bug Fixes**
  - Speech-only models are excluded from chat model listings by default.
  - Chat requests targeting speech models now return a validation error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->