### PR TITLE
(MOT-4684) fix(eval): follow the harness dropping the ask/agent mode option

### DIFF
--- a/eval/src/contract.rs
+++ b/eval/src/contract.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use harness::functions::metrics::SessionMetricsResponseV1;
-use harness::prompt::{Mode, SystemPromptStrategy};
+use harness::prompt::SystemPromptStrategy;
 use harness::types::model::ThinkingLevel;
 use harness::types::output::OutputContract;
 use harness::types::turn::FunctionPolicy;
@@ -89,8 +89,6 @@ pub struct EvalModelConfigV1 {
     pub provider: Option<String>,
     #[serde(default)]
     pub system_prompt_strategy: SystemPromptStrategy,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub mode: Option<Mode>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub thinking_level: Option<ThinkingLevel>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -495,7 +493,6 @@ mod tests {
                 model: "model".into(),
                 provider: Some("provider".into()),
                 system_prompt_strategy: SystemPromptStrategy::Override,
-                mode: Some(Mode::Agent),
                 thinking_level: None,
                 provider_options: None,
             },

--- a/eval/src/report.rs
+++ b/eval/src/report.rs
@@ -542,7 +542,6 @@ mod tests {
                 model: "model".into(),
                 provider: Some("provider".into()),
                 system_prompt_strategy: SystemPromptStrategy::Override,
-                mode: None,
                 thinking_level: None,
                 provider_options: None,
             },

--- a/eval/src/runtime.rs
+++ b/eval/src/runtime.rs
@@ -684,7 +684,6 @@ fn send_options(job: &EvalJobRecordV1, variant: &crate::contract::EvalVariantV1)
         } else {
             Some(job.request.model.system_prompt_strategy)
         },
-        mode: job.request.model.mode,
         max_turns: Some(job.request.limits.execution.max_turns),
         max_output_tokens: Some(job.request.limits.execution.max_output_tokens_per_call),
         max_total_tokens: job.request.limits.execution.max_total_tokens,

--- a/eval/src/state.rs
+++ b/eval/src/state.rs
@@ -292,7 +292,6 @@ mod tests {
                 model: "model".into(),
                 provider: None,
                 system_prompt_strategy: SystemPromptStrategy::Override,
-                mode: None,
                 thinking_level: None,
                 provider_options: None,
             },

--- a/eval/tests/golden/schemas/eval.assert.exact.json
+++ b/eval/tests/golden/schemas/eval.assert.exact.json
@@ -442,7 +442,7 @@
             "type": "integer"
           },
           "system_prompt": {
-            "description": "Final assembled system prompt excluding tokens attributed to `skills`: mode paragraph, identity, per-step aids, and any compaction summary section.",
+            "description": "Final assembled system prompt excluding tokens attributed to `skills`: identity, per-step aids, and any compaction summary section.",
             "format": "uint64",
             "minimum": 0.0,
             "type": "integer"

--- a/eval/tests/golden/schemas/eval.assert.normalized_text.json
+++ b/eval/tests/golden/schemas/eval.assert.normalized_text.json
@@ -442,7 +442,7 @@
             "type": "integer"
           },
           "system_prompt": {
-            "description": "Final assembled system prompt excluding tokens attributed to `skills`: mode paragraph, identity, per-step aids, and any compaction summary section.",
+            "description": "Final assembled system prompt excluding tokens attributed to `skills`: identity, per-step aids, and any compaction summary section.",
             "format": "uint64",
             "minimum": 0.0,
             "type": "integer"

--- a/eval/tests/golden/schemas/eval.compare-sessions.json
+++ b/eval/tests/golden/schemas/eval.compare-sessions.json
@@ -859,7 +859,7 @@
             "type": "integer"
           },
           "system_prompt": {
-            "description": "Final assembled system prompt excluding tokens attributed to `skills`: mode paragraph, identity, per-step aids, and any compaction summary section.",
+            "description": "Final assembled system prompt excluding tokens attributed to `skills`: identity, per-step aids, and any compaction summary section.",
             "format": "uint64",
             "minimum": 0.0,
             "type": "integer"

--- a/eval/tests/golden/schemas/eval.result.json
+++ b/eval/tests/golden/schemas/eval.result.json
@@ -410,16 +410,6 @@
       "EvalModelConfigV1": {
         "additionalProperties": false,
         "properties": {
-          "mode": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Mode"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "model": {
             "type": "string"
           },
@@ -966,14 +956,6 @@
         },
         "type": "object"
       },
-      "Mode": {
-        "description": "Operating mode prepended to the identity prompt; `ask` also caps the dispatch policy at the configured default.",
-        "enum": [
-          "ask",
-          "agent"
-        ],
-        "type": "string"
-      },
       "NormalizedEvalRequestV1": {
         "additionalProperties": false,
         "properties": {
@@ -1488,7 +1470,7 @@
             "type": "integer"
           },
           "system_prompt": {
-            "description": "Final assembled system prompt excluding tokens attributed to `skills`: mode paragraph, identity, per-step aids, and any compaction summary section.",
+            "description": "Final assembled system prompt excluding tokens attributed to `skills`: identity, per-step aids, and any compaction summary section.",
             "format": "uint64",
             "minimum": 0.0,
             "type": "integer"

--- a/eval/tests/golden/schemas/eval.start.json
+++ b/eval/tests/golden/schemas/eval.start.json
@@ -40,16 +40,6 @@
       "EvalModelConfigV1": {
         "additionalProperties": false,
         "properties": {
-          "mode": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Mode"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "model": {
             "type": "string"
           },
@@ -239,14 +229,6 @@
           }
         },
         "type": "object"
-      },
-      "Mode": {
-        "description": "Operating mode prepended to the identity prompt; `ask` also caps the dispatch policy at the configured default.",
-        "enum": [
-          "ask",
-          "agent"
-        ],
-        "type": "string"
       },
       "OutputContract": {
         "description": "Free text by default; `json` constrains the final answer to a JSON value, validated against `schema` when supplied.",


### PR DESCRIPTION
Fixes MOT-4684.

**`main` does not build.** `eval` fails to compile on `3040c717`:

```
error[E0432]: unresolved import `harness::prompt::Mode`
  --> src/contract.rs:4:23
error[E0560]: struct `SendOptions` has no field named `mode`
  --> src/runtime.rs:687:9
error: could not compile `eval` (lib) due to 2 previous errors
```

## Cause

#1086 removed the ask/agent mode from the harness: the enum in `harness/src/prompt/mode.rs`, the `SendOptions.mode` field, and the `clamp_for_mode` policy cap. Its own description says so — *"the wire dropped `options.mode` with the harness"*.

It updated `security-scan`, whose test asserted the field, but missed `eval`, which both re-exports `Mode` in its public contract and forwards it into `SendOptions`.

## The change

Follows the direction the harness set, the same way #1086 handled `security-scan`:

- `mode` off `EvalModelConfigV1`
- `mode` off the `SendOptions` construction in `runtime.rs`
- `mode` off the three fixtures in `contract.rs`, `state.rs`, `report.rs`
- golden schemas regenerated

Three goldens also drop the phrase *"mode paragraph"* from a description the harness no longer produces. That text comes from harness types, so it is a consequence of #1086 that had not reached eval's goldens.

**This narrows eval's public contract.** `EvalModelConfigV1` carries `deny_unknown_fields`, so a request still sending `model.mode` is now rejected rather than ignored. That is the honest outcome: nothing beneath it can act on the field any more, so accepting it would be a lie. Flagging it explicitly in case any caller still sends it.

## Checks

- `cargo check --locked`: clean
- `cargo test --locked`: **41 passed**, 0 failed
- `cargo clippy --locked --all-targets --all-features -- -D warnings`: clean
- Swept the repository for other crates left behind by the same removal. `eval` was the only one; the remaining `Mode` matches are unrelated enums (`ExposeMode`, `TlsMode`, `SortMode`).

## The pattern worth naming

This is the second break today of the same shape, after the `approval-gate` lockfile in #1090. The per-worker suite runs only for workers whose files changed, which is right for speed, but it means a crate nobody touches is never revalidated, so a break introduced elsewhere in the workspace lands on main unseen. Both were found only because #1088 touches every worker's catalog entry and forced all sixty suites to run.

A periodic full-fleet build outside the pull-request path would catch this class without needing an unrelated change to trip over it.

https://claude.ai/code/session_01GPtEQRm7GvSq66FBv6PzVR