### PR TITLE
(MOT-4666) perf(harness): reduce repeated function result noise

### DIFF
--- a/console/web/src/lib/backend/harness-send.test.ts
+++ b/console/web/src/lib/backend/harness-send.test.ts
@@ -68,6 +68,7 @@ describe('getTurnStatus', () => {
   it('triggers harness::status and returns the report (or null)', async () => {
     const report = {
       session_id: 's-1',
+      turn_id: 't-1',
       status: 'running' as const,
       step: 2,
       turn_count: 1,
@@ -80,9 +81,15 @@ describe('getTurnStatus', () => {
       partial_result_available: true,
       pending_function_calls: [],
       children: [],
+      expects_wake: false,
+      armed_wakes: [],
     }
     const client = fakeClient(() => report)
     expect(await getTurnStatus(client, 's-1')).toEqual(report)
+    expect(client.trigger).toHaveBeenCalledWith('harness::status', {
+      session_id: 's-1',
+      verbose: true,
+    })
 
     const empty = fakeClient(() => null)
     expect(await getTurnStatus(empty, 's-1')).toBeNull()

--- a/console/web/src/lib/backend/harness-send.ts
+++ b/console/web/src/lib/backend/harness-send.ts
@@ -144,6 +144,15 @@ export interface HarnessChildRef {
   turn_id: string
 }
 
+/** One active wake subscription owned by the session. */
+export interface HarnessArmedWake {
+  subscription_id: string
+  trigger_type?: string
+  config?: unknown
+  created_at: number
+  expires_at?: number
+}
+
 /**
  * One message parked in the harness's per-session queue while a step streams
  * (mirrors `harness_queue` rows surfaced by `harness::status`). `message` is
@@ -158,12 +167,13 @@ export interface HarnessQueuedMessage {
     role: string
     content?: Array<{ type: string; text?: string }>
   }
+  origin?: unknown
   queued_at: number
 }
 
 export interface HarnessStatusReport {
   session_id: string
-  turn_id?: string
+  turn_id: string | null
   status: HarnessTurnStatus
   step: number
   turn_count: number
@@ -177,6 +187,10 @@ export interface HarnessStatusReport {
   /** function_call_ids parked awaiting a deferred result / approval. */
   pending_function_calls: string[]
   children: HarnessChildRef[]
+  /** A completed turn is parked rather than terminal while this is true. */
+  expects_wake: boolean
+  /** Wake details are omitted when no wake is armed. */
+  armed_wakes?: HarnessArmedWake[]
   /** Messages queued while a step streams, in arrival order. */
   queued?: HarnessQueuedMessage[]
   result?: unknown
@@ -267,5 +281,6 @@ export function getTurnStatus(
 ): Promise<HarnessStatusReport | null> {
   return client.trigger<HarnessStatusReport | null>('harness::status', {
     session_id: sessionId,
+    verbose: true,
   })
 }

--- a/eval/src/comparison.rs
+++ b/eval/src/comparison.rs
@@ -185,6 +185,7 @@ pub async fn compare(
                     "harness::status",
                     StatusRequest {
                         session_id: session_id.clone(),
+                        verbose: false,
                     },
                 ),
                 trigger::<_, SessionMetricsResponseV1>(

--- a/eval/src/runtime.rs
+++ b/eval/src/runtime.rs
@@ -805,6 +805,7 @@ async fn harness_status(
         "harness::status",
         StatusRequest {
             session_id: session_id.into(),
+            verbose: true,
         },
         job.request.limits.execution.invocation_timeout_seconds,
     )

--- a/harness/src/functions/mod.rs
+++ b/harness/src/functions/mod.rs
@@ -65,7 +65,9 @@ pub const STOP_DESC: &str =
     "Request cancellation of an in-flight turn (cascades to spawned children).";
 
 pub const STATUS_ID: &str = "harness::status";
-pub const STATUS_DESC: &str = "Read the current turn status for a session.";
+pub const STATUS_DESC: &str =
+    "Read a session's current turn. Returns a lean summary by default; pass verbose: true for the \
+     full runtime report and untruncated result.";
 
 pub const SYSTEM_PROMPT_ID: &str = "harness::system-prompt::get";
 pub const SYSTEM_PROMPT_DESC: &str =

--- a/harness/src/functions/mod.rs
+++ b/harness/src/functions/mod.rs
@@ -44,7 +44,7 @@ pub const SPAWN_ID: &str = "harness::spawn";
 pub const SPAWN_DESC: &str =
     "Spawn a sub-agent in a child session (never a trigger target) and return \
      { child_session_id, child_turn_id } immediately; the child's outcome reaches you only \
-     through whatever destination its task names. Children are leaves unless \
+     through whatever destination its task names. Check `harness::status` for child health; children are leaves unless \
      options.orchestrator is true.";
 
 pub const TURN_ID: &str = "harness::turn";
@@ -428,4 +428,20 @@ pub fn register_all(iii: &Arc<IIIClient>, deps: &Arc<Deps>) {
     );
 
     tracing::info!("all harness::* functions registered");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SPAWN_DESC;
+
+    #[test]
+    fn spawn_tool_description_includes_a_one_shot_child_health_cue() {
+        assert_eq!(
+            SPAWN_DESC,
+            "Spawn a sub-agent in a child session (never a trigger target) and return \
+             { child_session_id, child_turn_id } immediately; the child's outcome reaches you only \
+             through whatever destination its task names. Check `harness::status` for child health; children are leaves unless \
+             options.orchestrator is true."
+        );
+    }
 }

--- a/harness/src/functions/status.rs
+++ b/harness/src/functions/status.rs
@@ -2,6 +2,7 @@
 //! (harness.md § `harness::status`). Read-only; safe to expose to agents.
 
 use schemars::JsonSchema;
+use serde::ser::SerializeMap;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -12,6 +13,9 @@ use crate::types::turn::TurnStatus;
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct StatusRequest {
     pub session_id: String,
+    /// Include the full runtime report and unmodified result.
+    #[serde(default)]
+    pub verbose: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -21,21 +25,21 @@ pub struct ChildRef {
     pub turn_id: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
 pub struct StatusReport {
     pub session_id: String,
     pub turn_id: Option<String>,
     pub status: TurnStatus,
     pub step: u64,
     pub turn_count: u32,
-    pub max_turns: u32,
-    pub validation_retries: u32,
-    pub max_validation_retries: u32,
-    pub transient_resumes: u32,
-    pub max_transient_resumes: u32,
-    pub partial_result_available: bool,
-    pub depth: u32,
-    pub pending_function_calls: Vec<String>,
+    pub max_turns: Option<u32>,
+    pub validation_retries: Option<u32>,
+    pub max_validation_retries: Option<u32>,
+    pub transient_resumes: Option<u32>,
+    pub max_transient_resumes: Option<u32>,
+    pub partial_result_available: Option<bool>,
+    pub depth: Option<u32>,
+    pub pending_function_calls: Option<Vec<String>>,
     pub children: Vec<ChildRef>,
     /// The session owns an armed wake (a one-shot notify subscription): a
     /// completed turn here is NOT the run's outcome — a later turn in this
@@ -49,16 +53,134 @@ pub struct StatusReport {
     /// watch and deadline, so "parked 12m on state operation_meta/status —
     /// never written" is readable from the outside instead of the session
     /// just looking quietly done.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub armed_wakes: Vec<crate::bindings::ArmedWake>,
+    pub armed_wakes: Option<Vec<crate::bindings::ArmedWake>>,
     /// Messages queued while a step streams, in arrival order; they land in
     /// the transcript when the stream ends.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub queued: Vec<crate::state::QueuedMessage>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    pub queued: Option<Vec<crate::state::QueuedMessage>>,
     pub result: Option<Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub result_error: Option<String>,
+}
+
+const LEAN_RESULT_CHAR_LIMIT: usize = 600;
+const LEAN_RESULT_TRUNCATION_SUFFIX: &str = " …(truncated; use verbose: true for the full result)";
+
+impl StatusReport {
+    fn is_verbose(&self) -> bool {
+        // Verbose reports always populate this field, including with `[]`.
+        self.pending_function_calls.is_some()
+    }
+}
+
+impl Serialize for StatusReport {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let verbose = self.is_verbose();
+        let mut report = serializer.serialize_map(None)?;
+        report.serialize_entry("session_id", &self.session_id)?;
+        report.serialize_entry("turn_id", &self.turn_id)?;
+        report.serialize_entry("status", &self.status)?;
+        report.serialize_entry("step", &self.step)?;
+        report.serialize_entry("turn_count", &self.turn_count)?;
+
+        if verbose {
+            serialize_optional(&mut report, "max_turns", &self.max_turns)?;
+            serialize_optional(&mut report, "validation_retries", &self.validation_retries)?;
+            serialize_optional(
+                &mut report,
+                "max_validation_retries",
+                &self.max_validation_retries,
+            )?;
+            serialize_optional(&mut report, "transient_resumes", &self.transient_resumes)?;
+            serialize_optional(
+                &mut report,
+                "max_transient_resumes",
+                &self.max_transient_resumes,
+            )?;
+            serialize_optional(
+                &mut report,
+                "partial_result_available",
+                &self.partial_result_available,
+            )?;
+            serialize_optional(&mut report, "depth", &self.depth)?;
+            serialize_optional(
+                &mut report,
+                "pending_function_calls",
+                &self.pending_function_calls,
+            )?;
+        }
+
+        report.serialize_entry("children", &self.children)?;
+        report.serialize_entry("expects_wake", &self.expects_wake)?;
+
+        if verbose {
+            serialize_non_empty(&mut report, "armed_wakes", &self.armed_wakes)?;
+            serialize_non_empty(&mut report, "queued", &self.queued)?;
+        }
+
+        if let Some(result) = &self.result {
+            if verbose {
+                report.serialize_entry("result", result)?;
+            } else {
+                let result = lean_result(result).map_err(serde::ser::Error::custom)?;
+                report.serialize_entry("result", &result)?;
+            }
+        }
+
+        if verbose {
+            serialize_optional(&mut report, "result_error", &self.result_error)?;
+        } else {
+            report.serialize_entry("result_error", &self.result_error)?;
+        }
+
+        report.end()
+    }
+}
+
+fn serialize_optional<M, T>(
+    map: &mut M,
+    key: &'static str,
+    value: &Option<T>,
+) -> Result<(), M::Error>
+where
+    M: SerializeMap,
+    T: Serialize,
+{
+    if let Some(value) = value {
+        map.serialize_entry(key, value)?;
+    }
+    Ok(())
+}
+
+fn serialize_non_empty<M, T>(
+    map: &mut M,
+    key: &'static str,
+    value: &Option<Vec<T>>,
+) -> Result<(), M::Error>
+where
+    M: SerializeMap,
+    T: Serialize,
+{
+    if let Some(value) = value.as_ref().filter(|value| !value.is_empty()) {
+        map.serialize_entry(key, value)?;
+    }
+    Ok(())
+}
+
+fn lean_result(result: &Value) -> Result<Value, serde_json::Error> {
+    let compact = serde_json::to_string(result)?;
+    if compact.chars().count() <= LEAN_RESULT_CHAR_LIMIT {
+        return Ok(result.clone());
+    }
+
+    let truncated = compact
+        .chars()
+        .take(LEAN_RESULT_CHAR_LIMIT)
+        .collect::<String>();
+    Ok(Value::String(format!(
+        "{truncated}{LEAN_RESULT_TRUNCATION_SUFFIX}"
+    )))
 }
 
 /// `null` for unknown sessions.
@@ -69,8 +191,11 @@ pub async fn handle(deps: &Deps, req: StatusRequest) -> Result<Option<StatusRepo
     else {
         return Ok(None);
     };
-    let queued =
-        crate::state::list_queued(&deps.iii, &req.session_id, cfg.session_timeout_ms).await?;
+    let queued = if req.verbose {
+        Some(crate::state::list_queued(&deps.iii, &req.session_id, cfg.session_timeout_ms).await?)
+    } else {
+        None
+    };
     let children = record
         .spawned_children()
         .into_iter()
@@ -83,25 +208,230 @@ pub async fn handle(deps: &Deps, req: StatusRequest) -> Result<Option<StatusRepo
     // One store read answers both: the flag (fail-closed on an unreadable
     // store, same as `session_expects_wake`) and the detail rows behind it.
     let armed = crate::bindings::armed_wakes(deps, &req.session_id).await;
+    let expects_wake = armed.as_ref().is_none_or(|wakes| !wakes.is_empty());
+    let armed_wakes = req
+        .verbose
+        .then(|| armed.unwrap_or_default())
+        .filter(|wakes| !wakes.is_empty());
+    let queued = queued.filter(|messages| !messages.is_empty());
     Ok(Some(StatusReport {
         session_id: record.session_id.clone(),
         turn_id: Some(record.turn_id.clone()),
         status: record.status,
         step: record.step,
         turn_count: record.turn_count,
-        max_turns: record.options.max_turns,
-        validation_retries: record.validation_retries,
-        max_validation_retries: record.options.max_validation_retries,
-        transient_resumes: record.transient_resumes,
-        max_transient_resumes: record.options.max_transient_resumes,
-        partial_result_available: record.result.is_some(),
-        depth: record.depth,
-        pending_function_calls: record.pending_call_ids(),
+        max_turns: req.verbose.then_some(record.options.max_turns),
+        validation_retries: req.verbose.then_some(record.validation_retries),
+        max_validation_retries: req.verbose.then_some(record.options.max_validation_retries),
+        transient_resumes: req.verbose.then_some(record.transient_resumes),
+        max_transient_resumes: req.verbose.then_some(record.options.max_transient_resumes),
+        partial_result_available: req.verbose.then_some(record.result.is_some()),
+        depth: req.verbose.then_some(record.depth),
+        pending_function_calls: req.verbose.then(|| record.pending_call_ids()),
         children,
         queued,
         result: record.result.clone(),
         result_error: record.result_error.clone(),
-        expects_wake: armed.as_ref().is_none_or(|wakes| !wakes.is_empty()),
-        armed_wakes: armed.unwrap_or_default(),
+        expects_wake,
+        armed_wakes,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use serde_json::json;
+
+    use super::*;
+
+    const TRUNCATION_SUFFIX: &str = " …(truncated; use verbose: true for the full result)";
+
+    fn lean_report(result: Option<Value>) -> StatusReport {
+        let mut value = json!({
+            "session_id": "s_parent",
+            "turn_id": "t_parent",
+            "status": "completed",
+            "step": 4,
+            "turn_count": 3,
+            "expects_wake": false,
+            "result_error": null,
+            "children": [{
+                "function_call_id": "call_child",
+                "session_id": "s_child",
+                "turn_id": "t_child"
+            }]
+        });
+        if let Some(result) = result {
+            value["result"] = result;
+        }
+        serde_json::from_value(value).expect("lean status fixture deserializes")
+    }
+
+    fn keys(value: &Value) -> BTreeSet<&str> {
+        value
+            .as_object()
+            .expect("status serializes as an object")
+            .keys()
+            .map(String::as_str)
+            .collect()
+    }
+
+    #[test]
+    fn omitted_verbose_request_defaults_to_false() {
+        let request: StatusRequest =
+            serde_json::from_value(json!({ "session_id": "s_parent" })).unwrap();
+
+        let serialized = serde_json::to_value(request).unwrap();
+
+        assert_eq!(serialized["verbose"], false);
+    }
+
+    #[test]
+    fn lean_status_serializes_only_the_model_facing_keys() {
+        let serialized = serde_json::to_value(lean_report(None)).unwrap();
+
+        assert_eq!(
+            keys(&serialized),
+            BTreeSet::from([
+                "children",
+                "expects_wake",
+                "result_error",
+                "session_id",
+                "status",
+                "step",
+                "turn_count",
+                "turn_id",
+            ])
+        );
+        assert!(serialized["result_error"].is_null());
+        assert_eq!(
+            serialized["children"],
+            json!([{
+                "function_call_id": "call_child",
+                "session_id": "s_child",
+                "turn_id": "t_child"
+            }])
+        );
+    }
+
+    #[test]
+    fn lean_status_preserves_a_short_result_json_value() {
+        let result = json!({ "answer": [1, true, "done"] });
+
+        let serialized = serde_json::to_value(lean_report(Some(result.clone()))).unwrap();
+
+        assert_eq!(serialized["result"], result);
+        assert!(serialized["result"].is_object());
+    }
+
+    #[test]
+    fn lean_status_preserves_a_result_at_the_600_character_boundary() {
+        let result = Value::String("x".repeat(598));
+        assert_eq!(serde_json::to_string(&result).unwrap().chars().count(), 600);
+
+        let serialized = serde_json::to_value(lean_report(Some(result.clone()))).unwrap();
+
+        assert_eq!(serialized["result"], result);
+    }
+
+    #[test]
+    fn lean_status_truncates_a_long_result_by_unicode_scalar_count() {
+        let result = json!({ "answer": "猫".repeat(700) });
+        let compact_json = serde_json::to_string(&result).unwrap();
+        let expected = format!(
+            "{}{}",
+            compact_json.chars().take(600).collect::<String>(),
+            TRUNCATION_SUFFIX
+        );
+
+        let serialized = serde_json::to_value(lean_report(Some(result))).unwrap();
+
+        assert_eq!(serialized["result"], Value::String(expected));
+    }
+
+    #[test]
+    fn verbose_status_preserves_the_complete_legacy_response() {
+        let full_result = json!({ "answer": "猫".repeat(700) });
+        let fixture = json!({
+            "session_id": "s_parent",
+            "turn_id": "t_parent",
+            "status": "awaiting_functions",
+            "step": 4,
+            "turn_count": 3,
+            "max_turns": 12,
+            "validation_retries": 1,
+            "max_validation_retries": 2,
+            "transient_resumes": 1,
+            "max_transient_resumes": 3,
+            "partial_result_available": true,
+            "depth": 1,
+            "pending_function_calls": ["call_pending"],
+            "children": [{
+                "function_call_id": "call_child",
+                "session_id": "s_child",
+                "turn_id": "t_child"
+            }],
+            "expects_wake": true,
+            "armed_wakes": [{
+                "subscription_id": "sub_1",
+                "trigger_type": "state:change",
+                "config": { "scope": "work" },
+                "created_at": 10,
+                "expires_at": 20
+            }],
+            "queued": [{
+                "id": "q_1",
+                "session_id": "s_parent",
+                "message": {
+                    "role": "user",
+                    "content": [],
+                    "timestamp": 11
+                },
+                "entry_id": "e_1",
+                "queued_at": 12
+            }],
+            "result": full_result,
+            "result_error": "contract failed"
+        });
+        let report: StatusReport = serde_json::from_value(fixture.clone()).unwrap();
+
+        let serialized = serde_json::to_value(report).unwrap();
+
+        assert_eq!(serialized, fixture);
+    }
+
+    #[test]
+    fn verbose_status_keeps_legacy_empty_collection_omissions() {
+        let mut fixture = json!({
+            "session_id": "s_parent",
+            "turn_id": "t_parent",
+            "status": "running",
+            "step": 1,
+            "turn_count": 1,
+            "max_turns": 12,
+            "validation_retries": 0,
+            "max_validation_retries": 2,
+            "transient_resumes": 0,
+            "max_transient_resumes": 3,
+            "partial_result_available": false,
+            "depth": 0,
+            "pending_function_calls": [],
+            "children": [],
+            "expects_wake": false,
+            "armed_wakes": [],
+            "queued": []
+        });
+        let report: StatusReport = serde_json::from_value(fixture.clone()).unwrap();
+        let fixture = fixture.as_object_mut().unwrap();
+        fixture.remove("armed_wakes");
+        fixture.remove("queued");
+        let expected = Value::Object(std::mem::take(fixture));
+
+        let serialized = serde_json::to_value(report).unwrap();
+
+        assert_eq!(serialized, expected);
+        assert_eq!(serialized["pending_function_calls"], json!([]));
+        assert!(!serialized.as_object().unwrap().contains_key("result_error"));
+    }
 }

--- a/harness/src/functions/subscribe.rs
+++ b/harness/src/functions/subscribe.rs
@@ -157,7 +157,9 @@ pub struct UnsubscribeResponse {
 /// `once`, no `lifecycle`, no `conditions`, `function_id` required).
 pub const REGISTER_TOOL_DESC: &str =
     "Subscribe the current harness session to a iii trigger: omit function_id to be \
-     notified in this session, or name a non-harness function to call with the event.";
+     notified in this session, or name a non-harness function to call with the event. \
+     Returns `subscription_id`, effective `once`, and optional `note` advisories; call-target \
+     results do not return to this session.";
 pub const UNREGISTER_TOOL_DESC: &str =
     "Remove a trigger subscription owned by the current harness session.";
 
@@ -685,14 +687,6 @@ async fn handle(
         standing_binding_advisory(&req, once),
         state_catchall_advisory(&req),
         armed_wake_advisory(&req, once),
-        (binding.target.function_id != crate::functions::SEND_ID).then(|| {
-            format!(
-                "note: this binding dispatches `{}` — its result reaches nobody and cannot wake \
-                 you. Anything that must reach this chat writes state you watch with a plain \
-                 notify (no `function_id`).",
-                binding.target.function_id
-            )
-        }),
     ]
     .into_iter()
     .flatten()
@@ -1026,9 +1020,8 @@ async fn register_post_turn_hook(
         subscription_id,
         once: false,
         note: Some(format!(
-            "post-turn validator bound to THIS session only ({session_id}): every completing \
-             turn must pass {function_id} or it is re-prompted, bounded by \
-             max_validation_retries. STANDING — unregister with this id when the goal is met."
+            "post-turn validator bound to THIS session only ({session_id}); unregister with this \
+             id when the goal is met."
         )),
     })
 }
@@ -1968,6 +1961,24 @@ mod tests {
             expose: Default::default(),
         }));
         assert!(native_control_tools(&walled).is_empty());
+    }
+
+    #[test]
+    fn register_control_tool_contract_has_compact_return_guidance() {
+        let expected = "Subscribe the current harness session to a iii trigger: omit function_id to be \
+                        notified in this session, or name a non-harness function to call with the event. \
+                        Returns `subscription_id`, effective `once`, and optional `note` advisories; call-target \
+                        results do not return to this session.";
+        let (description, _) = control_contract(REGISTER_TRIGGER_ID)
+            .expect("register_trigger should expose a public control contract");
+        assert_eq!(description, expected);
+
+        let tool = native_control_tools(&policy_allowing(&[REGISTER_TRIGGER_ID]))
+            .into_iter()
+            .next()
+            .expect("register_trigger should be present on the native control surface");
+        assert_eq!(tool.name, REGISTER_TRIGGER_ID);
+        assert_eq!(tool.description, expected);
     }
 
     fn policy_allowing(allow: &[&str]) -> CompiledPolicy {

--- a/harness/src/functions/subscribe.rs
+++ b/harness/src/functions/subscribe.rs
@@ -158,8 +158,8 @@ pub struct UnsubscribeResponse {
 pub const REGISTER_TOOL_DESC: &str =
     "Subscribe the current harness session to a iii trigger: omit function_id to be \
      notified in this session, or name a non-harness function to call with the event. \
-     Returns `subscription_id`, effective `once`, and optional `note` advisories; call-target \
-     results do not return to this session.";
+     Returns `{ subscription_id, once }`; a `note` means registration succeeded but its wiring \
+     looks suspicious. Call-target results are discarded and do not return to this session.";
 pub const UNREGISTER_TOOL_DESC: &str =
     "Remove a trigger subscription owned by the current harness session.";
 
@@ -1967,8 +1967,8 @@ mod tests {
     fn register_control_tool_contract_has_compact_return_guidance() {
         let expected = "Subscribe the current harness session to a iii trigger: omit function_id to be \
                         notified in this session, or name a non-harness function to call with the event. \
-                        Returns `subscription_id`, effective `once`, and optional `note` advisories; call-target \
-                        results do not return to this session.";
+                        Returns `{ subscription_id, once }`; a `note` means registration succeeded but its wiring \
+                        looks suspicious. Call-target results are discarded and do not return to this session.";
         let (description, _) = control_contract(REGISTER_TRIGGER_ID)
             .expect("register_trigger should expose a public control contract");
         assert_eq!(description, expected);

--- a/harness/src/subagent.rs
+++ b/harness/src/subagent.rs
@@ -132,9 +132,7 @@ fn enforce_fanout(
     ))
 }
 
-/// The immediate function result for a successful fire-and-forget spawn. The
-/// hint line teaches models still carrying the old parked-spawn doctrine that
-/// no result will come back through this call.
+/// The immediate function result for a successful fire-and-forget spawn.
 pub fn spawned_result(child: &ChildIds) -> ResultData {
     let ids = json!({
         "child_session_id": child.session_id,
@@ -146,12 +144,7 @@ pub fn spawned_result(child: &ChildIds) -> ResultData {
     } else {
         ""
     };
-    let text = format!(
-        "{ids}{reuse_note}\nfire-and-forget: this turn will NOT receive the child's result — or its \
-         failure. The child talks to the world only through the destination its task names; \
-         read that destination, poll `harness::status` on the child for its health, and put a \
-         deadline (a `timer` wake or a binding `lifecycle`) on anything you wait for."
-    );
+    let text = format!("{ids}{reuse_note}");
     ResultData {
         content: vec![ContentBlock::text(text)],
         is_error: false,
@@ -1152,20 +1145,50 @@ mod tests {
     }
 
     #[test]
-    fn spawned_result_promises_no_failure_backchannel() {
-        // A child's death is not injected into the spawner: the result text
-        // must steer the caller to the medium + status + deadlines instead of
-        // promising a [child-failure] wake-up that no longer exists.
-        let ids = ChildIds {
+    fn spawned_result_is_compact_for_fresh_and_reused_children() {
+        let fresh = spawned_result(&ChildIds {
             session_id: "s_child".into(),
             turn_id: "t_child".into(),
             reused: false,
-        };
-        let result = spawned_result(&ids);
-        let text = serde_json::to_string(&result.content).unwrap();
-        assert!(!text.contains("[child-failure]"));
-        assert!(text.contains("harness::status"));
-        assert!(text.contains("deadline"));
+        });
+        assert_eq!(
+            fresh.content,
+            vec![ContentBlock::text(
+                r#"{"child_session_id":"s_child","child_turn_id":"t_child"}"#,
+            )]
+        );
+        assert_eq!(
+            fresh.details,
+            json!({
+                "child_session_id": "s_child",
+                "child_turn_id": "t_child",
+                "fire_and_forget": true,
+                "reused": false,
+            })
+        );
+
+        let reused = spawned_result(&ChildIds {
+            session_id: "s_child".into(),
+            turn_id: "t_child".into(),
+            reused: true,
+        });
+        assert_eq!(
+            reused.content,
+            vec![ContentBlock::text(
+                "{\"child_session_id\":\"s_child\",\"child_turn_id\":\"t_child\"}\nreused: \
+                 the named session already existed (inside your own tree) — its prior transcript is \
+                 retained and this task was appended to it.",
+            )]
+        );
+        assert_eq!(
+            reused.details,
+            json!({
+                "child_session_id": "s_child",
+                "child_turn_id": "t_child",
+                "fire_and_forget": true,
+                "reused": true,
+            })
+        );
     }
 
     /// Prevents: the courier-k3m7 mis-nesting — an in-turn spawn naming an id

--- a/harness/tests/e2e/src/context.rs
+++ b/harness/tests/e2e/src/context.rs
@@ -27,17 +27,23 @@ struct RootProgress {
     expects_wake: bool,
 }
 
-impl From<&StatusReport> for RootProgress {
-    fn from(status: &StatusReport) -> Self {
-        Self {
+impl TryFrom<&StatusReport> for RootProgress {
+    type Error = anyhow::Error;
+
+    fn try_from(status: &StatusReport) -> Result<Self> {
+        let pending_function_calls = status
+            .pending_function_calls
+            .as_ref()
+            .ok_or_else(|| anyhow!("verbose harness::status omitted pending_function_calls"))?;
+        Ok(Self {
             turn_id: status.turn_id.clone(),
             status: status.status,
             step: status.step,
-            pending_function_calls: status.pending_function_calls.len(),
+            pending_function_calls: pending_function_calls.len(),
             children: status.children.len(),
-            queued_messages: status.queued.len(),
+            queued_messages: status.queued.as_ref().map_or(0, Vec::len),
             expects_wake: status.expects_wake,
-        }
+        })
     }
 }
 
@@ -138,18 +144,24 @@ impl E2eContext {
         let mut metrics_progress = None;
         loop {
             let status: Option<StatusReport> = self
-                .trigger("harness::status", json!({ "session_id": session_id }))
+                .trigger(
+                    "harness::status",
+                    json!({ "session_id": session_id, "verbose": true }),
+                )
                 .await?;
             if let Some(status) = status {
                 if let Some(turn_id) = &status.turn_id {
                     active_turn_id.clone_from(turn_id);
                 }
+                let observed = RootProgress::try_from(&status)?;
+                let max_turns = status
+                    .max_turns
+                    .ok_or_else(|| anyhow!("verbose harness::status omitted max_turns"))?;
                 if session_is_terminal(&status)? {
                     return Ok(status);
                 }
-                let observed = RootProgress::from(&status);
                 if root_progress.as_ref() != Some(&observed) {
-                    root_progress = Some(observed);
+                    root_progress = Some(observed.clone());
                     last_progress = tokio::time::Instant::now();
                 }
                 if progress_due(&mut next_progress, progress_interval) {
@@ -161,10 +173,10 @@ impl E2eContext {
                         status = ?status.status,
                         step = status.step,
                         turns = status.turn_count,
-                        max_turns = status.max_turns,
-                        pending_functions = status.pending_function_calls.len(),
+                        max_turns,
+                        pending_functions = observed.pending_function_calls,
                         children = status.children.len(),
-                        queued_messages = status.queued.len(),
+                        queued_messages = observed.queued_messages,
                         expects_wake = status.expects_wake,
                         "E2E scenario progress"
                     );
@@ -455,18 +467,18 @@ mod tests {
             status,
             step: 0,
             turn_count: 1,
-            max_turns: 100,
-            validation_retries: 0,
-            max_validation_retries: 0,
-            transient_resumes: 0,
-            max_transient_resumes: 0,
-            partial_result_available: false,
-            depth: 0,
-            pending_function_calls: Vec::new(),
+            max_turns: Some(100),
+            validation_retries: Some(0),
+            max_validation_retries: Some(0),
+            transient_resumes: Some(0),
+            max_transient_resumes: Some(0),
+            partial_result_available: Some(false),
+            depth: Some(0),
+            pending_function_calls: Some(Vec::new()),
             children: Vec::new(),
             expects_wake,
-            armed_wakes: Vec::new(),
-            queued: Vec::new(),
+            armed_wakes: None,
+            queued: None,
             result: None,
             result_error: None,
         }

--- a/harness/tests/e2e/src/scenarios/subagent_validation_failure.rs
+++ b/harness/tests/e2e/src/scenarios/subagent_validation_failure.rs
@@ -123,7 +123,10 @@ fn evaluate<'a>(
     Box::pin(async move {
         let child = child_session(run_id);
         let child_status = context
-            .trigger_value("harness::status", json!({ "session_id": child }))
+            .trigger_value(
+                "harness::status",
+                json!({ "session_id": child, "verbose": false }),
+            )
             .await
             .ok()
             .and_then(|status| {

--- a/harness/tests/golden/schemas/harness.status.json
+++ b/harness/tests/golden/schemas/harness.status.json
@@ -5,6 +5,11 @@
     "properties": {
       "session_id": {
         "type": "string"
+      },
+      "verbose": {
+        "default": false,
+        "description": "Include the full runtime report and unmodified result.",
+        "type": "boolean"
       }
     },
     "required": [
@@ -447,7 +452,10 @@
             "items": {
               "$ref": "#/definitions/ArmedWake"
             },
-            "type": "array"
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "children": {
             "items": {
@@ -458,7 +466,10 @@
           "depth": {
             "format": "uint32",
             "minimum": 0.0,
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "expects_wake": {
             "default": false,
@@ -468,33 +479,51 @@
           "max_transient_resumes": {
             "format": "uint32",
             "minimum": 0.0,
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "max_turns": {
             "format": "uint32",
             "minimum": 0.0,
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "max_validation_retries": {
             "format": "uint32",
             "minimum": 0.0,
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "partial_result_available": {
-            "type": "boolean"
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "pending_function_calls": {
             "items": {
               "type": "string"
             },
-            "type": "array"
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "queued": {
             "description": "Messages queued while a step streams, in arrival order; they land in the transcript when the stream ends.",
             "items": {
               "$ref": "#/definitions/QueuedMessage"
             },
-            "type": "array"
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "result": true,
           "result_error": {
@@ -517,7 +546,10 @@
           "transient_resumes": {
             "format": "uint32",
             "minimum": 0.0,
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "turn_count": {
             "format": "uint32",
@@ -533,23 +565,18 @@
           "validation_retries": {
             "format": "uint32",
             "minimum": 0.0,
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           }
         },
         "required": [
           "children",
-          "depth",
-          "max_transient_resumes",
-          "max_turns",
-          "max_validation_retries",
-          "partial_result_available",
-          "pending_function_calls",
           "session_id",
           "status",
           "step",
-          "transient_resumes",
-          "turn_count",
-          "validation_retries"
+          "turn_count"
         ],
         "type": "object"
       },

--- a/harness/tests/integration/src/scenario/phases/completion.rs
+++ b/harness/tests/integration/src/scenario/phases/completion.rs
@@ -179,7 +179,7 @@ impl ScenarioRunner<'_> {
                     .client()
                     .call_with_deadline(
                         "harness::status",
-                        json!({ "session_id": session_id }),
+                        json!({ "session_id": session_id, "verbose": true }),
                         status_deadline,
                         DEFAULT_CALL_TIMEOUT_MS,
                     )
@@ -264,7 +264,7 @@ impl ScenarioRunner<'_> {
             .client()
             .call_with_deadline(
                 "harness::status",
-                json!({ "session_id": self.session_id }),
+                json!({ "session_id": self.session_id, "verbose": true }),
                 evidence_deadline,
                 DEFAULT_CALL_TIMEOUT_MS,
             )

--- a/harness/tests/integration/src/scenario/phases/intervention.rs
+++ b/harness/tests/integration/src/scenario/phases/intervention.rs
@@ -783,7 +783,7 @@ where
                 let status = client
                     .call_with_deadline(
                         "harness::status",
-                        json!({ "session_id": session_id }),
+                        json!({ "session_id": session_id, "verbose": true }),
                         deadline,
                         DEFAULT_CALL_TIMEOUT_MS,
                     )
@@ -823,7 +823,7 @@ async fn wait_for_child_statuses(
                         let status = client
                             .call_with_deadline(
                                 "harness::status",
-                                json!({ "session_id": session_id }),
+                                json!({ "session_id": session_id, "verbose": true }),
                                 deadline,
                                 DEFAULT_CALL_TIMEOUT_MS,
                             )

--- a/harness/tests/quickstart/run-ci.sh
+++ b/harness/tests/quickstart/run-ci.sh
@@ -475,14 +475,14 @@ wait_for_terminal_turns() {
   ((${#session_ids[@]} == 2)) \
     || die "browser evidence must contain exactly two unique session ids"
 
-  log_command "iii trigger harness::status --port $engine_port --json '{\"session_id\":\"<console-session>\"}'"
+  log_command "iii trigger harness::status --port $engine_port --json '{\"session_id\":\"<console-session>\",\"verbose\":true}'"
   for session_id in "${session_ids[@]}"; do
     log "Verifying the durable terminal turn for session $session_id"
     response=''
     completed=0
     for ((attempt = 0; attempt < wait_seconds; attempt++)); do
       response=$("$iii_bin" trigger harness::status --port "$engine_port" \
-        --json "{\"session_id\":\"$session_id\"}" 2>>"$log_dir/terminal-status.log" || true)
+        --json "{\"session_id\":\"$session_id\",\"verbose\":true}" 2>>"$log_dir/terminal-status.log" || true)
       if jq -e '.status == "completed" and (.expects_wake // false) == false' \
         <<<"$response" >/dev/null 2>&1; then
         statuses=$(jq -c \
@@ -512,11 +512,11 @@ verify_first_capability() {
     || die "first capability browser evidence has no session id"
 
   log "Verifying the first capability for session $session_id"
-  log_command "iii trigger harness::status --port $engine_port --json '{\"session_id\":\"<capability-session>\"}'"
+  log_command "iii trigger harness::status --port $engine_port --json '{\"session_id\":\"<capability-session>\",\"verbose\":true}'"
   response=''
   for ((attempt = 0; attempt < wait_seconds; attempt++)); do
     response=$("$iii_bin" trigger harness::status --port "$engine_port" \
-      --json "{\"session_id\":\"$session_id\"}" \
+      --json "{\"session_id\":\"$session_id\",\"verbose\":true}" \
       2>>"$log_dir/first-capability-terminal.log" || true)
     if jq -e '.status == "completed" and (.expects_wake // false) == false' \
       <<<"$response" >/dev/null 2>&1; then

--- a/openwiki/src/lib/harness.mjs
+++ b/openwiki/src/lib/harness.mjs
@@ -153,7 +153,10 @@ export async function awaitTurn(worker, session_id, { timeoutMs = 240_000, inter
   for (;;) {
     let s;
     try {
-      s = await worker.trigger({ function_id: 'harness::status', payload: { session_id } });
+      s = await worker.trigger({
+        function_id: 'harness::status',
+        payload: { session_id, verbose: true },
+      });
     } catch (e) {
       throw new Error(`harness::status failed: ${e?.message || e}`);
     }

--- a/security-scan/src/iii_runtime.rs
+++ b/security-scan/src/iii_runtime.rs
@@ -451,7 +451,7 @@ impl IiiRuntime {
         let response = self
             .call(
                 "harness::status",
-                json!({ "session_id": harness.session_id }),
+                json!({ "session_id": harness.session_id, "verbose": true }),
                 None,
                 Some(RPC_TIMEOUT_MS),
             )

--- a/security-scan/src/iii_runtime/execution_runtime.rs
+++ b/security-scan/src/iii_runtime/execution_runtime.rs
@@ -144,7 +144,7 @@ impl ExecutionRuntime for IiiRuntime {
         let existing = self
             .call(
                 "harness::status",
-                json!({ "session_id": plan.session_id }),
+                json!({ "session_id": plan.session_id, "verbose": true }),
                 None,
                 Some(RPC_TIMEOUT_MS),
             )

--- a/tech-specs/2026-06-agentic/harness.md
+++ b/tech-specs/2026-06-agentic/harness.md
@@ -970,30 +970,45 @@ type StopResponse = { stopping: boolean };
 - Invocation: **sync**
 
 ```typescript
-type StatusRequest = { session_id: string };
+type StatusRequest = {
+  session_id: string;
+  verbose?: boolean;                   // default false
+};
 type StatusResponse = {
   session_id: string;
   turn_id: string | null;
   status: TurnStatus;
   step: number;
   turn_count: number;
-  max_turns: number;
-  validation_retries: number;
-  max_validation_retries: number;
-  transient_resumes: number;
-  max_transient_resumes: number;
-  partial_result_available: boolean;
-  depth: number;                      // 0 for top-level turns; >0 for sub-agents
-  pending_function_calls: string[];   // function_call ids awaiting results (incl. parked children)
-  children: Array<{                   // live spawned children of the current turn
+  expects_wake: boolean;
+  result_error?: string | null;        // null when absent in lean mode; omitted when absent in verbose mode
+  children: Array<{                    // spawned children of the current turn; IDs only
     function_call_id: string;
     session_id: string;
     turn_id: string;
   }>;
-  result?: unknown;                   // output-contract result (terminal turns)
-  result_error?: string;
-} | null;                          // null for unknown sessions
+  result?: unknown;                    // output-contract result (terminal turns)
+
+  // verbose: true only
+  max_turns?: number;
+  validation_retries?: number;
+  max_validation_retries?: number;
+  transient_resumes?: number;
+  max_transient_resumes?: number;
+  partial_result_available?: boolean;
+  depth?: number;                      // 0 for top-level turns; >0 for sub-agents
+  pending_function_calls?: string[];   // present even when empty
+  armed_wakes?: ArmedWake[];           // omitted when empty
+  queued?: QueuedMessage[];            // omitted when empty
+} | null;                              // null for unknown sessions
 ```
+
+The default response contains exactly the common fields above. `result` keeps its original JSON
+type and value when its compact JSON serialization is at most 600 Unicode scalar characters. A
+longer result becomes a string containing the first 600 characters followed by
+` …(truncated; use verbose: true for the full result)`. Pass `verbose: true` for the complete
+runtime report and unmodified result; this preserves the legacy response's field and empty-value
+omission behavior.
 
 The transcript also records user-visible lifecycle entries. `recovery` entries identify the
 interruption reason and attempt budget; `error` entries carry a stable code, phase, retryability,

--- a/workflow/src/reconcile.rs
+++ b/workflow/src/reconcile.rs
@@ -111,7 +111,7 @@ pub async fn reconcile_run(
             .iii
             .trigger(iii_sdk::protocol::TriggerRequest {
                 function_id: "harness::status".into(),
-                payload: json!({ "session_id": session_id }),
+                payload: json!({ "session_id": session_id, "verbose": true }),
                 action: None,
                 timeout_ms: Some(timeout_ms),
             })


### PR DESCRIPTION
## Summary

- reduce successful `harness::spawn` and `engine::register_trigger` acknowledgement noise while keeping durable guidance in their tool descriptions
- make `harness::status` lean by default, with Unicode-safe result truncation and `verbose: true` for the legacy full report
- opt full-result consumers into verbose status and update Console types, schemas, tests, and Harness documentation

## Verification

- Harness fmt and clippy
- Harness workspace: 650 tests passed, including 62 E2E tests
- Harness integration: 28 fixtures validated and all 22 direct service-backed scenarios passed
- Console: 1,981 tests and typecheck passed
- OpenWiki: 45 tests and syntax check passed
- eval: 41 tests passed
- workflow: 139 tests passed
- security-scan: 108 tests passed
- live deterministic comparison: lean status saved 509 bytes (25.22%), fresh spawn saved 319 bytes, and verbose status matched the baseline byte-for-byte

Fixes MOT-4666
Refs MOT-4636


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional verbose status reports with detailed runtime information, queued messages, and active wake subscriptions.
  - Added wake expectation and turn identifiers to status responses.
  - Lean status responses now provide a concise summary and truncate lengthy results.

- **Documentation**
  - Updated status, spawning, and subscription guidance to explain response formats and verbose reporting behavior.

- **Bug Fixes**
  - Improved status polling and progress tracking by explicitly requesting the appropriate level of detail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->