### PR TITLE
(MOT-4663) fix(kanban): start bundled worker from release path

### DIFF
--- a/.github/scripts/tests/test_deployment_compiler.py
+++ b/.github/scripts/tests/test_deployment_compiler.py
@@ -83,6 +83,7 @@ def test_kanban_bundle_install_uses_its_pnpm_build_policy():
         "install",
         "--frozen-lockfile",
     ]
+    assert descriptor["runtime"]["start"] == "node ./dist/bundle/index.mjs"
     policy = deployment_compiler.read_yaml(
         ROOT / descriptor["artifact"]["workspace_root"] / "pnpm-workspace.yaml"
     )["allowBuilds"]

--- a/kanban/iii.worker.yaml
+++ b/kanban/iii.worker.yaml
@@ -11,7 +11,7 @@ runtime:
   kind: javascript
 
 scripts:
-  start: node ./index.mjs
+  start: node ./dist/bundle/index.mjs
 
 dependencies:
   console: "^1.9.11"


### PR DESCRIPTION
## Summary

- start the Kanban release bundle from its packaged `dist/bundle/index.mjs` path
- assert the compiled deployment descriptor uses that runtime command

## Validation

- `PYTHONPATH=.github/scripts python -m pytest .github/scripts/tests/test_deployment_compiler.py` (5 passed)
- executed the assembled Kanban artifact against an isolated engine with the corrected command; the worker, functions, and trigger type registered successfully

Refs MOT-4663

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the Kanban worker deployment to start the bundled runtime entry point.
  - This ensures the worker launches using the packaged build output during deployment.
  - Added validation to confirm the deployment configuration uses the correct runtime start command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->