### PR TITLE
feat(console): open the function document on its contract

### DIFF
--- a/console/ui/src/catalog/FunctionsPage.tsx
+++ b/console/ui/src/catalog/FunctionsPage.tsx
@@ -3,7 +3,12 @@
  * function on the bus — each row led by the `ƒ` tile, grouped by the worker
  * that registered it — and a workspace that is always present: a hero when
  * nothing is selected, the function document (breadcrumb, identity head,
- * overview/invoke/input/output/triggers/activity tabs) when one is.
+ * overview/invoke/triggers/activity tabs) when one is.
+ *
+ * The document opens on the overview, and the overview is the contract:
+ * input schema, output schema, metadata. Selecting a function used to land
+ * on the invoke editor, which showed a name, a description, and a JSON box —
+ * nothing about the fields that box wanted.
  *
  * Live, never polled. `engine::functions-available` fires whenever functions
  * are registered or unregistered, so a worker connecting or dying is visible
@@ -380,12 +385,12 @@ export function FunctionsPage({
             body="select a function from the sidebar to understand its contract, test it, and follow its recent calls. the catalog updates whenever workers connect or disconnect."
             items={[
               {
-                label: 'overview',
-                value: 'ownership, runtime, triggers, and metadata',
+                label: 'contract',
+                value: 'input and output schemas in a readable field table',
               },
               {
-                label: 'contracts',
-                value: 'input and output schemas in a readable field table',
+                label: 'bindings',
+                value: 'the triggers that fire it, and who registered it',
               },
               {
                 label: 'test',
@@ -421,11 +426,14 @@ function FunctionDocument({
     [host, functionId],
   )
   const detail = useResource(load)
-  const [tab, setTab] = useState('invoke')
+  // Selecting a function opens on its contract, not on the editor: the first
+  // question an operator has is what the function takes and returns, and a
+  // JSON box answers neither. `run function` is one click away in the head.
+  const [tab, setTab] = useState('overview')
   const [prefill, setPrefill] = useState<{ value: unknown; nonce: number }>()
 
   useEffect(() => {
-    setTab('invoke')
+    setTab('overview')
     setPrefill(undefined)
   }, [functionId])
 
@@ -512,8 +520,6 @@ function FunctionDocument({
             <TabsList>
               <TabsTrigger value="overview">Overview</TabsTrigger>
               <TabsTrigger value="invoke">Trigger</TabsTrigger>
-              <TabsTrigger value="input">Input</TabsTrigger>
-              <TabsTrigger value="output">Output</TabsTrigger>
               <TabsTrigger value="triggers">
                 Triggers
                 {detail.data.registered_triggers.length > 0 ? (
@@ -534,18 +540,6 @@ function FunctionDocument({
                 label="run function"
                 runningLabel="running…"
                 runRef={invokeRunRef}
-              />
-            </TabsContent>
-            <TabsContent value="input">
-              <SchemaTable
-                schema={detail.data.request_schema}
-                empty="This function registered no input schema."
-              />
-            </TabsContent>
-            <TabsContent value="output">
-              <SchemaTable
-                schema={detail.data.response_schema}
-                empty="This function registered no output schema."
               />
             </TabsContent>
             <TabsContent value="triggers">
@@ -677,9 +671,13 @@ function FunctionContext({
 }
 
 /**
- * Function identity and contract facts already live in the contextual rail.
- * The overview is reserved for extra metadata so it never repeats that same
- * fact sheet in the main work surface.
+ * The function's contract, which is what the operator came to read: the input
+ * fields a caller must supply, then the shape that comes back, then whatever
+ * metadata the worker attached.
+ *
+ * Identity facts (id, worker, language) stay in the contextual rail so this
+ * surface never repeats them. The rail's "input schema: defined" line is a
+ * yes/no; this is the answer to what those fields actually are.
  */
 function FunctionOverview({ detail }: { detail: FunctionDetail }) {
   const hasMetadata =
@@ -689,17 +687,29 @@ function FunctionOverview({ detail }: { detail: FunctionDetail }) {
       Array.isArray(detail.metadata) ||
       Object.keys(detail.metadata).length > 0)
 
-  return hasMetadata ? (
+  return (
     <div className="console-catalog-overview">
-      <span className="console-catalog-field-label">Metadata</span>
-      <JsonHighlight
-        code={pretty(detail.metadata)}
-        className="console-catalog-json"
-        wrap
+      <span className="console-catalog-field-label">Input schema</span>
+      <SchemaTable
+        schema={detail.request_schema}
+        empty="This function registered no input schema."
       />
+      <span className="console-catalog-field-label">Output schema</span>
+      <SchemaTable
+        schema={detail.response_schema}
+        empty="This function registered no output schema."
+      />
+      {hasMetadata ? (
+        <>
+          <span className="console-catalog-field-label">Metadata</span>
+          <JsonHighlight
+            code={pretty(detail.metadata)}
+            className="console-catalog-json"
+            wrap
+          />
+        </>
+      ) : null}
     </div>
-  ) : (
-    <Note>This function registered no additional metadata.</Note>
   )
 }
 

--- a/console/ui/src/catalog/SchemaTable.tsx
+++ b/console/ui/src/catalog/SchemaTable.tsx
@@ -2,8 +2,9 @@
  * A JSON Schema as a field table: name, type, required, default, and the
  * schema's own description, nested objects indented under their parent.
  *
- * The raw schema stays one tab away for the cases this cannot express
- * (`oneOf` unions, `$ref` chains, custom keywords). This view exists because
+ * A schema this cannot flatten into fields (`oneOf` unions, `$ref` chains,
+ * custom keywords) falls back to the raw draft-07 JSON rather than to an
+ * empty table — see the `rows.length === 0` branch. This view exists because
  * an operator reading "what does this function take" should not have to parse
  * draft-07 by eye — the same reason the registry site renders functions as
  * docs rather than as JSON.


### PR DESCRIPTION
Selecting a function in the Functions catalog landed on the invoke editor: a name, a description, and a JSON box, with nothing on screen about the fields that box expects or the shape that comes back. The input and output schemas were a tab click away, and the contextual rail only answered "defined" or "none".

Fold the Input and Output tabs into Overview and open the document there, so the contract is the first thing on the work surface. Overview now renders the input schema, the output schema, and any registered metadata; the tab strip drops from six entries to four; `run function` in the identity head still switches to the editor in one click.

No new styles: the section labels and the overview column reuse the existing `console-catalog-field-label` and `console-catalog-overview` rules, and the field tables are the same `SchemaTable` the two removed tabs rendered.

Verified against a live engine (iii 0.23.0) with the `shell` worker registered: selecting `shell::fs::ls` opens on Overview with the `LsRequest` and `LsResponse` field tables, and the tab strip reads Overview / Trigger / Triggers / Activity.

After overview:
<img width="3200" height="2000" alt="after-overview" src="https://github.com/user-attachments/assets/ca5da6f2-f592-4271-b4d1-a5ff71cb7906" />

Metadata function:
<img width="3200" height="2000" alt="metadata-fn" src="https://github.com/user-attachments/assets/0127e2b0-8c6f-4d9e-a944-cf58b96bb796" />

Trigger tab:
<img width="3200" height="2000" alt="trigger-tab" src="https://github.com/user-attachments/assets/f4248df0-75b2-4838-a057-ad1182de2a1e" />


**Only validated on iii 0.23.0** - Needs testing on older versions for backward compatibility.

I verified some dead code is actually dead and removed it. This works on 0.23.0, but I'm suspicious older versions rely on this api.

Closes #223 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Experience**
  * Selecting a function now opens its Overview tab by default.
  * The Overview displays the function contract, including input schema, output schema, and metadata.
  * Removed the separate Input and Output tabs from the function view.
  * Updated interface copy to clarify that the Overview represents the function’s contract.

* **Documentation**
  * Clarified that schemas that cannot be represented as fields display their raw JSON schema instead of an empty table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->