### PR TITLE
(MOT-4665) feat(voice): router engine for speech to text and read-aloud

### DIFF
--- a/.github/scripts/tests/test_worker_compose.py
+++ b/.github/scripts/tests/test_worker_compose.py
@@ -55,8 +55,8 @@ def test_rust_frontends_are_explicit_workspace_locked_builds():
         for worker in document["workers"].values()
         for frontend in worker["artifact"].get("frontends", [])
     ]
-    assert sum(bool(worker["artifact"].get("frontends")) for worker in document["workers"].values()) == 41
-    assert len(frontends) == 44
+    assert sum(bool(worker["artifact"].get("frontends")) for worker in document["workers"].values()) == 42
+    assert len(frontends) == 45
     for frontend in frontends:
         assert set(frontend) == {
             "workspace_root", "source_path", "runtime", "package_manager", "lockfile",

--- a/voice/README.md
+++ b/voice/README.md
@@ -100,7 +100,7 @@ endpointing change reloads the recognizer on next use.
 | --- | --- | --- |
 | `models_dir` | `data/voice/models` | Where models live (relative to the project directory). |
 | `stt.backend` | `local` | `local` (bundled recognizer), `openai` (any `/v1/audio/transcriptions` server), or `router` (llm-router's `router::transcribe`, any registered speech provider). |
-| `stt.model` | `zipformer-en-20m` | Streaming model id from `voice::models::list` (live partial text). |
+| `stt.model` | `zipformer-en-20m` | Streaming model for live words and sentence boundaries: `zipformer-en-20m` (44 MB, fastest) or `zipformer-en-large` (73 MB, fewer misheard words in the preview). |
 | `stt.final_model` | `parakeet-tdt-0.6b-v2` | Second-pass model that re-decodes each utterance for the final text. Empty disables the second pass. |
 | `stt.num_threads` | `2` | Decoder threads. |
 | `stt.silence_after_speech_secs` | `0.8` | Trailing silence that commits an utterance. |

--- a/voice/README.md
+++ b/voice/README.md
@@ -99,7 +99,7 @@ endpointing change reloads the recognizer on next use.
 | Field | Default | Meaning |
 | --- | --- | --- |
 | `models_dir` | `data/voice/models` | Where models live (relative to the project directory). |
-| `stt.backend` | `local` | `local` (bundled recognizer) or `openai` (any `/v1/audio/transcriptions` server). |
+| `stt.backend` | `local` | `local` (bundled recognizer), `openai` (any `/v1/audio/transcriptions` server), or `router` (llm-router's `router::transcribe`, any registered speech provider). |
 | `stt.model` | `zipformer-en-20m` | Streaming model id from `voice::models::list` (live partial text). |
 | `stt.final_model` | `parakeet-tdt-0.6b-v2` | Second-pass model that re-decodes each utterance for the final text. Empty disables the second pass. |
 | `stt.num_threads` | `2` | Decoder threads. |
@@ -107,10 +107,12 @@ endpointing change reloads the recognizer on next use.
 | `stt.silence_without_speech_secs` | `2.4` | Trailing silence that ends an empty segment. |
 | `stt.max_utterance_secs` | `20` | Longest utterance before a forced commit. |
 | `stt.openai.base_url`, `api_key`, `model`, `language` | OpenAI defaults | The remote transcription endpoint. `api_key` accepts `${OPENAI_API_KEY}`. |
-| `tts.backend` | `host` | `host` (`say` on macOS, `espeak-ng` on Linux), `openai` (`/v1/audio/speech`, audio returned to the caller), or `off`. |
+| `stt.router.model`, `language` | empty | Router model (`provider::model`) for `voice::transcribe` and for the second pass of every dictated sentence; empty lets the router pick. Keys live in the router's Settings, not here. |
+| `tts.backend` | `host` | `host` (`say` on macOS, `espeak-ng` on Linux), `openai` (`/v1/audio/speech`, audio returned to the caller), `router` (llm-router's `router::speak`, any registered speech provider, audio returned to the caller), or `off`. |
 | `tts.voice`, `tts.rate_wpm` | system default | Host voice and speaking rate. |
 | `tts.max_speak_chars` | `4000` | Longest text one `voice::speak` call reads. |
 | `tts.openai.base_url`, `api_key`, `model`, `voice` | OpenAI defaults | The remote speech endpoint. |
+| `tts.router.model`, `voice`, `format` | empty, empty, `mp3` | Router model, voice id or name, and container for `voice::speak`. |
 | `max_audio_bytes` | `10485760` | Largest inline (`audio_base64`) file for `voice::transcribe`. |
 | `max_sessions` | `8` | Open dictation sessions across all callers. |
 | `session_idle_secs` | `120` | Idle time before a session is closed. |

--- a/voice/README.md
+++ b/voice/README.md
@@ -131,7 +131,9 @@ the `openai` backend with an empty `api_key`.
 | `voice::doctor` | Backends, model state, open sessions. |
 
 Triggers: `voice::transcript`, `voice::session-started`,
-`voice::session-stopped`, `voice::model-progress`.
+`voice::session-stopped`, `voice::model-progress`, `voice::speech-ended`
+(host playback finished: `ended`, `stopped` or `failed`; filter with
+`speech_id`).
 
 ## Limits
 

--- a/voice/skills/SKILL.md
+++ b/voice/skills/SKILL.md
@@ -5,7 +5,7 @@ description: Speech in and out for iii — transcribe audio files to timestamped
 
 # voice
 
-Local speech-to-text and read-aloud on the iii bus. Nothing leaves the machine by default: a small streaming recognizer produces live text and a large second-pass model re-decodes each finished utterance with punctuation and casing, both with models the worker downloads once. An OpenAI-compatible audio endpoint can replace either half through configuration.
+Local speech-to-text and read-aloud on the iii bus. Nothing leaves the machine by default: a small streaming recognizer produces live text and a large second-pass model re-decodes each finished utterance with punctuation and casing, both with models the worker downloads once. An OpenAI-compatible audio endpoint, or any speech provider registered with llm-router (`stt.backend` / `tts.backend` set to `router`), can replace either half through configuration.
 
 ## When to Use
 

--- a/voice/src/config.rs
+++ b/voice/src/config.rs
@@ -58,12 +58,15 @@ pub enum SttBackend {
     Local,
     /// An OpenAI-compatible `/v1/audio/transcriptions` endpoint.
     Openai,
+    /// llm-router's `router::transcribe`: any speech provider registered
+    /// with the router (ElevenLabs, OpenAI, a self-hosted server).
+    Router,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct SttConfig {
-    /// `local` (default) or `openai`.
+    /// `local` (default), `openai`, or `router`.
     #[serde(default = "default_stt_backend")]
     pub backend: SttBackend,
 
@@ -102,6 +105,23 @@ pub struct SttConfig {
     /// Settings for the `openai` backend.
     #[serde(default)]
     pub openai: OpenaiSttConfig,
+
+    /// Settings for the `router` backend.
+    #[serde(default)]
+    pub router: RouterSttConfig,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct RouterSttConfig {
+    /// Speech-to-text model as the router lists it (`provider::model`, or a
+    /// bare id the router resolves). Empty lets the router pick.
+    #[serde(default)]
+    pub model: String,
+
+    /// Language hint (BCP-47) sent with each request. Empty means detect.
+    #[serde(default)]
+    pub language: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
@@ -136,6 +156,9 @@ pub enum TtsBackend {
     /// An OpenAI-compatible `/v1/audio/speech` endpoint. Audio is returned to
     /// the caller for playback in the browser.
     Openai,
+    /// llm-router's `router::speak`: any speech provider registered with the
+    /// router. Audio is returned to the caller for playback in the browser.
+    Router,
     /// Read-aloud disabled.
     Off,
 }
@@ -164,6 +187,42 @@ pub struct TtsConfig {
     /// Settings for the `openai` backend.
     #[serde(default)]
     pub openai: OpenaiTtsConfig,
+
+    /// Settings for the `router` backend.
+    #[serde(default)]
+    pub router: RouterTtsConfig,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct RouterTtsConfig {
+    /// Text-to-speech model as the router lists it (`provider::model`, or a
+    /// bare id the router resolves). Empty lets the router pick.
+    #[serde(default)]
+    pub model: String,
+
+    /// Voice id or name as the provider knows it. Empty uses the provider's
+    /// default voice.
+    #[serde(default)]
+    pub voice: String,
+
+    /// Audio container to ask for: `mp3` (default), `wav`, `pcm16`, `opus`.
+    #[serde(default = "default_router_format")]
+    pub format: String,
+}
+
+fn default_router_format() -> String {
+    "mp3".to_string()
+}
+
+impl Default for RouterTtsConfig {
+    fn default() -> Self {
+        Self {
+            model: String::new(),
+            voice: String::new(),
+            format: default_router_format(),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
@@ -302,6 +361,7 @@ impl Default for SttConfig {
             silence_without_speech_secs: default_silence_without_speech_secs(),
             max_utterance_secs: default_max_utterance_secs(),
             openai: OpenaiSttConfig::default(),
+            router: RouterSttConfig::default(),
         }
     }
 }
@@ -325,6 +385,7 @@ impl Default for TtsConfig {
             rate_wpm: 0,
             max_speak_chars: default_max_speak_chars(),
             openai: OpenaiTtsConfig::default(),
+            router: RouterTtsConfig::default(),
         }
     }
 }

--- a/voice/src/engine.rs
+++ b/voice/src/engine.rs
@@ -669,6 +669,10 @@ impl Engine {
         language: Option<&str>,
     ) -> Result<(Transcript, &'static str, String), String> {
         match cfg.stt.backend {
+            SttBackend::Router => Err(
+                "the router engine is served by voice::transcribe, not the local engine"
+                    .to_string(),
+            ),
             SttBackend::Local => {
                 let loaded = self.ensure_loaded(cfg, None).await?;
                 let refiner = self.ensure_final_loaded(cfg, None).await?;

--- a/voice/src/events.rs
+++ b/voice/src/events.rs
@@ -22,6 +22,7 @@ pub const TRANSCRIPT: &str = "voice::transcript";
 pub const SESSION_STARTED: &str = "voice::session-started";
 pub const SESSION_STOPPED: &str = "voice::session-stopped";
 pub const MODEL_PROGRESS: &str = "voice::model-progress";
+pub const SPEECH_ENDED: &str = "voice::speech-ended";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum EventKind {
@@ -29,6 +30,7 @@ pub enum EventKind {
     SessionStarted,
     SessionStopped,
     ModelProgress,
+    SpeechEnded,
 }
 
 impl EventKind {
@@ -38,32 +40,45 @@ impl EventKind {
             EventKind::SessionStarted => SESSION_STARTED,
             EventKind::SessionStopped => SESSION_STOPPED,
             EventKind::ModelProgress => MODEL_PROGRESS,
+            EventKind::SpeechEnded => SPEECH_ENDED,
         }
     }
 
-    pub fn all() -> [EventKind; 4] {
+    pub fn all() -> [EventKind; 5] {
         [
             EventKind::Transcript,
             EventKind::SessionStarted,
             EventKind::SessionStopped,
             EventKind::ModelProgress,
+            EventKind::SpeechEnded,
         ]
     }
 }
 
 /// Config accepted by every `voice::*` trigger binding. The only filter is an
-/// optional session-id equality match; unknown fields fail at registration so
-/// a misspelled filter key fails loudly instead of silently receiving nothing.
+/// optional id equality match: `session_id` for dictation events,
+/// `speech_id` for `voice::speech-ended`. Unknown fields fail at
+/// registration so a misspelled filter key fails loudly instead of silently
+/// receiving nothing.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct BindingConfig {
     /// Only deliver events for this dictation session.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub session_id: Option<String>,
+    /// Only deliver the end of this playback (`voice::speech-ended`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub speech_id: Option<String>,
 }
 
-pub fn binding_matches(filter: &BindingConfig, session_id: Option<&str>) -> bool {
-    match (&filter.session_id, session_id) {
+/// `id` is the session id for dictation events and the speech id for
+/// `voice::speech-ended`; each kind consults its own filter field.
+pub fn binding_matches(filter: &BindingConfig, kind: EventKind, id: Option<&str>) -> bool {
+    let want = match kind {
+        EventKind::SpeechEnded => &filter.speech_id,
+        _ => &filter.session_id,
+    };
+    match (want, id) {
         (Some(want), Some(have)) => want == have,
         (Some(_), None) => false,
         (None, _) => true,
@@ -113,6 +128,18 @@ pub struct SessionStartedEvent {
 pub struct SessionStoppedEvent {
     pub session_id: String,
     /// One of `stopped`, `discarded`, `idle`, `shutdown`.
+    pub reason: String,
+    pub timestamp_ms: i64,
+}
+
+/// `voice::speech-ended` — a host playback started by `voice::speak` is
+/// over. Fires for the `host` engine only: the other engines hand the audio
+/// to the caller, who plays it and knows when it ends.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SpeechEndedEvent {
+    pub speech_id: String,
+    /// `ended` (played to the end), `stopped` (voice::speak::stop), or
+    /// `failed` (the speech command exited with an error).
     pub reason: String,
     pub timestamp_ms: i64,
 }
@@ -189,7 +216,7 @@ impl SubscriberSet {
             .lock()
             .unwrap_or_else(|p| p.into_inner())
             .values()
-            .filter(|b| binding_matches(&b.filter, session_id))
+            .filter(|b| binding_matches(&b.filter, self.kind, session_id))
             .cloned()
             .collect()
     }
@@ -247,7 +274,7 @@ impl TriggerHandler for VoiceTriggerHandler {
 /// `functions::register_all` so handlers can capture the subscriber sets.
 pub fn register_trigger_types(iii: &Arc<IIIClient>) -> TriggerSets {
     let sets = TriggerSets::new();
-    let descriptions: [(EventKind, &str); 4] = [
+    let descriptions: [(EventKind, &str); 5] = [
         (
             EventKind::Transcript,
             "A dictation session produced text: a partial replaces the in-progress text, a \
@@ -265,6 +292,11 @@ pub fn register_trigger_types(iii: &Arc<IIIClient>) -> TriggerSets {
             EventKind::ModelProgress,
             "Bytes received while a speech model downloads, one event per megabyte and a \
              final done event (with error when the download failed).",
+        ),
+        (
+            EventKind::SpeechEnded,
+            "A host read-aloud started by voice::speak finished: reason ended, stopped or \
+             failed. Filter with speech_id.",
         ),
     ];
     for (kind, description) in descriptions {
@@ -444,4 +476,19 @@ mod tests {
         assert_eq!(deliveries[0].1, "fn-y");
         assert_eq!(deliveries[0].0, SESSION_STOPPED);
     }
+}
+
+/// A deliverer that drops every event; for speakers built in tests.
+pub struct NoopDeliverer;
+
+#[async_trait]
+impl EventDeliverer for NoopDeliverer {
+    async fn deliver(&self, _trigger_type: &str, _function_id: &str, _payload: Value) {}
+}
+
+pub fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
 }

--- a/voice/src/events.rs
+++ b/voice/src/events.rs
@@ -434,6 +434,38 @@ mod tests {
     use super::*;
 
     #[test]
+    fn a_filter_on_the_other_kind_never_matches() {
+        let dictation = BindingConfig {
+            session_id: Some("d_1".into()),
+            speech_id: None,
+        };
+        assert!(!binding_matches(
+            &dictation,
+            EventKind::SpeechEnded,
+            Some("s_1")
+        ));
+        assert!(binding_matches(
+            &dictation,
+            EventKind::Transcript,
+            Some("d_1")
+        ));
+        let speech = BindingConfig {
+            session_id: None,
+            speech_id: Some("s_1".into()),
+        };
+        assert!(!binding_matches(
+            &speech,
+            EventKind::Transcript,
+            Some("d_1")
+        ));
+        assert!(binding_matches(
+            &speech,
+            EventKind::SpeechEnded,
+            Some("s_1")
+        ));
+    }
+
+    #[test]
     fn a_misspelled_filter_key_is_rejected() {
         let set = SubscriberSet::new(EventKind::Transcript);
         let err = set

--- a/voice/src/events.rs
+++ b/voice/src/events.rs
@@ -72,12 +72,17 @@ pub struct BindingConfig {
 }
 
 /// `id` is the session id for dictation events and the speech id for
-/// `voice::speech-ended`; each kind consults its own filter field.
+/// `voice::speech-ended`; each kind consults its own filter field. A
+/// filter on the other kind's field can never match, so a binding that
+/// sets it receives nothing rather than everything.
 pub fn binding_matches(filter: &BindingConfig, kind: EventKind, id: Option<&str>) -> bool {
-    let want = match kind {
-        EventKind::SpeechEnded => &filter.speech_id,
-        _ => &filter.session_id,
+    let (want, stray) = match kind {
+        EventKind::SpeechEnded => (&filter.speech_id, &filter.session_id),
+        _ => (&filter.session_id, &filter.speech_id),
     };
+    if stray.is_some() {
+        return false;
+    }
     match (want, id) {
         (Some(want), Some(have)) => want == have,
         (Some(_), None) => false,

--- a/voice/src/functions/doctor.rs
+++ b/voice/src/functions/doctor.rs
@@ -81,6 +81,22 @@ pub async fn handle(state: &AppState, _req: Request) -> Result<Response, String>
                 .await
                 .map(|l| l.load_ms as u64),
         },
+        SttBackend::Router => SttReport {
+            backend: "router".into(),
+            model: if cfg.stt.router.model.trim().is_empty() {
+                "router picks".into()
+            } else {
+                cfg.stt.router.model.clone()
+            },
+            installed: true,
+            loaded: true,
+            load_ms: None,
+            models_dir: dir.to_string_lossy().into_owned(),
+            problem: crate::router::problem(&state.iii, "stt").await,
+            final_model: String::new(),
+            final_state: FinalState::Off,
+            final_load_ms: None,
+        },
         SttBackend::Openai => SttReport {
             backend: "openai".into(),
             model: cfg.stt.openai.model.clone(),
@@ -114,6 +130,12 @@ pub async fn handle(state: &AppState, _req: Request) -> Result<Response, String>
             backend: "openai".into(),
             command: None,
             available: !cfg.tts.openai.base_url.trim().is_empty(),
+            playing: 0,
+        },
+        TtsBackend::Router => TtsReport {
+            backend: "router".into(),
+            command: crate::router::problem(&state.iii, "tts").await,
+            available: crate::router::problem(&state.iii, "tts").await.is_none(),
             playing: 0,
         },
         TtsBackend::Off => TtsReport {

--- a/voice/src/functions/doctor.rs
+++ b/voice/src/functions/doctor.rs
@@ -19,11 +19,18 @@ pub struct Request {}
 
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct SttReport {
-    /// `local` or `openai`.
+    /// `local`, `router` or `openai`.
     pub backend: String,
+    /// The model that writes final text: the local accurate model, the
+    /// router model, or the endpoint model.
     pub model: String,
     pub installed: bool,
     pub loaded: bool,
+    /// The local streaming model that shows live words and finds sentence
+    /// ends while dictating, whatever the engine.
+    pub live_model: String,
+    pub live_installed: bool,
+    pub live_loaded: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub load_ms: Option<u64>,
     pub models_dir: String,
@@ -62,12 +69,18 @@ pub async fn handle(state: &AppState, _req: Request) -> Result<Response, String>
     let dir = cfg.models_path();
     let spec = models::find(&cfg.stt.model);
     let loaded = state.engine.loaded_for(&cfg).await;
+    let live_model = cfg.stt.model.clone();
+    let live_installed = spec.is_some_and(|s| s.is_installed(&dir));
+    let live_loaded = loaded.is_some();
     let stt = match cfg.stt.backend {
         SttBackend::Local => SttReport {
             backend: "local".into(),
             model: cfg.stt.model.clone(),
-            installed: spec.is_some_and(|s| s.is_installed(&dir)),
-            loaded: loaded.is_some(),
+            installed: live_installed,
+            loaded: live_loaded,
+            live_model: live_model.clone(),
+            live_installed,
+            live_loaded,
             load_ms: loaded.as_ref().map(|l| l.load_ms as u64),
             models_dir: dir.to_string_lossy().into_owned(),
             problem: spec
@@ -90,6 +103,9 @@ pub async fn handle(state: &AppState, _req: Request) -> Result<Response, String>
             },
             installed: true,
             loaded: true,
+            live_model: live_model.clone(),
+            live_installed,
+            live_loaded,
             load_ms: None,
             models_dir: dir.to_string_lossy().into_owned(),
             problem: crate::router::problem(&state.iii, "stt").await,
@@ -102,6 +118,9 @@ pub async fn handle(state: &AppState, _req: Request) -> Result<Response, String>
             model: cfg.stt.openai.model.clone(),
             installed: true,
             loaded: true,
+            live_model: live_model.clone(),
+            live_installed,
+            live_loaded,
             load_ms: None,
             models_dir: dir.to_string_lossy().into_owned(),
             problem: cfg

--- a/voice/src/functions/mod.rs
+++ b/voice/src/functions/mod.rs
@@ -25,6 +25,7 @@ use crate::tts::Speaker;
 
 /// Everything a handler can reach.
 pub struct AppState {
+    pub iii: Arc<IIIClient>,
     pub cfg: ConfigCell,
     pub engine: Arc<Engine>,
     pub sessions: Arc<Sessions>,

--- a/voice/src/functions/speak.rs
+++ b/voice/src/functions/speak.rs
@@ -3,13 +3,16 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use base64::Engine as _;
+
 use super::AppState;
+use crate::config::TtsBackend;
 use crate::tts::Spoken;
 
 pub const ID: &str = "voice::speak";
 pub const DESC: &str = "Read text aloud. On the host backend playback starts on the machine running \
-                        the worker and the call returns at once with a speech_id; on the openai backend \
-                        the audio comes back base64 for the caller to play.";
+                        the worker and the call returns at once with a speech_id; on the openai and \
+                        router backends the audio comes back base64 for the caller to play.";
 
 pub const STOP_ID: &str = "voice::speak::stop";
 pub const STOP_DESC: &str =
@@ -32,6 +35,18 @@ pub type Response = Spoken;
 
 pub async fn handle(state: &AppState, req: Request) -> Result<Response, String> {
     let cfg = state.cfg.read().await.clone();
+    if cfg.tts.backend == TtsBackend::Router {
+        let text = crate::tts::clip_text(&req.text, cfg.tts.max_speak_chars)?;
+        let (audio, mime, _model) =
+            crate::router::speak(&state.iii, &cfg, &text, req.voice.as_deref()).await?;
+        return Ok(Spoken {
+            backend: "router".into(),
+            speech_id: format!("s_{}", uuid::Uuid::new_v4().simple()),
+            played: false,
+            audio_base64: Some(base64::engine::general_purpose::STANDARD.encode(audio)),
+            mime: Some(mime),
+        });
+    }
     state
         .speaker
         .speak(&cfg, &req.text, req.voice.as_deref(), req.rate_wpm)

--- a/voice/src/functions/speak.rs
+++ b/voice/src/functions/speak.rs
@@ -11,8 +11,9 @@ use crate::tts::Spoken;
 
 pub const ID: &str = "voice::speak";
 pub const DESC: &str = "Read text aloud. On the host backend playback starts on the machine running \
-                        the worker and the call returns at once with a speech_id; on the openai and \
-                        router backends the audio comes back base64 for the caller to play.";
+                        the worker and the call returns at once with a speech_id and voice::speech-ended \
+                        fires when it is over; on the openai and router backends the audio comes back \
+                        base64 for the caller to play.";
 
 pub const STOP_ID: &str = "voice::speak::stop";
 pub const STOP_DESC: &str =

--- a/voice/src/functions/transcribe.rs
+++ b/voice/src/functions/transcribe.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use super::AppState;
 use crate::audio;
+use crate::config::SttBackend;
 use crate::engine::Segment;
 
 pub const ID: &str = "voice::transcribe";
@@ -36,7 +37,7 @@ pub struct Response {
     pub segments: Vec<Segment>,
     pub duration_secs: f32,
     pub model: String,
-    /// `local` or `openai`.
+    /// `local`, `openai`, or `router`.
     pub backend: String,
 }
 
@@ -80,10 +81,17 @@ pub async fn handle(state: &AppState, req: Request) -> Result<Response, String> 
     if decoded.samples.is_empty() {
         return Err("the file holds no audio samples".to_string());
     }
-    let (transcript, backend, model) = state
-        .engine
-        .transcribe(&cfg, decoded.samples, req.language.as_deref())
-        .await?;
+    let (transcript, backend, model) = if cfg.stt.backend == SttBackend::Router {
+        let (transcript, model) =
+            crate::router::transcribe(&state.iii, &cfg, &decoded.samples, req.language.as_deref())
+                .await?;
+        (transcript, "router", model)
+    } else {
+        state
+            .engine
+            .transcribe(&cfg, decoded.samples, req.language.as_deref())
+            .await?
+    };
     Ok(Response {
         text: transcript.text,
         segments: transcript.segments,

--- a/voice/src/lib.rs
+++ b/voice/src/lib.rs
@@ -6,6 +6,7 @@ pub mod events;
 pub mod functions;
 pub mod manifest;
 pub mod models;
+pub mod router;
 pub mod session;
 pub mod tts;
 pub mod ui;

--- a/voice/src/main.rs
+++ b/voice/src/main.rs
@@ -139,7 +139,7 @@ async fn main() -> anyhow::Result<()> {
         emitter.clone(),
         cell.clone(),
     ));
-    let speaker = Arc::new(Speaker::new());
+    let speaker = Arc::new(Speaker::new(emitter.clone()));
     let state = Arc::new(AppState {
         iii: iii.clone(),
         cfg: cell.clone(),

--- a/voice/src/main.rs
+++ b/voice/src/main.rs
@@ -133,9 +133,15 @@ async fn main() -> anyhow::Result<()> {
     let sets = events::register_trigger_types(&iii);
     let emitter = Arc::new(Emitter::new(sets, Arc::new(IiiDeliverer::new(iii.clone()))));
     let engine = Arc::new(Engine::new());
-    let sessions = Arc::new(Sessions::new(engine.clone(), emitter.clone(), cell.clone()));
+    let sessions = Arc::new(Sessions::new(
+        iii.clone(),
+        engine.clone(),
+        emitter.clone(),
+        cell.clone(),
+    ));
     let speaker = Arc::new(Speaker::new());
     let state = Arc::new(AppState {
+        iii: iii.clone(),
         cfg: cell.clone(),
         engine: engine.clone(),
         sessions: sessions.clone(),

--- a/voice/src/models.rs
+++ b/voice/src/models.rs
@@ -115,6 +115,33 @@ static ZIPFORMER_EN_20M_FILES: [ModelFile; 4] = [
     },
 ];
 
+static ZIPFORMER_EN_LARGE_FILES: [ModelFile; 4] = [
+    ModelFile {
+        name: "encoder-epoch-99-avg-1-chunk-16-left-128.int8.onnx",
+        url: "https://huggingface.co/csukuangfj/sherpa-onnx-streaming-zipformer-en-2023-06-26/resolve/main/encoder-epoch-99-avg-1-chunk-16-left-128.int8.onnx",
+        sha256: "563fde436d16cf7607cf408cd6b30909819d03162652ef389c2450ced3f45ac1",
+        size_bytes: 71_083_163,
+    },
+    ModelFile {
+        name: "decoder-epoch-99-avg-1-chunk-16-left-128.int8.onnx",
+        url: "https://huggingface.co/csukuangfj/sherpa-onnx-streaming-zipformer-en-2023-06-26/resolve/main/decoder-epoch-99-avg-1-chunk-16-left-128.int8.onnx",
+        sha256: "98da299f471e38bb4e1a8df579b8cc9122d6039576a77e357b3c60f17dd83b02",
+        size_bytes: 1_307_236,
+    },
+    ModelFile {
+        name: "joiner-epoch-99-avg-1-chunk-16-left-128.int8.onnx",
+        url: "https://huggingface.co/csukuangfj/sherpa-onnx-streaming-zipformer-en-2023-06-26/resolve/main/joiner-epoch-99-avg-1-chunk-16-left-128.int8.onnx",
+        sha256: "d944208d660d67c8d72cd2acaeac971fa5ceb8c80e76c1968148846fedd6e297",
+        size_bytes: 259_335,
+    },
+    ModelFile {
+        name: "tokens.txt",
+        url: "https://huggingface.co/csukuangfj/sherpa-onnx-streaming-zipformer-en-2023-06-26/resolve/main/tokens.txt",
+        sha256: "49e3c2646595fd907228b3c6787069658f67b17377c60aeb8619c4551b2316fb",
+        size_bytes: 5_048,
+    },
+];
+
 static PARAKEET_TDT_06B_V2_FILES: [ModelFile; 4] = [
     ModelFile {
         name: "encoder.int8.onnx",
@@ -142,7 +169,7 @@ static PARAKEET_TDT_06B_V2_FILES: [ModelFile; 4] = [
     },
 ];
 
-static CATALOG: [ModelSpec; 2] = [
+static CATALOG: [ModelSpec; 3] = [
     ModelSpec {
         id: DEFAULT_MODEL,
         name: "Zipformer streaming 20M",
@@ -156,6 +183,20 @@ static CATALOG: [ModelSpec; 2] = [
         encoder: "encoder-epoch-99-avg-1.int8.onnx",
         decoder: "decoder-epoch-99-avg-1.int8.onnx",
         joiner: "joiner-epoch-99-avg-1.int8.onnx",
+        tokens: "tokens.txt",
+    },
+    ModelSpec {
+        id: "zipformer-en-large",
+        name: "Zipformer streaming large",
+        kind: ModelKind::StreamingTransducer,
+        languages: &["en"],
+        license: "Apache-2.0",
+        author: "k2-fsa (icefall)",
+        source: "https://huggingface.co/csukuangfj/sherpa-onnx-streaming-zipformer-en-2023-06-26",
+        files: &ZIPFORMER_EN_LARGE_FILES,
+        encoder: "encoder-epoch-99-avg-1-chunk-16-left-128.int8.onnx",
+        decoder: "decoder-epoch-99-avg-1-chunk-16-left-128.int8.onnx",
+        joiner: "joiner-epoch-99-avg-1-chunk-16-left-128.int8.onnx",
         tokens: "tokens.txt",
     },
     ModelSpec {

--- a/voice/src/router.rs
+++ b/voice/src/router.rs
@@ -1,0 +1,234 @@
+//! The `router` engines: speech to text and text to speech through
+//! llm-router's `router::transcribe` and `router::speak`, so any speech
+//! provider registered with the router (ElevenLabs, OpenAI, a self-hosted
+//! server) serves the voice worker without the worker knowing its API.
+//! Model ids are the router's `provider::model` form or a bare id the
+//! router resolves; an empty id lets the router pick.
+
+use base64::Engine as _;
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::IIIClient;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::audio;
+use crate::audio::TARGET_SAMPLE_RATE;
+use crate::config::WorkerConfig;
+use crate::engine::{Segment, Transcript};
+
+const TRANSCRIBE_TIMEOUT_MS: u64 = 300_000;
+const SPEAK_TIMEOUT_MS: u64 = 120_000;
+const LIST_TIMEOUT_MS: u64 = 10_000;
+
+#[derive(Debug, Deserialize)]
+struct WireSegment {
+    text: String,
+    #[serde(default)]
+    start_secs: Option<f64>,
+    #[serde(default)]
+    end_secs: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct WireTranscript {
+    provider: String,
+    model: String,
+    text: String,
+    #[serde(default)]
+    segments: Vec<WireSegment>,
+    #[serde(default)]
+    duration_secs: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct WireSpeech {
+    provider: String,
+    model: String,
+    audio_base64: String,
+    #[serde(default)]
+    mime: Option<String>,
+}
+
+/// One speech model the router lists.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RouterSpeechModel {
+    pub id: String,
+    pub provider: String,
+    #[serde(default)]
+    pub display_name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct WireModels {
+    #[serde(default)]
+    models: Vec<RouterSpeechModel>,
+}
+
+fn describe(err: &Error, function_id: &str) -> String {
+    match err {
+        Error::Remote { code, .. } if code.eq_ignore_ascii_case("function_not_found") => {
+            format!("llm-router is not running, or is too old to offer {function_id}")
+        }
+        Error::Remote { code, message, .. } => format!("{function_id}: {code}: {message}"),
+        other => format!("{function_id}: {other}"),
+    }
+}
+
+async fn call(
+    iii: &IIIClient,
+    function_id: &str,
+    payload: Value,
+    timeout_ms: u64,
+) -> Result<Value, String> {
+    iii.trigger(TriggerRequest {
+        function_id: function_id.to_string(),
+        payload,
+        action: None,
+        timeout_ms: Some(timeout_ms),
+    })
+    .await
+    .map_err(|e| describe(&e, function_id))
+}
+
+fn non_empty(value: &str) -> Option<&str> {
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then_some(trimmed)
+}
+
+/// Transcribe a whole buffer through `router::transcribe`. Returns the
+/// transcript and the `provider::model` that produced it.
+pub async fn transcribe(
+    iii: &IIIClient,
+    cfg: &WorkerConfig,
+    samples: &[f32],
+    language: Option<&str>,
+) -> Result<(Transcript, String), String> {
+    transcribe_within(iii, cfg, samples, language, TRANSCRIBE_TIMEOUT_MS).await
+}
+
+/// [`transcribe`] with the caller's deadline: dictation gives a sentence a
+/// short one and keeps its streaming text past it.
+pub async fn transcribe_within(
+    iii: &IIIClient,
+    cfg: &WorkerConfig,
+    samples: &[f32],
+    language: Option<&str>,
+    timeout_ms: u64,
+) -> Result<(Transcript, String), String> {
+    let wav = audio::encode_wav(samples, TARGET_SAMPLE_RATE)?;
+    let language = language
+        .and_then(non_empty)
+        .or_else(|| non_empty(&cfg.stt.router.language));
+    let reply = call(
+        iii,
+        "router::transcribe",
+        json!({
+            "model": non_empty(&cfg.stt.router.model),
+            "audio_base64": base64::engine::general_purpose::STANDARD.encode(wav),
+            "mime": "audio/wav",
+            "language": language,
+        }),
+        timeout_ms,
+    )
+    .await?;
+    let wire: WireTranscript = serde_json::from_value(reply)
+        .map_err(|e| format!("router::transcribe answered an unexpected shape: {e}"))?;
+    let duration_secs = wire
+        .duration_secs
+        .map(|d| d as f32)
+        .unwrap_or(samples.len() as f32 / TARGET_SAMPLE_RATE as f32);
+    let segments: Vec<Segment> = if wire.segments.is_empty() {
+        vec![Segment {
+            segment: 0,
+            text: wire.text.clone(),
+            start_secs: None,
+            end_secs: None,
+        }]
+    } else {
+        wire.segments
+            .into_iter()
+            .enumerate()
+            .map(|(i, s)| Segment {
+                segment: i as u32,
+                text: s.text,
+                start_secs: s.start_secs.map(|v| v as f32),
+                end_secs: s.end_secs.map(|v| v as f32),
+            })
+            .collect()
+    };
+    Ok((
+        Transcript {
+            text: wire.text,
+            segments,
+            duration_secs,
+        },
+        format!("{}::{}", wire.provider, wire.model),
+    ))
+}
+
+/// Speak `text` through `router::speak`. Returns the audio bytes, their
+/// MIME type and the `provider::model` that produced them.
+pub async fn speak(
+    iii: &IIIClient,
+    cfg: &WorkerConfig,
+    text: &str,
+    voice: Option<&str>,
+) -> Result<(Vec<u8>, String, String), String> {
+    let voice = voice
+        .and_then(non_empty)
+        .or_else(|| non_empty(&cfg.tts.router.voice));
+    let reply = call(
+        iii,
+        "router::speak",
+        json!({
+            "model": non_empty(&cfg.tts.router.model),
+            "text": text,
+            "voice": voice,
+            "format": non_empty(&cfg.tts.router.format).unwrap_or("mp3"),
+        }),
+        SPEAK_TIMEOUT_MS,
+    )
+    .await?;
+    let wire: WireSpeech = serde_json::from_value(reply)
+        .map_err(|e| format!("router::speak answered an unexpected shape: {e}"))?;
+    let audio = base64::engine::general_purpose::STANDARD
+        .decode(wire.audio_base64.trim())
+        .map_err(|e| format!("router::speak returned audio that is not base64: {e}"))?;
+    Ok((
+        audio,
+        wire.mime.unwrap_or_else(|| "audio/mpeg".to_string()),
+        format!("{}::{}", wire.provider, wire.model),
+    ))
+}
+
+/// The speech models the router knows for one family (`stt` or `tts`).
+pub async fn models(iii: &IIIClient, modality: &str) -> Result<Vec<RouterSpeechModel>, String> {
+    let reply = call(
+        iii,
+        "router::models::list",
+        json!({ "modality": modality }),
+        LIST_TIMEOUT_MS,
+    )
+    .await?;
+    let wire: WireModels = serde_json::from_value(reply)
+        .map_err(|e| format!("router::models::list answered an unexpected shape: {e}"))?;
+    Ok(wire.models)
+}
+
+/// What stands in the way of the router engine, in one sentence, or `None`.
+pub async fn problem(iii: &IIIClient, modality: &str) -> Option<String> {
+    match models(iii, modality).await {
+        Ok(list) if list.is_empty() => Some(format!(
+            "llm-router lists no {} models; install a speech provider (for example \
+             provider-elevenlabs) and add its key in Settings",
+            if modality == "stt" {
+                "speech-to-text"
+            } else {
+                "text-to-speech"
+            }
+        )),
+        Ok(_) => None,
+        Err(e) => Some(e),
+    }
+}

--- a/voice/src/session.rs
+++ b/voice/src/session.rs
@@ -77,9 +77,13 @@ impl Refiner {
                 )
                 .await
                 .map(|(transcript, _)| transcript.text),
-                SttBackend::Openai => engine::remote_transcribe(cfg, &audio, None)
-                    .await
-                    .map(|transcript| transcript.text),
+                SttBackend::Openai => tokio::time::timeout(
+                    Duration::from_millis(REMOTE_REFINE_TIMEOUT_MS),
+                    engine::remote_transcribe(cfg, &audio, None),
+                )
+                .await
+                .map_err(|_| "second pass timed out".to_string())?
+                .map(|transcript| transcript.text),
                 SttBackend::Local => Ok(String::new()),
             },
         }

--- a/voice/src/session.rs
+++ b/voice/src/session.rs
@@ -10,7 +10,7 @@
 //! saw. A session that goes quiet for `session_idle_secs` is closed by the
 //! sweep with reason `idle`.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -98,6 +98,44 @@ impl Refiner {
     }
 }
 
+/// One committed segment on its way to the second pass.
+struct RefineJob {
+    index: usize,
+    audio: Vec<f32>,
+    refiner: Option<Arc<Refiner>>,
+}
+
+/// Second passes finish in any order; Final events must leave in segment
+/// order. Each staged segment waits here until every earlier one has its
+/// text. A settled `None` keeps the streaming text.
+#[derive(Default)]
+struct RefineQueue {
+    pending: VecDeque<(usize, Option<String>)>,
+}
+
+impl RefineQueue {
+    fn stage(&mut self, index: usize) {
+        self.pending.push_back((index, None));
+    }
+
+    fn settle(&mut self, index: usize, refined: Option<String>) -> Vec<(usize, Option<String>)> {
+        if let Some(slot) = self.pending.iter_mut().find(|(i, _)| *i == index) {
+            slot.1 = Some(refined.unwrap_or_default());
+        }
+        let mut ready = Vec::new();
+        while self.pending.front().is_some_and(|(_, text)| text.is_some()) {
+            let (index, text) = self.pending.pop_front().expect("front was checked");
+            let text = text.map(|s| s.trim().to_string()).filter(|s| !s.is_empty());
+            ready.push((index, text));
+        }
+        ready
+    }
+
+    fn clear(&mut self) {
+        self.pending.clear();
+    }
+}
+
 pub struct Session {
     pub id: String,
     pub output_function_id: String,
@@ -110,6 +148,10 @@ pub struct Session {
     partial: String,
     /// Audio since the last committed segment, for the second pass.
     utterance: Vec<f32>,
+    /// Committed segments whose second pass has not settled yet.
+    queue: RefineQueue,
+    /// Second passes still running; drained on stop.
+    passes: Vec<tokio::task::JoinHandle<()>>,
     pub started_at: Instant,
     last_audio: Instant,
 }
@@ -154,25 +196,41 @@ impl Session {
         }
     }
 
-    /// Commit one streaming segment: the second pass replaces its text when
-    /// the model is loaded and heard something; the utterance buffer keeps
-    /// only a short tail so the next utterance's onset survives.
-    async fn commit(&mut self, mut seg: Segment) -> TranscriptEvent {
-        if let Some(refiner) = self.refiner.clone() {
-            let audio = self.utterance.clone();
-            match refiner.refine(audio).await {
-                Ok(refined) if !refined.trim().is_empty() => seg.text = refined.trim().to_string(),
-                Ok(_) => {}
-                Err(e) => tracing::warn!(error = %e, "second pass failed; streaming text stands"),
-            }
-        }
+    /// Commit one streaming segment: its transcript slot is reserved now and
+    /// its audio goes to the second pass, which runs off the session lock so
+    /// live words keep flowing meanwhile. The utterance buffer keeps only a
+    /// short tail so the next utterance's onset survives.
+    fn stage(&mut self, seg: Segment) -> RefineJob {
+        let audio = self.utterance.clone();
         let keep = self.utterance.len().min(ONSET_PAD_SAMPLES);
         let tail = self.utterance.split_off(self.utterance.len() - keep);
         self.utterance = tail;
         self.partial.clear();
-        let text = seg.text.clone();
+        let index = self.segments.len();
         self.segments.push(seg);
-        self.event(TranscriptKind::Final, text, None)
+        self.queue.stage(index);
+        RefineJob {
+            index,
+            audio,
+            refiner: self.refiner.clone(),
+        }
+    }
+
+    /// Take one finished second pass and turn every segment that is now
+    /// complete, front of the queue first, into its Final event.
+    fn settle(&mut self, index: usize, refined: Option<String>) -> Vec<TranscriptEvent> {
+        let mut events = Vec::new();
+        for (index, refined) in self.queue.settle(index, refined) {
+            if let Some(refined) = refined {
+                self.segments[index].text = refined;
+            }
+            let text = self.segments[index].text.clone();
+            let segment = self.segments[index].segment;
+            let mut event = self.event(TranscriptKind::Final, text, None);
+            event.segment = segment;
+            events.push(event);
+        }
+        events
     }
 
     fn transcript(&self) -> Transcript {
@@ -292,6 +350,8 @@ impl Sessions {
             segments: Vec::new(),
             partial: String::new(),
             utterance: Vec::new(),
+            queue: RefineQueue::default(),
+            passes: Vec::new(),
             started_at: Instant::now(),
             last_audio: Instant::now(),
         };
@@ -338,8 +398,11 @@ impl Sessions {
         let step = session.stream.feed(&samples);
         let mut events = Vec::new();
         for seg in step.finals {
-            events.push(session.commit(seg).await);
+            let job = session.stage(seg);
+            let pass = self.spawn_pass(handle.clone(), job);
+            session.passes.push(pass);
         }
+        session.passes.retain(|pass| !pass.is_finished());
         if let Some(partial) = step.partial {
             session.partial = partial.clone();
             events.push(session.event(TranscriptKind::Partial, partial, None));
@@ -362,13 +425,24 @@ impl Sessions {
             .ok_or_else(|| format!("no dictation session `{id}`"))?;
         let mut session = handle.lock().await;
         let mut events = Vec::new();
-        if !discard {
-            for seg in session.stream.finish() {
-                events.push(session.commit(seg).await);
+        if discard {
+            for pass in session.passes.drain(..) {
+                pass.abort();
             }
-        } else {
+            session.queue.clear();
             session.segments.clear();
             session.partial.clear();
+        } else {
+            let mut passes: Vec<tokio::task::JoinHandle<()>> = session.passes.drain(..).collect();
+            for seg in session.stream.finish() {
+                let job = session.stage(seg);
+                passes.push(self.spawn_pass(handle.clone(), job));
+            }
+            drop(session);
+            for pass in passes {
+                let _ = pass.await;
+            }
+            session = handle.lock().await;
         }
         let transcript = session.transcript();
         tracing::info!(
@@ -450,10 +524,35 @@ impl Sessions {
     }
 
     async fn deliver(&self, output_function_id: &str, event: &TranscriptEvent) {
-        self.emitter.deliver_direct(output_function_id, event).await;
-        self.emitter
-            .emit(EventKind::Transcript, Some(&event.session_id), event)
-            .await;
+        deliver(&self.emitter, output_function_id, event).await;
+    }
+
+    /// Run one second pass off the session lock, then settle it and deliver
+    /// the Final events that are ready, holding the lock through delivery so
+    /// finals leave in segment order.
+    fn spawn_pass(
+        &self,
+        handle: Arc<Mutex<Session>>,
+        job: RefineJob,
+    ) -> tokio::task::JoinHandle<()> {
+        let emitter = self.emitter.clone();
+        tokio::spawn(async move {
+            let refined = match &job.refiner {
+                Some(refiner) => match refiner.refine(job.audio).await {
+                    Ok(text) => Some(text),
+                    Err(e) => {
+                        tracing::warn!(error = %e, "second pass failed; streaming text stands");
+                        None
+                    }
+                },
+                None => None,
+            };
+            let mut session = handle.lock().await;
+            let output = session.output_function_id.clone();
+            for event in session.settle(job.index, refined) {
+                deliver(&emitter, &output, &event).await;
+            }
+        })
     }
 
     /// Spawn the idle sweep.
@@ -493,9 +592,30 @@ pub fn validate_output_function_id(id: &str) -> Result<(), String> {
     Ok(())
 }
 
+async fn deliver(emitter: &Emitter, output_function_id: &str, event: &TranscriptEvent) {
+    emitter.deliver_direct(output_function_id, event).await;
+    emitter
+        .emit(EventKind::Transcript, Some(&event.session_id), event)
+        .await;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn finals_leave_in_segment_order() {
+        let mut queue = RefineQueue::default();
+        queue.stage(0);
+        queue.stage(1);
+        assert!(queue.settle(1, Some("second".into())).is_empty());
+        assert_eq!(
+            queue.settle(0, None),
+            vec![(0, None), (1, Some("second".to_string()))]
+        );
+        queue.stage(2);
+        assert_eq!(queue.settle(2, Some("  ".into())), vec![(2, None)]);
+    }
 
     #[test]
     fn output_function_ids_are_checked() {

--- a/voice/src/session.rs
+++ b/voice/src/session.rs
@@ -14,10 +14,11 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+use iii_sdk::IIIClient;
 use tokio::sync::Mutex;
 
 use crate::audio::{self, TARGET_SAMPLE_RATE};
-use crate::config::WorkerConfig;
+use crate::config::{SttBackend, WorkerConfig};
 use crate::configuration::ConfigCell;
 use crate::engine::{self, Engine, FinalLoaded, Segment, Stream, Transcript};
 use crate::events::{
@@ -41,12 +42,68 @@ pub fn now_ms() -> i64 {
         .unwrap_or(0)
 }
 
+/// Where a finished utterance goes for its final text. Live words always
+/// come from the local streaming model; the second pass follows the
+/// configured engine, so the model a person picked is the one that writes
+/// the transcript.
+pub enum Refiner {
+    Local(Arc<FinalLoaded>),
+    Remote {
+        iii: Arc<IIIClient>,
+        cfg: Arc<WorkerConfig>,
+    },
+}
+
+/// A remote second pass that has not answered by then keeps the streaming
+/// text; dictation must not stall on a slow provider.
+const REMOTE_REFINE_TIMEOUT_MS: u64 = 30_000;
+
+impl Refiner {
+    async fn refine(&self, audio: Vec<f32>) -> Result<String, String> {
+        match self {
+            Refiner::Local(loaded) => {
+                let loaded = loaded.clone();
+                tokio::task::spawn_blocking(move || loaded.refine(&audio))
+                    .await
+                    .map_err(|e| format!("second pass task failed: {e}"))
+            }
+            Refiner::Remote { iii, cfg } => match cfg.stt.backend {
+                SttBackend::Router => crate::router::transcribe_within(
+                    iii,
+                    cfg,
+                    &audio,
+                    None,
+                    REMOTE_REFINE_TIMEOUT_MS,
+                )
+                .await
+                .map(|(transcript, _)| transcript.text),
+                SttBackend::Openai => engine::remote_transcribe(cfg, &audio, None)
+                    .await
+                    .map(|transcript| transcript.text),
+                SttBackend::Local => Ok(String::new()),
+            },
+        }
+    }
+
+    fn label(&self) -> String {
+        match self {
+            Refiner::Local(loaded) => loaded.key.model.clone(),
+            Refiner::Remote { cfg, .. } => match cfg.stt.backend {
+                SttBackend::Router if cfg.stt.router.model.trim().is_empty() => "router".into(),
+                SttBackend::Router => cfg.stt.router.model.trim().to_string(),
+                SttBackend::Openai => cfg.stt.openai.model.clone(),
+                SttBackend::Local => String::new(),
+            },
+        }
+    }
+}
+
 pub struct Session {
     pub id: String,
     pub output_function_id: String,
     pub model: String,
     stream: Stream,
-    refiner: Option<Arc<FinalLoaded>>,
+    refiner: Option<Arc<Refiner>>,
     seq: u64,
     last_push_seq: Option<u64>,
     segments: Vec<Segment>,
@@ -103,8 +160,8 @@ impl Session {
     async fn commit(&mut self, mut seg: Segment) -> TranscriptEvent {
         if let Some(refiner) = self.refiner.clone() {
             let audio = self.utterance.clone();
-            match tokio::task::spawn_blocking(move || refiner.refine(&audio)).await {
-                Ok(refined) if !refined.is_empty() => seg.text = refined,
+            match refiner.refine(audio).await {
+                Ok(refined) if !refined.trim().is_empty() => seg.text = refined.trim().to_string(),
                 Ok(_) => {}
                 Err(e) => tracing::warn!(error = %e, "second pass failed; streaming text stands"),
             }
@@ -149,6 +206,7 @@ pub struct SessionSummary {
 
 pub struct Sessions {
     inner: Mutex<HashMap<String, Arc<Mutex<Session>>>>,
+    iii: Arc<IIIClient>,
     engine: Arc<Engine>,
     emitter: Arc<Emitter>,
     cfg: ConfigCell,
@@ -156,9 +214,15 @@ pub struct Sessions {
 }
 
 impl Sessions {
-    pub fn new(engine: Arc<Engine>, emitter: Arc<Emitter>, cfg: ConfigCell) -> Self {
+    pub fn new(
+        iii: Arc<IIIClient>,
+        engine: Arc<Engine>,
+        emitter: Arc<Emitter>,
+        cfg: ConfigCell,
+    ) -> Self {
         Self {
             inner: Mutex::new(HashMap::new()),
+            iii,
             engine,
             emitter,
             cfg,
@@ -197,16 +261,23 @@ impl Sessions {
         }
         let progress = self.progress.lock().await.clone();
         let loaded = self.engine.ensure_loaded(&cfg, progress.clone()).await?;
-        let refiner = match self.engine.ensure_final_loaded(&cfg, progress).await {
-            Ok(refiner) => refiner,
-            Err(e) => {
-                tracing::warn!(error = %e, "second-pass model unavailable; streaming text stands");
-                None
-            }
+        let refiner = match cfg.stt.backend {
+            SttBackend::Local => match self.engine.ensure_final_loaded(&cfg, progress).await {
+                Ok(refiner) => refiner.map(Refiner::Local),
+                Err(e) => {
+                    tracing::warn!(error = %e, "second-pass model unavailable; streaming text stands");
+                    None
+                }
+            },
+            SttBackend::Router | SttBackend::Openai => Some(Refiner::Remote {
+                iii: self.iii.clone(),
+                cfg: cfg.clone(),
+            }),
         };
+        let refiner = refiner.map(Arc::new);
         let id = format!("d_{}", uuid::Uuid::new_v4().simple());
         let model = match &refiner {
-            Some(r) => format!("{}+{}", loaded.key.model, r.key.model),
+            Some(r) => format!("{}+{}", loaded.key.model, r.label()),
             None => loaded.key.model.clone(),
         };
         tracing::info!(session_id = %id, model = %model, output = %output_function_id, "dictation session started");

--- a/voice/src/tts.rs
+++ b/voice/src/tts.rs
@@ -196,6 +196,9 @@ impl Speaker {
                     mime: Some(mime),
                 })
             }
+            TtsBackend::Router => {
+                Err("the router engine is served by voice::speak, not the host speaker".to_string())
+            }
         }
     }
 

--- a/voice/src/tts.rs
+++ b/voice/src/tts.rs
@@ -8,13 +8,16 @@
 //! Child processes are tracked so `voice::speak::stop` can end them.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use base64::Engine;
 use tokio::process::{Child, Command};
-use tokio::sync::Mutex;
+use tokio::sync::{oneshot, Mutex};
 
 use crate::config::{TtsBackend, WorkerConfig};
+use crate::events::{Emitter, EventKind, SpeechEndedEvent};
+use crate::session::now_ms;
 
 /// The host command this platform speaks with, if any.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -120,20 +123,57 @@ pub struct Spoken {
 }
 
 pub struct Speaker {
-    children: Mutex<HashMap<String, Child>>,
-}
-
-impl Default for Speaker {
-    fn default() -> Self {
-        Self::new()
-    }
+    /// Live host playbacks by speech id; sending on the channel stops one.
+    playing: Arc<Mutex<HashMap<String, oneshot::Sender<()>>>>,
+    emitter: Arc<Emitter>,
 }
 
 impl Speaker {
-    pub fn new() -> Self {
+    pub fn new(emitter: Arc<Emitter>) -> Self {
         Self {
-            children: Mutex::new(HashMap::new()),
+            playing: Arc::new(Mutex::new(HashMap::new())),
+            emitter,
         }
+    }
+
+    /// Own the child until it exits or is told to stop, then drop it from the
+    /// live set and announce `voice::speech-ended` with why.
+    fn watch(&self, speech_id: String, mut child: Child) {
+        let (stop_tx, stop_rx) = oneshot::channel::<()>();
+        let playing = self.playing.clone();
+        let emitter = self.emitter.clone();
+        let ended_id = speech_id.clone();
+        tokio::spawn(async move {
+            let reason = tokio::select! {
+                status = child.wait() => match status {
+                    Ok(status) if status.success() => "ended",
+                    Ok(_) => "failed",
+                    Err(_) => "failed",
+                },
+                _ = stop_rx => {
+                    let _ = child.kill().await;
+                    "stopped"
+                }
+            };
+            playing.lock().await.remove(&ended_id);
+            emitter
+                .emit(
+                    EventKind::SpeechEnded,
+                    Some(&ended_id),
+                    &SpeechEndedEvent {
+                        speech_id: ended_id.clone(),
+                        reason: reason.to_string(),
+                        timestamp_ms: now_ms(),
+                    },
+                )
+                .await;
+        });
+        // A stop that arrives before the watcher polls the channel still
+        // lands: the sender is stored, the receiver is awaited above.
+        let playing = self.playing.clone();
+        tokio::spawn(async move {
+            playing.lock().await.insert(speech_id, stop_tx);
+        });
     }
 
     /// Speak `text` on the configured backend.
@@ -176,8 +216,7 @@ impl Speaker {
                         .map_err(|e| format!("write to {}: {e}", command.program))?;
                     stdin.shutdown().await.ok();
                 }
-                self.reap().await;
-                self.children.lock().await.insert(speech_id.clone(), child);
+                self.watch(speech_id.clone(), child);
                 Ok(Spoken {
                     backend: "host".into(),
                     speech_id,
@@ -204,20 +243,19 @@ impl Speaker {
 
     /// Stop every host playback (or one, by id). Returns how many were live.
     pub async fn stop(&self, speech_id: Option<&str>) -> usize {
-        let mut children = self.children.lock().await;
+        let mut playing = self.playing.lock().await;
         let ids: Vec<String> = match speech_id {
-            Some(id) => children
+            Some(id) => playing
                 .contains_key(id)
                 .then(|| id.to_string())
                 .into_iter()
                 .collect(),
-            None => children.keys().cloned().collect(),
+            None => playing.keys().cloned().collect(),
         };
         let mut stopped = 0;
         for id in ids {
-            if let Some(mut child) = children.remove(&id) {
-                if child.try_wait().ok().flatten().is_none() {
-                    let _ = child.kill().await;
+            if let Some(stop) = playing.remove(&id) {
+                if stop.send(()).is_ok() {
                     stopped += 1;
                 }
             }
@@ -225,21 +263,9 @@ impl Speaker {
         stopped
     }
 
-    /// `true` while any host playback is still running.
+    /// How many host playbacks are still running.
     pub async fn playing(&self) -> usize {
-        self.reap().await;
-        self.children.lock().await.len()
-    }
-
-    async fn reap(&self) {
-        let mut children = self.children.lock().await;
-        let done: Vec<String> = children
-            .iter_mut()
-            .filter_map(|(id, child)| child.try_wait().ok().flatten().map(|_| id.clone()))
-            .collect();
-        for id in done {
-            children.remove(&id);
-        }
+        self.playing.lock().await.len()
     }
 }
 
@@ -305,6 +331,11 @@ async fn remote_speech(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::events::{NoopDeliverer, TriggerSets};
+
+    fn test_emitter() -> Arc<Emitter> {
+        Arc::new(Emitter::new(TriggerSets::new(), Arc::new(NoopDeliverer)))
+    }
 
     #[test]
     fn host_args_follow_each_command() {
@@ -328,7 +359,7 @@ mod tests {
 
     #[tokio::test]
     async fn stop_with_nothing_playing_is_zero() {
-        let speaker = Speaker::new();
+        let speaker = Speaker::new(test_emitter());
         assert_eq!(speaker.stop(None).await, 0);
         assert_eq!(speaker.playing().await, 0);
     }
@@ -337,7 +368,7 @@ mod tests {
     async fn off_backend_refuses() {
         let mut cfg = WorkerConfig::default();
         cfg.tts.backend = TtsBackend::Off;
-        let err = Speaker::new()
+        let err = Speaker::new(test_emitter())
             .speak(&cfg, "hello", None, None)
             .await
             .unwrap_err();

--- a/voice/src/tts.rs
+++ b/voice/src/tts.rs
@@ -138,8 +138,9 @@ impl Speaker {
 
     /// Own the child until it exits or is told to stop, then drop it from the
     /// live set and announce `voice::speech-ended` with why.
-    fn watch(&self, speech_id: String, mut child: Child) {
+    async fn watch(&self, speech_id: String, mut child: Child) {
         let (stop_tx, stop_rx) = oneshot::channel::<()>();
+        self.playing.lock().await.insert(speech_id.clone(), stop_tx);
         let playing = self.playing.clone();
         let emitter = self.emitter.clone();
         let ended_id = speech_id.clone();
@@ -167,12 +168,6 @@ impl Speaker {
                     },
                 )
                 .await;
-        });
-        // A stop that arrives before the watcher polls the channel still
-        // lands: the sender is stored, the receiver is awaited above.
-        let playing = self.playing.clone();
-        tokio::spawn(async move {
-            playing.lock().await.insert(speech_id, stop_tx);
         });
     }
 
@@ -216,7 +211,7 @@ impl Speaker {
                         .map_err(|e| format!("write to {}: {e}", command.program))?;
                     stdin.shutdown().await.ok();
                 }
-                self.watch(speech_id.clone(), child);
+                self.watch(speech_id.clone(), child).await;
                 Ok(Spoken {
                     backend: "host".into(),
                     speech_id,

--- a/voice/ui/src/configuration/index.tsx
+++ b/voice/ui/src/configuration/index.tsx
@@ -21,6 +21,7 @@ import {
 import { useEffect, useState } from 'react'
 import { modelsList } from '../lib/client'
 import { DEFAULTS, NONE, numberAt, setPath, stringAt } from '../lib/config'
+import { routerModelOptions, useRouterSpeechModels } from '../lib/router'
 import type { ModelInfo } from '../lib/types'
 
 function describeModel(m: ModelInfo): string {
@@ -85,6 +86,8 @@ export function createVoiceConfigForm(host: Host) {
     const liveModel = stringAt(value, ['stt', 'model'], DEFAULTS.model)
     const offline = (models ?? []).filter((m) => m.kind === 'offline_nemo_transducer')
     const streaming = (models ?? []).filter((m) => m.kind === 'streaming_transducer')
+    const routerStt = useRouterSpeechModels(host.iii, 'stt', sttBackend === 'router')
+    const routerTts = useRouterSpeechModels(host.iii, 'tts', ttsBackend === 'router')
 
     return (
       <>
@@ -95,7 +98,7 @@ export function createVoiceConfigForm(host: Host) {
           <SettingsList>
             <SettingsField
               label="Engine"
-              description="Local models, or any server that speaks the OpenAI audio API (a local whisper server counts)."
+              description="Local models, a speech provider registered with llm-router (ElevenLabs, OpenAI, ...), or any server that speaks the OpenAI audio API (a local whisper server counts)."
               renderControl={(c) => (
                 <Select
                   id={c.id}
@@ -103,11 +106,41 @@ export function createVoiceConfigForm(host: Host) {
                   onChange={(next) => set(['stt', 'backend'], next)}
                   options={[
                     { value: 'local', label: 'Local models on this machine' },
+                    { value: 'router', label: 'A speech provider through llm-router' },
                     { value: 'openai', label: 'OpenAI-compatible endpoint' },
                   ]}
                 />
               )}
             />
+            {sttBackend === 'router' ? (
+              <>
+                <SettingsField
+                  label="Model"
+                  description="A speech-to-text model the router lists; its provider's key lives in the router's own settings. Empty lets the router pick."
+                  renderControl={(c) => (
+                    <Select
+                      id={c.id}
+                      value={stringAt(value, ['stt', 'router', 'model'])}
+                      onChange={(next) => set(['stt', 'router', 'model'], next)}
+                      aria-busy={routerStt.models === null}
+                      options={routerModelOptions(routerStt.models, stringAt(value, ['stt', 'router', 'model']))}
+                    />
+                  )}
+                />
+                <SettingsField
+                  label="Language hint"
+                  description="BCP-47 tag sent with each request, for example en or hi. Empty lets the model detect it."
+                  controlSize="compact"
+                  renderControl={(c) => (
+                    <Input
+                      id={c.id}
+                      value={stringAt(value, ['stt', 'router', 'language'])}
+                      onChange={(raw) => set(['stt', 'router', 'language'], raw)}
+                    />
+                  )}
+                />
+              </>
+            ) : null}
             {sttBackend === 'local' ? (
               <>
                 <SettingsField
@@ -261,7 +294,7 @@ export function createVoiceConfigForm(host: Host) {
           <SettingsList>
             <SettingsField
               label="Engine"
-              description="The host command plays on the machine running the worker (say on macOS, espeak-ng on Linux). An OpenAI-compatible endpoint returns audio to the browser."
+              description="The host command plays on the machine running the worker (say on macOS, espeak-ng on Linux). A router speech provider or an OpenAI-compatible endpoint returns audio to the browser."
               renderControl={(c) => (
                 <Select
                   id={c.id}
@@ -269,12 +302,59 @@ export function createVoiceConfigForm(host: Host) {
                   onChange={(next) => set(['tts', 'backend'], next)}
                   options={[
                     { value: 'host', label: "This machine's speech command" },
+                    { value: 'router', label: 'A speech provider through llm-router' },
                     { value: 'openai', label: 'OpenAI-compatible endpoint' },
                     { value: 'off', label: 'Off' },
                   ]}
                 />
               )}
             />
+            {ttsBackend === 'router' ? (
+              <>
+                <SettingsField
+                  label="Model"
+                  description="A text-to-speech model the router lists. Empty lets the router pick."
+                  renderControl={(c) => (
+                    <Select
+                      id={c.id}
+                      value={stringAt(value, ['tts', 'router', 'model'])}
+                      onChange={(next) => set(['tts', 'router', 'model'], next)}
+                      aria-busy={routerTts.models === null}
+                      options={routerModelOptions(routerTts.models, stringAt(value, ['tts', 'router', 'model']))}
+                    />
+                  )}
+                />
+                <SettingsField
+                  label="Voice"
+                  description="A voice id or name as the provider knows it (for ElevenLabs, a voice on the account such as George). Empty uses the provider's default."
+                  renderControl={(c) => (
+                    <Input
+                      id={c.id}
+                      value={stringAt(value, ['tts', 'router', 'voice'])}
+                      onChange={(raw) => set(['tts', 'router', 'voice'], raw)}
+                      preserveCase
+                    />
+                  )}
+                />
+                <SettingsField
+                  label="Audio format"
+                  description="What the browser receives. mp3 works everywhere."
+                  controlSize="compact"
+                  renderControl={(c) => (
+                    <Select
+                      id={c.id}
+                      value={stringAt(value, ['tts', 'router', 'format'], DEFAULTS.routerFormat)}
+                      onChange={(next) => set(['tts', 'router', 'format'], next)}
+                      options={[
+                        { value: 'mp3', label: 'mp3' },
+                        { value: 'wav', label: 'wav' },
+                        { value: 'opus', label: 'opus' },
+                      ]}
+                    />
+                  )}
+                />
+              </>
+            ) : null}
             {ttsBackend === 'host' ? (
               <>
                 <SettingsField

--- a/voice/ui/src/configuration/index.tsx
+++ b/voice/ui/src/configuration/index.tsx
@@ -235,7 +235,8 @@ export function createVoiceConfigForm(host: Host) {
                   )}
                 />
               </>
-            ) : (
+            ) : null}
+            {sttBackend === 'openai' ? (
               <>
                 <SettingsField
                   label="Base URL"
@@ -286,7 +287,7 @@ export function createVoiceConfigForm(host: Host) {
                   )}
                 />
               </>
-            )}
+            ) : null}
           </SettingsList>
         </SettingsSection>
 

--- a/voice/ui/src/lib/client.ts
+++ b/voice/ui/src/lib/client.ts
@@ -20,6 +20,7 @@ import type {
   ModelsListResponse,
   ModelsRemoveRequest,
   ModelsRemoveResponse,
+  RouterModelsListResponse,
   SpeakRequest,
   SpeakResponse,
   SpeakStopRequest,
@@ -73,4 +74,9 @@ export function modelsRemove(iii: ExtensionIii, req: ModelsRemoveRequest): Promi
 
 export function doctor(iii: ExtensionIii): Promise<DoctorResponse> {
   return iii.trigger<DoctorResponse>('voice::doctor', {})
+}
+
+/** Speech models llm-router knows for one family; empty when no speech provider is registered. */
+export function routerSpeechModels(iii: ExtensionIii, modality: 'stt' | 'tts'): Promise<RouterModelsListResponse> {
+  return iii.trigger<RouterModelsListResponse>('router::models::list', { modality })
 }

--- a/voice/ui/src/lib/config.ts
+++ b/voice/ui/src/lib/config.ts
@@ -83,6 +83,7 @@ export const DEFAULTS = {
   maxSpeakChars: 4000,
   openaiTtsModel: 'tts-1',
   openaiTtsVoice: 'alloy',
+  routerFormat: 'mp3',
   modelsDir: 'data/voice/models',
   maxAudioBytes: 10 * 1024 * 1024,
   maxSessions: 8,

--- a/voice/ui/src/lib/playback.ts
+++ b/voice/ui/src/lib/playback.ts
@@ -1,0 +1,32 @@
+/**
+ * Host read-aloud ends on the worker's side, so the worker says so: this
+ * hook binds a browser function to the `voice::speech-ended` trigger for
+ * as long as the component lives, the same way the shell page listens for
+ * workspace changes. No timers, no doctor polling.
+ */
+
+import type { Host } from '@iii-dev/console-ui'
+import { useEffect, useRef } from 'react'
+import type { SpeechEndedEvent } from './types'
+
+const EVENTS_FN = 'iii::voice-ui::speech-ended'
+
+export function useSpeechEnded(host: Host, onEnded: (event: SpeechEndedEvent) => void): void {
+  const handlerRef = useRef(onEnded)
+  handlerRef.current = onEnded
+  useEffect(() => {
+    const offHandler = host.iii.on<SpeechEndedEvent>(EVENTS_FN, (event) => {
+      if (typeof event?.speech_id !== 'string') return
+      handlerRef.current(event)
+    })
+    const offTrigger = host.iii.registerTrigger({
+      type: 'voice::speech-ended',
+      function_id: `${EVENTS_FN}::${host.iii.browserId}`,
+      config: {},
+    })
+    return () => {
+      offTrigger()
+      offHandler()
+    }
+  }, [host])
+}

--- a/voice/ui/src/lib/router.ts
+++ b/voice/ui/src/lib/router.ts
@@ -1,0 +1,52 @@
+/**
+ * The router's speech models for one family, fetched once per mount.
+ * `null` while loading, `[]` when the router is absent or lists none; the
+ * error names why so a page can say it.
+ */
+import { useEffect, useState } from 'react'
+import { routerSpeechModels } from './client'
+import { errorMessage } from './format'
+import type { ExtensionIii, RouterSpeechModel } from './types'
+
+export interface RouterModelsState {
+  models: RouterSpeechModel[] | null
+  error: string | null
+}
+
+export function useRouterSpeechModels(iii: ExtensionIii, modality: 'stt' | 'tts', enabled: boolean): RouterModelsState {
+  const [state, setState] = useState<RouterModelsState>({ models: null, error: null })
+  useEffect(() => {
+    if (!enabled) return
+    let cancelled = false
+    routerSpeechModels(iii, modality)
+      .then((res) => {
+        if (!cancelled) setState({ models: res.models ?? [], error: null })
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setState({ models: [], error: errorMessage(err) })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [iii, modality, enabled])
+  return state
+}
+
+/** The config value for a router model: the console's `provider::model` form. */
+export function routerModelValue(model: RouterSpeechModel): string {
+  return `${model.provider}::${model.id}`
+}
+
+export function routerModelOptions(
+  models: RouterSpeechModel[] | null,
+  current: string,
+): Array<{ value: string; label: string; description?: string }> {
+  const options: Array<{ value: string; label: string; description?: string }> = (models ?? []).map((m) => ({
+    value: routerModelValue(m),
+    label: m.display_name ?? m.id,
+    description: `${m.provider}${m.speech?.languages?.length ? ` · ${m.speech.languages.length} languages` : ''}`,
+  }))
+  if (current && !options.some((o) => o.value === current)) options.push({ value: current, label: current })
+  options.unshift({ value: '', label: 'Let the router pick', description: 'First provider that offers one' })
+  return options
+}

--- a/voice/ui/src/lib/types.ts
+++ b/voice/ui/src/lib/types.ts
@@ -164,8 +164,7 @@ export interface DoctorResponse {
     backend: 'host' | 'openai' | 'router' | 'off'
     command?: string
     available: boolean
-    /** Utterances currently playing on this backend, polled to detect an
-        ended `host`-backend speech (never poll it faster than every 2s). */
+    /** Host playbacks still running; their end arrives on `voice::speech-ended`. */
     playing: number
   }
   sessions: number
@@ -192,6 +191,13 @@ export interface SessionStartedEvent {
 export interface SessionStoppedEvent {
   session_id: string
   reason: string
+  timestamp_ms: number
+}
+
+/** `voice::speech-ended`: a host playback is over (`ended`, `stopped` or `failed`). */
+export interface SpeechEndedEvent {
+  speech_id: string
+  reason: 'ended' | 'stopped' | 'failed' | string
   timestamp_ms: number
 }
 

--- a/voice/ui/src/lib/types.ts
+++ b/voice/ui/src/lib/types.ts
@@ -4,7 +4,10 @@
  * page or chip may bind. Mirrors the Rust side exactly; kept
  * dependency-free so client.ts and every consumer can import it directly.
  */
+import type { ExtensionIii } from '@iii-dev/console-ui'
 import type { ComponentType } from 'react'
+
+export type { ExtensionIii }
 
 export interface Segment {
   segment: number
@@ -76,7 +79,7 @@ export interface TranscribeResponse {
   segments: Segment[]
   duration_secs: number
   model: string
-  backend: 'local' | 'openai'
+  backend: 'local' | 'openai' | 'router'
 }
 
 export type SpeakRequest = {
@@ -92,7 +95,7 @@ export type SpeakRequest = {
  * speech has finished.
  */
 export interface SpeakResponse {
-  backend: 'host' | 'openai'
+  backend: 'host' | 'openai' | 'router'
   speech_id: string
   played: boolean
   audio_base64?: string
@@ -146,7 +149,7 @@ export interface ModelsRemoveResponse {
 
 export interface DoctorResponse {
   stt: {
-    backend: 'local' | 'openai'
+    backend: 'local' | 'openai' | 'router'
     model: string
     installed: boolean
     loaded: boolean
@@ -158,7 +161,7 @@ export interface DoctorResponse {
     final_load_ms?: number
   }
   tts: {
-    backend: 'host' | 'openai' | 'off'
+    backend: 'host' | 'openai' | 'router' | 'off'
     command?: string
     available: boolean
     /** Utterances currently playing on this backend, polled to detect an
@@ -235,4 +238,21 @@ export interface ComposerActionRegistration {
 /** `host.chat` on a console that ships the composer toolbar slot; feature-detect the method. */
 export interface ComposerCapableChat {
   registerComposerAction?(action: ComposerActionRegistration): () => void
+}
+
+/* ── llm-router speech models, as `router::models::list` returns them ─── */
+
+export interface RouterSpeechModel {
+  id: string
+  provider: string
+  display_name?: string
+  speech?: {
+    modality: 'stt' | 'tts'
+    languages?: string[]
+    streaming?: boolean
+  }
+}
+
+export interface RouterModelsListResponse {
+  models: RouterSpeechModel[]
 }

--- a/voice/ui/src/lib/types.ts
+++ b/voice/ui/src/lib/types.ts
@@ -153,6 +153,9 @@ export interface DoctorResponse {
     model: string
     installed: boolean
     loaded: boolean
+    live_model: string
+    live_installed: boolean
+    live_loaded: boolean
     load_ms?: number
     models_dir: string
     problem?: string

--- a/voice/ui/src/live/index.tsx
+++ b/voice/ui/src/live/index.tsx
@@ -16,12 +16,31 @@ export function createVoiceLiveSummary(_host: Host, controller: DictationControl
     const { state } = useDictation(controller)
     const listening = state.status === 'listening' || state.status === 'starting'
     if (!listening) return null
-    const tail = [...state.committed.slice(-2), state.partial].filter(Boolean).join(' ')
-    const shown = tail.length > PARTIAL_MAX_CHARS ? `…${tail.slice(-PARTIAL_MAX_CHARS)}` : tail
+    const settled = state.committed.slice(-2).join(' ')
+    const room = Math.max(0, PARTIAL_MAX_CHARS - state.partial.length)
+    const settledShown = settled.length > room ? `…${settled.slice(-room)}` : settled
+    const idle = state.status === 'starting' ? 'starting…' : 'listening'
     return (
       <output className="voice-live" aria-live="polite">
         <span className="voice-chip-dot" aria-hidden="true" />
-        <span className="voice-live-text">{shown || (state.status === 'starting' ? 'starting…' : 'listening')}</span>
+        <span className="voice-live-text">
+          {settledShown || state.partial ? (
+            <>
+              {settledShown}
+              {settledShown && state.partial ? ' ' : ''}
+              {state.partial ? (
+                <span
+                  className="voice-live-partial"
+                  title="Live words from the streaming model; the final text arrives when the sentence ends"
+                >
+                  {state.partial}
+                </span>
+              ) : null}
+            </>
+          ) : (
+            idle
+          )}
+        </span>
       </output>
     )
   }

--- a/voice/ui/src/live/index.tsx
+++ b/voice/ui/src/live/index.tsx
@@ -18,7 +18,7 @@ export function createVoiceLiveSummary(_host: Host, controller: DictationControl
     if (!listening) return null
     const settled = state.committed.slice(-2).join(' ')
     const room = Math.max(0, PARTIAL_MAX_CHARS - state.partial.length)
-    const settledShown = settled.length > room ? `…${settled.slice(-room)}` : settled
+    const settledShown = settled.length > room ? `…${settled.slice(settled.length - room)}` : settled
     const idle = state.status === 'starting' ? 'starting…' : 'listening'
     return (
       <output className="voice-live" aria-live="polite">

--- a/voice/ui/src/page/Overview.tsx
+++ b/voice/ui/src/page/Overview.tsx
@@ -22,10 +22,12 @@ import {
   TableRow,
   TableViewport,
 } from '@iii-dev/console-ui'
+import { useEffect, useState } from 'react'
 import { modelsDownload } from '../lib/client'
-import { NONE, patchConfig, setPath } from '../lib/config'
+import { NONE, patchConfig, readConfig, setPath, stringAt } from '../lib/config'
 import { MicIcon } from '../lib/icons'
 import { type ProgressById, percent } from '../lib/progress'
+import { routerModelOptions, useRouterSpeechModels } from '../lib/router'
 import type { DictationListEntry, DoctorResponse, ModelInfo, ModelsListResponse } from '../lib/types'
 import { Fact, Facts, formatBytes, formatDuration, SectionCard, useBusyAction } from './shared'
 
@@ -58,6 +60,21 @@ export function Overview({
   const accurate: ModelInfo | undefined = offline.find((m) => m.id === stt.final_model)
   const live: ModelInfo | undefined = models?.models.find((m) => m.id === stt.model)
   const pct = percent(progress[stt.final_model])
+  const routerStt = useRouterSpeechModels(host.iii, 'stt', stt.backend === 'router')
+  const routerTts = useRouterSpeechModels(host.iii, 'tts', tts.backend === 'router')
+  const [routerTtsModel, setRouterTtsModel] = useState('')
+  useEffect(() => {
+    if (tts.backend !== 'router') return
+    let cancelled = false
+    readConfig(host.iii)
+      .then((value) => {
+        if (!cancelled) setRouterTtsModel(stringAt(value, ['tts', 'router', 'model']))
+      })
+      .catch(() => undefined)
+    return () => {
+      cancelled = true
+    }
+  }, [host.iii, tts.backend])
 
   const choose = (path: readonly string[], next: string, label: string) =>
     run(
@@ -94,6 +111,62 @@ export function Overview({
           </Button>
         }
       >
+        <Facts>
+          <Fact label="Engine">
+            <span className="voice-choice">
+              <Select
+                aria-label="speech to text engine"
+                value={stt.backend}
+                disabled={busy !== null}
+                onChange={(next) => choose(['stt', 'backend'], next, `Speech to text uses ${next}.`)}
+                options={[
+                  { value: 'local', label: 'Local models on this machine', description: 'Nothing leaves the machine' },
+                  {
+                    value: 'router',
+                    label: 'A speech provider through llm-router',
+                    description: 'ElevenLabs, OpenAI, ...',
+                  },
+                  {
+                    value: 'openai',
+                    label: 'OpenAI-compatible endpoint',
+                    description: 'Any /audio/transcriptions server',
+                  },
+                ]}
+              />
+            </span>
+          </Fact>
+        </Facts>
+        {stt.backend === 'router' ? (
+          <Facts>
+            <Fact label="Model">
+              <span className="voice-choice">
+                <Select
+                  aria-label="router speech to text model"
+                  value={report.stt.model === 'router picks' ? '' : report.stt.model}
+                  disabled={busy !== null || routerStt.models === null}
+                  onChange={(next) =>
+                    choose(
+                      ['stt', 'router', 'model'],
+                      next,
+                      next ? `Transcripts use ${next}.` : 'The router picks the model.',
+                    )
+                  }
+                  options={routerModelOptions(
+                    routerStt.models,
+                    report.stt.model === 'router picks' ? '' : report.stt.model,
+                  )}
+                />
+                {routerStt.models !== null && routerStt.models.length === 0 ? (
+                  <Chip tone="warning">no speech provider registered</Chip>
+                ) : null}
+              </span>
+              <span className="voice-sub voice-block">
+                Audio goes to the provider that serves this model; its key lives in the router's Settings. While you
+                dictate, live words stay local and each finished sentence is re-decoded by this model.
+              </span>
+            </Fact>
+          </Facts>
+        ) : null}
         {stt.backend === 'local' ? (
           <Facts>
             <Fact label="Model">
@@ -156,19 +229,20 @@ export function Overview({
               <span>this machine, nothing leaves it</span>
             </Fact>
           </Facts>
-        ) : (
+        ) : null}
+        {stt.backend === 'openai' ? (
           <Facts>
-            <Fact label="Engine">
+            <Fact label="Endpoint model">
               <span className="voice-fact-line">
                 <Chip tone="neutral">OpenAI-compatible</Chip>
                 <span className="voice-mono">{stt.model}</span>
               </span>
               <span className="voice-sub voice-block">
-                Audio is sent to the configured endpoint. Switch to local models under All settings.
+                Audio is sent to the configured endpoint; its address and key are under All settings.
               </span>
             </Fact>
           </Facts>
-        )}
+        ) : null}
         {stt.problem ? <p className="voice-note voice-warn">{stt.problem}</p> : null}
       </SectionCard>
 
@@ -189,6 +263,11 @@ export function Overview({
                     label: "This machine's speech command",
                     description: 'say on macOS, espeak-ng on Linux',
                   },
+                  {
+                    value: 'router',
+                    label: 'A speech provider through llm-router',
+                    description: 'Audio plays in the browser',
+                  },
                   { value: 'openai', label: 'OpenAI-compatible endpoint', description: 'Audio plays in the browser' },
                   { value: 'off', label: 'Off' },
                 ]}
@@ -196,6 +275,32 @@ export function Overview({
               {ttsAvailability}
             </span>
           </Fact>
+          {tts.backend === 'router' ? (
+            <Fact label="Model">
+              <span className="voice-choice">
+                <Select
+                  aria-label="router text to speech model"
+                  value={routerTtsModel}
+                  disabled={busy !== null || routerTts.models === null}
+                  onChange={(next) => {
+                    setRouterTtsModel(next)
+                    choose(
+                      ['tts', 'router', 'model'],
+                      next,
+                      next ? `Read aloud uses ${next}.` : 'The router picks the voice model.',
+                    )
+                  }}
+                  options={routerModelOptions(routerTts.models, routerTtsModel)}
+                />
+                {routerTts.models !== null && routerTts.models.length === 0 ? (
+                  <Chip tone="warning">no speech provider registered</Chip>
+                ) : null}
+              </span>
+              <span className="voice-sub voice-block">
+                {tts.command ?? 'The voice name and audio format are under All settings.'}
+              </span>
+            </Fact>
+          ) : null}
           <Fact label="Playing">
             <span>{tts.playing === 0 ? 'nothing' : `${tts.playing} clip${tts.playing === 1 ? '' : 's'}`}</span>
           </Fact>

--- a/voice/ui/src/page/Overview.tsx
+++ b/voice/ui/src/page/Overview.tsx
@@ -85,6 +85,28 @@ export function Overview({
 
   const download = (id: string) => run(id, modelsDownload(host.iii, { id }), `${id} is installed and ready.`)
 
+  const liveWordsFact = (
+    <Fact label="Live words">
+      <span className="voice-choice">
+        <span className="voice-fact-line">
+          <StatusDot tone={stt.loaded ? 'accent' : 'ink'} />
+          <span>{live?.name ?? stt.model}</span>
+        </span>
+        {!stt.installed ? (
+          <Chip tone="warning">downloads on first use</Chip>
+        ) : (
+          <Chip tone="success">{stt.loaded ? 'running' : 'installed'}</Chip>
+        )}
+      </span>
+      <span className="voice-sub voice-block">
+        Shows words as you speak and decides where a sentence ends; it always runs on this machine. Change it under All
+        settings.
+      </span>
+    </Fact>
+  )
+
+  const providerOf = (model: string) => model.split('::')[0] ?? ''
+
   const accurateStatus = (() => {
     if (stt.final_state === 'off') return null
     if (stt.final_state === 'loaded') return <Chip tone="success">ready</Chip>
@@ -165,6 +187,7 @@ export function Overview({
                 dictate, live words stay local and each finished sentence is re-decoded by this model.
               </span>
             </Fact>
+            {liveWordsFact}
           </Facts>
         ) : null}
         {stt.backend === 'local' ? (
@@ -209,22 +232,7 @@ export function Overview({
                   : 'Each sentence is re-decoded by this model after you pause, so transcripts get punctuation, casing and its accuracy.'}
               </span>
             </Fact>
-            <Fact label="Live words">
-              <span className="voice-choice">
-                <span className="voice-fact-line">
-                  <StatusDot tone={stt.loaded ? 'accent' : 'ink'} />
-                  <span>{live?.name ?? stt.model}</span>
-                </span>
-                {!stt.installed ? (
-                  <Chip tone="warning">downloads on first use</Chip>
-                ) : (
-                  <Chip tone="success">{stt.loaded ? 'running' : 'installed'}</Chip>
-                )}
-              </span>
-              <span className="voice-sub voice-block">
-                Shows words as you speak and decides where a sentence ends. Change it under All settings.
-              </span>
-            </Fact>
+            {liveWordsFact}
             <Fact label="Runs on">
               <span>this machine, nothing leaves it</span>
             </Fact>
@@ -283,11 +291,17 @@ export function Overview({
                   value={routerTtsModel}
                   disabled={busy !== null || routerTts.models === null}
                   onChange={(next) => {
+                    const providerChanged = providerOf(next) !== providerOf(routerTtsModel)
                     setRouterTtsModel(next)
-                    choose(
-                      ['tts', 'router', 'model'],
-                      next,
-                      next ? `Read aloud uses ${next}.` : 'The router picks the voice model.',
+                    run(
+                      'config',
+                      patchConfig(host.iii, (current) => {
+                        const withModel = setPath(current, ['tts', 'router', 'model'], next)
+                        return providerChanged ? setPath(withModel, ['tts', 'router', 'voice'], '') : withModel
+                      }),
+                      next
+                        ? `Read aloud uses ${next}.${providerChanged ? " Voice reset to that provider's default." : ''}`
+                        : 'The router picks the voice model.',
                     )
                   }}
                   options={routerModelOptions(routerTts.models, routerTtsModel)}

--- a/voice/ui/src/page/Overview.tsx
+++ b/voice/ui/src/page/Overview.tsx
@@ -58,7 +58,7 @@ export function Overview({
   const [busy, run] = useBusyAction(onNotice, onChanged)
   const offline = (models?.models ?? []).filter((m) => m.kind === 'offline_nemo_transducer')
   const accurate: ModelInfo | undefined = offline.find((m) => m.id === stt.final_model)
-  const live: ModelInfo | undefined = models?.models.find((m) => m.id === stt.model)
+  const live: ModelInfo | undefined = models?.models.find((m) => m.id === stt.live_model)
   const pct = percent(progress[stt.final_model])
   const routerStt = useRouterSpeechModels(host.iii, 'stt', stt.backend === 'router')
   const routerTts = useRouterSpeechModels(host.iii, 'tts', tts.backend === 'router')
@@ -89,13 +89,13 @@ export function Overview({
     <Fact label="Live words">
       <span className="voice-choice">
         <span className="voice-fact-line">
-          <StatusDot tone={stt.loaded ? 'accent' : 'ink'} />
-          <span>{live?.name ?? stt.model}</span>
+          <StatusDot tone={stt.live_loaded ? 'accent' : 'ink'} />
+          <span>{live?.name ?? stt.live_model}</span>
         </span>
-        {!stt.installed ? (
+        {!stt.live_installed ? (
           <Chip tone="warning">downloads on first use</Chip>
         ) : (
-          <Chip tone="success">{stt.loaded ? 'running' : 'installed'}</Chip>
+          <Chip tone="success">{stt.live_loaded ? 'running' : 'installed'}</Chip>
         )}
       </span>
       <span className="voice-sub voice-block">

--- a/voice/ui/src/page/ReadAloudSection.tsx
+++ b/voice/ui/src/page/ReadAloudSection.tsx
@@ -26,6 +26,7 @@ export function ReadAloudSection({ host, report }: { host: Host; report: DoctorR
   const [state, setState] = useState<SpeakState>({ phase: 'idle' })
   const audioRef = useRef<HTMLAudioElement | null>(null)
   const speechIdRef = useRef<string | undefined>(undefined)
+  const fallbackRef = useRef<number | null>(null)
   const { tts } = report
   useSpeechEnded(host, (event) => {
     if (!speechIdRef.current || speechIdRef.current === event.speech_id) speechIdRef.current = undefined
@@ -37,10 +38,21 @@ export function ReadAloudSection({ host, report }: { host: Host; report: DoctorR
   })
   const disabled = tts.backend === 'off' || !tts.available
 
+  const clearFallback = () => {
+    if (fallbackRef.current !== null) window.clearTimeout(fallbackRef.current)
+    fallbackRef.current = null
+  }
+
+  useEffect(() => {
+    if (tts.playing !== 0) return
+    setState((current) => (current.phase === 'speaking' && !audioRef.current ? { phase: 'idle' } : current))
+  }, [tts.playing])
+
   useEffect(
     () => () => {
       audioRef.current?.pause()
       audioRef.current = null
+      if (fallbackRef.current !== null) window.clearTimeout(fallbackRef.current)
       const speechId = speechIdRef.current
       speechIdRef.current = undefined
       if (speechId) speakStop(host.iii, { speech_id: speechId }).catch(() => {})
@@ -64,6 +76,16 @@ export function ReadAloudSection({ host, report }: { host: Host; report: DoctorR
       } else if (res.played) {
         setState({ phase: 'speaking', speechId: res.speech_id })
         speechIdRef.current = res.speech_id
+        const words = body.split(/\s+/).length
+        clearFallback()
+        fallbackRef.current = window.setTimeout(
+          () => {
+            fallbackRef.current = null
+            speechIdRef.current = undefined
+            setState((current) => (current.phase === 'speaking' ? { phase: 'idle' } : current))
+          },
+          Math.min(180_000, Math.max(15_000, (words / 150) * 60_000 * 2)),
+        )
       } else {
         setState({ phase: 'idle' })
       }
@@ -73,6 +95,7 @@ export function ReadAloudSection({ host, report }: { host: Host; report: DoctorR
   }
 
   const onStop = () => {
+    clearFallback()
     audioRef.current?.pause()
     audioRef.current = null
     const speechId = state.phase === 'speaking' ? state.speechId : undefined

--- a/voice/ui/src/page/ReadAloudSection.tsx
+++ b/voice/ui/src/page/ReadAloudSection.tsx
@@ -9,6 +9,7 @@ import { useEffect, useRef, useState } from 'react'
 import { speak, speakStop } from '../lib/client'
 import { errorMessage } from '../lib/format'
 import { SpeakerIcon, StopIcon } from '../lib/icons'
+import { useSpeechEnded } from '../lib/playback'
 import type { DoctorResponse } from '../lib/types'
 import { Fact, Facts, SectionCard } from './shared'
 
@@ -24,23 +25,22 @@ export function ReadAloudSection({ host, report }: { host: Host; report: DoctorR
   const [text, setText] = useState(SAMPLE)
   const [state, setState] = useState<SpeakState>({ phase: 'idle' })
   const audioRef = useRef<HTMLAudioElement | null>(null)
-  const timerRef = useRef<number | null>(null)
   const speechIdRef = useRef<string | undefined>(undefined)
   const { tts } = report
+  useSpeechEnded(host, (event) => {
+    if (!speechIdRef.current || speechIdRef.current === event.speech_id) speechIdRef.current = undefined
+    setState((current) =>
+      current.phase === 'speaking' && (!current.speechId || current.speechId === event.speech_id)
+        ? { phase: 'idle' }
+        : current,
+    )
+  })
   const disabled = tts.backend === 'off' || !tts.available
-
-  const clearTimer = () => {
-    if (timerRef.current !== null) {
-      window.clearTimeout(timerRef.current)
-      timerRef.current = null
-    }
-  }
 
   useEffect(
     () => () => {
       audioRef.current?.pause()
       audioRef.current = null
-      if (timerRef.current !== null) window.clearTimeout(timerRef.current)
       const speechId = speechIdRef.current
       speechIdRef.current = undefined
       if (speechId) speakStop(host.iii, { speech_id: speechId }).catch(() => {})
@@ -64,15 +64,6 @@ export function ReadAloudSection({ host, report }: { host: Host; report: DoctorR
       } else if (res.played) {
         setState({ phase: 'speaking', speechId: res.speech_id })
         speechIdRef.current = res.speech_id
-        const words = body.split(/\s+/).length
-        clearTimer()
-        timerRef.current = window.setTimeout(
-          () => {
-            speechIdRef.current = undefined
-            setState({ phase: 'idle' })
-          },
-          Math.min(60_000, Math.max(1500, (words / 150) * 60_000)),
-        )
       } else {
         setState({ phase: 'idle' })
       }
@@ -84,7 +75,6 @@ export function ReadAloudSection({ host, report }: { host: Host; report: DoctorR
   const onStop = () => {
     audioRef.current?.pause()
     audioRef.current = null
-    clearTimer()
     const speechId = state.phase === 'speaking' ? state.speechId : undefined
     speechIdRef.current = undefined
     speakStop(host.iii, speechId ? { speech_id: speechId } : {}).catch(() => {})

--- a/voice/ui/src/turn-summary/index.tsx
+++ b/voice/ui/src/turn-summary/index.tsx
@@ -6,7 +6,7 @@
  * through an `<audio>` element with a real `onended`. The `host` backend
  * returns as soon as playback STARTS (`played: true`, no audio) — "Stop" is
  * hidden by whichever comes first: an estimated duration (~150 wpm, capped
- * at 60s) or `voice::doctor` reporting `tts.playing === 0`, polled no
+ * the worker's `voice::speech-ended` trigger for host playback.
  * faster than every 2s. "Stop" calls `voice::speak::stop` with the
  * utterance's `speech_id`. Hidden while the turn is streaming; disabled
  * with a tooltip when the doctor reports the tts backend `off`.
@@ -17,11 +17,9 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { doctor, speak, speakStop } from '../lib/client'
 import { errorMessage, stripCodeFences } from '../lib/format'
 import { SpeakerIcon } from '../lib/icons'
+import { useSpeechEnded } from '../lib/playback'
 import type { SessionContentBlock, SessionMessageEntry, SessionMessagesResponse } from '../lib/types'
 
-const WORDS_PER_MINUTE = 150
-const MAX_ESTIMATE_SECS = 60
-const POLL_INTERVAL_MS = 2000
 const MAX_PAGES = 20
 
 function extractAssistantText(entry: SessionMessageEntry): string | null {
@@ -55,12 +53,6 @@ async function fetchLastAssistantText(host: Host, sessionId: string): Promise<st
   return lastText
 }
 
-function estimateSpeechSeconds(text: string): number {
-  const words = text.trim().split(/\s+/).filter(Boolean).length
-  if (words === 0) return 1
-  return Math.min(MAX_ESTIMATE_SECS, Math.max(1, (words / WORDS_PER_MINUTE) * 60))
-}
-
 type SpeakState =
   | { phase: 'idle' }
   | { phase: 'loading' }
@@ -72,8 +64,6 @@ export function createVoiceTurnSummary(host: Host): SessionTurnSummaryRegistrati
     const [ttsOff, setTtsOff] = useState(false)
     const [speakState, setSpeakState] = useState<SpeakState>({ phase: 'idle' })
     const audioRef = useRef<HTMLAudioElement | null>(null)
-    const estimateTimerRef = useRef<number | null>(null)
-    const pollTimerRef = useRef<number | null>(null)
     const [lastReply, setLastReply] = useState<string | null>(null)
     const hasReply = lastReply !== null
 
@@ -106,44 +96,19 @@ export function createVoiceTurnSummary(host: Host): SessionTurnSummaryRegistrati
       }
     }, [])
 
-    const clearWatch = useCallback(() => {
-      if (estimateTimerRef.current !== null) {
-        window.clearTimeout(estimateTimerRef.current)
-        estimateTimerRef.current = null
-      }
-      if (pollTimerRef.current !== null) {
-        window.clearInterval(pollTimerRef.current)
-        pollTimerRef.current = null
-      }
-    }, [])
-
-    const armHostPlaybackWatch = useCallback(
-      (estimateSecs: number) => {
-        clearWatch()
-        estimateTimerRef.current = window.setTimeout(() => {
-          clearWatch()
-          setSpeakState({ phase: 'idle' })
-        }, estimateSecs * 1000)
-        pollTimerRef.current = window.setInterval(() => {
-          doctor(host.iii)
-            .then((res) => {
-              if (res.tts.playing === 0) {
-                clearWatch()
-                setSpeakState({ phase: 'idle' })
-              }
-            })
-            .catch(() => {})
-        }, POLL_INTERVAL_MS)
-      },
-      [clearWatch],
-    )
+    useSpeechEnded(host, (event) => {
+      setSpeakState((current) =>
+        current.phase === 'speaking' && (!current.speechId || current.speechId === event.speech_id)
+          ? { phase: 'idle' }
+          : current,
+      )
+    })
 
     useEffect(
       () => () => {
-        clearWatch()
         audioRef.current?.pause()
       },
-      [clearWatch],
+      [],
     )
 
     const onReadAloud = useCallback(async () => {
@@ -165,23 +130,21 @@ export function createVoiceTurnSummary(host: Host): SessionTurnSummaryRegistrati
           setSpeakState({ phase: 'speaking', speechId: res.speech_id })
         } else if (res.played) {
           setSpeakState({ phase: 'speaking', speechId: res.speech_id })
-          armHostPlaybackWatch(estimateSpeechSeconds(text))
         } else {
           setSpeakState({ phase: 'idle' })
         }
       } catch (err) {
         setSpeakState({ phase: 'error', message: errorMessage(err) })
       }
-    }, [sessionId, lastReply, armHostPlaybackWatch])
+    }, [sessionId, lastReply])
 
     const onStop = useCallback(() => {
       audioRef.current?.pause()
       audioRef.current = null
-      clearWatch()
       const speechId = speakState.phase === 'speaking' ? speakState.speechId : undefined
       speakStop(host.iii, speechId ? { speech_id: speechId } : {}).catch(() => {})
       setSpeakState({ phase: 'idle' })
-    }, [clearWatch, speakState])
+    }, [speakState])
 
     if (isStreaming || !hasReply) return null
 

--- a/voice/ui/src/turn-summary/index.tsx
+++ b/voice/ui/src/turn-summary/index.tsx
@@ -104,22 +104,31 @@ export function createVoiceTurnSummary(host: Host): SessionTurnSummaryRegistrati
       )
     })
 
+    const speakOpRef = useRef(0)
+
     useEffect(
       () => () => {
+        speakOpRef.current += 1
         audioRef.current?.pause()
       },
       [],
     )
 
     const onReadAloud = useCallback(async () => {
+      const op = ++speakOpRef.current
       setSpeakState({ phase: 'loading' })
       try {
         const text = lastReply ?? (await fetchLastAssistantText(host, sessionId))
+        if (op !== speakOpRef.current) return
         if (!text) {
           setSpeakState({ phase: 'idle' })
           return
         }
         const res = await speak(host.iii, { text })
+        if (op !== speakOpRef.current) {
+          if (res.speech_id) speakStop(host.iii, { speech_id: res.speech_id }).catch(() => {})
+          return
+        }
         if (res.audio_base64) {
           const mime = res.mime ?? 'audio/mpeg'
           const audio = new Audio(`data:${mime};base64,${res.audio_base64}`)
@@ -134,11 +143,12 @@ export function createVoiceTurnSummary(host: Host): SessionTurnSummaryRegistrati
           setSpeakState({ phase: 'idle' })
         }
       } catch (err) {
-        setSpeakState({ phase: 'error', message: errorMessage(err) })
+        if (op === speakOpRef.current) setSpeakState({ phase: 'error', message: errorMessage(err) })
       }
     }, [sessionId, lastReply])
 
     const onStop = useCallback(() => {
+      speakOpRef.current += 1
       audioRef.current?.pause()
       audioRef.current = null
       const speechId = speakState.phase === 'speaking' ? speakState.speechId : undefined

--- a/voice/ui/styles.css
+++ b/voice/ui/styles.css
@@ -426,6 +426,11 @@
   color: var(--color-ink);
 }
 
+[data-iii-ui='voice'] .voice-live-partial {
+  color: var(--color-ink-faint);
+  font-style: italic;
+}
+
 [data-iii-ui='voice'] .voice-chip-dot {
   width: 6px;
   height: 6px;


### PR DESCRIPTION
## What

A `router` engine for the voice worker, beside `local` and `openai`. With `stt.backend: router` or `tts.backend: router`, audio and text go to llm-router's `router::transcribe` and `router::speak` (#1074), so any speech provider registered with the router (ElevenLabs via #1075, OpenAI, a self-hosted server) serves the console without the voice worker knowing the vendor's API.

- `stt.router.model` (`provider::model`, empty lets the router pick) and `stt.router.language`; `tts.router.model`, `tts.router.voice` (id or name) and `tts.router.format` (`mp3`, `wav`, `opus`).
- The chosen engine writes dictation too. Live words and sentence boundaries stay with the local streaming model; each finished sentence is re-decoded by the selected engine (a router model, the OpenAI endpoint, or the local second-pass model), with a 30 s cap that keeps the streaming text when a provider is slow. The session model label names both halves, for example `zipformer-en-20m+elevenlabs::scribe_v1`.
- The live preview above the composer now shows settled sentences as text and the words still being recognized in faint italics, so the streaming model's guesses no longer read as the transcript. A second live model, `zipformer-en-large` (73 MB, same Apache-2.0 family, bigger encoder), can be picked for fewer misheard words in the preview; `zipformer-en-20m` stays the default.
- A `voice::speech-ended` trigger (reason `ended`, `stopped` or `failed`, filterable by `speech_id`) fires when a host read-aloud finishes; the turn summary and the page bind it the way the shell page binds its events and no longer poll `voice::doctor` or guess from a word count.
- `voice::doctor` reports the router engines and says when the router lists no speech models or is not running.
- Overview gains engine selects for both directions and router model selects fed by `router::models::list`; the configuration form gains the same plus the language hint, voice and format fields. Keys stay in the router's Settings.

Stacked on #1070 (the voice worker); the diff includes its commits until it lands. The worker count guards in the test file will conflict with #1075 on whichever merges second; the fix is one number.

## Verification

- `cargo fmt`, `cargo clippy -D warnings`, `cargo test`, UI build, vitest, biome.
- Live on a 0.23.0 rig with the router and ElevenLabs branches: `voice::transcribe` through Scribe returns the expected text with timed segments and `model: elevenlabs::scribe_v1`; `voice::speak` through Eleven Flash v2.5 with the voice "Sarah" returns mp3; browser dictation with the router engine lands a Scribe-punctuated sentence in the composer; the Overview and Settings selects list the router's speech models; doctor is clean.

Refs MOT-4664
Refs MOT-4665


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added llm-router support for speech-to-text and text-to-speech, including provider model, language, voice, and format selection.
  - Added a new streaming speech model option.
  - Added speech completion events for more reliable playback status and automation.
  - Improved live transcription display by separating committed text from the current partial transcript.
- **Improvements**
  - Enhanced voice settings, model availability diagnostics, and read-aloud state handling.
  - Added safeguards for overlapping or interrupted speech requests.
- **Documentation**
  - Updated voice configuration and skill documentation with router backends and speech completion events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->