### PR TITLE
(MOT-4657) fix(ci): bootstrap quickstart with project init

### DIFF
--- a/harness/tests/quickstart/README.md
+++ b/harness/tests/quickstart/README.md
@@ -4,18 +4,22 @@ This check exercises the published installation path in an isolated temporary
 home and project:
 
 ```bash
+iii project init quickstart --template quickstart
+cd quickstart
 printf 'workers: []\n' > config.yaml
 iii -c config.yaml
-iii compose --namespace default   # serves compose::* against the engine
+iii compose --engine ws://127.0.0.1:49134 --namespace default \
+  --file worker-compose.yaml --up
 iii trigger compose::add --json '{"file":"worker-compose.yaml","worker":"harness"}'
 iii trigger compose::add --json '{"file":"worker-compose.yaml","worker":"console"}'
 ```
 
-The validator seeds a minimal `worker-compose.yaml` (`namespace: default`,
-empty `containers:`); each `compose::add` resolves the worker's registry
-graph, pins every container to an exact version in the file, and restarts
-the project. It accepts the legacy synchronous `status: ok` response and, for
-newer CLIs, follows an admitted `status: accepted` operation through
+The `quickstart` project template seeds `worker-compose.yaml` with the
+namespace, engine URL, and empty `containers: {}`. Each `compose::add` then
+resolves the worker's registry graph, pins every container to an exact version
+in the file, and restarts the project. It accepts the legacy synchronous
+`status: ok` response and, for newer CLIs, follows an admitted `status: accepted`
+operation through
 `compose::operation` until it succeeds. A failed, cancelled, or timed-out
 operation stops the quickstart before it inspects a partially reconciled stack.
 

--- a/harness/tests/quickstart/run-ci.sh
+++ b/harness/tests/quickstart/run-ci.sh
@@ -690,8 +690,14 @@ start_engine() {
 # below reach it the same way every other function is reached. It runs in the
 # foreground by design; the script owns backgrounding it, like the engine.
 start_compose() {
-  local command=("$iii_bin" compose --engine "ws://127.0.0.1:$engine_port" --namespace default)
-  log_command "iii compose --engine ws://127.0.0.1:$engine_port --namespace default"
+  local command=(
+    "$iii_bin" compose
+    --engine "ws://127.0.0.1:$engine_port"
+    --namespace default
+    --file "$compose_file"
+    --up
+  )
+  log_command "iii compose --engine ws://127.0.0.1:$engine_port --namespace default --file worker-compose.yaml --up"
   if command -v setsid >/dev/null 2>&1; then
     ANTHROPIC_API_KEY="$anthropic_api_key" OPENAI_API_KEY="$openai_api_key" \
       setsid "${command[@]}" >"$log_dir/compose.log" 2>&1 &
@@ -742,26 +748,21 @@ cli_version=$("$iii_bin" --version 2>&1)
 printf '%s\n' "$cli_version" >"$artifact_dir/cli-version.txt"
 ok "installed $cli_version"
 
-log "Step 2/9: Start an empty engine and the compose daemon"
+log "Step 2/9: Initialize the project, start an empty engine and the compose daemon"
+log_command "iii project init --directory $project_dir --template quickstart --skip-iii"
+"$iii_bin" project init \
+  --directory "$project_dir" \
+  --template quickstart \
+  --skip-iii \
+  2>&1 | tee "$log_dir/project-init.log"
 printf 'workers: []\n' >config.yaml
 start_engine
 wait_for_engine
 start_compose
 wait_for_compose
-# The seed only names the project: `compose::add` writes every container.
-# `namespace: default` is required — harness and Console must register beside
-# the engine builtins, exactly like the flow this validates. Written only
-# AFTER the daemon is up: since 0.23.0-rc.8 the daemon validates the compose
-# file at startup and exits on empty containers (EMPTY_CONTAINERS), while
-# `compose::add` requires the file to exist — so the seed lands between the
-# daemon boot and the first add.
-cat >"$compose_file" <<'COMPOSE'
-namespace: default
-startup_timeout: 5m
-stop_timeout: 10s
-
-containers:
-COMPOSE
+# `project init --template quickstart` supplies the empty project declaration
+# with an engine URL, so Compose can load it before the first worker is added.
+[[ -s "$compose_file" ]] || die "project init did not create worker-compose.yaml"
 
 log "Step 3/9: Add harness and Console from worker tag $worker_tag via compose"
 run_compose_add "harness@$worker_tag" 2>&1 | tee "$log_dir/compose-add-harness.log"


### PR DESCRIPTION
Refs MOT-4657

Bootstrap the Harness QuickStart from the published `quickstart` project template before starting Compose.

The template provides an engine URL with an empty `containers` map, which is valid for the current Compose loader. Compose now starts with the generated file and `--up`, while the existing `harness@latest` and `console@latest` admissions remain unchanged.

## Verification

- `bash -n harness/tests/quickstart/run-ci.sh`
- `git diff --check`
- `python3 -m pytest .github/scripts/tests` (272 passed)
- Generated the `quickstart` template and verified the seed contains `engine` and `containers: {}`.
- Started Compose against the generated seed with an unavailable engine; the project loaded and reached `up: nothing to do` before the expected connection timeout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the quickstart guide to use the published project template.
  * Clarified that initialization provides the namespace, engine URL, and empty container configuration.

* **Tests**
  * Updated the quickstart workflow to initialize projects through the project command.
  * Compose now starts with the explicit configuration file and engine URL.
  * Added validation that the worker Compose file is generated during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->