### PR TITLE
(MOT-4702) fix(iii-directory): truncate over-long capabilities lists instead of rejecting the call

### DIFF
--- a/iii-directory/README.md
+++ b/iii-directory/README.md
@@ -421,7 +421,7 @@ catalog with `engine::functions::list`.
 
 | Function | Kind | What it does |
 |---|---|---|
-| `directory::search_functions` | public | `{ capabilities }` → `{ guidance, workers[], installable[]?, latency_ms }`: BM25 rank over the live engine catalog (at most 6 workers / 12 candidates) plus matching NOT-installed registry workers under `installable`. `capabilities` is a required list of one to six non-empty unmet external capability searches. Requests to summarize provided text/content are ignored. |
+| `directory::search_functions` | public | `{ capabilities }` → `{ guidance, workers[], installable[]?, latency_ms }`: BM25 rank over the live engine catalog (at most 6 workers / 12 candidates) plus matching NOT-installed registry workers under `installable`. `capabilities` is a required list of one to six non-empty unmet external capability searches; extra entries are not searched and are named in `guidance`. Requests to summarize provided text/content are ignored. |
 | `directory::pre-generate` | internal hook | Injects the conditional search hint into a harness generation (at most once per turn). |
 | `directory::on-functions-change` | internal | Refreshes the search catalog on the engine's functions-available push. |
 | `directory::hint-preview` | internal | The exact hint text per exposure mode, for the configuration UI. |

--- a/iii-directory/src/functions/search.rs
+++ b/iii-directory/src/functions/search.rs
@@ -309,11 +309,7 @@ pub struct SearchFunctionsRequest {
     /// IDs.
     // MOT-4654: kept verbatim on purpose — this is a tuned search directive pinned
     // phrase-by-phrase by tests/search_schemas.rs, not descriptive prose.
-    #[schemars(
-        with = "HashSet<String>",
-        length(min = 1, max = 6),
-        inner(length(min = 1))
-    )]
+    #[schemars(with = "HashSet<String>", length(min = 1), inner(length(min = 1)))]
     pub capabilities: Vec<String>,
 }
 
@@ -1110,16 +1106,17 @@ async fn registry_installable(
 /// candidates for only the ranked functions — never a whole worker.
 pub async fn search_functions(
     deps: &Deps,
-    request: SearchFunctionsRequest,
+    mut request: SearchFunctionsRequest,
 ) -> Result<SearchFunctionsResponse, Error> {
     if request.capabilities.is_empty() {
         return Err(Error::Handler("provide at least one capability".into()));
     }
-    if request.capabilities.len() > MAX_SEARCH_QUERIES {
-        return Err(Error::Handler(format!(
-            "provide at most {MAX_SEARCH_QUERIES} capabilities"
-        )));
-    }
+    // Over the cap: search the first MAX_SEARCH_QUERIES and name the rest in
+    // `guidance` so the agent keeps this turn's candidates instead of a
+    // rejected call.
+    let dropped = request
+        .capabilities
+        .split_off(request.capabilities.len().min(MAX_SEARCH_QUERIES));
     if request
         .capabilities
         .iter()
@@ -1237,6 +1234,15 @@ unchanged — reuse the earlier result): {}.",
             guidance = format!("{guidance} {SEARCH_INSTALL_NOTE}");
         }
         guidance
+    };
+    let guidance = if dropped.is_empty() {
+        guidance
+    } else {
+        format!(
+            "{guidance} Only the first {MAX_SEARCH_QUERIES} capabilities were searched; \
+search again for: {}.",
+            dropped.join(", ")
+        )
     };
     Ok(SearchFunctionsResponse {
         guidance,
@@ -2272,17 +2278,23 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn search_rejects_more_than_six_capabilities() {
+    async fn search_truncates_more_than_six_capabilities() {
         let request: SearchFunctionsRequest = serde_json::from_value(json!({
-            "capabilities": ["one", "two", "three", "four", "five", "six", "seven"]
+            "capabilities": ["one", "two", "three", "four", "five", "six", "seven", "eight"]
         }))
         .unwrap();
 
-        let error = search_functions(&search_deps(Vec::new()), request)
+        let response = search_functions(&search_deps(Vec::new()), request)
             .await
-            .unwrap_err();
+            .unwrap();
 
-        assert!(error.to_string().contains("at most 6 capabilities"));
+        assert!(
+            response.guidance.contains(
+                "Only the first 6 capabilities were searched; search again for: seven, eight."
+            ),
+            "{}",
+            response.guidance
+        );
     }
 
     #[tokio::test]

--- a/iii-directory/tests/golden/schemas/directory.search_functions.json
+++ b/iii-directory/tests/golden/schemas/directory.search_functions.json
@@ -10,7 +10,6 @@
           "minLength": 1,
           "type": "string"
         },
-        "maxItems": 6,
         "minItems": 1,
         "type": "array",
         "uniqueItems": true

--- a/iii-directory/tests/search_schemas.rs
+++ b/iii-directory/tests/search_schemas.rs
@@ -57,10 +57,8 @@ fn search_capabilities_schema_advertises_the_runtime_limit() {
         .find(|spec| spec.function_id == "directory::search_functions")
         .expect("search function is registered");
 
-    assert_eq!(
-        search.request_schema["properties"]["capabilities"]["maxItems"],
-        6
-    );
+    // No maxItems: the handler truncates over-long lists instead of rejecting them.
+    assert!(search.request_schema["properties"]["capabilities"]["maxItems"].is_null());
     assert_eq!(
         search.request_schema["properties"]["capabilities"]["minItems"],
         1


### PR DESCRIPTION
## Why

`directory::search_functions` hard-failed with `provide at most 6 capabilities` when an agent sent more than six entries, and the request schema advertised `maxItems: 6`, so strict providers rejected the call before the worker saw it. Either way the agent lost the whole turn and had to re-issue the search.

## What

- Search the first six capabilities and append to `guidance`: `Only the first 6 capabilities were searched; search again for: <dropped>.`
- Drop `maxItems` from the wire schema (`schemars length(max = 6)`) so the truncation path is reachable; the "one to six" field description stays as the directive to agents.
- Test `search_rejects_more_than_six_capabilities` → `search_truncates_more_than_six_capabilities`; schema golden and `search_schemas.rs` updated; README row mentions the truncation.

Not changed: `MAX_SEARCH_QUERIES` stays 6. Raising it was evaluated and rejected: the response is fixed at 12 candidates round-robin across capabilities, so more capabilities means fewer candidates each. Held-out set maxes at 2 capabilities per query, live sessions at 4; the cap never fired in practice.

## Verification

- `cargo test --lib` in iii-directory: 434 passed
- `cargo test --test search_schemas`: green
- `cargo clippy --all-features --all-targets -- -D warnings`: clean

https://claude.ai/code/session_01AqWfKxQWL7vozgm3byFVo2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Search requests with more than six capabilities are now accepted.
  - The first six capabilities are searched, while any additional entries are identified in guidance.
  - Updated documentation and schema details clarify the required capability format and handling of extra entries.

- **Bug Fixes**
  - Prevented overlong capability lists from being rejected outright.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->