### PR TITLE
(MOT-4663) fix(ci): publish OCI archives with root privileges

### DIFF
--- a/.github/scripts/tests/test_deployment_workflows.py
+++ b/.github/scripts/tests/test_deployment_workflows.py
@@ -233,6 +233,9 @@ def test_build_workflow_only_builds_and_uploads_immutable_bytes():
     assert "BUILD_TAG: build-${{ inputs.source_sha }}" in text
     assert 'gh release create "$BUILD_TAG" --target "$SOURCE_SHA" --prerelease' in text
     assert 'docker buildx imagetools create --tag "$base:$BUILD_TAG"' in text
+    assert 'sudo skopeo login --authfile "$authfile"' in text
+    assert 'sudo skopeo inspect --authfile "$authfile"' in text
+    assert 'sudo skopeo copy --authfile "$authfile"' in text
     assert "immutable assets are never overwritten" in text
     assert "immutable images are never overwritten" in text
     assert "deployment_train.py select-descriptor" in text

--- a/.github/scripts/tests/test_deployment_workflows.py
+++ b/.github/scripts/tests/test_deployment_workflows.py
@@ -234,6 +234,8 @@ def test_build_workflow_only_builds_and_uploads_immutable_bytes():
     assert 'gh release create "$BUILD_TAG" --target "$SOURCE_SHA" --prerelease' in text
     assert 'docker buildx imagetools create --tag "$base:$BUILD_TAG"' in text
     assert 'sudo skopeo login --authfile "$authfile"' in text
+    assert "--password-stdin" in text
+    assert '--password "$GH_TOKEN"' not in text
     assert 'sudo skopeo inspect --authfile "$authfile"' in text
     assert 'sudo skopeo copy --authfile "$authfile"' in text
     assert "immutable assets are never overwritten" in text

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -505,7 +505,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y skopeo
           base="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/$WORKER"
-          skopeo login ghcr.io --username "$GITHUB_ACTOR" --password "$GH_TOKEN"
+          authfile="$RUNNER_TEMP/skopeo-auth.json"
+          # OCI archives contain root-owned entries, so hardened runners must
+          # extract them through the same privileged path used during capture.
+          printf '%s' "$GH_TOKEN" | sudo skopeo login --authfile "$authfile" \
+            ghcr.io --username "$GITHUB_ACTOR" --password-stdin
           index_state=pushed
           if docker buildx imagetools inspect "$base:$BUILD_TAG" --raw >published-index.json 2>/dev/null; then
             index_state=existing
@@ -519,18 +523,21 @@ jobs:
             platform_slug=${platform//\//-}
             test -f "deploy-prepared/$archive"
             gzip -dc "deploy-prepared/$archive" >"image-$platform_slug.oci.tar"
-            source_digest=$(skopeo inspect --format '{{.Digest}}' "oci-archive:image-$platform_slug.oci.tar")
+            source_digest=$(sudo skopeo inspect --authfile "$authfile" --format '{{.Digest}}' \
+              "oci-archive:image-$platform_slug.oci.tar")
             [[ "$source_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
             # Per-platform manifests are addressed by the same build tag; they
             # are the inputs of the index, never version or channel tags.
             staging_tag="$BUILD_TAG-$platform_slug"
-            if remote_digest=$(skopeo inspect --format '{{.Digest}}' "docker://$base:$staging_tag" 2>/dev/null); then
+            if remote_digest=$(sudo skopeo inspect --authfile "$authfile" --format '{{.Digest}}' \
+              "docker://$base:$staging_tag" 2>/dev/null); then
               test "$remote_digest" = "$source_digest"
             elif [[ "$index_state" == existing ]]; then
               echo "::error::OCI index $base:$BUILD_TAG exists but its platform manifest $staging_tag is missing"
               exit 1
             else
-              skopeo copy "oci-archive:image-$platform_slug.oci.tar" "docker://$base:$staging_tag"
+              sudo skopeo copy --authfile "$authfile" \
+                "oci-archive:image-$platform_slug.oci.tar" "docker://$base:$staging_tag"
             fi
             docker buildx imagetools inspect "$base:$staging_tag" --raw >"staging-$platform_slug.json"
             if jq -e '.manifests | type == "array"' "staging-$platform_slug.json" >/dev/null; then


### PR DESCRIPTION
## Summary

- run Skopeo OCI archive operations with root privileges on hardened release runners
- pass GHCR authentication through an explicit temporary auth file and password stdin
- cover the privileged login, inspect, and copy contract in deployment workflow tests

## Problem

Docker-produced OCI archives contain root-owned entries. The unprivileged Skopeo upload step fails while extracting these entries with `chown: operation not permitted`, which prevents OCI workers such as Hermes from being published.

## Validation

- `pytest .github/scripts/tests/test_deployment_workflows.py -q` (20 passed)
- `.github/scripts/tests/` excluding the external link test (260 passed, 3 subtests passed)
- `git diff --check`

Refs MOT-4663

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the release pipeline’s handling of container image authentication and publication.
  * Container image inspection and copying now use a temporary authentication configuration with the required privileges.
  * Authentication credentials are supplied through a safer input method during publishing.
  * Existing digest verification, immutable image handling, and missing-platform error reporting remain unchanged.
  * Added automated checks to ensure these publishing safeguards remain in place.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->