### PR TITLE
(MOT-4667) feat(context-manager): add configurable function result decay

### DIFF
--- a/context-manager/README.md
+++ b/context-manager/README.md
@@ -92,7 +92,7 @@ full result retained in the session transcript. Requests that still cannot fit f
 with `context/overflow`; callers must not issue a provider request in that case.
 
 The other three functions: `context::count-tokens` (estimate messages + tools +
-system prompt vs a model), `context::prune` (replace verbose function outputs
+system prompt vs a model), `context::prune` (replace eligible old function outputs
 with `[output of {function_id} pruned: was ~N tokens; re-call it if still
 needed]` placeholders, no LLM involved), and `context::compact` (summarise the
 head, keep a recent tail verbatim — returns `ok | busy | empty | overflow`).
@@ -104,8 +104,10 @@ reserved_tokens_cap: 20000     # default reserve = min(cap, pct% of context wind
 reserved_pct: 10
 tail_turns: 2                  # user+assistant pairs kept verbatim by compaction
 protect_recent_tokens: 40000   # newest function-output tokens never pruned
+decay_user_turns: 0            # prune after this many subsequent user turns; 0 disables decay
+protected_user_turns: 2        # recent user turns exempt from normal pruning; 0 disables this guard
 min_free_tokens: 20000         # skip pruning when it would free less
-max_output_chars: 2000         # outputs at or under this size are never pruned
+max_output_chars: 2000         # larger outputs are immediately eligible; smaller ones may decay
 max_result_tokens: 20000       # per-result ceiling for assemble's unconditional cap pass; 0 disables
 lease_ttl_secs: 300            # compaction mutual-exclusion lease TTL
 allow_fallback_limits: true    # conservative 8192/1024 when limits can't resolve

--- a/context-manager/architecture/integration.md
+++ b/context-manager/architecture/integration.md
@@ -190,9 +190,9 @@ Pure and router-free; safe for cost-sensitive callers with no `llm-router`.
 `tokens` equals the sum of `by_role` plus the system-prompt and tools tokens
 (which belong to no role bucket). Counts customs, unlike `assemble`.
 
-### `context::prune` — placeholder verbose function outputs
+### `context::prune` — placeholder eligible old function outputs
 
-The cheap pass alone: rewrite verbose `function_result` outputs to
+The cheap pass alone: rewrite eligible `function_result` outputs to
 `[output of {function_id} pruned: was ~N tokens; re-call it if still
 needed]`. No LLM, no state, no removal.
 
@@ -202,16 +202,20 @@ needed]`. No LLM, no state, no removal.
   model?: ModelInput;              // only for token math; optional (heuristic needs none)
   options?: {
     protect_recent_tokens?: number;   // newest output tokens never pruned (default 40000)
+    decay_user_turns?: number;        // subsequent user turns before decay; null inherits, 0 disables (default 0)
+    protected_user_turns?: number;    // recent user turns exempt; null inherits, 0 disables (default 2)
     min_free_tokens?: number;         // skip the pass if it frees less (default 20000)
-    max_output_chars?: number;        // outputs at/under this are not "verbose" (default 2000)
+    max_output_chars?: number;        // larger outputs are immediately eligible; smaller ones may decay (default 2000)
     protected_functions?: string[];   // function_ids never pruned
   };
 }
 -> { messages: AgentMessage[]; pruned_tokens; pruned_parts; scanned_parts }
 ```
 
-The two most recent user turns are always exempt (a hard guard, independent of
-the window). The pass is idempotent.
+By default the two most recent user turns are exempt, independent of the token
+window. Age counts subsequent user messages, excluding wrappers that carry
+inline function results. The pass is idempotent and never replaces an output
+with a more expensive placeholder.
 
 ### `context::compact` — summarise the head, keep a tail
 

--- a/context-manager/architecture/integration.md
+++ b/context-manager/architecture/integration.md
@@ -214,8 +214,9 @@ needed]`. No LLM, no state, no removal.
 
 By default the two most recent user turns are exempt, independent of the token
 window. Age counts subsequent user messages, excluding wrappers that carry
-inline function results. The pass is idempotent and never replaces an output
-with a more expensive placeholder.
+inline function results. The pass is idempotent. Age-only eligibility never
+replaces an output when the enclosing message would estimate larger; legacy
+verbosity eligibility retains its existing behavior.
 
 ### `context::compact` — summarise the head, keep a tail
 

--- a/context-manager/architecture/internals.md
+++ b/context-manager/architecture/internals.md
@@ -18,7 +18,7 @@ in tests.
 | [src/main.rs](../src/main.rs) | Boot: CLI (`--config` seed, `--url`, `--manifest`), engine connect, **register the config schema (+ optional seed) with the `configuration` worker and fetch the authoritative value** (boot-fatal on failure), build adapters from it, `register_all`, then bind the `configuration` hot-reload trigger; Ctrl+C → `shutdown_async`. |
 | [src/lib.rs](../src/lib.rs) | Module tree only. |
 | [src/types.rs](../src/types.rs) | Wire contracts shared with the agentic family: `Role`, `ContentBlock` (5 variants), `AgentMessage` (4 roles), `ModelInput`, `ModelLimits`, `Model`, `ThinkingLevel`, `AgentFunction`. Serde renames keep the JSON byte-compatible with the TypeScript spec and session-manager's Rust copy. |
-| [src/config.rs](../src/config.rs) | `WorkerConfig` (11 budget/prune/cap/lease knobs incl. `lease_dir`, `~/`-expanded via `resolved_lease_dir`), each with a serde default; `deny_unknown_fields` so a typo'd key fails loudly. Also the JSON-Schema source (`json_schema`/`to_json`/`from_json`, derived `JsonSchema`) and the env-expanding seed parser (`from_file`/`from_yaml`); `boot_signature` names the one structural field (`lease_dir`). |
+| [src/config.rs](../src/config.rs) | `WorkerConfig` (13 budget/prune/cap/lease knobs incl. `lease_dir`, `~/`-expanded via `resolved_lease_dir`), each with a serde default; `deny_unknown_fields` so a typo'd key fails loudly. Also the JSON-Schema source (`json_schema`/`to_json`/`from_json`, derived `JsonSchema`) and the env-expanding seed parser (`from_file`/`from_yaml`); `boot_signature` names the one structural field (`lease_dir`). |
 | [src/configuration.rs](../src/configuration.rs) | The `configuration` worker client: `register_config` (schema + seed), `fetch_config` (authoritative, env-expanded), the `ConfigCell` snapshot + `apply_config`, the `FsLeaseStore` rebuild-and-swap on a `lease_dir` change, and the `context::on-config-change` trigger handler. |
 | [src/error.rs](../src/error.rs) | `ContextError` → `code: message` on the bus (`context/invalid_request`, `context/model_unresolved`, `context/state`). The two spec strings are kept verbatim. |
 | [src/ports.rs](../src/ports.rs) | The four seams: `ModelResolver`, `Summarizer`, `LeaseStore`, `Clock`, plus the `Deps` struct every handler receives. |
@@ -204,39 +204,45 @@ tail is "the last little bit kept raw", not a second copy of the window.
 ## 6. Pruning
 
 [core/prune.rs](../src/core/prune.rs). One pass, newest-to-oldest, that
-rewrites verbose `function_result` outputs to `[output of {function_id}
+rewrites eligible old `function_result` outputs to `[output of {function_id}
 pruned: was ~N tokens; re-call it if still needed]` and **never removes
 anything** — the message, its `function_call_id`, and the ordering all
 survive (the structural invariant providers depend on).
 
 Eligibility, applied while scanning from the newest message backward:
 
-1. **The two most recent user turns are always exempt** (`PROTECTED_USER_TURNS
-   = 2`, a hard prior-art constant, not operator-tunable): the scan counts
-   `user` messages and skips everything until it has passed two of them.
-2. **Protected token window:** accumulate each scanned output's tokens into
+1. **Protected user turns:** the scan counts subsequent `user` messages and
+   skips outputs in the newest `protected_user_turns` (default `2`). User
+   wrappers carrying inline function results do not increment age. `0`
+   disables only this exemption.
+2. **`protected_functions`** (by `function_id`) are never pruned and never even
+   counted as scanned.
+3. **Protected token window:** accumulate each scanned output's tokens into
    `window_tokens`; while `window_tokens <= protect_recent_tokens` the output
    is inside the newest window and kept. Because the scan is newest-first, the
    freshest outputs fill the window and push older ones out of it.
-3. **`protected_functions`** (by `function_id`) are never pruned and never even
-   counted as scanned.
-4. **Verbosity threshold:** an output whose text is `<= max_output_chars` is
-   not "verbose" — pruning it would free almost nothing — so it stays.
+4. **Size or age eligibility:** outside the token window, an output is eligible
+   when it exceeds `max_output_chars` or its age is at least
+   `decay_user_turns`. `decay_user_turns = 0` disables age eligibility. An
+   age-only candidate is kept unless its placeholder actually estimates
+   smaller. Exact placeholders produced by this pass are not aged again.
 5. **`min_free_tokens` guard:** sum what the eligible outputs *would* free; if
    that total is below `min_free_tokens`, **nothing is rewritten at all**. A
    no-op beats a destroyed-but-still-over context. This guard fires before any
    mutation, so a skipped pass leaves `messages` untouched.
 
 `PruneStats { pruned_tokens, pruned_parts, scanned_parts }` distinguishes
-"examined" from "rewritten". The pass is idempotent: a second run sees only the
-tiny placeholders, which are under `max_output_chars`, so nothing is verbose
-(`prune.feature` "pruning twice is idempotent"). On the assemble path the same
+"examined" from "rewritten". The pass is idempotent: exact placeholders it
+produced are excluded from decay eligibility (`prune.feature` "pruning twice
+is idempotent"). On the assemble path the same
 `core::prune::prune` runs with config-derived params plus the call's
-`protected_functions`.
+`protected_functions`; the two decay controls come from the same live config
+snapshot. Direct `context::prune` calls may override both, where absent or
+`null` inherits config and explicit `0` disables that control.
 
 The same file also holds the **cap pass** (`cap_results_with_sizes`) — a
-different kind of pass. Prune is policy: age window, `protected_functions`,
-`min_free_tokens` hysteresis. Cap is an unconditional ceiling with no
+different kind of pass. Prune is policy: size/age eligibility,
+`protected_functions`, `min_free_tokens` hysteresis. Cap is an unconditional ceiling with no
 exemptions beyond a `details` payload carrying `"status": "denied"` (which
 keeps its `details` even though its `content` is still capped). Any single
 result estimating over `max_result_tokens` (config default `20000`; `0`
@@ -486,8 +492,10 @@ reserved_tokens_cap: 20000     # default reserve = min(cap, reserved_pct% of con
 reserved_pct: 10
 tail_turns: 2                  # user+assistant pairs kept verbatim by compaction
 protect_recent_tokens: 40000   # newest function-output tokens never pruned
+decay_user_turns: 0            # prune after this many subsequent user turns; 0 disables decay
+protected_user_turns: 2        # recent user turns exempt from normal pruning; 0 disables this guard
 min_free_tokens: 20000         # skip pruning when it would free less
-max_output_chars: 2000         # outputs at/under this are not "verbose"; also the summariser truncation cap
+max_output_chars: 2000         # larger outputs immediately eligible; smaller ones may decay; also summariser cap
 max_result_tokens: 20000       # per-result ceiling for assemble's unconditional cap pass; 0 disables
 lease_ttl_secs: 300            # compaction mutual-exclusion lease TTL
 allow_fallback_limits: true    # conservative 8192/1024 when limits can't resolve

--- a/context-manager/architecture/offline-decay-replay.md
+++ b/context-manager/architecture/offline-decay-replay.md
@@ -39,7 +39,7 @@ CONTEXT_REPLAY_DIR=/home/anderson/.iii/data/session-manager \
 ```
 
 The measured production range was base `629647d91447a63298d11bf1c37fb636fcec0254`
-through `9550cbeb07faab4a2fe332d350c1850929cedbb3`. Re-run after any later
+through `eca84b17b53dccb90f8b4bcb35b6edc894b4b720`. Re-run after any later
 production change before comparing results.
 
 ## 2026-09-04 corpus result
@@ -52,6 +52,8 @@ All 36 sessions had zero decay savings. Aggregate final totals were 54,990
 tokens with both settings (0 saved, 0.00%). Over the 39 last-quarter endpoints,
 the totals were 98,381 tokens with both settings (0 saved, 0.00%); each mean
 was 2,522.59 tokens. The three multi-turn sessions also had zero savings.
+These totals were re-measured at the production revision above after adding
+the age-only enclosing-message savings guard; the result remained zero.
 
 This corpus is mostly single-turn and is not evidence about a long,
 steady-state conversation. The synthetic long-history test uses 130 actual

--- a/context-manager/architecture/offline-decay-replay.md
+++ b/context-manager/architecture/offline-decay-replay.md
@@ -1,0 +1,61 @@
+# Offline decay replay
+
+This is a reproducible, opt-in comparison of assembled-history estimates. It
+does not reconstruct provider requests or contact an engine, and it never
+writes or prints transcript contents.
+
+## Method
+
+The ignored `context_replay` integration test accepts the input directory only
+through `CONTEXT_REPLAY_DIR`. It parses JSONL records with `type: "entry"` and
+`entry.kind: "message"`, retains the final revision for each message ID while
+preserving its first-occurrence position, and rejects malformed records with
+only a file and line reference. Metadata, leaf, and non-message entries are
+not treated as conversation messages.
+
+Each actual user message without an inline function-result block defines a
+prefix endpoint. For every endpoint, the replay clones that deduplicated
+prefix and calls the production `context::assemble` handler independently with
+`decay_user_turns=0` and `decay_user_turns=4`. All other worker configuration
+remains at its shipped default. The request supplies inline limits of
+1,000,000 context tokens and one output token, no system prompt, tools, or
+request overhead, and `allow_compaction=false`. The harness fails if the
+pre-prune estimate exceeds the usable budget, preventing emergency reduction
+or overflow from affecting the comparison.
+
+It reports each session's final endpoint total and the mean over its final
+`ceil(user_turns / 4)` endpoints, along with absolute and percentage savings.
+Savings are signed, so an unexpected token increase is visible as a negative
+saving. The command's output uses filenames and token totals only.
+
+## Re-run
+
+From the repository root:
+
+```sh
+CONTEXT_REPLAY_DIR=/home/anderson/.iii/data/session-manager \
+  cargo test --manifest-path context-manager/Cargo.toml --test context_replay \
+  replays_an_explicit_session_manager_directory -- --ignored --nocapture
+```
+
+The measured production range was base `629647d91447a63298d11bf1c37fb636fcec0254`
+through `9550cbeb07faab4a2fe332d350c1850929cedbb3`. Re-run after any later
+production change before comparing results.
+
+## 2026-09-04 corpus result
+
+Input inventory: 36 JSONL files, 10,487,859 bytes, and 463 deduplicated
+message entries. It contained 49 actual user-turn endpoints: 33 sessions had
+one endpoint, and the remaining sessions had 5, 5, and 6 endpoints.
+
+All 36 sessions had zero decay savings. Aggregate final totals were 54,990
+tokens with both settings (0 saved, 0.00%). Over the 39 last-quarter endpoints,
+the totals were 98,381 tokens with both settings (0 saved, 0.00%); each mean
+was 2,522.59 tokens. The three multi-turn sessions also had zero savings.
+
+This corpus is mostly single-turn and is not evidence about a long,
+steady-state conversation. The synthetic long-history test uses 130 actual
+user turns and 129 medium-sized (1,999-character) results with the shipped
+protection, minimum-saving, and window guards intact; it verifies that the
+same production assembler produces a strictly smaller final estimate with
+decay four than with decay disabled.

--- a/context-manager/src/config.rs
+++ b/context-manager/src/config.rs
@@ -33,16 +33,26 @@ pub struct WorkerConfig {
     #[serde(default = "default_tail_turns")]
     pub tail_turns: usize,
 
-    /// Newest function-output tokens never pruned (prune default).
+    /// Newest function-output tokens kept by normal pruning.
     #[serde(default = "default_protect_recent_tokens")]
     pub protect_recent_tokens: u64,
+
+    /// Prune function outputs after this many subsequent user turns.
+    /// `0` disables age-based pruning.
+    #[serde(default = "default_decay_user_turns")]
+    pub decay_user_turns: usize,
+
+    /// Most recent user turns always exempt from normal pruning.
+    /// `0` disables only this exemption.
+    #[serde(default = "default_protected_user_turns")]
+    pub protected_user_turns: usize,
 
     /// Skip pruning entirely when it would free fewer tokens than this.
     #[serde(default = "default_min_free_tokens")]
     pub min_free_tokens: u64,
 
-    /// Per-output verbosity threshold (chars): outputs at or under this
-    /// size are never considered verbose enough to prune.
+    /// Per-output verbosity threshold (chars). Larger outputs are immediately
+    /// eligible outside protection; smaller outputs may still decay by age.
     #[serde(default = "default_max_output_chars")]
     pub max_output_chars: usize,
 
@@ -161,6 +171,14 @@ fn default_protect_recent_tokens() -> u64 {
     40_000
 }
 
+fn default_decay_user_turns() -> usize {
+    0
+}
+
+fn default_protected_user_turns() -> usize {
+    2
+}
+
 fn default_min_free_tokens() -> u64 {
     20_000
 }
@@ -225,6 +243,8 @@ impl Default for WorkerConfig {
             reserved_pct: default_reserved_pct(),
             tail_turns: default_tail_turns(),
             protect_recent_tokens: default_protect_recent_tokens(),
+            decay_user_turns: default_decay_user_turns(),
+            protected_user_turns: default_protected_user_turns(),
             min_free_tokens: default_min_free_tokens(),
             max_output_chars: default_max_output_chars(),
             max_result_tokens: default_max_result_tokens(),
@@ -247,6 +267,8 @@ mod tests {
         assert_eq!(cfg.reserved_pct, 10);
         assert_eq!(cfg.tail_turns, 2);
         assert_eq!(cfg.protect_recent_tokens, 40_000);
+        assert_eq!(cfg.decay_user_turns, 0);
+        assert_eq!(cfg.protected_user_turns, 2);
         assert_eq!(cfg.min_free_tokens, 20_000);
         assert_eq!(cfg.max_output_chars, 2_000);
         assert_eq!(cfg.max_result_tokens, 20_000);
@@ -257,9 +279,25 @@ mod tests {
     }
 
     #[test]
+    fn decay_controls_have_defaults_and_accept_explicit_values() {
+        let defaults = WorkerConfig::from_json(&serde_json::json!({})).unwrap();
+        assert_eq!(defaults.to_json()["decay_user_turns"], 0);
+        assert_eq!(defaults.to_json()["protected_user_turns"], 2);
+
+        let configured = WorkerConfig::from_json(&serde_json::json!({
+            "decay_user_turns": 4,
+            "protected_user_turns": 0
+        }))
+        .unwrap();
+        assert_eq!(configured.to_json()["decay_user_turns"], 4);
+        assert_eq!(configured.to_json()["protected_user_turns"], 0);
+    }
+
+    #[test]
     fn custom_yaml_overrides_every_field() {
         let yaml = "reserved_tokens_cap: 1\nreserved_pct: 2\ntail_turns: 3\n\
-                    protect_recent_tokens: 4\nmin_free_tokens: 5\nmax_output_chars: 6\n\
+                    protect_recent_tokens: 4\ndecay_user_turns: 11\nprotected_user_turns: 12\n\
+                    min_free_tokens: 5\nmax_output_chars: 6\n\
                     max_result_tokens: 9\n\
                     lease_ttl_secs: 7\nallow_fallback_limits: false\nsummarizer_timeout_ms: 8\n\
                     lease_dir: /tmp/leases";
@@ -268,6 +306,8 @@ mod tests {
         assert_eq!(cfg.reserved_pct, 2);
         assert_eq!(cfg.tail_turns, 3);
         assert_eq!(cfg.protect_recent_tokens, 4);
+        assert_eq!(cfg.decay_user_turns, 11);
+        assert_eq!(cfg.protected_user_turns, 12);
         assert_eq!(cfg.min_free_tokens, 5);
         assert_eq!(cfg.max_output_chars, 6);
         assert_eq!(cfg.max_result_tokens, 9);
@@ -315,6 +355,8 @@ mod tests {
             "reserved_pct",
             "tail_turns",
             "protect_recent_tokens",
+            "decay_user_turns",
+            "protected_user_turns",
             "min_free_tokens",
             "max_output_chars",
             "max_result_tokens",
@@ -383,6 +425,8 @@ mod tests {
             tail_turns: base.tail_turns + 1,
             reserved_pct: base.reserved_pct + 1,
             protect_recent_tokens: base.protect_recent_tokens + 1,
+            decay_user_turns: base.decay_user_turns + 1,
+            protected_user_turns: base.protected_user_turns + 1,
             ..base.clone()
         };
         assert_eq!(base.boot_signature(), tuned.boot_signature());

--- a/context-manager/src/core/prune.rs
+++ b/context-manager/src/core/prune.rs
@@ -140,6 +140,28 @@ fn set_result_content(
     }
 }
 
+fn replacement_saves_enclosing_message(
+    message: &AgentMessage,
+    location: ResultLocation,
+    function_id: &str,
+    tokens: u64,
+    estimator: &dyn Estimator,
+) -> bool {
+    let mut proposed = [message.clone()];
+    let proposed_location = match location {
+        ResultLocation::Message(_) => ResultLocation::Message(0),
+        ResultLocation::Inline { block, .. } => ResultLocation::Inline { message: 0, block },
+    };
+    set_result_content(
+        &mut proposed,
+        proposed_location,
+        vec![ContentBlock::Text {
+            text: placeholder(function_id, tokens),
+        }],
+    );
+    estimator.message(&proposed[0]) < estimator.message(message)
+}
+
 /// Rewrite verbose outputs in place. Returns the stats; `messages` is
 /// mutated only when the pass actually runs (the `min_free_tokens`
 /// guard fires before any rewrite).
@@ -202,15 +224,24 @@ fn prune_impl(
                 let decay_enabled = params.decay_user_turns > 0;
                 let aged = decay_enabled && user_turns >= params.decay_user_turns;
                 let already_pruned = decay_enabled && is_prune_placeholder(content, function_id);
-                let age_only_saves_tokens =
-                    !aged || verbose || tokens > estimator.text(&placeholder(function_id, tokens));
-                if window_tokens > params.protect_recent_tokens
-                    && !already_pruned
-                    && (verbose || aged)
-                    && age_only_saves_tokens
+                if window_tokens <= params.protect_recent_tokens
+                    || already_pruned
+                    || (!verbose && !aged)
                 {
-                    queue.push((location, tokens, function_id.to_owned()));
+                    return;
                 }
+                if !verbose
+                    && !replacement_saves_enclosing_message(
+                        message,
+                        location,
+                        function_id,
+                        tokens,
+                        estimator,
+                    )
+                {
+                    return;
+                }
+                queue.push((location, tokens, function_id.to_owned()));
             };
 
         match message {
@@ -905,6 +936,78 @@ mod tests {
         let equal_stats = prune(&mut equal, &p, &EqualCostEstimator);
         assert_eq!(equal_stats.pruned_parts, 0);
         assert_eq!(text_of(equal[1].content()).len(), 40);
+    }
+
+    #[test]
+    fn age_only_message_with_escaped_function_id_does_not_expand() {
+        let function_id = "\\".repeat(500);
+        let mut messages = vec![
+            text_result(&function_id, "x".repeat(700), 1),
+            user("one", 2),
+            user("two", 3),
+            user("three", 4),
+            user("four", 5),
+        ];
+        let original = messages.clone();
+        let mut sizes = sizes_of(&messages);
+        let original_sizes = sizes.clone();
+        let mut p = params();
+        p.protect_recent_tokens = 0;
+        p.max_output_chars = 2_000;
+        p.decay_user_turns = 4;
+
+        let stats = prune_with_sizes(&mut messages, &mut sizes, &p, &HeuristicEstimator);
+
+        assert_eq!(stats.scanned_parts, 1);
+        assert_eq!(stats.pruned_parts, 0);
+        assert_eq!(stats.pruned_tokens, 0);
+        assert_eq!(messages, original);
+        assert_eq!(sizes, original_sizes);
+        assert_eq!(sizes, sizes_of(&messages));
+    }
+
+    #[test]
+    fn age_only_inline_result_with_escaped_function_id_does_not_expand() {
+        let function_id = "\\".repeat(500);
+        let mut messages: Vec<AgentMessage> = serde_json::from_value(json!([
+            {
+                "role": "assistant",
+                "content": [{
+                    "type": "function_call", "id": "c1", "function_id": function_id,
+                    "arguments": {}
+                }],
+                "stop_reason": "function_call", "model": "m", "provider": "p", "timestamp": 1
+            },
+            {
+                "role": "user",
+                "content": [{
+                    "type": "function_result", "function_call_id": "c1",
+                    "content": [{ "type": "text", "text": "x".repeat(700) }]
+                }],
+                "timestamp": 2
+            },
+            { "role": "user", "content": [{ "type": "text", "text": "one" }], "timestamp": 3 },
+            { "role": "user", "content": [{ "type": "text", "text": "two" }], "timestamp": 4 },
+            { "role": "user", "content": [{ "type": "text", "text": "three" }], "timestamp": 5 },
+            { "role": "user", "content": [{ "type": "text", "text": "four" }], "timestamp": 6 }
+        ]))
+        .unwrap();
+        let original = messages.clone();
+        let mut sizes = sizes_of(&messages);
+        let original_sizes = sizes.clone();
+        let mut p = params();
+        p.protect_recent_tokens = 0;
+        p.max_output_chars = 2_000;
+        p.decay_user_turns = 4;
+
+        let stats = prune_with_sizes(&mut messages, &mut sizes, &p, &HeuristicEstimator);
+
+        assert_eq!(stats.scanned_parts, 1);
+        assert_eq!(stats.pruned_parts, 0);
+        assert_eq!(stats.pruned_tokens, 0);
+        assert_eq!(messages, original);
+        assert_eq!(sizes, original_sizes);
+        assert_eq!(sizes, sizes_of(&messages));
     }
 
     #[test]

--- a/context-manager/src/core/prune.rs
+++ b/context-manager/src/core/prune.rs
@@ -69,11 +69,14 @@ fn is_prune_placeholder(blocks: &[ContentBlock], function_id: &str) -> bool {
         return false;
     };
     let prefix = format!("[output of {function_id} pruned: was ~");
-    text.strip_prefix(&prefix)
+    let Some(tokens) = text
+        .strip_prefix(&prefix)
         .and_then(|rest| rest.strip_suffix(" tokens; re-call it if still needed]"))
-        .is_some_and(|tokens| {
-            !tokens.is_empty() && tokens.bytes().all(|byte| byte.is_ascii_digit())
-        })
+        .and_then(|tokens| tokens.parse::<u64>().ok())
+    else {
+        return false;
+    };
+    placeholder(function_id, tokens) == *text
 }
 
 fn text_of(blocks: &[ContentBlock]) -> String {
@@ -695,6 +698,16 @@ mod tests {
         .unwrap()
     }
 
+    fn text_result(function_id: &str, text: String, ts: i64) -> AgentMessage {
+        serde_json::from_value(json!({
+            "role": "function_result", "function_call_id": format!("c{ts}"),
+            "function_id": function_id,
+            "content": [{ "type": "text", "text": text }],
+            "timestamp": ts
+        }))
+        .unwrap()
+    }
+
     fn params() -> PruneParams {
         PruneParams {
             protect_recent_tokens: 100,
@@ -923,6 +936,52 @@ mod tests {
         assert_eq!(stats.pruned_parts, 1);
         assert_eq!(messages[1], canonical_before);
         assert!(text_of(messages[2].content()).starts_with("[output of shell::run pruned"));
+    }
+
+    #[test]
+    fn noncanonical_leading_zero_marker_is_pruned() {
+        let marker = format!(
+            "[output of shell::run pruned: was ~{}1 tokens; re-call it if still needed]",
+            "0".repeat(256)
+        );
+        let mut messages = vec![
+            user("first", 1),
+            text_result("shell::run", marker.clone(), 2),
+            user("second", 3),
+        ];
+        let mut p = params();
+        p.protect_recent_tokens = 0;
+        p.max_output_chars = 0;
+        p.decay_user_turns = 1;
+        p.protected_user_turns = 0;
+
+        let stats = prune(&mut messages, &p, &HeuristicEstimator);
+
+        assert_eq!(stats.pruned_parts, 1);
+        assert_ne!(text_of(messages[1].content()), marker);
+    }
+
+    #[test]
+    fn noncanonical_overflow_marker_is_pruned() {
+        let marker = format!(
+            "[output of shell::run pruned: was ~{} tokens; re-call it if still needed]",
+            "9".repeat(10_000)
+        );
+        let mut messages = vec![
+            user("first", 1),
+            text_result("shell::run", marker.clone(), 2),
+            user("second", 3),
+        ];
+        let mut p = params();
+        p.protect_recent_tokens = 0;
+        p.max_output_chars = 0;
+        p.decay_user_turns = 1;
+        p.protected_user_turns = 0;
+
+        let stats = prune(&mut messages, &p, &HeuristicEstimator);
+
+        assert_eq!(stats.pruned_parts, 1);
+        assert_ne!(text_of(messages[1].content()), marker);
     }
 
     #[test]

--- a/context-manager/src/core/prune.rs
+++ b/context-manager/src/core/prune.rs
@@ -8,11 +8,11 @@
 //! single text placeholder carrying the freed size.
 //!
 //! Eligibility (ported from harness `context-compaction/prune.ts`):
-//! - the most recent two user turns are never touched;
+//! - the configured number of most recent user turns are never touched;
 //! - outputs inside the newest `protect_recent_tokens` window are kept;
 //! - `protected_functions` are never pruned;
-//! - outputs whose text is at or under `max_output_chars` are not
-//!   "verbose" and stay (pruning them frees almost nothing);
+//! - outputs outside that window are eligible when they exceed
+//!   `max_output_chars` or have reached `decay_user_turns` age;
 //! - when everything prunable frees under `min_free_tokens`, nothing is
 //!   touched at all. `context::assemble` may subsequently use the
 //!   unconditional emergency pass to enforce its hard budget.
@@ -22,10 +22,6 @@ use crate::types::{AgentMessage, ContentBlock, Role};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
-
-/// Recent user turns that are always exempt, independent of the token
-/// window (prior-art constant, not operator-tunable).
-const PROTECTED_USER_TURNS: usize = 2;
 
 /// Maximum number of Unicode scalar values copied from an oversized
 /// result into its emergency reference.
@@ -38,9 +34,13 @@ const EMERGENCY_RETRIEVAL_HINT: &str =
 pub struct PruneParams {
     /// Newest function-output tokens kept verbatim.
     pub protect_recent_tokens: u64,
+    /// Prune outputs after this many subsequent user turns; `0` disables decay.
+    pub decay_user_turns: usize,
+    /// Most recent user turns exempt from pruning; `0` disables this exemption.
+    pub protected_user_turns: usize,
     /// Skip the whole pass when it would free less than this.
     pub min_free_tokens: u64,
-    /// Outputs at or under this many chars are not considered verbose.
+    /// Larger outputs are immediately eligible outside protection.
     pub max_output_chars: usize,
     /// `function_id`s whose outputs are never pruned.
     pub protected_functions: Vec<String>,
@@ -62,6 +62,18 @@ pub struct PruneStats {
 /// the full result, but the model-facing view does not.
 pub fn placeholder(function_id: &str, tokens: u64) -> String {
     format!("[output of {function_id} pruned: was ~{tokens} tokens; re-call it if still needed]")
+}
+
+fn is_prune_placeholder(blocks: &[ContentBlock], function_id: &str) -> bool {
+    let [ContentBlock::Text { text }] = blocks else {
+        return false;
+    };
+    let prefix = format!("[output of {function_id} pruned: was ~");
+    text.strip_prefix(&prefix)
+        .and_then(|rest| rest.strip_suffix(" tokens; re-call it if still needed]"))
+        .is_some_and(|tokens| {
+            !tokens.is_empty() && tokens.bytes().all(|byte| byte.is_ascii_digit())
+        })
 }
 
 fn text_of(blocks: &[ContentBlock]) -> String {
@@ -167,28 +179,36 @@ fn prune_impl(
             user_turns += 1;
             continue;
         }
-        if user_turns < PROTECTED_USER_TURNS {
+        if user_turns < params.protected_user_turns {
             continue;
         }
-        let mut consider = |location: ResultLocation,
-                            function_id: &str,
-                            content: &[ContentBlock]| {
-            if params
-                .protected_functions
-                .iter()
-                .any(|protected| protected == function_id)
-            {
-                return;
-            }
-            let text = text_of(content);
-            let tokens = result_tokens(content, estimator);
-            scanned += 1;
-            window_tokens = window_tokens.saturating_add(tokens);
-            if window_tokens > params.protect_recent_tokens && text.len() > params.max_output_chars
-            {
-                queue.push((location, tokens, function_id.to_owned()));
-            }
-        };
+        let mut consider =
+            |location: ResultLocation, function_id: &str, content: &[ContentBlock]| {
+                if params
+                    .protected_functions
+                    .iter()
+                    .any(|protected| protected == function_id)
+                {
+                    return;
+                }
+                let text = text_of(content);
+                let tokens = result_tokens(content, estimator);
+                scanned += 1;
+                window_tokens = window_tokens.saturating_add(tokens);
+                let verbose = text.len() > params.max_output_chars;
+                let decay_enabled = params.decay_user_turns > 0;
+                let aged = decay_enabled && user_turns >= params.decay_user_turns;
+                let already_pruned = decay_enabled && is_prune_placeholder(content, function_id);
+                let age_only_saves_tokens =
+                    !aged || verbose || tokens > estimator.text(&placeholder(function_id, tokens));
+                if window_tokens > params.protect_recent_tokens
+                    && !already_pruned
+                    && (verbose || aged)
+                    && age_only_saves_tokens
+                {
+                    queue.push((location, tokens, function_id.to_owned()));
+                }
+            };
 
         match message {
             AgentMessage::FunctionResult {
@@ -678,6 +698,8 @@ mod tests {
     fn params() -> PruneParams {
         PruneParams {
             protect_recent_tokens: 100,
+            decay_user_turns: 0,
+            protected_user_turns: 2,
             min_free_tokens: 1,
             max_output_chars: 100,
             protected_functions: vec![],
@@ -696,23 +718,356 @@ mod tests {
     }
 
     #[test]
-    fn prunes_old_verbose_output_and_keeps_recent_turns() {
+    fn decay_disabled_preserves_legacy_literal_output_and_stats() {
         let mut messages = history();
         let stats = prune(&mut messages, &params(), &HeuristicEstimator);
-        assert_eq!(stats.pruned_parts, 1);
-        // Net of the placeholder written back: 2000 minus the tokens of
-        // "[output of shell::run pruned: was ~2000 tokens; re-call it if
-        // still needed]" (75 chars / 4 = 18).
-        assert_eq!(stats.pruned_tokens, 1_982);
-        // Oldest output replaced...
+        assert_eq!(
+            stats,
+            PruneStats {
+                pruned_tokens: 1_982,
+                pruned_parts: 1,
+                scanned_parts: 1,
+            }
+        );
         assert_eq!(
             messages[1].content(),
             &[ContentBlock::Text {
-                text: placeholder("shell::run", 2_000)
+                text: "[output of shell::run pruned: was ~2000 tokens; re-call it if still needed]"
+                    .into()
             }]
         );
-        // ...the one inside the last two user turns untouched.
         assert_eq!(text_of(messages[3].content()).len(), 8_000);
+    }
+
+    #[test]
+    fn decay_prunes_at_the_configured_age_not_one_turn_before() {
+        let mut messages = vec![
+            user("first", 1),
+            result("shell::run", 400, 2),
+            user("second", 3),
+        ];
+        let mut p = params();
+        p.protect_recent_tokens = 0;
+        p.max_output_chars = 10_000;
+        p.decay_user_turns = 2;
+        p.protected_user_turns = 0;
+
+        let before_boundary = prune(&mut messages, &p, &HeuristicEstimator);
+        assert_eq!(before_boundary.pruned_parts, 0);
+        assert_eq!(text_of(messages[1].content()).len(), 400);
+
+        messages.push(user("third", 4));
+        let at_boundary = prune(&mut messages, &p, &HeuristicEstimator);
+        assert_eq!(at_boundary.pruned_parts, 1);
+        assert_eq!(
+            text_of(messages[1].content()),
+            "[output of shell::run pruned: was ~100 tokens; re-call it if still needed]"
+        );
+    }
+
+    #[test]
+    fn decay_applies_below_and_at_the_verbose_threshold() {
+        let mut messages = vec![
+            user("first", 1),
+            result("below", 396, 2),
+            result("at", 400, 3),
+            user("second", 4),
+            user("third", 5),
+        ];
+        let mut p = params();
+        p.protect_recent_tokens = 0;
+        p.max_output_chars = 400;
+        p.decay_user_turns = 2;
+        p.protected_user_turns = 0;
+
+        let stats = prune(&mut messages, &p, &HeuristicEstimator);
+
+        assert_eq!(stats.pruned_parts, 2);
+        assert!(text_of(messages[1].content()).starts_with("[output of below pruned"));
+        assert!(text_of(messages[2].content()).starts_with("[output of at pruned"));
+    }
+
+    #[test]
+    fn decay_still_honors_the_newest_token_window() {
+        let mut messages = vec![
+            user("first", 1),
+            result("older", 400, 2),
+            result("newer", 400, 3),
+            user("second", 4),
+            user("third", 5),
+        ];
+        let mut p = params();
+        p.protect_recent_tokens = 100;
+        p.max_output_chars = 10_000;
+        p.decay_user_turns = 2;
+        p.protected_user_turns = 0;
+
+        let stats = prune(&mut messages, &p, &HeuristicEstimator);
+
+        assert_eq!(stats.pruned_parts, 1);
+        assert!(text_of(messages[1].content()).starts_with("[output of older pruned"));
+        assert_eq!(text_of(messages[2].content()).len(), 400);
+    }
+
+    #[test]
+    fn zero_protected_turns_removes_only_the_turn_exemption() {
+        let original = vec![user("first", 1), result("shell::run", 8_000, 2)];
+        let mut protected = original.clone();
+        let mut p = params();
+        p.protect_recent_tokens = 0;
+        let protected_stats = prune(&mut protected, &p, &HeuristicEstimator);
+        assert_eq!(protected_stats.scanned_parts, 0);
+        assert_eq!(protected, original);
+
+        p.protected_user_turns = 0;
+        let mut unprotected = original;
+        let unprotected_stats = prune(&mut unprotected, &p, &HeuristicEstimator);
+        assert_eq!(unprotected_stats.pruned_parts, 1);
+        assert!(text_of(unprotected[1].content()).starts_with("[output of shell::run pruned"));
+    }
+
+    #[test]
+    fn decay_honors_protected_functions_and_minimum_free_tokens() {
+        let original = vec![
+            user("first", 1),
+            result("keep::me", 400, 2),
+            user("second", 3),
+        ];
+        let mut p = params();
+        p.protect_recent_tokens = 0;
+        p.max_output_chars = 10_000;
+        p.decay_user_turns = 1;
+        p.protected_user_turns = 0;
+        p.protected_functions = vec!["keep::me".into()];
+
+        let mut protected = original.clone();
+        let protected_stats = prune(&mut protected, &p, &HeuristicEstimator);
+        assert_eq!(protected_stats.scanned_parts, 0);
+        assert_eq!(protected, original);
+
+        p.protected_functions.clear();
+        p.min_free_tokens = 1_000;
+        let mut below_minimum = original.clone();
+        let minimum_stats = prune(&mut below_minimum, &p, &HeuristicEstimator);
+        assert_eq!(minimum_stats.scanned_parts, 1);
+        assert_eq!(minimum_stats.pruned_parts, 0);
+        assert_eq!(minimum_stats.pruned_tokens, 0);
+        assert_eq!(below_minimum, original);
+    }
+
+    #[test]
+    fn decay_does_not_expand_tiny_or_equal_cost_outputs() {
+        let mut tiny = vec![user("first", 1), result("tiny", 1, 2), user("second", 3)];
+        let mut p = params();
+        p.protect_recent_tokens = 0;
+        p.max_output_chars = 10_000;
+        p.decay_user_turns = 1;
+        p.protected_user_turns = 0;
+        p.min_free_tokens = 0;
+
+        let tiny_stats = prune(&mut tiny, &p, &HeuristicEstimator);
+        assert_eq!(tiny_stats.pruned_parts, 0);
+        assert_eq!(text_of(tiny[1].content()), "x");
+
+        struct EqualCostEstimator;
+        impl Estimator for EqualCostEstimator {
+            fn kind(&self) -> crate::core::estimate::EstimatorKind {
+                crate::core::estimate::EstimatorKind::Heuristic
+            }
+
+            fn message(&self, _message: &AgentMessage) -> u64 {
+                10
+            }
+
+            fn text(&self, _text: &str) -> u64 {
+                10
+            }
+
+            fn function(&self, _function: &crate::types::AgentFunction) -> u64 {
+                0
+            }
+        }
+
+        let mut equal = vec![user("first", 1), result("equal", 40, 2), user("second", 3)];
+        let equal_stats = prune(&mut equal, &p, &EqualCostEstimator);
+        assert_eq!(equal_stats.pruned_parts, 0);
+        assert_eq!(text_of(equal[1].content()).len(), 40);
+    }
+
+    #[test]
+    fn decay_skips_only_exact_canonical_prune_placeholders() {
+        let canonical = placeholder("shell::run", 1_000);
+        let marker_like = format!("{canonical} ordinary trailing output {}", "x".repeat(100));
+        let mut messages: Vec<AgentMessage> = serde_json::from_value(json!([
+            { "role": "user", "content": [{ "type": "text", "text": "first" }], "timestamp": 1 },
+            {
+                "role": "function_result", "function_call_id": "c1", "function_id": "shell::run",
+                "content": [{ "type": "text", "text": canonical }], "timestamp": 2
+            },
+            {
+                "role": "function_result", "function_call_id": "c2", "function_id": "shell::run",
+                "content": [{ "type": "text", "text": marker_like }], "timestamp": 3
+            },
+            { "role": "user", "content": [{ "type": "text", "text": "second" }], "timestamp": 4 }
+        ]))
+        .unwrap();
+        let canonical_before = messages[1].clone();
+        let mut p = params();
+        p.protect_recent_tokens = 0;
+        p.max_output_chars = 10_000;
+        p.decay_user_turns = 1;
+        p.protected_user_turns = 0;
+
+        let stats = prune(&mut messages, &p, &HeuristicEstimator);
+
+        assert_eq!(stats.pruned_parts, 1);
+        assert_eq!(messages[1], canonical_before);
+        assert!(text_of(messages[2].content()).starts_with("[output of shell::run pruned"));
+    }
+
+    #[test]
+    fn inline_result_wrappers_do_not_increment_age_and_keep_siblings() {
+        let original: Vec<AgentMessage> = serde_json::from_value(json!([
+            {
+                "role": "assistant",
+                "content": [{
+                    "type": "function_call", "id": "c1", "function_id": "shell::run",
+                    "arguments": { "command": "status" }
+                }],
+                "stop_reason": "function_call", "model": "m", "provider": "p", "timestamp": 1
+            },
+            {
+                "role": "user",
+                "content": [
+                    { "type": "text", "text": "before" },
+                    {
+                        "type": "function_result", "function_call_id": "c1", "is_error": true,
+                        "content": [{ "type": "text", "text": "x".repeat(400) }]
+                    },
+                    { "type": "text", "text": "after" }
+                ],
+                "timestamp": 2
+            },
+            { "role": "user", "content": [{ "type": "text", "text": "next" }], "timestamp": 3 },
+            { "role": "user", "content": [{ "type": "text", "text": "again" }], "timestamp": 4 }
+        ]))
+        .unwrap();
+        let mut p = params();
+        p.protect_recent_tokens = 0;
+        p.max_output_chars = 10_000;
+        p.protected_user_turns = 0;
+        p.decay_user_turns = 3;
+
+        let mut too_young = original.clone();
+        assert_eq!(
+            prune(&mut too_young, &p, &HeuristicEstimator).pruned_parts,
+            0
+        );
+        assert_eq!(too_young, original);
+
+        p.decay_user_turns = 2;
+        let mut at_age = original;
+        let stats = prune(&mut at_age, &p, &HeuristicEstimator);
+        assert_eq!(stats.pruned_parts, 1);
+        assert_eq!(text_of(&at_age[1].content()[0..1]), "before");
+        assert_eq!(text_of(&at_age[1].content()[2..3]), "after");
+        let ContentBlock::FunctionResult {
+            function_call_id,
+            content,
+            is_error,
+        } = &at_age[1].content()[1]
+        else {
+            panic!("inline result block changed kind");
+        };
+        assert_eq!(function_call_id, "c1");
+        assert_eq!(*is_error, Some(true));
+        assert!(text_of(content).starts_with("[output of shell::run pruned"));
+    }
+
+    #[test]
+    fn decay_preserves_message_metadata_and_keeps_size_memo_exact() {
+        let mut messages: Vec<AgentMessage> = serde_json::from_value(json!([
+            { "role": "user", "content": [{ "type": "text", "text": "first" }], "timestamp": 1 },
+            {
+                "role": "function_result", "function_call_id": "call-7", "function_id": "fs::read",
+                "content": [{ "type": "text", "text": "x".repeat(400) }],
+                "details": { "path": "/tmp/example", "line": 7 }, "is_error": true, "timestamp": 2
+            },
+            { "role": "user", "content": [{ "type": "text", "text": "second" }], "timestamp": 3 }
+        ]))
+        .unwrap();
+        let mut sizes = sizes_of(&messages);
+        let mut p = params();
+        p.protect_recent_tokens = 0;
+        p.max_output_chars = 10_000;
+        p.decay_user_turns = 1;
+        p.protected_user_turns = 0;
+
+        let stats = prune_with_sizes(&mut messages, &mut sizes, &p, &HeuristicEstimator);
+
+        assert_eq!(stats.pruned_parts, 1);
+        let AgentMessage::FunctionResult {
+            function_call_id,
+            function_id,
+            details,
+            is_error,
+            timestamp,
+            ..
+        } = &messages[1]
+        else {
+            panic!("message result changed kind");
+        };
+        assert_eq!(function_call_id, "call-7");
+        assert_eq!(function_id, "fs::read");
+        assert_eq!(details, &json!({ "path": "/tmp/example", "line": 7 }));
+        assert!(*is_error);
+        assert_eq!(*timestamp, 2);
+        assert_eq!(sizes, sizes_of(&messages));
+    }
+
+    #[test]
+    fn synthetic_long_session_saves_medium_results_with_decay_four() {
+        let mut history = Vec::new();
+        let mut timestamp = 0;
+        for turn in 0..10 {
+            timestamp += 1;
+            history.push(user(&format!("turn {turn}"), timestamp));
+            timestamp += 1;
+            history.push(result("medium::lookup", 2_400, timestamp));
+            if turn == 0 {
+                timestamp += 1;
+                history.push(result("keep::me", 2_400, timestamp));
+            }
+        }
+
+        let mut off = history.clone();
+        let mut off_sizes = sizes_of(&off);
+        let mut off_params = params();
+        off_params.protect_recent_tokens = 600;
+        off_params.max_output_chars = 10_000;
+        off_params.protected_user_turns = 2;
+        off_params.decay_user_turns = 0;
+        off_params.protected_functions = vec!["keep::me".into()];
+        let off_stats =
+            prune_with_sizes(&mut off, &mut off_sizes, &off_params, &HeuristicEstimator);
+
+        let mut decayed = history.clone();
+        let mut decayed_sizes = sizes_of(&decayed);
+        let mut decay_params = off_params;
+        decay_params.decay_user_turns = 4;
+        let decay_stats = prune_with_sizes(
+            &mut decayed,
+            &mut decayed_sizes,
+            &decay_params,
+            &HeuristicEstimator,
+        );
+
+        assert_eq!(off_stats.pruned_parts, 0);
+        assert!(decay_stats.pruned_parts > 0);
+        assert!(decayed_sizes.iter().sum::<u64>() < off_sizes.iter().sum::<u64>());
+        assert_eq!(decayed[2], history[2]);
+        assert_eq!(decayed.last(), history.last());
+        assert_eq!(decayed_sizes, sizes_of(&decayed));
     }
 
     #[test]
@@ -1434,6 +1789,8 @@ mod tests {
         let shipped = crate::config::WorkerConfig::default();
         let defaults = PruneParams {
             protect_recent_tokens: shipped.protect_recent_tokens,
+            decay_user_turns: shipped.decay_user_turns,
+            protected_user_turns: shipped.protected_user_turns,
             min_free_tokens: shipped.min_free_tokens,
             max_output_chars: shipped.max_output_chars,
             protected_functions: vec![],

--- a/context-manager/src/functions/assemble.rs
+++ b/context-manager/src/functions/assemble.rs
@@ -365,6 +365,8 @@ pub async fn handle(deps: &Deps, req: AssembleRequest) -> Result<AssembleRespons
     if options.allow_prune.unwrap_or(true) {
         let params = PruneParams {
             protect_recent_tokens: config.protect_recent_tokens,
+            decay_user_turns: config.decay_user_turns,
+            protected_user_turns: config.protected_user_turns,
             min_free_tokens: config.min_free_tokens,
             max_output_chars: config.max_output_chars,
             protected_functions: options.protected_functions.clone().unwrap_or_default(),

--- a/context-manager/src/functions/mod.rs
+++ b/context-manager/src/functions/mod.rs
@@ -38,7 +38,7 @@ pub const COMPACT_DESC: &str =
 
 pub const PRUNE_ID: &str = "context::prune";
 pub const PRUNE_DESC: &str =
-    "Replace verbose function outputs with placeholders without summarising. \
+    "Replace eligible old function outputs with placeholders without summarising. \
      A cheaper first pass before compaction.";
 
 pub const COUNT_TOKENS_ID: &str = "context::count-tokens";

--- a/context-manager/src/functions/prune.rs
+++ b/context-manager/src/functions/prune.rs
@@ -1,4 +1,4 @@
-//! `context::prune` — replace verbose function outputs with
+//! `context::prune` — replace eligible old function outputs with
 //! placeholders without summarising (context-manager.md §
 //! context::prune). The cheaper first pass before compaction; safe to
 //! expose to agents (no LLM call, no state).
@@ -14,14 +14,22 @@ use crate::types::{AgentMessage, ModelInput};
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 pub struct PruneOptions {
-    /// Newest function-output tokens never pruned (default 40000).
+    /// Newest function-output tokens kept by normal pruning (default 40000).
     #[serde(default)]
     pub protect_recent_tokens: Option<u64>,
+    /// Prune outputs after this many subsequent user turns. `null` uses
+    /// worker config (default 0); `0` disables age-based pruning.
+    #[serde(default)]
+    pub decay_user_turns: Option<usize>,
+    /// Most recent user turns exempt from normal pruning. `null` uses
+    /// worker config (default 2); `0` disables only this exemption.
+    #[serde(default)]
+    pub protected_user_turns: Option<usize>,
     /// Skip the pass entirely when it would free less (default 20000).
     #[serde(default)]
     pub min_free_tokens: Option<u64>,
-    /// Per-output verbosity threshold in chars (default 2000): outputs
-    /// at or under it are never pruned.
+    /// Per-output verbosity threshold in chars (default 2000). Outputs
+    /// at or under it can still be pruned after the configured decay age.
     #[serde(default)]
     pub max_output_chars: Option<usize>,
     /// `function_id`s whose outputs are never pruned.
@@ -65,6 +73,10 @@ pub async fn handle(deps: &Deps, req: PruneRequest) -> Result<PruneResponse, Con
         protect_recent_tokens: options
             .protect_recent_tokens
             .unwrap_or(config.protect_recent_tokens),
+        decay_user_turns: options.decay_user_turns.unwrap_or(config.decay_user_turns),
+        protected_user_turns: options
+            .protected_user_turns
+            .unwrap_or(config.protected_user_turns),
         min_free_tokens: options.min_free_tokens.unwrap_or(config.min_free_tokens),
         max_output_chars: options.max_output_chars.unwrap_or(config.max_output_chars),
         protected_functions: options.protected_functions.unwrap_or_default(),
@@ -81,4 +93,33 @@ pub async fn handle(deps: &Deps, req: PruneRequest) -> Result<PruneResponse, Con
         pruned_parts: stats.pruned_parts,
         scanned_parts: stats.scanned_parts,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prune_options_schema_exposes_decay_controls() {
+        let schema = schemars::schema_for!(PruneOptions);
+        let properties = schema.schema.object.expect("object schema").properties;
+        assert!(properties.contains_key("decay_user_turns"));
+        assert!(properties.contains_key("protected_user_turns"));
+
+        let explicit_zero: PruneOptions = serde_json::from_value(serde_json::json!({
+            "decay_user_turns": 0,
+            "protected_user_turns": 0
+        }))
+        .unwrap();
+        assert_eq!(explicit_zero.decay_user_turns, Some(0));
+        assert_eq!(explicit_zero.protected_user_turns, Some(0));
+
+        let inherited: PruneOptions = serde_json::from_value(serde_json::json!({
+            "decay_user_turns": null,
+            "protected_user_turns": null
+        }))
+        .unwrap();
+        assert_eq!(inherited.decay_user_turns, None);
+        assert_eq!(inherited.protected_user_turns, None);
+    }
 }

--- a/context-manager/src/ui.rs
+++ b/context-manager/src/ui.rs
@@ -42,6 +42,8 @@ mod tests {
             "reserved_pct",
             "tail_turns",
             "protect_recent_tokens",
+            "decay_user_turns",
+            "protected_user_turns",
             "min_free_tokens",
             "max_output_chars",
             "max_result_tokens",

--- a/context-manager/tests/context_replay.rs
+++ b/context-manager/tests/context_replay.rs
@@ -1,0 +1,132 @@
+#[allow(dead_code)]
+mod common;
+mod replay_support;
+
+use replay_support::{compare_decay_four, compare_directory, parse_session_lines};
+use serde_json::json;
+
+#[test]
+fn keeps_the_last_revision_in_first_occurrence_order() {
+    let lines = [
+        r#"{"type":"entry","entry":{"kind":"message","id":"first","revision":0,"message":{"role":"user","content":[{"type":"text","text":"old"}],"timestamp":1}}}"#,
+        r#"{"type":"entry","entry":{"kind":"message","id":"second","revision":0,"message":{"role":"user","content":[{"type":"text","text":"second"}],"timestamp":2}}}"#,
+        r#"{"type":"entry","entry":{"kind":"message","id":"first","revision":1,"message":{"role":"user","content":[{"type":"text","text":"new"}],"timestamp":3}}}"#,
+    ];
+
+    let history = parse_session_lines("synthetic.jsonl", lines).expect("valid session records");
+
+    assert_eq!(history.ids(), ["first", "second"]);
+    assert_eq!(history.revisions(), [1, 0]);
+    assert_eq!(history.text_at(0), Some("new"));
+}
+
+#[test]
+fn finds_only_actual_user_turn_endpoints() {
+    let lines = [
+        r#"{"type":"entry","entry":{"kind":"message","id":"one","revision":0,"message":{"role":"user","content":[{"type":"text","text":"first"}],"timestamp":1}}}"#,
+        r#"{"type":"entry","entry":{"kind":"message","id":"inline","revision":0,"message":{"role":"user","content":[{"type":"function_result","function_call_id":"call","content":[{"type":"text","text":"result"}]}],"timestamp":2}}}"#,
+        r#"{"type":"entry","entry":{"kind":"custom","id":"notice","revision":0,"data":{}}}"#,
+        r#"{"type":"entry","entry":{"kind":"message","id":"assistant","revision":0,"message":{"role":"assistant","content":[],"stop_reason":"end","model":"test","provider":"test","timestamp":3}}}"#,
+        r#"{"type":"entry","entry":{"kind":"message","id":"two","revision":0,"message":{"role":"user","content":[{"type":"text","text":"second"}],"timestamp":4}}}"#,
+    ];
+
+    let history = parse_session_lines("synthetic.jsonl", lines).expect("valid session records");
+
+    assert_eq!(history.user_turn_endpoints(), [0, 3]);
+}
+
+#[test]
+fn rejects_malformed_records_without_echoing_their_contents() {
+    let result = parse_session_lines(
+        "synthetic.jsonl",
+        [
+            r#"{"type":"entry","entry":{"kind":"message","id":"one","revision":0,"message":{"role":"user","content":"private transcript text"}}}"#,
+        ],
+    );
+    let Err(error) = result else {
+        panic!("invalid message shape must be rejected");
+    };
+
+    assert_eq!(error, "synthetic.jsonl:1: message entry message is invalid");
+    assert!(!error.contains("private transcript text"));
+}
+
+#[tokio::test]
+async fn shrinks_a_long_medium_result_history_with_shipped_guards() {
+    let mut lines = Vec::new();
+    for turn in 0..130 {
+        lines.push(
+            json!({
+                "type": "entry",
+                "entry": {
+                    "kind": "message",
+                    "id": format!("user-{turn}"),
+                    "revision": 0,
+                    "message": {
+                        "role": "user",
+                        "content": [{ "type": "text", "text": "continue" }],
+                        "timestamp": turn * 2
+                    }
+                }
+            })
+            .to_string(),
+        );
+        if turn < 129 {
+            lines.push(
+                json!({
+                    "type": "entry",
+                    "entry": {
+                        "kind": "message",
+                        "id": format!("result-{turn}"),
+                        "revision": 0,
+                        "message": {
+                            "role": "function_result",
+                            "function_call_id": format!("call-{turn}"),
+                            "function_id": "read_file",
+                            "content": [{ "type": "text", "text": "x".repeat(1_999) }],
+                            "details": {},
+                            "is_error": false,
+                            "timestamp": turn * 2 + 1
+                        }
+                    }
+                })
+                .to_string(),
+            );
+        }
+    }
+    let history = parse_session_lines("synthetic-long.jsonl", lines.iter().map(String::as_str))
+        .expect("valid session records");
+
+    let comparison = compare_decay_four(&history)
+        .await
+        .expect("generous inline budget avoids emergency reduction");
+
+    assert_eq!(comparison.turn_count(), 130);
+    assert!(comparison.final_decay_tokens() < comparison.final_baseline_tokens());
+}
+
+#[tokio::test]
+async fn compares_an_empty_history_without_dividing_by_zero() {
+    let history = parse_session_lines("empty.jsonl", std::iter::empty())
+        .expect("an empty JSONL history is valid");
+
+    let comparison = compare_decay_four(&history)
+        .await
+        .expect("empty history needs no assembly calls");
+
+    assert_eq!(comparison.turn_count(), 0);
+    assert_eq!(comparison.final_baseline_tokens(), 0);
+    assert_eq!(comparison.final_decay_tokens(), 0);
+}
+
+#[tokio::test]
+#[ignore = "reads the explicitly selected session-manager corpus"]
+async fn replays_an_explicit_session_manager_directory() {
+    let directory = std::env::var("CONTEXT_REPLAY_DIR")
+        .expect("set CONTEXT_REPLAY_DIR to the session-manager JSONL directory");
+    let report = compare_directory(std::path::Path::new(&directory))
+        .await
+        .expect("corpus records and production assembly must succeed");
+
+    print!("{}", report.render());
+}

--- a/context-manager/tests/features/assemble.feature
+++ b/context-manager/tests/features/assemble.feature
@@ -62,11 +62,10 @@ Feature: context::assemble — the model-ready context pipeline
     And the response messages equal the request history
     And the summariser was never invoked
 
-  # Prevents: aged verbose outputs riding in context until the window
-  # overflows — the evidence session re-sent one 85k-token result on ~35
-  # consecutive calls. Prune is age-based now: under budget, outputs
-  # outside the protected window are still placeholdered.
-  Scenario: aged verbose outputs are pruned even under budget
+  # Prevents: old verbose outputs riding in context until the window
+  # overflows. Under budget, verbose outputs outside the protected window
+  # are still placeholdered even when decay is disabled.
+  Scenario: old verbose outputs are pruned even under budget
     Given the router knows model "big" with context window 200000 and max output 8000
     And config "protect_recent_tokens" is 0
     And config "min_free_tokens" is 1
@@ -80,6 +79,23 @@ Feature: context::assemble — the model-ready context pipeline
     And the response field "applied.pruned" is true
     And the response field "token_count" does not exceed 172000
     And response message 2 text is "[output of shell::run pruned: was ~5000 tokens; re-call it if still needed]"
+
+  Scenario: assemble reads decay controls from the worker config
+    Given the router knows model "big" with context window 200000 and max output 8000
+    And config "protect_recent_tokens" is 0
+    And config "min_free_tokens" is 1
+    And config "max_output_chars" is 10000
+    And config "decay_user_turns" is 2
+    And config "protected_user_turns" is 0
+    And a user message "task"
+    And an assistant function call "c1" to "shell::run"
+    And a function result for call "c1" from "shell::run" of ~100 tokens
+    And a user message "next"
+    And a user message "done"
+    When I assemble the history with model "big"
+    Then the call succeeds
+    And the response field "applied.pruned" is true
+    And response message 2 text is "[output of shell::run pruned: was ~100 tokens; re-call it if still needed]"
 
   # Prevents: the always-on trigger swallowing the allow_prune switch.
   # This is the only scenario that fails if prune fires when explicitly

--- a/context-manager/tests/features/prune.feature
+++ b/context-manager/tests/features/prune.feature
@@ -1,5 +1,5 @@
 @pure
-Feature: context::prune — placeholder verbose function outputs
+Feature: context::prune — placeholder eligible old function outputs
 
   Contract (context-manager.md § context::prune, § Structural
   invariants): walk function_result content newest to oldest, freeing
@@ -8,8 +8,9 @@ Feature: context::prune — placeholder verbose function outputs
   all survive; placeholders name the source function and the freed
   size, and point back at the recovery path
   (`[output of {function_id} pruned: was ~N tokens; re-call it if
-  still needed]`). The most recent two user turns are always exempt
-  (prior-art guard, independent of the window).
+  still needed]`). A configurable number of recent user turns are exempt
+  (default two, independent of the token window), and smaller outputs can
+  become eligible after their configured decay age.
 
   Background:
     Given a user message "investigate the failure"
@@ -104,6 +105,45 @@ Feature: context::prune — placeholder verbose function outputs
     And the response field "pruned_parts" is 0
     And the response field "scanned_parts" is 1
     And response message 2 text is "value=42"
+
+  Scenario: prune inherits configured decay controls
+    Given config "decay_user_turns" is 2
+    And config "protected_user_turns" is 0
+    When I prune the history with options:
+      """
+      { "protect_recent_tokens": 0, "min_free_tokens": 1, "max_output_chars": 10000 }
+      """
+    Then the call succeeds
+    And the response field "pruned_parts" is 1
+    And response message 2 text is "[output of shell::run pruned: was ~2000 tokens; re-call it if still needed]"
+
+  Scenario: explicit zero disables configured decay
+    Given config "decay_user_turns" is 1
+    And config "protected_user_turns" is 0
+    When I prune the history with options:
+      """
+      { "protect_recent_tokens": 0, "min_free_tokens": 1, "max_output_chars": 10000,
+        "decay_user_turns": 0, "protected_user_turns": 0 }
+      """
+    Then the call succeeds
+    And the response field "pruned_parts" is 0
+    And the response field "scanned_parts" is 1
+    And response message 2 text has 8000 chars
+
+  Scenario: explicit zero removes the configured recent-turn exemption
+    Given an empty history
+    And config "protected_user_turns" is 2
+    And a user message "start"
+    And an assistant function call "c9" to "shell::run"
+    And a function result for call "c9" from "shell::run" of ~2000 tokens
+    When I prune the history with options:
+      """
+      { "protect_recent_tokens": 0, "min_free_tokens": 1, "max_output_chars": 100,
+        "decay_user_turns": 0, "protected_user_turns": 0 }
+      """
+    Then the call succeeds
+    And the response field "pruned_parts" is 1
+    And response message 2 text is "[output of shell::run pruned: was ~2000 tokens; re-call it if still needed]"
 
   # Prevents: the always-exempt recent turns being pruned under token
   # pressure — outputs the user is actively working with must survive

--- a/context-manager/tests/golden/schemas/context.prune.json
+++ b/context-manager/tests/golden/schemas/context.prune.json
@@ -1,5 +1,5 @@
 {
-  "description": "Replace verbose function outputs with placeholders without summarising. A cheaper first pass before compaction.",
+  "description": "Replace eligible old function outputs with placeholders without summarising. A cheaper first pass before compaction.",
   "function_id": "context::prune",
   "request_schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -407,9 +407,19 @@
       },
       "PruneOptions": {
         "properties": {
+          "decay_user_turns": {
+            "default": null,
+            "description": "Prune outputs after this many subsequent user turns. `null` uses worker config (default 0); `0` disables age-based pruning.",
+            "format": "uint",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
           "max_output_chars": {
             "default": null,
-            "description": "Per-output verbosity threshold in chars (default 2000): outputs at or under it are never pruned.",
+            "description": "Per-output verbosity threshold in chars (default 2000). Outputs at or under it can still be pruned after the configured decay age.",
             "format": "uint",
             "minimum": 0.0,
             "type": [
@@ -429,7 +439,7 @@
           },
           "protect_recent_tokens": {
             "default": null,
-            "description": "Newest function-output tokens never pruned (default 40000).",
+            "description": "Newest function-output tokens kept by normal pruning (default 40000).",
             "format": "uint64",
             "minimum": 0.0,
             "type": [
@@ -445,6 +455,16 @@
             },
             "type": [
               "array",
+              "null"
+            ]
+          },
+          "protected_user_turns": {
+            "default": null,
+            "description": "Most recent user turns exempt from normal pruning. `null` uses worker config (default 2); `0` disables only this exemption.",
+            "format": "uint",
+            "minimum": 0.0,
+            "type": [
+              "integer",
               "null"
             ]
           }

--- a/context-manager/tests/replay_support/mod.rs
+++ b/context-manager/tests/replay_support/mod.rs
@@ -1,0 +1,460 @@
+use std::collections::HashMap;
+use std::fmt::Write as _;
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use context_manager::config::WorkerConfig;
+use context_manager::functions::assemble::{self, AssembleOptions, AssembleRequest};
+use context_manager::ports::{lease_cell, Deps};
+use context_manager::types::{AgentMessage, ContentBlock, ModelInput, ModelLimits};
+use serde_json::Value;
+use tokio::sync::RwLock;
+
+use crate::common::fakes::{FakeClock, FakeModelResolver, FakeSummarizer, InMemoryLeaseStore};
+
+pub struct ReplayHistory {
+    entries: Vec<ReplayEntry>,
+}
+
+struct ReplayEntry {
+    id: String,
+    revision: u64,
+    message: AgentMessage,
+}
+
+impl ReplayHistory {
+    pub fn message_count(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn ids(&self) -> Vec<&str> {
+        self.entries.iter().map(|entry| entry.id.as_str()).collect()
+    }
+
+    pub fn revisions(&self) -> Vec<u64> {
+        self.entries.iter().map(|entry| entry.revision).collect()
+    }
+
+    pub fn text_at(&self, index: usize) -> Option<&str> {
+        let entry = self.entries.get(index)?;
+        let [ContentBlock::Text { text }] = entry.message.content() else {
+            return None;
+        };
+        Some(text)
+    }
+
+    pub fn user_turn_endpoints(&self) -> Vec<usize> {
+        self.entries
+            .iter()
+            .enumerate()
+            .filter_map(|(index, entry)| {
+                (entry.message.role() == context_manager::types::Role::User
+                    && !entry.message.has_function_result_block())
+                .then_some(index)
+            })
+            .collect()
+    }
+
+    fn prefix_at(&self, endpoint: usize) -> Vec<AgentMessage> {
+        self.entries[..=endpoint]
+            .iter()
+            .map(|entry| entry.message.clone())
+            .collect()
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct EndpointEstimate {
+    pub baseline_tokens: u64,
+    pub decay_tokens: u64,
+}
+
+pub struct ReplayComparison {
+    estimates: Vec<EndpointEstimate>,
+}
+
+pub struct ReplayReport {
+    sessions: Vec<ReplaySession>,
+}
+
+struct ReplaySession {
+    name: String,
+    messages: usize,
+    comparison: ReplayComparison,
+}
+
+impl ReplayComparison {
+    pub fn turn_count(&self) -> usize {
+        self.estimates.len()
+    }
+
+    pub fn estimates(&self) -> &[EndpointEstimate] {
+        &self.estimates
+    }
+
+    pub fn final_baseline_tokens(&self) -> u64 {
+        self.estimates
+            .last()
+            .map(|estimate| estimate.baseline_tokens)
+            .unwrap_or(0)
+    }
+
+    pub fn final_decay_tokens(&self) -> u64 {
+        self.estimates
+            .last()
+            .map(|estimate| estimate.decay_tokens)
+            .unwrap_or(0)
+    }
+}
+
+pub fn parse_session_lines<'a>(
+    path: &str,
+    lines: impl IntoIterator<Item = &'a str>,
+) -> Result<ReplayHistory, String> {
+    let mut entries = Vec::new();
+    let mut by_id = HashMap::new();
+
+    for (offset, line) in lines.into_iter().enumerate() {
+        let line_number = offset + 1;
+        let record: Value = serde_json::from_str(line)
+            .map_err(|_| format!("{path}:{line_number}: invalid JSON record"))?;
+        let record = record
+            .as_object()
+            .ok_or_else(|| format!("{path}:{line_number}: record is not an object"))?;
+        let record_type = required_string(record, "type", path, line_number)?;
+        match record_type {
+            "meta" | "leaf" => {}
+            "entry" => {
+                let entry = required_object(record, "entry", path, line_number)?;
+                let kind = required_string(entry, "kind", path, line_number)?;
+                if kind != "message" {
+                    continue;
+                }
+                let id = required_string(entry, "id", path, line_number)?.to_owned();
+                if id.is_empty() {
+                    return Err(format!("{path}:{line_number}: message entry id is empty"));
+                }
+                let revision = entry
+                    .get("revision")
+                    .and_then(Value::as_u64)
+                    .ok_or_else(|| {
+                        format!("{path}:{line_number}: message entry revision is invalid")
+                    })?;
+                let raw_message = entry.get("message").ok_or_else(|| {
+                    format!("{path}:{line_number}: message entry message is missing")
+                })?;
+                let message = serde_json::from_value(raw_message.clone()).map_err(|_| {
+                    format!("{path}:{line_number}: message entry message is invalid")
+                })?;
+                let next = ReplayEntry {
+                    id: id.clone(),
+                    revision,
+                    message,
+                };
+                if let Some(index) = by_id.get(&id) {
+                    entries[*index] = next;
+                } else {
+                    by_id.insert(id, entries.len());
+                    entries.push(next);
+                }
+            }
+            _ => return Err(format!("{path}:{line_number}: unsupported record type")),
+        }
+    }
+
+    Ok(ReplayHistory { entries })
+}
+
+pub async fn compare_decay_four(history: &ReplayHistory) -> Result<ReplayComparison, String> {
+    let mut estimates = Vec::new();
+    for endpoint in history.user_turn_endpoints() {
+        let original_prefix = history.prefix_at(endpoint);
+        let baseline = assemble_prefix(original_prefix.clone(), 0).await?;
+        let decay = assemble_prefix(original_prefix, 4).await?;
+        estimates.push(EndpointEstimate {
+            baseline_tokens: baseline.token_count,
+            decay_tokens: decay.token_count,
+        });
+    }
+    Ok(ReplayComparison { estimates })
+}
+
+pub async fn compare_directory(directory: &Path) -> Result<ReplayReport, String> {
+    let mut paths = session_paths(directory)?;
+    paths.sort();
+    let mut sessions = Vec::with_capacity(paths.len());
+    for path in paths {
+        let history = read_history(&path)?;
+        let comparison = compare_decay_four(&history).await?;
+        let name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| format!("{}: file name is not valid UTF-8", path.display()))?
+            .to_owned();
+        sessions.push(ReplaySession {
+            name,
+            messages: history.message_count(),
+            comparison,
+        });
+    }
+    Ok(ReplayReport { sessions })
+}
+
+impl ReplayReport {
+    pub fn render(&self) -> String {
+        let mut output = String::new();
+        writeln!(
+            output,
+            "Offline context::assemble replay (assembled-history estimates)"
+        )
+        .unwrap();
+        writeln!(output, "config: defaults except decay_user_turns=0 versus 4; inline 1000000/1 limits; no prompt/tools/overhead; compaction disabled").unwrap();
+        writeln!(output, "session\tmessages\tuser_turns\tlast_quarter_endpoints\tfinal_0\tfinal_4\tfinal_saved\tfinal_saved_pct\tlast_quarter_mean_0\tlast_quarter_mean_4\tmean_saved\tmean_saved_pct").unwrap();
+
+        let mut message_count = 0usize;
+        let mut turn_count = 0usize;
+        let mut sample_count = 0usize;
+        let mut final_baseline = 0u64;
+        let mut final_decay = 0u64;
+        let mut sample_baseline = 0u64;
+        let mut sample_decay = 0u64;
+        for session in &self.sessions {
+            let summary = summary(&session.comparison);
+            message_count += session.messages;
+            turn_count += summary.turn_count;
+            sample_count += summary.sample_count;
+            final_baseline = final_baseline.saturating_add(summary.final_baseline);
+            final_decay = final_decay.saturating_add(summary.final_decay);
+            sample_baseline = sample_baseline.saturating_add(summary.sample_baseline);
+            sample_decay = sample_decay.saturating_add(summary.sample_decay);
+            writeln!(
+                output,
+                "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:.2}\t{:.2}\t{:.2}\t{:.2}\t{:.2}",
+                session.name,
+                session.messages,
+                summary.turn_count,
+                summary.sample_count,
+                summary.final_baseline,
+                summary.final_decay,
+                delta(summary.final_baseline, summary.final_decay),
+                percentage(
+                    delta(summary.final_baseline, summary.final_decay),
+                    summary.final_baseline
+                ),
+                mean(summary.sample_baseline, summary.sample_count),
+                mean(summary.sample_decay, summary.sample_count),
+                mean_delta(
+                    summary.sample_baseline,
+                    summary.sample_decay,
+                    summary.sample_count
+                ),
+                percentage(
+                    delta(summary.sample_baseline, summary.sample_decay),
+                    summary.sample_baseline
+                ),
+            )
+            .unwrap();
+        }
+        writeln!(
+            output,
+            "aggregate_final\tfiles={} messages={} user_turns={}\tbaseline={}\tdecay4={}\tsaved={}\tsaved_pct={:.2}",
+            self.sessions.len(),
+            message_count,
+            turn_count,
+            final_baseline,
+            final_decay,
+            delta(final_baseline, final_decay),
+            percentage(delta(final_baseline, final_decay), final_baseline),
+        )
+        .unwrap();
+        writeln!(
+            output,
+            "aggregate_last_quarter\tendpoints={}\tbaseline_total={}\tdecay4_total={}\tsaved_total={}\tsaved_pct={:.2}\tmean_0={:.2}\tmean_4={:.2}",
+            sample_count,
+            sample_baseline,
+            sample_decay,
+            delta(sample_baseline, sample_decay),
+            percentage(delta(sample_baseline, sample_decay), sample_baseline),
+            mean(sample_baseline, sample_count),
+            mean(sample_decay, sample_count),
+        )
+        .unwrap();
+        output
+    }
+}
+
+struct ComparisonSummary {
+    turn_count: usize,
+    sample_count: usize,
+    final_baseline: u64,
+    final_decay: u64,
+    sample_baseline: u64,
+    sample_decay: u64,
+}
+
+fn summary(comparison: &ReplayComparison) -> ComparisonSummary {
+    let estimates = comparison.estimates();
+    let sample_count = estimates.len().div_ceil(4);
+    let sampled = if sample_count == 0 {
+        &[]
+    } else {
+        &estimates[estimates.len() - sample_count..]
+    };
+    ComparisonSummary {
+        turn_count: estimates.len(),
+        sample_count,
+        final_baseline: comparison.final_baseline_tokens(),
+        final_decay: comparison.final_decay_tokens(),
+        sample_baseline: sampled
+            .iter()
+            .map(|estimate| estimate.baseline_tokens)
+            .sum(),
+        sample_decay: sampled.iter().map(|estimate| estimate.decay_tokens).sum(),
+    }
+}
+
+fn mean(total: u64, count: usize) -> f64 {
+    if count == 0 {
+        0.0
+    } else {
+        total as f64 / count as f64
+    }
+}
+
+fn mean_delta(baseline: u64, decay: u64, count: usize) -> f64 {
+    if count == 0 {
+        0.0
+    } else {
+        delta(baseline, decay) as f64 / count as f64
+    }
+}
+
+fn delta(baseline: u64, decay: u64) -> i128 {
+    i128::from(baseline) - i128::from(decay)
+}
+
+fn percentage(saved: i128, baseline: u64) -> f64 {
+    if baseline == 0 {
+        0.0
+    } else {
+        saved as f64 * 100.0 / baseline as f64
+    }
+}
+
+fn session_paths(directory: &Path) -> Result<Vec<PathBuf>, String> {
+    let entries = fs::read_dir(directory)
+        .map_err(|_| format!("{}: cannot read input directory", directory.display()))?;
+    let mut paths = Vec::new();
+    for entry in entries {
+        let entry =
+            entry.map_err(|_| format!("{}: cannot read directory entry", directory.display()))?;
+        let path = entry.path();
+        if path.is_file()
+            && path
+                .extension()
+                .is_some_and(|extension| extension == "jsonl")
+        {
+            paths.push(path);
+        }
+    }
+    if paths.is_empty() {
+        return Err(format!(
+            "{}: no JSONL session files found",
+            directory.display()
+        ));
+    }
+    Ok(paths)
+}
+
+fn read_history(path: &Path) -> Result<ReplayHistory, String> {
+    let file =
+        fs::File::open(path).map_err(|_| format!("{}: cannot open input file", path.display()))?;
+    let reader = BufReader::new(file);
+    let mut lines = Vec::new();
+    for (offset, line) in reader.lines().enumerate() {
+        lines.push(
+            line.map_err(|_| format!("{}:{}: cannot read input line", path.display(), offset + 1))?,
+        );
+    }
+    parse_session_lines(
+        path.to_string_lossy().as_ref(),
+        lines.iter().map(String::as_str),
+    )
+}
+
+async fn assemble_prefix(
+    messages: Vec<AgentMessage>,
+    decay_user_turns: usize,
+) -> Result<assemble::AssembleResponse, String> {
+    let config = WorkerConfig {
+        decay_user_turns,
+        ..WorkerConfig::default()
+    };
+    let deps = replay_deps(config);
+    let response = assemble::handle(
+        &deps,
+        AssembleRequest {
+            messages: Some(messages),
+            model: ModelInput {
+                id: "offline-replay".to_string(),
+                provider: None,
+                limits: Some(ModelLimits {
+                    context_window: 1_000_000,
+                    max_output_tokens: 1,
+                    input_limit: None,
+                }),
+            },
+            system_prompt: None,
+            tools: None,
+            parts: None,
+            options: Some(AssembleOptions {
+                allow_compaction: Some(false),
+                ..AssembleOptions::default()
+            }),
+        },
+    )
+    .await
+    .map_err(|error| format!("assemble failed: {error}"))?;
+
+    if response.applied.compacted || response.applied.initial_token_count > response.usable {
+        return Err("replay budget allowed compaction or emergency reduction".to_string());
+    }
+    Ok(response)
+}
+
+fn replay_deps(config: WorkerConfig) -> Deps {
+    let leases = Arc::new(InMemoryLeaseStore::new());
+    Deps {
+        config: Arc::new(RwLock::new(Arc::new(config))),
+        resolver: Arc::new(FakeModelResolver::new()),
+        summarizer: Arc::new(FakeSummarizer::new()),
+        leases: lease_cell(leases),
+        clock: Arc::new(FakeClock::new()),
+    }
+}
+
+fn required_object<'a>(
+    value: &'a serde_json::Map<String, Value>,
+    field: &str,
+    path: &str,
+    line: usize,
+) -> Result<&'a serde_json::Map<String, Value>, String> {
+    value
+        .get(field)
+        .and_then(Value::as_object)
+        .ok_or_else(|| format!("{path}:{line}: {field} is missing or invalid"))
+}
+
+fn required_string<'a>(
+    value: &'a serde_json::Map<String, Value>,
+    field: &str,
+    path: &str,
+    line: usize,
+) -> Result<&'a str, String> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("{path}:{line}: {field} is missing or invalid"))
+}

--- a/context-manager/tests/steps/model_steps.rs
+++ b/context-manager/tests/steps/model_steps.rs
@@ -127,6 +127,8 @@ async fn config_numeric(world: &mut ContextWorld, field: String, value: u64) {
         "reserved_pct" => world.config.reserved_pct = value,
         "tail_turns" => world.config.tail_turns = value as usize,
         "protect_recent_tokens" => world.config.protect_recent_tokens = value,
+        "decay_user_turns" => world.config.decay_user_turns = value as usize,
+        "protected_user_turns" => world.config.protected_user_turns = value as usize,
         "min_free_tokens" => world.config.min_free_tokens = value,
         "max_output_chars" => world.config.max_output_chars = value as usize,
         "lease_ttl_secs" => world.config.lease_ttl_secs = value,

--- a/context-manager/ui/src/configuration/index.tsx
+++ b/context-manager/ui/src/configuration/index.tsx
@@ -38,7 +38,19 @@ const PRUNING_FIELDS: NumericField[] = [
     key: 'protect_recent_tokens',
     label: 'Protected recent output (tokens)',
     defaultValue: 40_000,
-    description: 'Newest function-output tokens protected from age-based pruning.',
+    description: 'Newest function-output tokens kept during normal pruning. Set to 0 to disable this window.',
+  },
+  {
+    key: 'decay_user_turns',
+    label: 'Function result decay (user turns)',
+    defaultValue: 0,
+    description: 'Prune eligible outputs after this many subsequent user turns. Set to 0 to turn decay off.',
+  },
+  {
+    key: 'protected_user_turns',
+    label: 'Protected recent turns',
+    defaultValue: 2,
+    description: 'Keep outputs in this many most recent user turns. Set to 0 to disable this protection.',
   },
   {
     key: 'min_free_tokens',
@@ -50,7 +62,7 @@ const PRUNING_FIELDS: NumericField[] = [
     key: 'max_output_chars',
     label: 'Verbose output threshold (characters)',
     defaultValue: 2_000,
-    description: 'Shorter function outputs are not considered for normal pruning.',
+    description: 'Longer outputs are immediately eligible outside protection; shorter outputs can still decay.',
   },
   {
     key: 'max_result_tokens',

--- a/tech-specs/2026-06-agentic/context-manager.md
+++ b/tech-specs/2026-06-agentic/context-manager.md
@@ -72,7 +72,7 @@ Whatever capping, pruning, or compaction does, the returned context must still b
   of any boundary: the compaction tail never starts between an assistant's call and its result
   (providers reject orphaned results), so tail selection only cuts at user/assistant turn
   boundaries.
-- **Prune replaces, never removes.** Pruning rewrites a verbose output's content to a single text
+- **Prune replaces, never removes.** Pruning rewrites an eligible old output's content to a single text
   placeholder (`[output of {function_id} pruned: was ~N tokens; re-call it if still needed]`); the
   block, the message, and the `function_call_id` linkage all survive. The unconditional per-result
   cap pass (see `context::assemble`) replaces the same way, with its own marker: `[…result capped:
@@ -95,7 +95,7 @@ Whatever capping, pruning, or compaction does, the returned context must still b
   history. The main "sync messages with context" entry point.
 - `context::compact` — Summarise older history into a single compaction summary and return the
   preserved tail. Transient: the caller uses the result; the session keeps its full transcript.
-- `context::prune` — Strip/truncate verbose function outputs without summarising. The cheap policy
+- `context::prune` — Replace eligible old function outputs without summarising. The cheap policy
   pass, run on every call (not just when over budget).
 - `context::count-tokens` — Estimate token usage for a set of messages (+ optional invocation schema /
   system) vs a model.
@@ -302,7 +302,7 @@ worker log and callers should treat it as "compaction unavailable".
 
 ### `context::prune`
 
-Replace verbose function outputs with a `[output of {function_id} pruned: was ~N tokens; re-call
+Replace eligible old function outputs with a `[output of {function_id} pruned: was ~N tokens; re-call
 it if still needed]` placeholder, without summarising. Walks `function_result` content newest to
 oldest, freeing outputs outside a protected token window. Per the
 [structural invariants](#structural-invariants), pruning rewrites content in place — it never
@@ -318,12 +318,21 @@ type PruneRequest = {
   model?: ModelInput;              // only needed for token math; optional
   options?: {
     protect_recent_tokens?: number; // default 40000
+    decay_user_turns?: number;      // subsequent user turns before decay; null inherits, 0 disables (default 0)
+    protected_user_turns?: number;  // recent user turns exempt; null inherits, 0 disables (default 2)
     min_free_tokens?: number;       // skip if it would free less (default 20000)
-    max_output_chars?: number;      // per-output truncation cap (default 2000)
+    max_output_chars?: number;      // larger outputs immediately eligible; smaller outputs may decay (default 2000)
     protected_functions?: string[];     // function_ids never pruned
   };
 };
 ```
+
+Age is the number of subsequent user messages, excluding user wrappers that
+carry inline function results. Outputs inside either the protected-user-turn
+window or `protect_recent_tokens` window remain verbatim, as do protected
+functions. Age-only candidates are replaced only when the placeholder saves
+estimated tokens. `context::assemble` reads both decay controls from the live
+worker config; it does not expose per-call overrides for them.
 
 Response:
 


### PR DESCRIPTION
## Summary

Allow older function results to leave the active context after a configurable number of user turns, while preserving recent results, call/result pairing, and retrieval hints. Age-based decay remains disabled by default.

Fixes MOT-4667

## Technical details

- Add `decay_user_turns` (default `0`) and `protected_user_turns` (default `2`) to worker configuration, the `context::prune` contract, context assembly, and the configuration UI.
- Let smaller results become eligible by age while retaining the recent-token window, protected-function exemptions, and minimum-saving guard. Explicit zero values disable their respective controls.
- Preserve message metadata and inline result siblings, recognize only canonical prune markers, and avoid replacing a result when the enclosing-message token estimate would not shrink.
- Add boundary, compatibility, idempotency, schema-golden, BDD, and offline replay coverage, with updated configuration and behavior documentation.

## Validation

- [x] `cargo test --locked --manifest-path context-manager/Cargo.toml` — passed, including 99 BDD scenarios and schema goldens. The explicitly selected corpus replay remains opt-in and was ignored by this invocation.
- [x] `cargo fmt --manifest-path context-manager/Cargo.toml --check`
- [x] `pnpm --dir context-manager/ui build` — TypeScript checking and bundle build passed.
- [x] `git diff --check origin/main...HEAD`
- [x] Merge-tree check against the current `main` — no conflicts; branch history unchanged.

### Long-session live validation

Previously exercised this same revision through `harness::send` using the real harness library in isolated namespaces on a running engine, with the real Codex provider (`codex/gpt-5.4-mini`) and an immutable, read-only synthetic tool. Each session received 31 user messages: 24 collection rounds, five recall/revision checks, and two additional checks under an artificially reduced assembly budget. No global configuration changes were made.

The comparison used these complete profiles; it does not isolate the effect of decay age alone:

| Setting | Default | Decay profile |
| --- | ---: | ---: |
| `decay_user_turns` | 0 | 4 |
| `protected_user_turns` | 2 | 2 |
| `protect_recent_tokens` | 40,000 | 8,000 |
| `min_free_tokens` | 20,000 | 1,000 |

For the first 29 user messages, without forced compaction:

| Metric | Default | Decay profile |
| --- | ---: | ---: |
| Cumulative input tokens, including cache | 1,071,299 | 642,271 |
| Input served from cache | 88.58% | 56.52% |
| Function calls | 96 | 103 |
| API-equivalent estimated cost | $0.17401065 | $0.24854385 |

The decay profile used 40.05% fewer input tokens but cost 42.83% more in this run, alongside lower prompt-cache reuse. Including the two additional checks and the summarizer calls, the estimates were $0.21020220 versus $0.27030510 (+28.59%). These are equivalents using published GPT-5.4 mini API rates, not verified charges against a Codex subscription. Summarizer usage was recovered from router traces and added separately because it is not included in the harness usage totals.

Without tools, the decay session correctly reported three old records as unavailable rather than inventing values. With tools, it recovered the requested records, adding seven reads during the natural phase. Both sessions completed one forced compaction and answered all six subsequent record checks correctly, preserving a recent user revision. Original results remained intact in durable history.

The default session also made two duplicate collection calls, missing two requested IDs, and later supplied an incorrect quantity for one missing record. This is a model error observed in this execution, not evidence that retention itself caused it. One synthetic comparison does not establish a general quality or cost advantage, and the forced-compaction phase is not a measurement of repeated natural compactions. These results support keeping decay opt-in and avoiding a claim of guaranteed monetary savings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable pruning controls for output aging and protection of recent user turns.
  * Updated pruning behavior so large outputs are immediately eligible, while smaller outputs may become eligible after subsequent user turns.
  * Added corresponding settings to configuration forms and request schemas.

* **Documentation**
  * Clarified pruning behavior, configuration options, and offline replay analysis guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->