### PR TITLE
(MOT-4682) fix(approval-gate): record the SDK the harness dev-dependency needs

### DIFF
--- a/approval-gate/Cargo.lock
+++ b/approval-gate/Cargo.lock
@@ -92,7 +92,7 @@ dependencies = [
  "clap",
  "futures",
  "harness",
- "iii-sdk",
+ "iii-sdk 0.22.1-alpha.25",
  "regex",
  "schemars",
  "serde",
@@ -552,8 +552,8 @@ dependencies = [
  "clap",
  "globset",
  "iii-console-ui",
- "iii-helpers",
- "iii-sdk",
+ "iii-helpers 0.23.0",
+ "iii-sdk 0.23.0",
  "jsonschema",
  "schemars",
  "serde",
@@ -810,7 +810,7 @@ dependencies = [
 name = "iii-console-ui"
 version = "0.1.0"
 dependencies = [
- "iii-sdk",
+ "iii-sdk 0.22.1-alpha.25",
  "schemars",
  "serde",
  "serde_json",
@@ -840,6 +840,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "iii-helpers"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e654538584cf6feec82f4f9e773d4b9f8c84bba5085e49a585aebe7227f8af8c"
+dependencies = [
+ "futures-util",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry_sdk",
+ "reqwest",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sysinfo",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "iii-sdk"
 version = "0.22.1-alpha.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -848,7 +869,28 @@ dependencies = [
  "async-trait",
  "futures-util",
  "hostname",
- "iii-helpers",
+ "iii-helpers 0.22.1-alpha.25",
+ "reqwest",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "iii-sdk"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3952d1ac84c88304fa27fef8ce0a9350585abe9e9b9f7513730497e72918186f"
+dependencies = [
+ "async-trait",
+ "futures-util",
+ "hostname",
+ "iii-helpers 0.23.0",
  "reqwest",
  "schemars",
  "serde",


### PR DESCRIPTION
Fixes MOT-4682.

`approval-gate` fails `cargo build --locked` and `cargo clippy --locked`, so both of its CI jobs fail:

```
error: cannot update the lock file approval-gate/Cargo.lock
because --locked was passed to prevent this
```

## Cause

`approval-gate/Cargo.toml` pins `iii-sdk = "=0.22.1-alpha.25"` directly. Its dev-dependency `harness = { path = "../harness" }` pins `iii-sdk = "=0.23.0"`. Those are semver-incompatible in 0.x, so both versions legitimately coexist in the graph and the lockfile has to record both. It records only the first: when `harness` moved to 0.23.0, this lockfile was not regenerated.

```
$ cargo tree -i iii-sdk@0.23.0
iii-sdk v0.23.0
└── harness v1.8.8-rc.3
    [dev-dependencies]
    └── approval-gate v1.0.15-rc.3
```

## The change

Resolved without `--locked` so it stays minimal rather than a wholesale refresh:

| | |
| --- | --- |
| Entries added | `iii-sdk 0.23.0`, `iii-helpers 0.23.0` |
| Entries removed | none |
| Existing versions moved | none |
| Package entries | 287 → 289 |

`approval-gate`'s own `=0.22.1-alpha.25` pin is untouched. This records what the graph already requires; it does not upgrade anything.

## Why it hid

The per-worker suite runs only for workers whose files changed, which is the right call for speed. The side effect is that a crate nobody touches is never revalidated, so a break introduced elsewhere in the workspace stays invisible.

It surfaced by accident: #1088 touches every worker's entry in `.deploy/workers.yaml`, which made CI run all sixty suites, and this was the single failure. #1088 is blocked on it.

I audited all 61 rust workers with `cargo metadata --locked`: **60 intact, this one stale**. Isolated, not systemic. A periodic full-fleet sweep outside the pull-request path would have caught it without needing an unrelated change to trip over it, which is noted on the ticket.

https://claude.ai/code/session_01GPtEQRm7GvSq66FBv6PzVR