### PR TITLE
(MOT-4665) fix(console): hide configured providers without chat models from the picker

### DIFF
--- a/console/web/src/components/chat/ModelPicker.tsx
+++ b/console/web/src/components/chat/ModelPicker.tsx
@@ -501,8 +501,12 @@ export function ModelPickerPanel({
         matchesFilter(option, group.label),
       ),
     })),
+    // A provider with no chat models is listed only while it still needs
+    // setup: a configured one without chat models serves another modality
+    // (speech, embeddings) and has nothing to offer this picker.
     ...presentIds
       .filter((id) => !grouped.has(id))
+      .filter((id) => providerById.get(id)?.configured !== true)
       .map((id) => ({ label: id, options: [] })),
   ]
     .filter((group) => filterWords.length === 0 || group.options.length > 0)


### PR DESCRIPTION
## What

The chat model picker lists every registered provider and fills each group with chat models. A provider that is configured but serves another modality showed as an empty "No models available" group with a Configure prompt, which reads as a misconfiguration. With speech providers behind the router (#1074, #1075) that is the normal state for ElevenLabs.

A configured provider with no chat models is now skipped. A provider that still needs setup keeps its group and its Configure row.

## Verification

- `tsc --noEmit`, biome.
- Browser on a rig with ElevenLabs registered and configured: the picker no longer shows the empty ElevenLabs group; OpenAI and Codex groups are unchanged; an unconfigured provider still shows its Configure row.

Refs MOT-4665
