### PR TITLE
fix(cursor,tailscale,vscode): update iii SDK to 0.23.0

### DIFF
--- a/cursor/package.json
+++ b/cursor/package.json
@@ -23,7 +23,7 @@
     "cursor-worker": "./dist/index.js"
   },
   "dependencies": {
-    "iii-sdk": "0.22.1-alpha.25",
+    "iii-sdk": "0.23.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/cursor/pnpm-lock.yaml
+++ b/cursor/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       iii-sdk:
-        specifier: 0.22.1-alpha.25
-        version: 0.22.1-alpha.25
+        specifier: 0.23.0
+        version: 0.23.0
       zod:
         specifier: ^4.0.0
         version: 4.4.3
@@ -401,8 +401,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@iii-dev/helpers@0.22.1-alpha.25':
-    resolution: {integrity: sha512-q3XQZ4i+eMA4mi1iRaNHlTcIGJVvhCYkmfiIPn0rvlFjLYU32vEqjbxKeNsy9YyRbAhGbjF+kzXp2cUpycVhJw==}
+  '@iii-dev/helpers@0.23.0':
+    resolution: {integrity: sha512-q5iG1zZ8QNo32OuPqgxsSV4VM6/OYD43m/CObPYNUW2+loZBLniaoKo4sR20odxvH+aBue0pDz2G1z+K9sOK7A==}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -778,8 +778,8 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  iii-sdk@0.22.1-alpha.25:
-    resolution: {integrity: sha512-WUDzAydJacutn5IQz3Tcx296fAn88UnUt8S5/2slRsZK7WCadMS9o3qXmkgKAUAmPHsdCOAwVolBWNnAz4imqQ==}
+  iii-sdk@0.23.0:
+    resolution: {integrity: sha512-qpz7801IVfzwBy4nA/jGmabwZnDvN3Lf39RE6o9CgfIT4QAzgyYudXOfhOZypngmLfBBV/LDX6qJbUzgTlkSig==}
 
   import-in-the-middle@1.15.0:
     resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
@@ -1199,7 +1199,7 @@ snapshots:
   '@esbuild/win32-x64@0.28.2':
     optional: true
 
-  '@iii-dev/helpers@0.22.1-alpha.25':
+  '@iii-dev/helpers@0.23.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.57.2
@@ -1572,9 +1572,9 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  iii-sdk@0.22.1-alpha.25:
+  iii-sdk@0.23.0:
     dependencies:
-      '@iii-dev/helpers': 0.22.1-alpha.25
+      '@iii-dev/helpers': 0.23.0
       '@opentelemetry/api': 1.9.1
       ws: 8.21.3
     transitivePeerDependencies:

--- a/tailscale/Cargo.lock
+++ b/tailscale/Cargo.lock
@@ -682,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0342a8980e12e9bb994d9221637914a719a156cee73705b595d6588e45c9cfca"
+checksum = "e654538584cf6feec82f4f9e773d4b9f8c84bba5085e49a585aebe7227f8af8c"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -703,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.22.1-alpha.25"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb1167081b82a1aa9f12b05ad9e093fdf1cd2a3ed282bb66451a26e37f4a459"
+checksum = "3952d1ac84c88304fa27fef8ce0a9350585abe9e9b9f7513730497e72918186f"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/tailscale/Cargo.toml
+++ b/tailscale/Cargo.toml
@@ -16,7 +16,7 @@ name = "tailscale"
 path = "src/main.rs"
 
 [dependencies]
-iii-sdk = "=0.22.1-alpha.25"
+iii-sdk = "=0.23.0"
 iii-console-ui = { path = "../crates/console-ui" }
 arc-swap = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "process", "signal", "time", "io-util", "sync"] }

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -25,7 +25,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "iii-sdk": "0.22.1-alpha.25",
+    "iii-sdk": "0.23.0",
     "yaml": "^2.6.0",
     "zod": "^4.0.0"
   },

--- a/vscode/pnpm-lock.yaml
+++ b/vscode/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       iii-sdk:
-        specifier: 0.22.1-alpha.25
-        version: 0.22.1-alpha.25
+        specifier: 0.23.0
+        version: 0.23.0
       yaml:
         specifier: ^2.6.0
         version: 2.9.0
@@ -404,8 +404,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@iii-dev/helpers@0.22.1-alpha.25':
-    resolution: {integrity: sha512-q3XQZ4i+eMA4mi1iRaNHlTcIGJVvhCYkmfiIPn0rvlFjLYU32vEqjbxKeNsy9YyRbAhGbjF+kzXp2cUpycVhJw==}
+  '@iii-dev/helpers@0.23.0':
+    resolution: {integrity: sha512-q5iG1zZ8QNo32OuPqgxsSV4VM6/OYD43m/CObPYNUW2+loZBLniaoKo4sR20odxvH+aBue0pDz2G1z+K9sOK7A==}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -781,8 +781,8 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  iii-sdk@0.22.1-alpha.25:
-    resolution: {integrity: sha512-WUDzAydJacutn5IQz3Tcx296fAn88UnUt8S5/2slRsZK7WCadMS9o3qXmkgKAUAmPHsdCOAwVolBWNnAz4imqQ==}
+  iii-sdk@0.23.0:
+    resolution: {integrity: sha512-qpz7801IVfzwBy4nA/jGmabwZnDvN3Lf39RE6o9CgfIT4QAzgyYudXOfhOZypngmLfBBV/LDX6qJbUzgTlkSig==}
 
   import-in-the-middle@1.15.0:
     resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
@@ -1207,7 +1207,7 @@ snapshots:
   '@esbuild/win32-x64@0.28.2':
     optional: true
 
-  '@iii-dev/helpers@0.22.1-alpha.25':
+  '@iii-dev/helpers@0.23.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.57.2
@@ -1580,9 +1580,9 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  iii-sdk@0.22.1-alpha.25:
+  iii-sdk@0.23.0:
     dependencies:
-      '@iii-dev/helpers': 0.22.1-alpha.25
+      '@iii-dev/helpers': 0.23.0
       '@opentelemetry/api': 1.9.1
       ws: 8.21.3
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

- update cursor, tailscale, and vscode from iii-sdk 0.22.1-alpha.25 to 0.23.0
- refresh the matching pnpm and Cargo lockfiles
- restore worker registration from the immutable release artifacts

## Context

Stable release attempts built successfully but failed interface capture because the workers did not register with the release engine. The current SDK restores the expected registration handshake.

## Validation

- cursor: typecheck, lint, 130 tests, bundle build, and live engine registration with 14 functions
- vscode: worker and UI typecheck, lint, 23 tests, bundle build, and live engine registration with 6 functions
- tailscale: cargo fmt, clippy, 34 tests, release build, and live engine registration with 40 functions