### PR TITLE
(MOT-4706) docs(compose): explain full container settings in worker guidance

### DIFF
--- a/harness/README.md
+++ b/harness/README.md
@@ -126,6 +126,64 @@ the only contract.
 
 TL;DR: list, info, call. The engine tells you the truth; trust it over memory.
 
+## Adding workers with container settings
+
+Fetch `compose::schema { function_id: "compose::add" }` before choosing the payload.
+Use container objects only if the running daemon's schema supports them. The singular
+`worker` field remains a string shorthand. For settings, use `workers`, which can mix
+strings and objects. Put settings inside each object, not at the request's top level.
+Only `add` accepts objects; `update` and `remove` take worker names.
+
+After registering the one-shot wake described above, call `compose::add` with a payload
+like this (the local worker directory and env file must already exist):
+
+```json
+{
+  "operation_id": "<operation-id>",
+  "workers": [
+    "state",
+    {
+      "worker": "./workers/api",
+      "start_after": ["state"],
+      "scripts": {
+        "pre_run": "pnpm build",
+        "pre_run_timeout": "60s",
+        "run": "pnpm start",
+        "post_run": "echo stopped"
+      },
+      "config_name": "api",
+      "config_override": { "port": 3000 },
+      "working_dir": "./workers/api",
+      "environment": { "NODE_ENV": "development" },
+      "env_file": ["./api.env"],
+      "startup_timeout": "30s"
+    }
+  ]
+}
+```
+
+`worker` accepts a package name, `name@version`, registry reference, or local directory,
+including `package://` and `path://` sources. Objects also accept `version` for packages;
+it must agree with any version in `worker`. Omission resolves the latest matching package
+version, so keep an explicit version when it must stay pinned.
+
+Use `scripts` (plural); `scripts.run` is valid only for local workers. `start_after`
+contains container keys, derived from the last part of each worker name or directory;
+required package dependencies are also included. `config_name` selects the base configuration,
+and `config_override` supplies values over it. `environment` values must be strings.
+`startup_timeout` limits the wait for registration.
+
+Relative `worker`, `working_dir`, and `env_file` paths start at the compose file's directory.
+`working_dir` sets the process and hook directory; when omitted, local workers use their own
+directory and packages use the compose directory.
+
+For an existing container, omitted settings stay in place. A supplied field replaces that
+whole field, including `scripts`, `environment`, and `config_override`; these are not
+partial map edits. Use `{}` or `[]` to clear maps or lists. A supplied `start_after` replaces
+the list while retaining required package dependencies. Changes can restart running workers.
+The acceptance response does not mean ready: finish the same `compose-operation` workflow
+before using the worker.
+
 ## Configuration
 
 The `harness` configuration entry is owned by the `configuration` worker; every

--- a/harness/agents/worker-builder.md
+++ b/harness/agents/worker-builder.md
@@ -23,7 +23,10 @@ reports `experimental: true`.
 Everything happens through `agent_trigger` as the base identity describes. Files go
 through `coder::*`, processes through `shell::exec` / `shell::exec_bg`, HTTP through
 `web::fetch` (never curl). If `github::*`, `worktree::*`, or `web::*` are not
-registered, say why and install them with `compose::add { worker: "<name>" }`.
+registered, say why and install them with the base identity's `compose-operation`
+wake flow. Fetch `compose::schema { function_id: "compose::add" }`; use the singular
+`worker` shorthand for defaults, or objects in `workers` when settings are needed.
+Wait for terminal success before calling the new functions.
 
 The skill filter above names the iii knowledge catalog from the `iii-hq/iii` repository
 (`npx skills add iii-hq/iii/skills` installs it into `.agents/skills`). A skill that is
@@ -172,8 +175,24 @@ Then verify at the wire:
 
 1. Start the built worker against the live engine as a background process with the
    engine's namespace: `III_NAMESPACE=<ns> ./target/debug/<slug> --url ws://127.0.0.1:49134`
-   (Node: `III_NAMESPACE=<ns> node dist/bundle/index.mjs`). A local `path://` compose
-   stanza also works; `compose::add` with a local path does not for binary workers.
+   (Node: `III_NAMESPACE=<ns> node dist/bundle/index.mjs`). To let Compose manage a
+   local binary, use a container object with `scripts.run` after checking that the
+   daemon's schema accepts objects. For a compose file at the repository root:
+
+   ```json
+   {
+     "operation_id": "<operation-id>",
+     "workers": [{
+       "worker": "./<slug>",
+       "scripts": { "run": "./target/debug/<slug> --url ws://127.0.0.1:49134" }
+     }]
+   }
+   ```
+
+   Build the binary first and use the actual engine URL. The default `working_dir`
+   is the worker directory, so the command resolves there. Put `start_after`,
+   `config_override`, `environment`, and other settings in that same object.
+   Register the wake before `compose::add` and wait for terminal success.
    Confirm `engine::functions::list { prefix: "<slug>::" }` shows every id.
 2. Call each function through `agent_trigger` with a real payload, and a real
    credential when the worker wraps a vendor. Docs and `--help` lie; the wire does not.
@@ -229,8 +248,9 @@ workflow to dispatch and you must not add one. What you own:
    `api.workers.iii.dev`, path `/w/<slug>`: `.worker.version` ends in
    `-experimental`, `.worker.experimental` is `true`, `.worker.functions` is
    non-empty; the `/w/<slug>/skills` path serves the skill.
-5. Install it the documented way, `compose::add { worker: "<slug>@latest" }`, call one
-   function through the bus, and report.
+5. Install `<slug>@latest` with the base identity's `compose-operation` wake flow.
+   Use `workers` objects if settings are needed. After terminal success, call one
+   function through the bus and report.
 
 ## Hard stops (ask, do not act)
 

--- a/harness/agents/worker-builder.md
+++ b/harness/agents/worker-builder.md
@@ -189,8 +189,11 @@ Then verify at the wire:
    }
    ```
 
-   Build the binary first and use the actual engine URL. The default `working_dir`
-   is the worker directory, so the command resolves there. Put `start_after`,
+   Build in the worker's isolated Cargo workspace first: from the repository root,
+   run `cargo build --locked --manifest-path <slug>/Cargo.toml`. This writes the binary
+   to `<slug>/target/debug/<slug>`. Use the actual engine URL. The default `working_dir`
+   is `./<slug>`, so `./target/debug/<slug>` resolves to that binary. If the build
+   overrides Cargo's target directory, adjust the command to match. Put `start_after`,
    `config_override`, `environment`, and other settings in that same object.
    Register the wake before `compose::add` and wait for terminal success.
    Confirm `engine::functions::list { prefix: "<slug>::" }` shows every id.

--- a/harness/prompts/default.txt
+++ b/harness/prompts/default.txt
@@ -312,7 +312,7 @@ outcome, not the caveats, and a pipeline waiting on that call stalls silently.
 - `engine::workers::list` — workers connected right now.
 - `engine::workers::info { name }` — one worker's functions, trigger types, and triggers.
 - `compose::status` — declared workers and their current state.
-- Compose ops: `compose::add` (declare and start a registry worker), `compose::up`,
+- Compose ops: `compose::add` (declare or configure package and local workers), `compose::up`,
   `compose::down`, `compose::restart`, `compose::update`, and `compose::remove`.
 - Get Compose contracts with `compose::schema { function_id: "compose::<operation>" }`.
   The harness routes these calls to its supervising Compose daemon and scopes them to its own
@@ -320,6 +320,64 @@ outcome, not the caveats, and a pipeline waiting on that call stalls silently.
 
 An empty list can mean lag, not absence. A successful call is the authoritative signal. Never
 unbind or re-register anything just because a list came back empty.
+
+### Adding workers with container settings
+
+Fetch `compose::schema { function_id: "compose::add" }` before choosing the payload.
+Use container objects only if the running daemon's schema supports them. The singular
+`worker` field remains a string shorthand. For settings, use `workers`, which can mix
+strings and objects. Put settings inside each object, not at the request's top level.
+Only `add` accepts objects; `update` and `remove` take worker names.
+
+After registering the one-shot wake described above, call `compose::add` with a payload
+like this (the local worker directory and env file must already exist):
+
+```json
+{
+  "operation_id": "<operation-id>",
+  "workers": [
+    "state",
+    {
+      "worker": "./workers/api",
+      "start_after": ["state"],
+      "scripts": {
+        "pre_run": "pnpm build",
+        "pre_run_timeout": "60s",
+        "run": "pnpm start",
+        "post_run": "echo stopped"
+      },
+      "config_name": "api",
+      "config_override": { "port": 3000 },
+      "working_dir": "./workers/api",
+      "environment": { "NODE_ENV": "development" },
+      "env_file": ["./api.env"],
+      "startup_timeout": "30s"
+    }
+  ]
+}
+```
+
+`worker` accepts a package name, `name@version`, registry reference, or local directory,
+including `package://` and `path://` sources. Objects also accept `version` for packages;
+it must agree with any version in `worker`. Omission resolves the latest matching package
+version, so keep an explicit version when it must stay pinned.
+
+Use `scripts` (plural); `scripts.run` is valid only for local workers. `start_after`
+contains container keys, derived from the last part of each worker name or directory;
+required package dependencies are also included. `config_name` selects the base configuration,
+and `config_override` supplies values over it. `environment` values must be strings.
+`startup_timeout` limits the wait for registration.
+
+Relative `worker`, `working_dir`, and `env_file` paths start at the compose file's directory.
+`working_dir` sets the process and hook directory; when omitted, local workers use their own
+directory and packages use the compose directory.
+
+For an existing container, omitted settings stay in place. A supplied field replaces that
+whole field, including `scripts`, `environment`, and `config_override`; these are not
+partial map edits. Use `{}` or `[]` to clear maps or lists. A supplied `start_after` replaces
+the list while retaining required package dependencies. Changes can restart running workers.
+The acceptance response does not mean ready: finish the same `compose-operation` workflow
+before using the worker.
 
 ## Triggers
 

--- a/iii-directory/README.md
+++ b/iii-directory/README.md
@@ -72,6 +72,36 @@ iii trigger compose::add worker=iii-directory
 `iii trigger compose::add` resolves the worker and its dependencies, writes
 exact declarations to `worker-compose.yaml`, and reconciles the Compose project.
 
+For container settings, fetch `compose::schema { function_id: "compose::add" }` and use
+its `workers` list. For example, after registering the completion wake described below:
+
+```json
+{
+  "operation_id": "<operation-id>",
+  "workers": [
+    "state",
+    {
+      "worker": "iii-directory",
+      "start_after": ["state"],
+      "config_override": { "registry_search": true }
+    }
+  ]
+}
+```
+
+The list can mix worker names and objects. Each object accepts `scripts`, `config_name`,
+`config_override`, `working_dir`, `environment`, `env_file`, `startup_timeout`, and
+package `version` as well as `worker` and `start_after`. `scripts.run` is for local
+workers only. Supplied maps replace the whole field; omitted settings are retained.
+
+The returned `install.payload` from function search is a minimal shorthand. If the worker
+needs settings, replace its singular `worker` with an object in `workers`.
+Register a one-shot `compose-operation` wake before calling `compose::add`, use the same
+`operation_id` in both calls, and wait for terminal success before using the new functions.
+An acceptance response does not mean the worker is ready. See the
+[container settings example and completion flow](https://github.com/iii-hq/workers/blob/main/harness/README.md#adding-workers-with-container-settings)
+for field behavior, path resolution, and recovery.
+
 ---
 
 ## Skills

--- a/iii-directory/prompts/iii.md
+++ b/iii-directory/prompts/iii.md
@@ -316,7 +316,7 @@ outcome, not the caveats, and a pipeline waiting on that call stalls silently.
 - `engine::workers::list` — workers connected right now.
 - `engine::workers::info { name }` — one worker's functions, trigger types, and triggers.
 - `compose::status` — declared workers and their current state.
-- Compose ops: `compose::add` (declare and start a registry worker), `compose::up`,
+- Compose ops: `compose::add` (declare or configure package and local workers), `compose::up`,
   `compose::down`, `compose::restart`, `compose::update`, and `compose::remove`.
 - Get Compose contracts with `compose::schema { function_id: "compose::<operation>" }`.
   The harness routes these calls to its supervising Compose daemon and scopes them to its own
@@ -324,6 +324,64 @@ outcome, not the caveats, and a pipeline waiting on that call stalls silently.
 
 An empty list can mean lag, not absence. A successful call is the authoritative signal. Never
 unbind or re-register anything just because a list came back empty.
+
+### Adding workers with container settings
+
+Fetch `compose::schema { function_id: "compose::add" }` before choosing the payload.
+Use container objects only if the running daemon's schema supports them. The singular
+`worker` field remains a string shorthand. For settings, use `workers`, which can mix
+strings and objects. Put settings inside each object, not at the request's top level.
+Only `add` accepts objects; `update` and `remove` take worker names.
+
+After registering the one-shot wake described above, call `compose::add` with a payload
+like this (the local worker directory and env file must already exist):
+
+```json
+{
+  "operation_id": "<operation-id>",
+  "workers": [
+    "state",
+    {
+      "worker": "./workers/api",
+      "start_after": ["state"],
+      "scripts": {
+        "pre_run": "pnpm build",
+        "pre_run_timeout": "60s",
+        "run": "pnpm start",
+        "post_run": "echo stopped"
+      },
+      "config_name": "api",
+      "config_override": { "port": 3000 },
+      "working_dir": "./workers/api",
+      "environment": { "NODE_ENV": "development" },
+      "env_file": ["./api.env"],
+      "startup_timeout": "30s"
+    }
+  ]
+}
+```
+
+`worker` accepts a package name, `name@version`, registry reference, or local directory,
+including `package://` and `path://` sources. Objects also accept `version` for packages;
+it must agree with any version in `worker`. Omission resolves the latest matching package
+version, so keep an explicit version when it must stay pinned.
+
+Use `scripts` (plural); `scripts.run` is valid only for local workers. `start_after`
+contains container keys, derived from the last part of each worker name or directory;
+required package dependencies are also included. `config_name` selects the base configuration,
+and `config_override` supplies values over it. `environment` values must be strings.
+`startup_timeout` limits the wait for registration.
+
+Relative `worker`, `working_dir`, and `env_file` paths start at the compose file's directory.
+`working_dir` sets the process and hook directory; when omitted, local workers use their own
+directory and packages use the compose directory.
+
+For an existing container, omitted settings stay in place. A supplied field replaces that
+whole field, including `scripts`, `environment`, and `config_override`; these are not
+partial map edits. Use `{}` or `[]` to clear maps or lists. A supplied `start_after` replaces
+the list while retaining required package dependencies. Changes can restart running workers.
+The acceptance response does not mean ready: finish the same `compose-operation` workflow
+before using the worker.
 
 ## Triggers
 

--- a/iii-directory/skills/function-search.md
+++ b/iii-directory/skills/function-search.md
@@ -32,8 +32,8 @@ ids, then fetch their contracts in one batched `engine::functions::info` call.
 - The response may also carry an `installable` section: workers from the
   public registry (verified authors only) whose functions match but are NOT
   installed. Those functions are not callable yet — confirm with the user,
-  install with `compose::add` (`{ "worker": "<worker>" }`) and wait for that
-  call to report the worker ready, and only then
+  fetch `compose::schema { function_id: "compose::add" }`, install with
+  `compose::add` using the completion flow below, and only after terminal success
   search again, batch the selected ids through `engine::functions::info`, and
   then call them. The `registry_search` configuration knob turns the section
   off.
@@ -44,6 +44,51 @@ ids, then fetch their contracts in one batched `engine::functions::info` call.
   current task window, the surface spans fewer than `hint_min_workers`
   workers, the current task is already calling real functions, or it already
   names a callable function id.
+
+## Install with container settings
+
+The returned `install.payload` is a minimal `{ "worker": "<worker>" }` shorthand.
+If configuration is needed and the running daemon's schema supports objects, replace
+that singular field with `workers`:
+
+```json
+{
+  "operation_id": "<operation-id>",
+  "workers": [
+    "state",
+    {
+      "worker": "<worker>",
+      "start_after": ["state"],
+      "config_override": { "<config-key>": "<value>" }
+    }
+  ]
+}
+```
+
+Review `directory::registry::workers::info` for the worker's configuration before
+choosing values. Objects also accept package `version`, `config_name`, `scripts`
+(`pre_run`, `pre_run_timeout`, `run`, `post_run`), `working_dir`, `environment`
+(string values), `env_file`, and `startup_timeout`. Use `scripts`, not `script`;
+`scripts.run` is valid only for local workers. `worker` accepts local directories
+and `path://` sources as well as packages. Relative paths resolve from the compose
+file. `working_dir` sets where the process and hooks run; its default is the local
+worker directory, or the compose directory for packages.
+
+Omitted settings stay in place. A supplied map replaces the whole field, including
+`scripts`, `environment`, and `config_override`; use `{}` or `[]` to clear maps
+or lists. `start_after` names container keys and includes required package dependencies.
+An unversioned package resolves the latest matching version; use an explicit version
+to keep it pinned. Settings changes can restart a running worker.
+
+Before installation, choose a unique operation ID and register a one-shot wake with
+`engine::register_trigger { trigger_type: "compose-operation", config: {
+operation_id: "<operation-id>", terminal_only: true }, once: true }`.
+Keep the subscription ID and pass the same `operation_id` to `compose::add`.
+Read `compose::operation { operation_id: "<operation-id>" }` once for race recovery.
+If terminal, unregister the wake and inspect the result; otherwise end the turn with
+the wake armed. Do not poll. Acceptance is not readiness, and a terminal event can
+report failure. Search again and fetch function contracts only after terminal success.
+Under the harness, omit `namespace` and `file`; it supplies the Compose scope.
 
 `directory::pre-generate`, `directory::on-functions-change`, and
 `directory::hint-preview` are internal handlers, not direct tools.

--- a/iii-directory/src/functions/search.rs
+++ b/iii-directory/src/functions/search.rs
@@ -280,8 +280,12 @@ const SEARCH_INSTALL_GUIDANCE: &str = "No INSTALLED function matched these capab
 `installable` entries are registry workers whose functions WOULD match, \
 but they are NOT installed: calling their functions now FAILS with function_not_found. To \
 use one, fetch compose::schema { function_id: \"compose::add\" }. The install.payload is a \
-minimal shorthand; for settings use objects in workers with scripts, start_after, \
-config_override, or other supported container fields. Register a one-shot compose-operation \
+minimal shorthand. Replace worker with objects in workers only if the returned schema \
+supports them, to set scripts, start_after, config_override, or other supported fields. \
+Otherwise keep install.payload as shorthand for defaults; if settings are required, \
+report that they cannot be applied and stop the installation. Explain the worker and \
+follow the caller's installation approval requirements; if approval is still needed, \
+wait for explicit confirmation before compose::add. Register a one-shot compose-operation \
 wake with terminal_only: true before compose::add and pass the same unique operation_id \
 in both calls. Read compose::operation once for race recovery; if terminal, unregister \
 the wake, otherwise wait for it. Wait for terminal success, not just acceptance, \
@@ -299,9 +303,13 @@ const SEARCH_INSTALL_NOTE: &str = "Select from `workers` before considering `ins
 `installable` entries are registry workers that are NOT installed: calling their functions now \
 FAILS with function_not_found. Do not pass an `installable` function ID to \
 engine::functions::info. Only when no `workers` entry fits, FIRST fetch compose::schema \
-{ function_id: \"compose::add\" }. The install.payload is a minimal shorthand; for settings \
-use objects in workers with scripts, start_after, config_override, or other supported \
-container fields. Register a one-shot compose-operation wake with terminal_only: true \
+{ function_id: \"compose::add\" }. The install.payload is a minimal shorthand. Replace worker \
+with objects in workers only if the returned schema supports them, to set scripts, \
+start_after, config_override, or other supported fields. Otherwise keep install.payload \
+as shorthand for defaults; if settings are required, report that they cannot be applied \
+and stop the installation. Explain the worker and follow the caller's installation \
+approval requirements; if approval is still needed, wait for explicit confirmation \
+before compose::add. Register a one-shot compose-operation wake with terminal_only: true \
 before compose::add and pass the same unique operation_id in both calls. Read \
 compose::operation once for race recovery; if terminal, unregister the wake, otherwise \
 wait for it. Wait for terminal success, not just acceptance, then search again and fetch \
@@ -2280,6 +2288,33 @@ mod tests {
             response.installable[0].install.payload,
             json!({ "worker": "mailer" })
         );
+        *deps.catalog.write().await = Arc::new(Vec::new());
+        let installable_only = search_functions(
+            &deps,
+            SearchFunctionsRequest {
+                capabilities: vec!["send an email message".into()],
+            },
+        )
+        .await
+        .unwrap();
+        assert!(installable_only.workers.is_empty());
+        assert_eq!(installable_only.installable[0].name, "mailer");
+        for guidance in [&response.guidance, &installable_only.guidance] {
+            assert!(
+                guidance.contains("objects in workers only if the returned schema supports them")
+            );
+            assert!(guidance.contains("Otherwise keep install.payload as shorthand for defaults"));
+            assert!(
+                guidance.contains("report that they cannot be applied and stop the installation")
+            );
+            let approval = guidance
+                .find("if approval is still needed, wait for explicit confirmation before compose::add")
+                .expect("installation honors any outstanding approval requirement");
+            let registration = guidance
+                .find("Register a one-shot compose-operation wake")
+                .unwrap();
+            assert!(approval < registration);
+        }
         assert!(
             response.guidance.contains(
                 "Do not search for intrinsic reasoning, summarization, planning, or formatting"

--- a/iii-directory/src/functions/search.rs
+++ b/iii-directory/src/functions/search.rs
@@ -279,8 +279,13 @@ user writes in another language; preserve proper names, URLs, and function IDs."
 const SEARCH_INSTALL_GUIDANCE: &str = "No INSTALLED function matched these capabilities. The \
 `installable` entries are registry workers whose functions WOULD match, \
 but they are NOT installed: calling their functions now FAILS with function_not_found. To \
-use one, run its `install` call exactly as given (compose::add), wait for it to report the \
-new worker ready, then call directory::search_functions again \
+use one, fetch compose::schema { function_id: \"compose::add\" }. The install.payload is a \
+minimal shorthand; for settings use objects in workers with scripts, start_after, \
+config_override, or other supported container fields. Register a one-shot compose-operation \
+wake with terminal_only: true before compose::add and pass the same unique operation_id \
+in both calls. Read compose::operation once for race recovery; if terminal, unregister \
+the wake, otherwise wait for it. Wait for terminal success, not just acceptance, \
+then call directory::search_functions again \
 for the newly registered candidates and fetch selected contracts with one batched \
 engine::functions::info call. If none fit, search once more with concrete unmet \
 `capabilities`; for a need no function covers — authoring a worker, registering a new \
@@ -293,9 +298,14 @@ writes in another language; preserve proper names, URLs, and function IDs.";
 const SEARCH_INSTALL_NOTE: &str = "Select from `workers` before considering `installable`. The \
 `installable` entries are registry workers that are NOT installed: calling their functions now \
 FAILS with function_not_found. Do not pass an `installable` function ID to \
-engine::functions::info. Only when no `workers` entry fits, FIRST call the provided install \
-function with its payload (compose::add), wait for it to report the worker ready, then search \
-again and fetch selected contracts with one batched \
+engine::functions::info. Only when no `workers` entry fits, FIRST fetch compose::schema \
+{ function_id: \"compose::add\" }. The install.payload is a minimal shorthand; for settings \
+use objects in workers with scripts, start_after, config_override, or other supported \
+container fields. Register a one-shot compose-operation wake with terminal_only: true \
+before compose::add and pass the same unique operation_id in both calls. Read \
+compose::operation once for race recovery; if terminal, unregister the wake, otherwise \
+wait for it. Wait for terminal success, not just acceptance, then search again and fetch \
+selected contracts with one batched \
 engine::functions::info call — never call an installable function before installing.";
 
 #[derive(Debug, Clone, serde::Deserialize, schemars::JsonSchema)]
@@ -2241,14 +2251,18 @@ mod tests {
         assert!(response
             .guidance
             .contains("Do not pass an `installable` function ID to engine::functions::info"));
-        let install_call = response
+        let install_schema = response
             .guidance
-            .find("FIRST call the provided install function")
-            .expect("mixed guidance installs before lookup");
+            .find("FIRST fetch compose::schema")
+            .expect("mixed guidance checks the install contract");
+        let wake = response
+            .guidance
+            .find("Register a one-shot compose-operation wake")
+            .expect("mixed guidance registers the completion wake before installing");
         let ready_wait = response
             .guidance
-            .find("wait for it to report the worker ready")
-            .expect("mixed guidance waits for compose readiness");
+            .find("Wait for terminal success, not just acceptance")
+            .expect("mixed guidance waits for successful completion");
         let search_again = response
             .guidance
             .find("then search again")
@@ -2257,7 +2271,8 @@ mod tests {
             .guidance
             .rfind("one batched engine::functions::info call")
             .expect("mixed guidance fetches the installed contract last");
-        assert!(install_call < ready_wait);
+        assert!(install_schema < wake);
+        assert!(wake < ready_wait);
         assert!(ready_wait < search_again);
         assert!(search_again < installed_info);
         assert_eq!(response.installable[0].install.function, "compose::add");


### PR DESCRIPTION
Harness and Directory currently show worker-name-only installs. Directory search guidance also tells callers to reuse the install payload unchanged and treat the call as a readiness result.

Update the bundled instructions and documentation to explain mixed worker names and container objects, every existing container field, map replacement, path resolution, and package version behavior. Document local binaries through scripts.run in Worker Builder. Keep the returned install payload compatible while teaching callers how to customize it and wait for successful compose-operation completion.

Container objects require the engine support in https://github.com/iii-hq/iii/pull/2143. The instructions require callers to check the running daemon's schema first.

Validation:

- Both worker suites: cargo test --locked --all-features.
- Both workers: cargo fmt --all and cargo clippy --locked --all-targets --all-features -- -D warnings.
- Built both required frontend bundles with pnpm in a Node container.
- Parsed six Compose payload examples and checked matching instructions for all ten container fields.
- Documentation structure check passed. Vale reported no findings on changed lines; 75 findings in existing prose remain outside this change.

Fixes MOT-4706


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring package and local workers with container settings.
  * Documented worker configuration fields, startup ordering, scripts, environment files, path handling, timeouts, and replacement behavior.
  * Updated installation guidance to use schema discovery and completion-based operation handling.
  * Added instructions for configuring local binaries and experimental releases through worker settings.
* **Tests**
  * Updated installation guidance coverage for mixed worker configurations and completion-based workflows.
  * Added coverage for approval requirements and unsupported worker settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->