### PR TITLE
fix(quickstart): wait for asynchronous compose additions

### DIFF
--- a/.github/scripts/tests/test_quickstart_compose_operation.py
+++ b/.github/scripts/tests/test_quickstart_compose_operation.py
@@ -1,0 +1,164 @@
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+HELPER = ROOT / "harness" / "tests" / "quickstart" / "wait_for_compose_operation.py"
+SPEC = importlib.util.spec_from_file_location("wait_for_compose_operation", HELPER)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class Clock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def snapshot(operation_id: str, status: str, detail: str = "") -> dict:
+    return {
+        "operation_id": operation_id,
+        "status": status,
+        "last_event": {"detail": detail} if detail else None,
+    }
+
+
+def test_waits_through_running_until_succeeded():
+    operation_id = "compose:success"
+    responses = iter(
+        [
+            snapshot(operation_id, "running"),
+            snapshot(operation_id, "running"),
+            snapshot(operation_id, "succeeded", "workers are ready"),
+        ]
+    )
+    clock = Clock()
+
+    result = MODULE.wait_for_operation(
+        operation_id,
+        lambda _remaining: next(responses),
+        5,
+        poll_interval_seconds=0.25,
+        monotonic=clock.monotonic,
+        sleep=clock.sleep,
+    )
+
+    assert result["status"] == "succeeded"
+    assert clock.now == 0.5
+
+
+@pytest.mark.parametrize("status", ["failed", "cancelled"])
+def test_rejects_terminal_non_success_with_detail(status: str):
+    operation_id = f"compose:{status}"
+
+    with pytest.raises(
+        MODULE.ComposeOperationError, match=f"{status}: registry unavailable"
+    ) as raised:
+        MODULE.wait_for_operation(
+            operation_id,
+            lambda _remaining: snapshot(operation_id, status, "registry unavailable"),
+            5,
+        )
+
+    assert raised.value.snapshot["status"] == status
+
+
+def test_times_out_while_operation_remains_running():
+    operation_id = "compose:slow"
+    clock = Clock()
+
+    with pytest.raises(MODULE.ComposeOperationError, match="did not finish within 1s"):
+        MODULE.wait_for_operation(
+            operation_id,
+            lambda _remaining: snapshot(operation_id, "running"),
+            1,
+            poll_interval_seconds=0.25,
+            monotonic=clock.monotonic,
+            sleep=clock.sleep,
+        )
+
+    assert clock.now == 1
+
+
+def test_rejects_snapshot_for_a_different_operation():
+    with pytest.raises(MODULE.ComposeOperationError, match="correlation mismatch"):
+        MODULE.wait_for_operation(
+            "compose:expected",
+            lambda _remaining: snapshot("compose:other", "succeeded"),
+            5,
+        )
+
+
+def test_fetches_snapshot_through_compose_operation(monkeypatch):
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps(snapshot("compose:123", "running")),
+            stderr="",
+        )
+
+    monkeypatch.setattr(MODULE.subprocess, "run", fake_run)
+
+    result = MODULE.fetch_operation("/tmp/iii", 49134, "compose:123", 12)
+
+    assert result["status"] == "running"
+    assert calls == [
+        (
+            [
+                "/tmp/iii",
+                "trigger",
+                "compose::operation",
+                "--port",
+                "49134",
+                "--timeout-ms",
+                "10000",
+                "--json",
+                '{"operation_id":"compose:123"}',
+            ],
+            {
+                "check": False,
+                "capture_output": True,
+                "text": True,
+                "timeout": 10.0,
+            },
+        )
+    ]
+
+
+def test_reports_cli_failure_without_accepting_stdout(monkeypatch):
+    monkeypatch.setattr(
+        MODULE.subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            returncode=1,
+            stdout='{"status":"succeeded"}',
+            stderr="operation not found",
+        ),
+    )
+
+    with pytest.raises(MODULE.ComposeOperationError, match="operation not found"):
+        MODULE.fetch_operation("/tmp/iii", 49134, "compose:missing", 1)
+
+
+def test_reports_cli_timeout(monkeypatch):
+    def timeout(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired("iii", 1)
+
+    monkeypatch.setattr(MODULE.subprocess, "run", timeout)
+
+    with pytest.raises(MODULE.ComposeOperationError, match="timed out reading"):
+        MODULE.fetch_operation("/tmp/iii", 49134, "compose:slow", 1)

--- a/.github/scripts/tests/test_quickstart_workflow.py
+++ b/.github/scripts/tests/test_quickstart_workflow.py
@@ -85,3 +85,14 @@ def test_quickstart_enforces_latest_and_applies_provider_environment():
     assert 'router::provider::list' in script
     assert "unset ANTHROPIC_API_KEY OPENAI_API_KEY" in script
     assert 'ANTHROPIC_API_KEY="$anthropic_api_key" OPENAI_API_KEY="$openai_api_key"' in script
+
+
+def test_quickstart_waits_for_admitted_compose_add_operations():
+    script = (ROOT / "harness" / "tests" / "quickstart" / "run-ci.sh").read_text(
+        encoding="utf-8"
+    )
+    assert "ok)" in script
+    assert "accepted)" in script
+    assert ".operation_id // empty" in script
+    assert 'wait_for_compose_operation.py"' in script
+    assert '--operation-id "$operation_id"' in script

--- a/harness/tests/quickstart/README.md
+++ b/harness/tests/quickstart/README.md
@@ -14,7 +14,10 @@ iii trigger compose::add --json '{"file":"worker-compose.yaml","worker":"console
 The validator seeds a minimal `worker-compose.yaml` (`namespace: default`,
 empty `containers:`); each `compose::add` resolves the worker's registry
 graph, pins every container to an exact version in the file, and restarts
-the project.
+the project. It accepts the legacy synchronous `status: ok` response and, for
+newer CLIs, follows an admitted `status: accepted` operation through
+`compose::operation` until it succeeds. A failed, cancelled, or timed-out
+operation stops the quickstart before it inspects a partially reconciled stack.
 
 It verifies that:
 

--- a/harness/tests/quickstart/run-ci.sh
+++ b/harness/tests/quickstart/run-ci.sh
@@ -607,11 +607,12 @@ assert_secret_safe_artifacts() {
 }
 
 # Declares one worker (and everything the registry resolves for it) in the
-# compose file, then lets the daemon restart the project. The call is
-# synchronous: it returns after installs finish and every container reports
-# ready, so it carries the old `worker add` timeout.
+# compose file, then waits for the daemon to finish reconciling the project.
+# Older Compose releases answer synchronously with status "ok". Newer releases
+# admit the mutation with status "accepted" and expose its terminal snapshot
+# through compose::operation.
 run_compose_add() {
-  local spec=$1 payload response
+  local spec=$1 payload response status operation_id terminal_snapshot
   payload=$(jq -cn --arg file "$compose_file" --arg worker "$spec" \
     '{file: $file, worker: $worker}')
   # `iii trigger` waits only 30s for the invocation result by default, far
@@ -628,10 +629,33 @@ run_compose_add() {
       --timeout-ms "$((add_timeout_seconds * 1000))" --json "$payload")
   fi
   printf '%s\n' "$response"
-  # A container that failed to start comes back as JSON with status "failed",
-  # not as a non-zero exit; the exit code alone proves nothing.
-  jq -e '.status == "ok"' <<<"$response" >/dev/null 2>&1 \
-    || die "compose::add $spec did not report ok"
+  status=$(jq -r '.status // empty' <<<"$response" 2>/dev/null || true)
+  case "$status" in
+    ok)
+      # Legacy synchronous response: every declared worker is already ready.
+      return 0
+      ;;
+    accepted)
+      operation_id=$(jq -r '.operation_id // empty' <<<"$response" 2>/dev/null || true)
+      [[ -n "$operation_id" ]] \
+        || die "compose::add $spec was accepted without an operation_id"
+      log_command "iii trigger compose::operation --port $engine_port --json '{\"operation_id\":\"$operation_id\"}' (until terminal)"
+      if ! terminal_snapshot=$(python3 "$script_dir/wait_for_compose_operation.py" \
+        --iii-bin "$iii_bin" \
+        --engine-port "$engine_port" \
+        --operation-id "$operation_id" \
+        --timeout-seconds "$add_timeout_seconds"); then
+        [[ -z "$terminal_snapshot" ]] || printf '%s\n' "$terminal_snapshot"
+        die "compose::add $spec operation did not succeed"
+      fi
+      printf '%s\n' "$terminal_snapshot"
+      ;;
+    *)
+      # A synchronous lifecycle failure is JSON with status "failed", not a
+      # non-zero CLI exit. Unexpected or missing statuses are equally unsafe.
+      die "compose::add $spec returned status ${status:-missing}"
+      ;;
+  esac
 }
 
 run_compose_restart() {

--- a/harness/tests/quickstart/wait_for_compose_operation.py
+++ b/harness/tests/quickstart/wait_for_compose_operation.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Wait for an admitted Compose mutation to reach a terminal state."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from collections.abc import Callable
+from typing import Any
+
+
+Snapshot = dict[str, Any]
+FetchSnapshot = Callable[[float], Snapshot]
+
+
+class ComposeOperationError(RuntimeError):
+    """A Compose operation could not be observed through successful completion."""
+
+    def __init__(self, message: str, snapshot: Snapshot | None = None) -> None:
+        super().__init__(message)
+        self.snapshot = snapshot
+
+
+def terminal_detail(snapshot: Snapshot) -> str | None:
+    last_event = snapshot.get("last_event")
+    if not isinstance(last_event, dict):
+        return None
+    detail = last_event.get("detail")
+    return detail if isinstance(detail, str) and detail else None
+
+
+def wait_for_operation(
+    operation_id: str,
+    fetch_snapshot: FetchSnapshot,
+    timeout_seconds: float,
+    *,
+    poll_interval_seconds: float = 0.2,
+    monotonic: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+) -> Snapshot:
+    """Poll an operation snapshot until it succeeds or reaches another terminal state."""
+
+    if timeout_seconds <= 0:
+        raise ValueError("timeout_seconds must be positive")
+    if poll_interval_seconds <= 0:
+        raise ValueError("poll_interval_seconds must be positive")
+
+    deadline = monotonic() + timeout_seconds
+    while True:
+        remaining = deadline - monotonic()
+        if remaining <= 0:
+            raise ComposeOperationError(
+                f"compose operation {operation_id} did not finish within {timeout_seconds:g}s"
+            )
+
+        snapshot = fetch_snapshot(remaining)
+        observed_id = snapshot.get("operation_id")
+        if observed_id != operation_id:
+            raise ComposeOperationError(
+                f"compose operation correlation mismatch: expected {operation_id}, got {observed_id!r}",
+                snapshot,
+            )
+
+        status = snapshot.get("status")
+        if status == "succeeded":
+            return snapshot
+        if status in {"failed", "cancelled"}:
+            detail = terminal_detail(snapshot)
+            suffix = f": {detail}" if detail else ""
+            raise ComposeOperationError(
+                f"compose operation {operation_id} {status}{suffix}", snapshot
+            )
+        if status != "running":
+            raise ComposeOperationError(
+                f"compose operation {operation_id} returned unexpected status {status!r}",
+                snapshot,
+            )
+
+        sleep(min(poll_interval_seconds, max(0.0, deadline - monotonic())))
+
+
+def fetch_operation(
+    iii_bin: str, engine_port: int, operation_id: str, remaining_seconds: float
+) -> Snapshot:
+    """Read one operation snapshot through the published CLI."""
+
+    request_timeout_seconds = max(0.1, min(10.0, remaining_seconds))
+    request_timeout_ms = max(1, int(request_timeout_seconds * 1_000))
+    payload = json.dumps({"operation_id": operation_id}, separators=(",", ":"))
+    try:
+        completed = subprocess.run(
+            [
+                iii_bin,
+                "trigger",
+                "compose::operation",
+                "--port",
+                str(engine_port),
+                "--timeout-ms",
+                str(request_timeout_ms),
+                "--json",
+                payload,
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=request_timeout_seconds,
+        )
+    except subprocess.TimeoutExpired as error:
+        raise ComposeOperationError(
+            f"timed out reading compose operation {operation_id}"
+        ) from error
+
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip() or "no CLI output"
+        raise ComposeOperationError(
+            f"could not read compose operation {operation_id}: {detail}"
+        )
+
+    try:
+        snapshot = json.loads(completed.stdout)
+    except json.JSONDecodeError as error:
+        raise ComposeOperationError(
+            f"compose operation {operation_id} returned invalid JSON: {error.msg}"
+        ) from error
+    if not isinstance(snapshot, dict):
+        raise ComposeOperationError(
+            f"compose operation {operation_id} returned a non-object snapshot"
+        )
+    return snapshot
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--iii-bin", required=True)
+    parser.add_argument("--engine-port", required=True, type=int)
+    parser.add_argument("--operation-id", required=True)
+    parser.add_argument("--timeout-seconds", required=True, type=float)
+    args = parser.parse_args()
+
+    try:
+        snapshot = wait_for_operation(
+            args.operation_id,
+            lambda remaining: fetch_operation(
+                args.iii_bin, args.engine_port, args.operation_id, remaining
+            ),
+            args.timeout_seconds,
+        )
+    except (ComposeOperationError, ValueError) as error:
+        if isinstance(error, ComposeOperationError) and error.snapshot is not None:
+            print(json.dumps(error.snapshot, indent=2, sort_keys=True))
+        print(f"[FAIL] {error}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(snapshot, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Accept both the legacy synchronous `status: "ok"` response and the asynchronous `status: "accepted"` response from `compose::add`.
- Poll the exact `compose::operation` until it succeeds, and stop on failure, cancellation, an unexpected status, correlation mismatch, or timeout.
- Preserve terminal snapshots in the QuickStart logs and cover the compatibility and terminal-state behavior with focused tests.

## Root cause

`iii 0.23.1-rc.1` changed `compose::add` from a synchronous terminal response to an asynchronous admission response. The QuickStart validator still required `.status == "ok"`, so it exited immediately after admission and before worker or browser validation began.

Failed run: https://github.com/iii-hq/workers/actions/runs/33839166677

Refs iii-hq/iii#2132

## Testing

- `bash -n harness/tests/quickstart/run-ci.sh`
- `python3 -m pytest .github/scripts/tests/ -q` (`272 passed, 3 subtests passed`)
- `git diff --check origin/main...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quickstart validation now supports both synchronous Compose responses and asynchronous operations.
  * Accepted Compose operations are monitored until completion, with clear handling for success, failure, cancellation, timeouts, and invalid responses.

* **Bug Fixes**
  * Prevented quickstart validation from continuing when Compose operations fail or only partially reconcile a stack.

* **Documentation**
  * Updated quickstart documentation to explain asynchronous Compose operation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->