### PR TITLE
(MOT-4663) fix(hermes): make OCI builds reproducible

### DIFF
--- a/hermes/Dockerfile
+++ b/hermes/Dockerfile
@@ -8,6 +8,7 @@ ARG TARGETARCH
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
+    UV_CACHE_DIR=/tmp/uv-cache \
     UV_FROZEN=1 \
     UV_LINK_MODE=copy \
     UV_PYTHON=/usr/local/bin/python3.11 \
@@ -23,7 +24,11 @@ ADD --checksum=sha256:8710e0017792e78369a7da3d96c16141f0787374285f1a6cf6f80d29b7
 RUN mkdir -p /opt/hermes-agent \
     && tar -xzf /tmp/hermes-agent.tar.gz --strip-components=1 -C /opt/hermes-agent \
     && uv sync --project /opt/hermes-agent --frozen --no-dev \
-    && test -x /opt/hermes-agent/.venv/bin/hermes
+    && test -x /opt/hermes-agent/.venv/bin/hermes \
+    && find /opt/hermes-agent/.venv -path '*.dist-info/uv_cache.json' -delete \
+    && find /opt/hermes-agent/.venv -path '*.dist-info/RECORD' -exec sed -i '/uv_cache\.json,/d' {} + \
+    && rm -rf /tmp/uv-cache \
+    && find /opt/hermes-agent -exec touch -h -d "@${SOURCE_DATE_EPOCH}" {} +
 
 # Download the exact iii release asset for the BuildKit target architecture,
 # validate its reviewed checksum, and install only the binary from the archive.
@@ -43,7 +48,10 @@ WORKDIR /app
 COPY pyproject.toml uv.lock ./
 COPY src/ src/
 RUN UV_PROJECT_ENVIRONMENT=/app/.venv uv sync --frozen --no-dev --no-editable \
-    && find /opt/hermes-agent /app -exec touch -h -d "@${SOURCE_DATE_EPOCH}" {} +
+    && find /app/.venv -path '*.dist-info/uv_cache.json' -delete \
+    && find /app/.venv -path '*.dist-info/RECORD' -exec sed -i '/uv_cache\.json,/d' {} + \
+    && rm -rf /tmp/uv-cache \
+    && find /app -exec touch -h -d "@${SOURCE_DATE_EPOCH}" {} +
 
 ENV PATH="/app/.venv/bin:/opt/hermes-agent/.venv/bin:${PATH}"
 


### PR DESCRIPTION
## Summary

- keep the uv cache outside the final OCI layers
- remove variable uv cache metadata from installed local distributions
- normalize the upstream Hermes environment in the layer that creates it

## Problem

Separate builds of the same Hermes source commit produced different OCI bytes. The uv cache used random archive directory names, and uv_cache.json stored build timestamps. A later release attempt then rejected the existing immutable build tag because its checksum differed.

## Validation

- two independent linux/amd64 OCI builds, including one with --no-cache, produced index digest 5062554fd72261886b09eb56702690999d42ba0dad6ebcecc9b6a0e1dcdd6c01
- OCI Dockerfile validator passed
- Hermes CLI smoke test passed
- Python package import smoke test passed
- Hermes test suite: 46 passed
- git diff --check

Refs MOT-4663

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved container build cache handling to reduce leftover temporary metadata.
  * Normalized timestamps independently across installed environments for more consistent build outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->