### PR TITLE
(MOT-4694) fix(console): show http-trigger status codes (incl. redirects) in Send Request

### DIFF
--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -40,6 +40,8 @@ tower = "0.5"
 tower-http = { version = "0.6", features = ["set-header"] }
 tokio-tungstenite = { version = "0.24", features = ["rustls-tls-native-roots"] }
 futures-util = "0.3"
+# Server-side client for `POST /probe` (reads a redirect's real status).
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 
 # Embed web/dist
 rust-embed = { version = "8", features = ["interpolate-folder-path"] }
@@ -49,6 +51,5 @@ mime_guess = "2"
 serde_json = "1"
 which = "8"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "signal"] }
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 tokio-tungstenite = { version = "0.24", features = ["rustls-tls-native-roots"] }
 futures-util = "0.3"

--- a/console/src/configuration.rs
+++ b/console/src/configuration.rs
@@ -587,7 +587,7 @@ mod tests {
     #[tokio::test]
     async fn rebind_starts_new_port_before_stopping_old_listener() {
         let (old_port, new_port) = two_free_ports();
-        let state = AppState::new(Arc::new("ws://127.0.0.1:1".to_string()), None, None);
+        let state = AppState::new(Arc::new("ws://127.0.0.1:1".to_string()), None, None, None);
         let handle = server::start(old_port, state.clone()).await.unwrap();
         let port = new_port_cell(old_port);
 
@@ -610,7 +610,7 @@ mod tests {
         let occupied = tokio::net::TcpListener::bind(("0.0.0.0", occupied_port))
             .await
             .unwrap();
-        let state = AppState::new(Arc::new("ws://127.0.0.1:1".to_string()), None, None);
+        let state = AppState::new(Arc::new("ws://127.0.0.1:1".to_string()), None, None, None);
         let handle = server::start(old_port, state.clone()).await.unwrap();
         let port = new_port_cell(old_port);
 

--- a/console/src/lib.rs
+++ b/console/src/lib.rs
@@ -6,6 +6,7 @@ pub mod config;
 pub mod configuration;
 pub mod functions;
 pub mod manifest;
+pub mod probe;
 pub mod proxy;
 pub mod server;
 pub mod ui;

--- a/console/src/main.rs
+++ b/console/src/main.rs
@@ -155,7 +155,7 @@ async fn main() -> Result<()> {
     }
 
     let engine_url_redacted = redact_url(&engine_url);
-    let state = server::AppState::new(Arc::new(engine_url), iii.namespace(), ui);
+    let state = server::AppState::new(Arc::new(engine_url), iii.namespace(), ui, Some(iii.clone()));
     let server_handle = server::start(cfg.http_port, state.clone()).await?;
     let apply_lock: configuration::ApplyLock = Arc::new(tokio::sync::Mutex::new(()));
 

--- a/console/src/probe.rs
+++ b/console/src/probe.rs
@@ -70,14 +70,25 @@ fn validate(method: &str, path: &str) -> Result<String, String> {
 }
 
 fn bad_request(message: impl Into<String>) -> Response {
-    (StatusCode::BAD_REQUEST, Json(json!({ "error": message.into() }))).into_response()
+    (
+        StatusCode::BAD_REQUEST,
+        Json(json!({ "error": message.into() })),
+    )
+        .into_response()
 }
 
 fn upstream_error(message: impl Into<String>) -> Response {
-    (StatusCode::BAD_GATEWAY, Json(json!({ "error": message.into() }))).into_response()
+    (
+        StatusCode::BAD_GATEWAY,
+        Json(json!({ "error": message.into() })),
+    )
+        .into_response()
 }
 
-pub async fn probe_handler(State(state): State<AppState>, Json(req): Json<ProbeRequest>) -> Response {
+pub async fn probe_handler(
+    State(state): State<AppState>,
+    Json(req): Json<ProbeRequest>,
+) -> Response {
     let Some(iii) = state.iii.clone() else {
         return upstream_error("probe is unavailable: no engine client");
     };
@@ -114,7 +125,7 @@ pub async fn probe_handler(State(state): State<AppState>, Json(req): Json<ProbeR
         builder = builder.body(body);
     }
 
-    let response = match builder.send().await {
+    let mut response = match builder.send().await {
         Ok(response) => response,
         Err(error) => return upstream_error(format!("request to {url} failed: {error}")),
     };
@@ -130,10 +141,21 @@ pub async fn probe_handler(State(state): State<AppState>, Json(req): Json<ProbeR
         .get(reqwest::header::CONTENT_TYPE)
         .and_then(|v| v.to_str().ok())
         .map(str::to_owned);
-    let mut body = response.text().await.unwrap_or_default();
-    if body.len() > MAX_BODY_BYTES {
-        body.truncate(MAX_BODY_BYTES);
+    // Read chunk by chunk and stop at the cap, so a large or fast upstream
+    // cannot exhaust console memory. `from_utf8_lossy` decodes the bounded
+    // buffer safely even when the cap lands inside a multibyte character.
+    // End of body, or a mid-stream read error, ends the loop: a partial body
+    // is an acceptable probe result — the status is what the panel needs.
+    let mut bytes: Vec<u8> = Vec::new();
+    while let Ok(Some(chunk)) = response.chunk().await {
+        let room = MAX_BODY_BYTES - bytes.len();
+        if chunk.len() >= room {
+            bytes.extend_from_slice(&chunk[..room]);
+            break;
+        }
+        bytes.extend_from_slice(&chunk);
     }
+    let body = String::from_utf8_lossy(&bytes).into_owned();
 
     Json(json!({
         "status": status,
@@ -170,7 +192,10 @@ async fn resolve_http_base(
         let Some(port) = value.get("port").and_then(Value::as_u64) else {
             continue;
         };
-        let host = value.get("host").and_then(Value::as_str).unwrap_or("127.0.0.1");
+        let host = value
+            .get("host")
+            .and_then(Value::as_str)
+            .unwrap_or("127.0.0.1");
         // The console runs beside the HTTP worker, so a wildcard/loopback bind
         // is always reachable at 127.0.0.1 — and that sidesteps the LAN
         // hostname rewrite the browser needed when it made the call itself.

--- a/console/src/probe.rs
+++ b/console/src/probe.rs
@@ -29,6 +29,13 @@ use crate::server::AppState;
 /// is built.
 const ALLOWED_METHODS: &[&str] = &["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"];
 
+/// Request headers this interface will forward. The panel only sets a content
+/// type; the rest are non-credential, non-sensitive request headers a tester
+/// might reasonably add. Anything outside this set is rejected rather than
+/// forwarded — a caller must never be able to push `Authorization`, `Cookie`,
+/// or the like over the plaintext hop to the HTTP worker.
+const ALLOWED_HEADERS: &[&str] = &["content-type", "accept", "accept-language"];
+
 /// Matches the HTTP worker's own `default_timeout`.
 const PROBE_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -69,6 +76,19 @@ fn validate(method: &str, path: &str) -> Result<String, String> {
     Ok(method)
 }
 
+/// Turn a configured bind host into a URL authority host. The console runs
+/// beside the HTTP worker, so a wildcard/loopback bind (v4 or v6) is always
+/// reachable at 127.0.0.1 — and that sidesteps the LAN hostname rewrite the
+/// browser needed when it made the call itself. A real IPv6 literal must be
+/// bracketed to be a valid URL authority.
+fn normalize_host(host: &str) -> String {
+    match host {
+        "0.0.0.0" | "localhost" | "" | "::" | "::1" => "127.0.0.1".to_string(),
+        other if other.contains(':') => format!("[{other}]"),
+        other => other.to_string(),
+    }
+}
+
 fn bad_request(message: impl Into<String>) -> Response {
     (
         StatusCode::BAD_REQUEST,
@@ -97,6 +117,11 @@ pub async fn probe_handler(
         Ok(method) => method,
         Err(message) => return bad_request(message),
     };
+    for name in req.headers.keys() {
+        if !ALLOWED_HEADERS.contains(&name.to_ascii_lowercase().as_str()) {
+            return bad_request(format!("header not allowed on this interface: {name}"));
+        }
+    }
 
     let base = match resolve_http_base(&iii, state.namespace.as_deref()).await {
         Ok(base) => base,
@@ -196,21 +221,26 @@ async fn resolve_http_base(
             .get("host")
             .and_then(Value::as_str)
             .unwrap_or("127.0.0.1");
-        // The console runs beside the HTTP worker, so a wildcard/loopback bind
-        // is always reachable at 127.0.0.1 — and that sidesteps the LAN
-        // hostname rewrite the browser needed when it made the call itself.
-        let host = match host {
-            "0.0.0.0" | "localhost" | "" => "127.0.0.1",
-            other => other,
-        };
-        return Ok(format!("http://{host}:{port}"));
+        return Ok(format!("http://{}:{port}", normalize_host(host)));
     }
     Err("no http worker configuration with a port found".to_string())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::validate;
+    use super::{normalize_host, validate};
+
+    #[test]
+    fn normalizes_hosts_for_url_authorities() {
+        for wildcard in ["0.0.0.0", "localhost", "", "::", "::1"] {
+            assert_eq!(normalize_host(wildcard), "127.0.0.1");
+        }
+        // A real IPv6 literal is bracketed so `http://<host>:<port>` parses.
+        assert_eq!(normalize_host("fe80::1"), "[fe80::1]");
+        // A plain v4 or hostname is passed through untouched.
+        assert_eq!(normalize_host("10.0.0.4"), "10.0.0.4");
+        assert_eq!(normalize_host("http.internal"), "http.internal");
+    }
 
     #[test]
     fn accepts_catalog_methods_and_normal_paths() {

--- a/console/src/probe.rs
+++ b/console/src/probe.rs
@@ -1,0 +1,207 @@
+//! `POST /probe` — run a trigger-catalog test request from the console
+//! process instead of the browser tab.
+//!
+//! A browser `fetch` cannot show a redirect's status code: following the 3xx
+//! lands on the (often cross-origin) target and trips CORS, while
+//! `redirect: 'manual'` yields an opaque `status: 0`. Making the request
+//! server-side reads the real status (302 and its `Location` included) and
+//! returns it same-origin, so the panel renders `302` exactly like `200`.
+//!
+//! SSRF note: the request body carries only the method, path, and body. The
+//! target host and port are resolved server-side from the HTTP worker's own
+//! configuration entry — never taken from the caller — so `/probe` can reach
+//! only that worker, not an arbitrary address the console can see.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use iii_sdk::protocol::TriggerRequest;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::server::AppState;
+
+/// The catalog's own method set; anything else is rejected before a request
+/// is built.
+const ALLOWED_METHODS: &[&str] = &["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"];
+
+/// Matches the HTTP worker's own `default_timeout`.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Cap the returned body so a large endpoint response cannot balloon the
+/// panel; the catalog only needs enough to confirm the shape.
+const MAX_BODY_BYTES: usize = 1_000_000;
+
+#[derive(Deserialize)]
+pub struct ProbeRequest {
+    method: String,
+    /// The part after the base URL, e.g. `/s/home?x=1`. Must start with a
+    /// single `/`; the host and port are never taken from the caller.
+    path: String,
+    #[serde(default)]
+    headers: HashMap<String, String>,
+    #[serde(default)]
+    body: Option<String>,
+}
+
+/// Validate the caller-supplied method and path, returning the normalized
+/// method. The path is concatenated straight after the server-chosen
+/// `host:port`, so it must be path-only: a leading `//` is a protocol-relative
+/// authority, and anything not starting with `/` could carry its own
+/// scheme/host — either would let a caller steer the request off the HTTP
+/// worker (SSRF). Whitespace and control characters are rejected for the same
+/// reason.
+fn validate(method: &str, path: &str) -> Result<String, String> {
+    let method = method.to_ascii_uppercase();
+    if !ALLOWED_METHODS.contains(&method.as_str()) {
+        return Err(format!("method not allowed: {method}"));
+    }
+    if !path.starts_with('/') || path.starts_with("//") {
+        return Err("path must start with a single '/'".to_string());
+    }
+    if path.chars().any(|c| c.is_control() || c == ' ') {
+        return Err("path contains whitespace or control characters".to_string());
+    }
+    Ok(method)
+}
+
+fn bad_request(message: impl Into<String>) -> Response {
+    (StatusCode::BAD_REQUEST, Json(json!({ "error": message.into() }))).into_response()
+}
+
+fn upstream_error(message: impl Into<String>) -> Response {
+    (StatusCode::BAD_GATEWAY, Json(json!({ "error": message.into() }))).into_response()
+}
+
+pub async fn probe_handler(State(state): State<AppState>, Json(req): Json<ProbeRequest>) -> Response {
+    let Some(iii) = state.iii.clone() else {
+        return upstream_error("probe is unavailable: no engine client");
+    };
+
+    let method = match validate(&req.method, &req.path) {
+        Ok(method) => method,
+        Err(message) => return bad_request(message),
+    };
+
+    let base = match resolve_http_base(&iii, state.namespace.as_deref()).await {
+        Ok(base) => base,
+        Err(message) => return upstream_error(message),
+    };
+    let url = format!("{base}{}", req.path);
+
+    let client = match reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .timeout(PROBE_TIMEOUT)
+        .build()
+    {
+        Ok(client) => client,
+        Err(error) => return upstream_error(format!("http client init failed: {error}")),
+    };
+
+    let reqwest_method = match reqwest::Method::from_bytes(method.as_bytes()) {
+        Ok(method) => method,
+        Err(_) => return bad_request(format!("invalid method: {method}")),
+    };
+    let mut builder = client.request(reqwest_method, &url);
+    for (name, value) in &req.headers {
+        builder = builder.header(name, value);
+    }
+    if let Some(body) = req.body {
+        builder = builder.body(body);
+    }
+
+    let response = match builder.send().await {
+        Ok(response) => response,
+        Err(error) => return upstream_error(format!("request to {url} failed: {error}")),
+    };
+
+    let status = response.status().as_u16();
+    let location = response
+        .headers()
+        .get(reqwest::header::LOCATION)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned);
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned);
+    let mut body = response.text().await.unwrap_or_default();
+    if body.len() > MAX_BODY_BYTES {
+        body.truncate(MAX_BODY_BYTES);
+    }
+
+    Json(json!({
+        "status": status,
+        "location": location,
+        "contentType": content_type,
+        "body": body,
+    }))
+    .into_response()
+}
+
+/// Read the HTTP worker's `host`/`port` from its configuration entry, in the
+/// console's own namespace, and build its base URL. Mirrors the panel's
+/// former client-side resolution; `http` is the current worker id and
+/// `iii-http` its deprecated predecessor.
+async fn resolve_http_base(
+    iii: &iii_sdk::IIIClient,
+    namespace: Option<&str>,
+) -> Result<String, String> {
+    // The HTTP worker's config lives in the console's operating namespace;
+    // fall back to "default" when the console runs without one.
+    let namespace = namespace.unwrap_or("default");
+    for id in ["http", "iii-http"] {
+        let request = TriggerRequest {
+            function_id: "configuration::get".to_string(),
+            payload: json!({ "id": id }),
+            action: None,
+            timeout_ms: Some(5000),
+        }
+        .namespace(namespace);
+        let Ok(entry) = iii.trigger(request).await else {
+            continue;
+        };
+        let value = entry.get("value").unwrap_or(&Value::Null);
+        let Some(port) = value.get("port").and_then(Value::as_u64) else {
+            continue;
+        };
+        let host = value.get("host").and_then(Value::as_str).unwrap_or("127.0.0.1");
+        // The console runs beside the HTTP worker, so a wildcard/loopback bind
+        // is always reachable at 127.0.0.1 — and that sidesteps the LAN
+        // hostname rewrite the browser needed when it made the call itself.
+        let host = match host {
+            "0.0.0.0" | "localhost" | "" => "127.0.0.1",
+            other => other,
+        };
+        return Ok(format!("http://{host}:{port}"));
+    }
+    Err("no http worker configuration with a port found".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate;
+
+    #[test]
+    fn accepts_catalog_methods_and_normal_paths() {
+        assert_eq!(validate("get", "/s/home").unwrap(), "GET");
+        assert_eq!(validate("POST", "/links?x=1").unwrap(), "POST");
+        // A funny-looking but host-safe path stays on the http worker.
+        assert!(validate("GET", "/@evil.com/x").is_ok());
+    }
+
+    #[test]
+    fn rejects_off_worker_paths_and_bad_methods() {
+        assert!(validate("GET", "//evil.com/").is_err()); // protocol-relative authority
+        assert!(validate("GET", "https://evil.com").is_err()); // own scheme/host
+        assert!(validate("GET", "s/home").is_err()); // no leading slash
+        assert!(validate("GET", "/a b").is_err()); // whitespace
+        assert!(validate("GET", "/a\nb").is_err()); // control char
+        assert!(validate("TRACE", "/s/home").is_err()); // method not in the set
+    }
+}

--- a/console/src/server.rs
+++ b/console/src/server.rs
@@ -20,8 +20,10 @@ use tokio::sync::{oneshot, Mutex};
 use tokio::task::{AbortHandle, JoinHandle};
 use tower_http::set_header::SetResponseHeaderLayer;
 
+use iii_sdk::IIIClient;
+
 use crate::ui_assets::UiRegistry;
-use crate::{assets, proxy};
+use crate::{assets, probe, proxy};
 
 /// Grace period before a superseded listener is hard-aborted. Graceful
 /// shutdown is the primary path; the abort only bounds how long a stuck
@@ -70,6 +72,9 @@ pub struct AppState {
     pub engine_url: Arc<String>,
     pub namespace: Option<String>,
     pub ui: Option<Arc<UiRegistry>>,
+    /// Engine client used by `POST /probe` to resolve the HTTP worker's
+    /// address. `None` in unit tests, which do not mount `/probe`.
+    pub iii: Option<Arc<IIIClient>>,
 }
 
 impl AppState {
@@ -77,11 +82,13 @@ impl AppState {
         engine_url: Arc<String>,
         namespace: Option<String>,
         ui: Option<Arc<UiRegistry>>,
+        iii: Option<Arc<IIIClient>>,
     ) -> Self {
         Self {
             engine_url,
             namespace,
             ui,
+            iii,
         }
     }
 }
@@ -104,6 +111,14 @@ pub fn router(state: AppState) -> Router {
         .route("/assets/*path", get(assets::asset_handler))
         .route("/runtime", get(runtime_handler))
         .route("/ws", get(proxy::ws_proxy));
+
+    // `/probe` runs the trigger-catalog test request server-side so the panel
+    // can read a redirect's real status (302 etc.) — a browser `fetch` cannot.
+    // Only mounted when an engine client is present; the target host is derived
+    // server-side, never taken from the request, so it cannot be an SSRF lever.
+    if state.iii.is_some() {
+        router = router.route("/probe", axum::routing::post(probe::probe_handler));
+    }
 
     if state.ui.is_some() {
         router = router
@@ -312,6 +327,7 @@ mod tests {
                 Arc::new("ws://127.0.0.1:1".to_string()),
                 Some("project-a".to_string()),
                 Some(ui.clone()),
+                None,
             ),
             ui,
         )
@@ -400,7 +416,7 @@ mod tests {
 
     #[tokio::test]
     async fn kill_switch_removes_ui_routes() {
-        let state = AppState::new(Arc::new("ws://127.0.0.1:1".to_string()), None, None);
+        let state = AppState::new(Arc::new("ws://127.0.0.1:1".to_string()), None, None, None);
         let response = get_response(router(state.clone()), "/ui", &[]).await;
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
         let response = get_response(router(state), "/vendor/react.js", &[]).await;
@@ -409,7 +425,7 @@ mod tests {
 
     #[tokio::test]
     async fn every_http_response_carries_defensive_browser_headers() {
-        let state = AppState::new(Arc::new("ws://127.0.0.1:1".to_string()), None, None);
+        let state = AppState::new(Arc::new("ws://127.0.0.1:1".to_string()), None, None, None);
         for uri in ["/", "/missing"] {
             let response = get_response(router(state.clone()), uri, &[]).await;
             assert_eq!(

--- a/console/tests/integration.rs
+++ b/console/tests/integration.rs
@@ -380,7 +380,7 @@ async fn ws_proxy_forwards_oversized_engine_message() {
     let (bound_tx, bound_rx) = tokio::sync::oneshot::channel();
     tokio::spawn(console::server::serve(
         0,
-        console::server::AppState::new(engine_url, None, None),
+        console::server::AppState::new(engine_url, None, None, None),
         shutdown_rx,
         Some(bound_tx),
     ));

--- a/console/ui/src/catalog/HttpTester.tsx
+++ b/console/ui/src/catalog/HttpTester.tsx
@@ -81,6 +81,10 @@ interface Outcome {
   durationMs: number
   body: string
   error?: string
+  // The endpoint answered with a cross-origin redirect. The browser will not
+  // reveal the target or the redirect's status code (302 etc.), so this is the
+  // honest ceiling: the trigger fired and redirected, we just can't read where.
+  redirected?: boolean
 }
 
 export function HttpTester({
@@ -142,7 +146,9 @@ export function HttpTester({
       setOutcome(null)
       return
     }
-    const init: RequestInit = { method }
+    // `manual` so a redirect returns an opaque response instead of the browser
+    // following it cross-origin and throwing an unreadable "Failed to fetch".
+    const init: RequestInit = { method, redirect: 'manual' }
     if (BODY_METHODS.has(method)) {
       try {
         JSON.parse(body)
@@ -159,6 +165,18 @@ export function HttpTester({
     const started = performance.now()
     try {
       const response = await fetch(url, init)
+      // A cross-origin redirect comes back opaque: status 0, body unreadable.
+      // Report it as the redirect it is, not a failure.
+      if (response.type === 'opaqueredirect') {
+        setOutcome({
+          ok: true,
+          status: null,
+          durationMs: performance.now() - started,
+          body: '',
+          redirected: true,
+        })
+        return
+      }
       const text = await response.text()
       const contentType = response.headers.get('content-type') ?? ''
       setOutcome({
@@ -317,7 +335,8 @@ export function HttpTester({
               outcome.ok ? 'console-catalog-ok' : 'console-catalog-invalid'
             }
           >
-            {outcome.status ?? 'failed'} · {Math.round(outcome.durationMs)}ms
+            {outcome.redirected ? 'redirected' : (outcome.status ?? 'failed')} ·{' '}
+            {Math.round(outcome.durationMs)}ms
           </span>
         ) : null}
       </div>
@@ -325,7 +344,14 @@ export function HttpTester({
       {outcome?.error ? (
         <div className="console-catalog-error">{outcome.error}</div>
       ) : null}
-      {outcome && !outcome.error ? (
+      {outcome?.redirected ? (
+        <Note>
+          The endpoint answered with a redirect to another origin. The browser
+          hides the target and its status code, so the response cannot be read
+          here, but the trigger fired and redirected as intended.
+        </Note>
+      ) : null}
+      {outcome && !outcome.error && !outcome.redirected ? (
         <JsonHighlight
           code={outcome.body || '(empty response)'}
           className="console-catalog-result"

--- a/console/ui/src/catalog/HttpTester.tsx
+++ b/console/ui/src/catalog/HttpTester.tsx
@@ -81,9 +81,10 @@ interface Outcome {
   durationMs: number
   body: string
   error?: string
-  // The endpoint answered with a cross-origin redirect. The browser will not
-  // reveal the target or the redirect's status code (302 etc.), so this is the
-  // honest ceiling: the trigger fired and redirected, we just can't read where.
+  // The endpoint answered with a redirect. Under `redirect: 'manual'` the
+  // browser returns it opaque — no target, no status code (302 etc.), same
+  // origin or not — so this is the honest ceiling: the trigger fired and
+  // redirected, we just can't read where.
   redirected?: boolean
 }
 
@@ -165,8 +166,8 @@ export function HttpTester({
     const started = performance.now()
     try {
       const response = await fetch(url, init)
-      // A cross-origin redirect comes back opaque: status 0, body unreadable.
-      // Report it as the redirect it is, not a failure.
+      // A redirect comes back opaque under `manual`: status 0, body
+      // unreadable. Report it as the redirect it is, not a failure.
       if (response.type === 'opaqueredirect') {
         setOutcome({
           ok: true,
@@ -346,9 +347,9 @@ export function HttpTester({
       ) : null}
       {outcome?.redirected ? (
         <Note>
-          The endpoint answered with a redirect to another origin. The browser
-          hides the target and its status code, so the response cannot be read
-          here, but the trigger fired and redirected as intended.
+          The endpoint answered with a redirect. The browser hides a redirect's
+          target and status code here, so the response cannot be read, but the
+          trigger fired and redirected as intended.
         </Note>
       ) : null}
       {outcome && !outcome.error && !outcome.redirected ? (

--- a/console/ui/src/catalog/HttpTester.tsx
+++ b/console/ui/src/catalog/HttpTester.tsx
@@ -81,11 +81,10 @@ interface Outcome {
   durationMs: number
   body: string
   error?: string
-  // The endpoint answered with a redirect. Under `redirect: 'manual'` the
-  // browser returns it opaque — no target, no status code (302 etc.), same
-  // origin or not — so this is the honest ceiling: the trigger fired and
-  // redirected, we just can't read where.
-  redirected?: boolean
+  // A redirect's `Location`, when the response carried one. The request runs
+  // server-side (`POST /probe`), so a 302 arrives with its real status and
+  // target — a browser `fetch` could show neither.
+  location?: string
 }
 
 export function HttpTester({
@@ -147,9 +146,13 @@ export function HttpTester({
       setOutcome(null)
       return
     }
-    // `manual` so a redirect returns an opaque response instead of the browser
-    // following it cross-origin and throwing an unreadable "Failed to fetch".
-    const init: RequestInit = { method, redirect: 'manual' }
+    // The request runs server-side via `POST /probe`: the console process
+    // reads a redirect's real status and target, which a browser `fetch`
+    // cannot, and there is no cross-origin CORS wall between the tab and the
+    // http worker. `path` is everything after the base URL; the server
+    // resolves the host itself.
+    const headers: Record<string, string> = {}
+    let requestBody: string | undefined
     if (BODY_METHODS.has(method)) {
       try {
         JSON.parse(body)
@@ -158,33 +161,40 @@ export function HttpTester({
         setOutcome(null)
         return
       }
-      init.headers = { 'Content-Type': 'application/json' }
-      init.body = body
+      headers['Content-Type'] = 'application/json'
+      requestBody = body
     }
+    const path = `${filledPath}${queryString ? `?${queryString}` : ''}`
     setInvalid(null)
     setSending(true)
     const started = performance.now()
     try {
-      const response = await fetch(url, init)
-      // A redirect comes back opaque under `manual`: status 0, body
-      // unreadable. Report it as the redirect it is, not a failure.
-      if (response.type === 'opaqueredirect') {
+      const response = await fetch('/probe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ method, path, headers, body: requestBody }),
+      })
+      const data = await response.json()
+      const durationMs = performance.now() - started
+      if (!response.ok) {
         setOutcome({
-          ok: true,
+          ok: false,
           status: null,
-          durationMs: performance.now() - started,
+          durationMs,
           body: '',
-          redirected: true,
+          error: typeof data?.error === 'string' ? data.error : 'probe failed',
         })
         return
       }
-      const text = await response.text()
-      const contentType = response.headers.get('content-type') ?? ''
+      const contentType =
+        typeof data.contentType === 'string' ? data.contentType : ''
+      const text = typeof data.body === 'string' ? data.body : ''
       setOutcome({
-        ok: response.ok,
-        status: response.status,
-        durationMs: performance.now() - started,
+        ok: data.status >= 200 && data.status < 400,
+        status: data.status,
+        durationMs,
         body: contentType.includes('json') ? pretty(safeJson(text)) : text,
+        location: typeof data.location === 'string' ? data.location : undefined,
       })
     } catch (err) {
       setOutcome({
@@ -336,8 +346,7 @@ export function HttpTester({
               outcome.ok ? 'console-catalog-ok' : 'console-catalog-invalid'
             }
           >
-            {outcome.redirected ? 'redirected' : (outcome.status ?? 'failed')} ·{' '}
-            {Math.round(outcome.durationMs)}ms
+            {outcome.status ?? 'failed'} · {Math.round(outcome.durationMs)}ms
           </span>
         ) : null}
       </div>
@@ -345,14 +354,13 @@ export function HttpTester({
       {outcome?.error ? (
         <div className="console-catalog-error">{outcome.error}</div>
       ) : null}
-      {outcome?.redirected ? (
-        <Note>
-          The endpoint answered with a redirect. The browser hides a redirect's
-          target and status code here, so the response cannot be read, but the
-          trigger fired and redirected as intended.
-        </Note>
+      {outcome?.location ? (
+        <div className="console-catalog-field-row">
+          <span className="console-catalog-key">Location</span>
+          <code className="console-catalog-path">{outcome.location}</code>
+        </div>
       ) : null}
-      {outcome && !outcome.error && !outcome.redirected ? (
+      {outcome && !outcome.error ? (
         <JsonHighlight
           code={outcome.body || '(empty response)'}
           className="console-catalog-result"


### PR DESCRIPTION
## Problem

The trigger catalog's **Send Request** panel showed a generic `Failed to fetch` for HTTP triggers that actually succeed, whenever the trigger redirects — and it could never show a redirect's status code.

```
Access to fetch at 'https://example.com/' (redirected from
'http://127.0.0.1:3111/s/home') ... blocked by CORS policy: No
'Access-Control-Allow-Origin' header is present on the requested resource.
```

The panel fetched the endpoint from the browser. Following the 302 landed cross-origin on a target with no CORS headers, so `fetch` threw. And a browser `fetch` can never expose a redirect's status anyway: `redirect: 'manual'` yields an opaque `status: 0`.

## Fix

Run the test request in the console process instead of the browser tab.

- New `POST /probe` (console server): takes `{method, path, headers, body}`, fetches the http worker with redirect-following disabled (`reqwest`), returns `{status, location, contentType, body}`.
- The panel posts to `/probe` same-origin and renders the result uniformly. A 302 now shows as **`302`** with its **`Location`**, exactly like a `200`/`201`. No CORS wall, no special-casing.

## Security (SSRF)

The target host and port are resolved **server-side** from the http worker's own configuration entry — never taken from the request. The caller supplies only a path, validated path-only:

- must start with a single `/` (a leading `//` is a protocol-relative authority; anything else could carry its own scheme/host),
- no whitespace or control characters.

So `/probe` can reach only the http worker, not an arbitrary address the console can see. The route is mounted only when an engine client is present. Unit tests cover the path/method validation.

## Testing

Verified end to end against an **isolated** compose stack (separate engine `49234`, http worker `3211`, namespace `cors-test`, a trigger answering `GET /s/:code` with a 302 to a different origin), console binary rebuilt to embed the new bundle. Playwright drove the real panel:

```
302 · 7ms
Location   https://example.com/
```

No `Failed to fetch`. Console unit tests: 87 passed (incl. the new probe tests). The developer's running instance was untouched.

## History on this branch

First commit reported redirects as a `redirected` outcome via `redirect: 'manual'` — honest, but it could only ever say "redirected", never the status code. Revised per feedback to the server-side probe above, which shows the real `302`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - HTTP tests now run through a server-side probe for more accurate response details.
  - Redirect responses display their actual status and destination.
  - Test results can show response bodies and content types, including for redirects.
  - HTTP test status is determined from the reported response code rather than browser redirect behavior.

- **Bug Fixes**
  - Invalid requests and upstream failures now provide clearer error messages.
  - Large response bodies are handled safely with a size limit.
  - Unsupported or credential-bearing headers are rejected to prevent unintended forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->