### PR TITLE
(MOT-4663) fix(kanban): honor pnpm build policy

### DIFF
--- a/.deploy/workers.yaml
+++ b/.deploy/workers.yaml
@@ -907,7 +907,6 @@ workers:
       install_command:
       - pnpm
       - install
-      - --ignore-workspace
       - --frozen-lockfile
       build_command:
       - pnpm

--- a/.github/scripts/tests/test_deployment_compiler.py
+++ b/.github/scripts/tests/test_deployment_compiler.py
@@ -83,3 +83,7 @@ def test_kanban_bundle_install_uses_its_pnpm_build_policy():
         "install",
         "--frozen-lockfile",
     ]
+    policy = deployment_compiler.read_yaml(
+        ROOT / descriptor["artifact"]["workspace_root"] / "pnpm-workspace.yaml"
+    )["allowBuilds"]
+    assert policy == {"esbuild": True, "protobufjs": False}

--- a/.github/scripts/tests/test_deployment_compiler.py
+++ b/.github/scripts/tests/test_deployment_compiler.py
@@ -65,3 +65,21 @@ def test_descriptor_schema_requires_explicit_interface_capture_policy():
     assert schema["properties"]["interface_capture"] == {
         "enum": ["required", "skipped"]
     }
+
+
+def test_kanban_bundle_install_uses_its_pnpm_build_policy():
+    catalog = deployment_compiler.read_yaml(ROOT / ".deploy" / "workers.yaml")["workers"]
+
+    descriptor = deployment_compiler.compile_worker(
+        ROOT,
+        "kanban",
+        catalog["kanban"],
+        "a" * 40,
+        "b" * 64,
+    )
+
+    assert descriptor["artifact"]["install_command"] == [
+        "pnpm",
+        "install",
+        "--frozen-lockfile",
+    ]


### PR DESCRIPTION
## Summary

- let the isolated Kanban release install read its pnpm v11 build policy
- keep esbuild postinstall enabled while protobufjs remains explicitly denied
- add a deployment descriptor regression test

## Validation

- `pytest -q -p no:cacheprovider test_deployment_compiler.py` (5 passed)
- containerized `pnpm install --frozen-lockfile`
- containerized `pnpm run build:bundle`

Refs MOT-4663

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Kanban worker deployments to use the frozen lockfile configuration, improving consistency and reliability during installation.
  * Adjusted deployment build settings to allow required build steps while preventing unnecessary postinstall processing.

* **Tests**
  * Added regression coverage to verify the Kanban deployment installation command and build settings remain correct.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->