### PR TITLE
(MOT-4663) fix(workers): start release artifacts against capture engine

### DIFF
--- a/.github/scripts/tests/test_worker_compose.py
+++ b/.github/scripts/tests/test_worker_compose.py
@@ -118,7 +118,14 @@ def test_claude_code_release_installs_its_shared_ui_workspace():
 def test_worker_bundle_start_commands_target_packaged_entrypoints():
     document = yaml.safe_load(CATALOG.read_text(encoding="utf-8"))
 
-    for worker_id in ("claude-code", "opencode", "opengantry", "openwiki"):
+    for worker_id in (
+        "claude-code",
+        "cursor",
+        "opencode",
+        "opengantry",
+        "openwiki",
+        "vscode",
+    ):
         worker = document["workers"][worker_id]
         manifest = yaml.safe_load(
             (ROOT / worker["source"]["path"] / "iii.worker.yaml").read_text(

--- a/cursor/iii.worker.yaml
+++ b/cursor/iii.worker.yaml
@@ -11,7 +11,7 @@ runtime:
   kind: javascript
 
 scripts:
-  start: node ./index.mjs
+  start: node ./dist/bundle/index.mjs
 
 dependencies:
   state: "^0.22.2"

--- a/tailscale/Cargo.toml
+++ b/tailscale/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = "1"
 serde_yaml = "0.9"
 schemars = "0.8"
 anyhow = "1"
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 qrcode = "0.14"

--- a/tailscale/src/main.rs
+++ b/tailscale/src/main.rs
@@ -18,7 +18,7 @@ struct Cli {
     #[arg(long)]
     config: Option<String>,
     /// iii engine WebSocket address.
-    #[arg(long, default_value = "ws://127.0.0.1:49134")]
+    #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
     url: String,
     /// Print the registry manifest as JSON and exit without connecting.
     #[arg(long)]
@@ -116,4 +116,22 @@ async fn main() -> Result<()> {
     tracing::info!("tailscale worker shutting down");
     iii.shutdown_async().await;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::CommandFactory;
+
+    use super::Cli;
+
+    #[test]
+    fn url_should_accept_the_release_engine_environment() {
+        let command = Cli::command();
+        let url = command
+            .get_arguments()
+            .find(|argument| argument.get_id() == "url")
+            .expect("url argument should exist");
+
+        assert_eq!(url.get_env(), Some(std::ffi::OsStr::new("III_URL")));
+    }
 }

--- a/vscode/iii.worker.yaml
+++ b/vscode/iii.worker.yaml
@@ -11,7 +11,7 @@ runtime:
   kind: javascript
 
 scripts:
-  start: node ./index.mjs
+  start: node ./dist/bundle/index.mjs
 
 dependencies:
   configuration: "0.x"


### PR DESCRIPTION
## Summary

- start the cursor and vscode bundles from their packaged dist/bundle paths
- let tailscale read the release engine address from III_URL
- extend release contract coverage for the two JavaScript bundle entrypoints
- add a focused test for the tailscale environment binding

## Problem

The prepared cursor and vscode archives retain dist/bundle/index.mjs, but their public manifests attempted to start ./index.mjs. Tailscale accepted --url but ignored the III_URL value that interface capture provides for its isolated engine. All three workers built successfully and then timed out without registering.

## Validation

- cargo fmt --manifest-path tailscale/Cargo.toml -- --check
- cargo clippy --manifest-path tailscale/Cargo.toml --all-targets --all-features --locked -- -D warnings
- cargo test --manifest-path tailscale/Cargo.toml --all-features --locked (35 passed)
- python -m pytest .github/scripts/tests/test_worker_compose.py -q (10 passed)
- replayed the prepared cursor and vscode archives against an isolated engine: 14 and 6 functions registered
- ran tailscale with only III_URL against an isolated engine: 40 functions registered

Refs MOT-4663

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The CLI `--url` option can now use the `III_URL` environment variable as its default value, with a fallback to the local WebSocket address.

* **Bug Fixes**
  * Worker startup now uses the bundled app entry point for `cursor` and `vscode`, matching the packaged runtime.
  
* **Tests**
  * Expanded coverage to verify packaged entrypoints and environment-based CLI configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->