### PR TITLE
(MOT-4681) chore(release): stop building Windows 32-bit and macOS Intel

### DIFF
--- a/.deploy/workers.yaml
+++ b/.deploy/workers.yaml
@@ -10,14 +10,12 @@ workers:
         version: 1.97.1
       binary: a2ui
       targets: &id001
-      - x86_64-apple-darwin
       - aarch64-apple-darwin
       - x86_64-unknown-linux-gnu
       - x86_64-unknown-linux-musl
       - aarch64-unknown-linux-gnu
       - armv7-unknown-linux-gnueabihf
       - x86_64-pc-windows-msvc
-      - i686-pc-windows-msvc
       - aarch64-pc-windows-msvc
       frontends:
       - workspace_root: .
@@ -51,7 +49,6 @@ workers:
         version: 1.97.1
       binary: iii-acp
       targets:
-      - x86_64-apple-darwin
       - aarch64-apple-darwin
       - x86_64-unknown-linux-gnu
       - x86_64-unknown-linux-musl
@@ -204,7 +201,6 @@ workers:
         version: 1.97.1
       binary: code-runner
       targets:
-      - x86_64-apple-darwin
       - aarch64-apple-darwin
       - x86_64-unknown-linux-gnu
       - x86_64-unknown-linux-musl
@@ -290,7 +286,6 @@ workers:
         version: 1.97.1
       binary: compose-ui
       targets:
-      - x86_64-apple-darwin
       - aarch64-apple-darwin
       - x86_64-unknown-linux-gnu
       - x86_64-unknown-linux-musl
@@ -412,7 +407,6 @@ workers:
         version: 1.97.1
       binary: context-manager
       targets:
-      - x86_64-apple-darwin
       - aarch64-apple-darwin
       - x86_64-unknown-linux-gnu
       - x86_64-unknown-linux-musl
@@ -612,7 +606,6 @@ workers:
         version: 1.97.1
       binary: editor
       targets:
-      - x86_64-apple-darwin
       - aarch64-apple-darwin
       - x86_64-unknown-linux-gnu
       - x86_64-unknown-linux-musl
@@ -959,7 +952,6 @@ workers:
         version: 1.97.1
       binary: lsp
       targets:
-      - x86_64-apple-darwin
       - aarch64-apple-darwin
       - x86_64-unknown-linux-gnu
       - x86_64-unknown-linux-musl
@@ -1678,7 +1670,6 @@ workers:
         version: 1.97.1
       binary: sandbox-code-runner
       targets:
-      - x86_64-apple-darwin
       - aarch64-apple-darwin
       - x86_64-unknown-linux-gnu
       - x86_64-unknown-linux-musl
@@ -1801,7 +1792,6 @@ workers:
         version: 1.97.1
       binary: shell
       targets:
-      - x86_64-apple-darwin
       - aarch64-apple-darwin
       - x86_64-unknown-linux-gnu
       - x86_64-unknown-linux-musl
@@ -2106,7 +2096,6 @@ workers:
         version: 1.97.1
       binary: workflow
       targets:
-      - x86_64-apple-darwin
       - aarch64-apple-darwin
       - x86_64-unknown-linux-gnu
       - x86_64-unknown-linux-musl

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -4,6 +4,5 @@ self-hosted-runner:
     - workers-ci-linux-8core
     - workers-release-control-linux-2core
     - workers-release-linux-8core
-    - workers-release-macos-aws-intel
     - workers-release-macos-12core
     - workers-release-macos-arm-5core

--- a/.github/scripts/deployment_targets.py
+++ b/.github/scripts/deployment_targets.py
@@ -6,7 +6,6 @@ from collections.abc import Iterable
 
 
 UNIX_TARGETS = [
-    "x86_64-apple-darwin",
     "aarch64-apple-darwin",
     "x86_64-unknown-linux-gnu",
     "x86_64-unknown-linux-musl",
@@ -16,24 +15,28 @@ UNIX_TARGETS = [
 
 WINDOWS_TARGETS = [
     "x86_64-pc-windows-msvc",
-    "i686-pc-windows-msvc",
     "aarch64-pc-windows-msvc",
 ]
 
-# Every worker that published Windows binaries before the deployment cutover
-# ships all three msvc triples, so the default matrix carries them: a worker
-# without Windows is the exception and must say so in its catalog entry.
+# Every worker that publishes Windows binaries ships both supported msvc
+# triples, so the default matrix carries them: a worker without Windows is
+# the exception and must say so in its catalog entry.
+#
+# Dropped on 2026-09-03: `i686-pc-windows-msvc`, because 64-bit Windows runs
+# 32-bit binaries through WOW64 and Windows 11 has no 32-bit edition; and
+# `x86_64-apple-darwin`, which was the only consumer of the paid
+# `workers-release-macos-12core` pool. Removing a triple here makes it an
+# unknown target, so a catalog entry that still names it fails the compile
+# instead of silently publishing a narrower set of binaries.
 DEFAULT_TARGETS = [*UNIX_TARGETS, *WINDOWS_TARGETS]
 
 TARGET_RUNNERS = {
-    "x86_64-apple-darwin": "macos-latest",
     "aarch64-apple-darwin": "macos-latest",
     "x86_64-unknown-linux-gnu": "ubuntu-22.04",
     "x86_64-unknown-linux-musl": "ubuntu-latest",
     "aarch64-unknown-linux-gnu": "ubuntu-22.04",
     "armv7-unknown-linux-gnueabihf": "ubuntu-22.04",
     "x86_64-pc-windows-msvc": "windows-latest",
-    "i686-pc-windows-msvc": "windows-latest",
     "aarch64-pc-windows-msvc": "windows-latest",
 }
 
@@ -41,9 +44,7 @@ TARGET_RUNNERS = {
 # Keep the execution label alongside the target-to-OS policy so every
 # Release Control path uses the same isolated GitHub-hosted capacity.
 TARGET_LARGER_RUNNERS = {
-    "x86_64-apple-darwin": "workers-release-macos-12core",
-    # Build Apple Silicon artifacts on a dedicated native M2 pool. This keeps
-    # the Intel and ARM macOS targets independently schedulable.
+    # macOS ships Apple Silicon only, built on a dedicated native M2 pool.
     "aarch64-apple-darwin": "workers-release-macos-arm-5core",
     "x86_64-unknown-linux-gnu": "workers-release-linux-8core",
     "x86_64-unknown-linux-musl": "workers-release-linux-8core",
@@ -52,7 +53,6 @@ TARGET_LARGER_RUNNERS = {
     # Windows has no self-hosted pool; GitHub-hosted capacity keeps these
     # targets schedulable without competing for the release runners.
     "x86_64-pc-windows-msvc": "windows-latest",
-    "i686-pc-windows-msvc": "windows-latest",
     "aarch64-pc-windows-msvc": "windows-latest",
 }
 

--- a/.github/scripts/tests/test_deployment_targets.py
+++ b/.github/scripts/tests/test_deployment_targets.py
@@ -7,14 +7,12 @@ import deployment_targets
 
 def test_binary_default_is_the_complete_release_matrix() -> None:
     assert deployment_targets.normalize_targets(None, deploy="binary") == [
-        "x86_64-apple-darwin",
         "aarch64-apple-darwin",
         "x86_64-unknown-linux-gnu",
         "x86_64-unknown-linux-musl",
         "aarch64-unknown-linux-gnu",
         "armv7-unknown-linux-gnueabihf",
         "x86_64-pc-windows-msvc",
-        "i686-pc-windows-msvc",
         "aarch64-pc-windows-msvc",
     ]
 
@@ -26,23 +24,32 @@ def test_unknown_targets_are_rejected() -> None:
         deployment_targets.normalize_targets("x86_64-pc-windows-gnu")
 
 
+def test_retired_triples_are_rejected_rather_than_ignored() -> None:
+    """A catalog entry left naming a dropped triple must fail the compile.
+
+    Silently narrowing the published set would ship fewer binaries than the
+    entry promises, and nothing downstream would notice.
+    """
+    for retired in ("i686-pc-windows-msvc", "x86_64-apple-darwin"):
+        with pytest.raises(ValueError, match="unknown release target"):
+            deployment_targets.normalize_targets(retired)
+
+
 def test_every_msvc_triple_is_accepted_and_ordered_last() -> None:
     assert deployment_targets.normalize_targets([
         "aarch64-pc-windows-msvc",
         "x86_64-unknown-linux-gnu",
-        "i686-pc-windows-msvc",
-        "x86_64-apple-darwin",
+        "aarch64-apple-darwin",
         "x86_64-pc-windows-msvc",
     ]) == [
-        "x86_64-apple-darwin",
+        "aarch64-apple-darwin",
         "x86_64-unknown-linux-gnu",
         "x86_64-pc-windows-msvc",
-        "i686-pc-windows-msvc",
         "aarch64-pc-windows-msvc",
     ]
 
 
 def test_explicit_subsets_are_canonicalized_and_non_binary_has_one_build() -> None:
     assert deployment_targets.normalize_targets(
-        ["aarch64-unknown-linux-gnu", "x86_64-apple-darwin"], deploy="binary"
-    ) == ["x86_64-apple-darwin", "aarch64-unknown-linux-gnu"]
+        ["aarch64-unknown-linux-gnu", "aarch64-apple-darwin"], deploy="binary"
+    ) == ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu"]

--- a/.github/scripts/tests/test_deployment_train.py
+++ b/.github/scripts/tests/test_deployment_train.py
@@ -402,7 +402,6 @@ def test_matrix_is_exactly_the_descriptor_build_units_windows_included(
     selected = rust_descriptor("smoke", "a" * 40, [
         "x86_64-unknown-linux-gnu",
         "x86_64-pc-windows-msvc",
-        "i686-pc-windows-msvc",
         "aarch64-pc-windows-msvc",
     ])
     descriptor_path = tmp_path / "deployment-descriptor.json"
@@ -421,12 +420,6 @@ def test_matrix_is_exactly_the_descriptor_build_units_windows_included(
             "unit": "smoke-x86_64-pc-windows-msvc",
             "kind": "rust-binary",
             "target": "x86_64-pc-windows-msvc",
-            "runner": "windows-latest",
-        },
-        {
-            "unit": "smoke-i686-pc-windows-msvc",
-            "kind": "rust-binary",
-            "target": "i686-pc-windows-msvc",
             "runner": "windows-latest",
         },
         {

--- a/.github/scripts/tests/test_rust_ci_workflows.py
+++ b/.github/scripts/tests/test_rust_ci_workflows.py
@@ -131,7 +131,6 @@ def test_actionlint_knows_the_repository_runner_pool_labels() -> None:
         "workers-ci-linux-8core",
         "workers-release-control-linux-2core",
         "workers-release-linux-8core",
-        "workers-release-macos-aws-intel",
         "workers-release-macos-12core",
         "workers-release-macos-arm-5core",
     ]
@@ -147,7 +146,6 @@ def test_runner_pool_contract_is_documented() -> None:
         "windows-latest",
         "workers-release-macos-12core",
         "workers-release-macos-arm-5core",
-        "workers-release-macos-aws-intel",
     }
     for label in labels:
         assert f"`{label}`" in runner_docs

--- a/.github/workflows/browser-scrapling-e2e.yml
+++ b/.github/workflows/browser-scrapling-e2e.yml
@@ -205,13 +205,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: x86_64-apple-darwin
-            os: macos-latest
           - target: aarch64-apple-darwin
             os: macos-latest
           - target: x86_64-pc-windows-msvc
-            os: windows-latest
-          - target: i686-pc-windows-msvc
             os: windows-latest
           - target: aarch64-pc-windows-msvc
             os: windows-latest

--- a/code-runner/iii.worker.yaml
+++ b/code-runner/iii.worker.yaml
@@ -19,7 +19,6 @@ dependencies:
 # Its explicit target list below keeps the release matrix on the supported
 # Unix triples while avoiding those platform-restricted shards.
 targets:
-  - x86_64-apple-darwin
   - aarch64-apple-darwin
   - x86_64-unknown-linux-gnu
   - x86_64-unknown-linux-musl

--- a/docs/architecture/testing-and-ci.md
+++ b/docs/architecture/testing-and-ci.md
@@ -119,9 +119,8 @@ cost, isolation and performance measurements.
 | `workers-release-control-linux-2core` | Larger GitHub-hosted Linux | 8 concurrent | Reserved for a later migration of release control jobs; no workflow selects it yet |
 | `workers-release-linux-8core` | Larger GitHub-hosted Linux | 8 concurrent | Linux release builds and, until migrated, release control jobs |
 | `windows-latest` | Standard GitHub-hosted Windows | GitHub-managed | Windows release builds |
-| `workers-release-macos-12core` | Larger GitHub-hosted Intel macOS | 3 concurrent | Intel macOS release builds |
+| `workers-release-macos-12core` | Larger GitHub-hosted Intel macOS | 3 concurrent | No release target left after `x86_64-apple-darwin` was dropped; only the manual capacity diagnostic selects it |
 | `workers-release-macos-arm-5core` | Larger GitHub-hosted Apple Silicon | 3 concurrent | ARM macOS release builds |
-| `workers-release-macos-aws-intel` | Self-hosted Intel macOS on AWS | 3 registered | Explicit contingency capacity; no workflow selects it by default |
 
 The `workers-ci-linux-8core` group is restricted to the Harness integration
 and benchmark workflows. Release pools stay in the release-only runner group

--- a/shell/iii.worker.yaml
+++ b/shell/iii.worker.yaml
@@ -11,7 +11,6 @@ description: Unix shell + filesystem worker — exec with denylist/timeout/outpu
 # POSIX-only: src/fs/host.rs uses std::os::unix::fs::PermissionsExt / chown /
 # OpenOptionsExt directly, so the Windows triples cannot compile.
 targets:
-  - x86_64-apple-darwin
   - aarch64-apple-darwin
   - x86_64-unknown-linux-gnu
   - x86_64-unknown-linux-musl


### PR DESCRIPTION
Drops `i686-pc-windows-msvc` and `x86_64-apple-darwin` from the release matrix: **111 of 512** rust build units, a fifth of every deployment's fan-out.

## The two are not equivalent

I checked which runner actually serves each target on a real run rather than assuming:

| Target | Runner | Cost |
| --- | --- | --- |
| `x86_64-apple-darwin` | `workers-release-macos-12core` | paid, macOS Large |
| `i686-pc-windows-msvc` | `windows-latest` | included minutes |

September's Actions bill is $77.99, of which **macOS Large is $21.48**. Windows is 1619 minutes at **$0.00**.

So the 32-bit Windows build costs queue time and nothing else, while macOS Intel was the only consumer of a paid pool.

**Windows 32-bit has no consumer to lose.** 64-bit Windows runs 32-bit binaries through WOW64, and Windows 11 ships no 32-bit edition.

**macOS Intel is the removal with a real edge.** An Intel Mac cannot run the aarch64 binary. The reverse works, because Apple Silicon runs x86_64 through Rosetta, so the direction being dropped is the one without a fallback. Anyone still on an Intel Mac loses the binary outright.

Worth stating plainly: the Registry counts downloads per worker, version, day and week, **never per target**. No telemetry exists that could size that population, so this is a judgement call made with the gap named rather than papered over. If that population turns out to be non-empty, restoring the triple is a revert of this commit.

## Why the halves move together

Removing a triple from `TARGET_RUNNERS` makes it an *unknown* target rather than a silently ignored one. A catalog entry that still named it would then fail the compile instead of quietly publishing a narrower set than it promises. That is the behaviour worth having, and it is why the policy and the catalogs change in one commit:

- `.github/scripts/deployment_targets.py`: the policy, its runner maps, and the rationale comment
- `.deploy/workers.yaml`: the private matrix, anchor and the nine unix-only lists
- `shell/iii.worker.yaml`, `code-runner/iii.worker.yaml`: the two public manifests that pin their own list, which the compiler cross-checks against the private one

The compiler's cross-check caught the public manifests when I had only changed the private catalog, which is exactly what it is there for.

`browser-scrapling-e2e.yml` drops both from the non-tier1 safe-compile matrix, so CI stops spending runners proving a target nobody ships.

## Checks

- `pytest .github/scripts/tests`: **263 passed**, including a new test asserting both retired triples are now rejected rather than ignored.
- Compiled the real catalog end to end: **70 workers, 70 publishable, 401 rust build units** where there were 512.

## Follow-up, deliberately not here

Release Control mirrors this list in `api/src/lib/deployment-targets.ts`. It should **not** be narrowed in lockstep: it reads descriptors compiled at an arbitrary source commit, so rejecting these triples would break every deployment pinned to a commit older than this one. Its set staying a superset is the correct asymmetry, and I will document that there rather than change it.

One stale comment left alone: `code-runner/iii.worker.yaml` explains its exclusions by naming `i686-pc-windows-msvc` and `armv7`. The armv7 half is still accurate; rewriting another worker's rationale was out of scope for this change.

https://claude.ai/code/session_01GPtEQRm7GvSq66FBv6PzVR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Platform Support**
  - Release builds no longer support Intel-based macOS (`x86_64-apple-darwin`) or 32-bit Windows (`i686-pc-windows-msvc`).
  - macOS releases continue to support Apple Silicon, while Windows releases support 64-bit Intel and ARM devices.

- **Build Validation**
  - Retired platform targets are now rejected with a clear “unknown release target” error instead of being silently ignored.
  - Automated deployment and compatibility checks now reflect the supported platform matrix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->