### PR TITLE
(MOT-4663) fix(security-scan): route configuration to default namespace

### DIFF
--- a/security-scan/src/configuration.rs
+++ b/security-scan/src/configuration.rs
@@ -97,12 +97,15 @@ async fn trigger_with_retry(
     let mut last_error = None;
     for attempt in 1..=CONFIG_RETRIES {
         match iii
-            .trigger(TriggerRequest {
-                function_id: function_id.into(),
-                payload: payload.clone(),
-                action: None,
-                timeout_ms: Some(CONFIG_TIMEOUT_MS),
-            })
+            .trigger(
+                TriggerRequest {
+                    function_id: function_id.into(),
+                    payload: payload.clone(),
+                    action: None,
+                    timeout_ms: Some(CONFIG_TIMEOUT_MS),
+                }
+                .namespace("default"),
+            )
             .await
         {
             Ok(response) => return Ok(response),


### PR DESCRIPTION
## Summary

- route Security Scan configuration RPCs to the control-plane namespace
- allow the worker to finish startup in project namespaces such as `worker_update`

## Validation

- `cargo test --manifest-path security-scan/Cargo.toml --locked` (108 passed)
- `cargo clippy --manifest-path security-scan/Cargo.toml --all-targets --all-features --locked -- -D warnings`
- reproduced with `security-scan@0.1.4`: worker connected but registered zero functions while configuration retries targeted `worker_update`

Refs MOT-4663

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration triggers now consistently target the `default` namespace when retrieving or registering configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->