### PR TITLE
(MOT-4702) feat(iii-directory): search over-long capabilities lists in batches of six

### DIFF
--- a/harness/prompts/default.txt
+++ b/harness/prompts/default.txt
@@ -46,8 +46,9 @@ payload shape, already satisfies Steps 1 and 2; call it directly without discove
 
 Step 1. Find the function id through exactly one task-capability discovery path. The default
 path is `directory::search_functions` with `{ capabilities: ["<needed capability>", ...] }` —
-one to six short, non-overlapping capability phrases, always written in English. It ranks the
-installed catalog and returns candidate ids (and, when a capability needs a worker that is not
+short, non-overlapping capability phrases covering every unmet capability of the step in one
+call (usually one to six, at most eighteen), always written in English. It ranks the installed
+catalog and returns candidate ids (and, when a capability needs a worker that is not
 installed, installable workers from the registry); it returns candidates, not contracts, and
 its own contract is given here, so never fetch it with `engine::functions::info` first. If
 `<discovery_assist>` is present, follow it instead of searching. Only when

--- a/iii-directory/README.md
+++ b/iii-directory/README.md
@@ -421,7 +421,7 @@ catalog with `engine::functions::list`.
 
 | Function | Kind | What it does |
 |---|---|---|
-| `directory::search_functions` | public | `{ capabilities }` → `{ guidance, workers[], installable[]?, latency_ms }`: BM25 rank over the live engine catalog (at most 6 workers / 12 candidates) plus matching NOT-installed registry workers under `installable`. `capabilities` is a required list of one to six non-empty unmet external capability searches; extra entries are not searched and are named in `guidance`. Requests to summarize provided text/content are ignored. |
+| `directory::search_functions` | public | `{ capabilities }` → `{ guidance, workers[], installable[]?, latency_ms }`: hybrid rank over the live engine catalog in batches of six capabilities (at most 6 workers / 12 candidates per batch, up to 3 batches) plus matching NOT-installed registry workers under `installable`. `capabilities` is a required list of non-empty unmet external capability searches (one to six is the norm); entries past the 18th are not searched and are named in `guidance`. Requests to summarize provided text/content are ignored. |
 | `directory::pre-generate` | internal hook | Injects the conditional search hint into a harness generation (at most once per turn). |
 | `directory::on-functions-change` | internal | Refreshes the search catalog on the engine's functions-available push. |
 | `directory::hint-preview` | internal | The exact hint text per exposure mode, for the configuration UI. |

--- a/iii-directory/README.md
+++ b/iii-directory/README.md
@@ -421,7 +421,7 @@ catalog with `engine::functions::list`.
 
 | Function | Kind | What it does |
 |---|---|---|
-| `directory::search_functions` | public | `{ capabilities }` → `{ guidance, workers[], installable[]?, latency_ms }`: hybrid rank over the live engine catalog in batches of six capabilities (at most 6 workers / 12 candidates per batch, up to 3 batches) plus matching NOT-installed registry workers under `installable`. `capabilities` is a required list of non-empty unmet external capability searches (one to six is the norm); entries past the 18th are not searched and are named in `guidance`. Requests to summarize provided text/content are ignored. |
+| `directory::search_functions` | public | `{ capabilities }` → `{ guidance, workers[], installable[]?, latency_ms }`: hybrid rank over the live engine catalog in batches of six capabilities (12 candidates per batch across at most max(6, 2 × capabilities) workers, up to 3 batches) plus matching NOT-installed registry workers under `installable`. `capabilities` is a required list of non-empty unmet external capability searches (one to six is the norm); entries past the 18th are not searched and are named in `guidance`. Requests to summarize provided text/content are ignored. |
 | `directory::pre-generate` | internal hook | Injects the conditional search hint into a harness generation (at most once per turn). |
 | `directory::on-functions-change` | internal | Refreshes the search catalog on the engine's functions-available push. |
 | `directory::hint-preview` | internal | The exact hint text per exposure mode, for the configuration UI. |

--- a/iii-directory/README.md
+++ b/iii-directory/README.md
@@ -455,8 +455,10 @@ Ranking pipeline:
    ranked per capability with BM25 fused with the MiniLM dense lane (same
    0.30 admission floor as the installed catalog), so a capability sharing no
    vocabulary with a contract ("retrieve web news articles" → `web::fetch`)
-   still surfaces. Returns up to 2 workers / 6 candidates that WOULD match if
-   installed, with `compose::add` guidance.
+   still surfaces. Returns up to 2 workers / 6 candidates per batch of six
+   capabilities (so up to 6 workers / 18 candidates across three batches; a
+   worker two batches both surface keeps one entry with its functions merged)
+   that WOULD match if installed, with `compose::add` guidance.
 6. **Session memory** (keyed by caller-supplied OTel baggage, fail-open):
    repeat queries omit candidates already delivered.
 

--- a/iii-directory/prompts/iii-minimal.md
+++ b/iii-directory/prompts/iii-minimal.md
@@ -22,8 +22,9 @@ payload shape, already satisfies Steps 1 and 2; call it directly without discove
 `engine::functions::info`.
 
 Step 1. Find the id: call `directory::search_functions` ONCE at each decision point with
-`{ capabilities: ["<needed capability>", ...] }` — one to six short, non-overlapping
-entries, always written in English. It returns candidate ids, not contracts; its own
+`{ capabilities: ["<needed capability>", ...] }` — short, non-overlapping entries covering
+every unmet capability of the step (usually one to six, at most eighteen), always written in
+English. It returns candidate ids, not contracts; its own
 contract is given here, so do not look it up first. The directory worker installs
 alongside the harness, so this is the default discovery path; only when
 `directory::search_functions` itself is unavailable (`function_not_found`), fall back to

--- a/iii-directory/prompts/iii.md
+++ b/iii-directory/prompts/iii.md
@@ -50,8 +50,9 @@ payload shape, already satisfies Steps 1 and 2; call it directly without discove
 
 Step 1. Find the function id through exactly one task-capability discovery path. The default
 path is `directory::search_functions` with `{ capabilities: ["<needed capability>", ...] }` —
-one to six short, non-overlapping capability phrases, always written in English. It ranks the
-installed catalog and returns candidate ids (and, when a capability needs a worker that is not
+short, non-overlapping capability phrases covering every unmet capability of the step in one
+call (usually one to six, at most eighteen), always written in English. It ranks the installed
+catalog and returns candidate ids (and, when a capability needs a worker that is not
 installed, installable workers from the registry); it returns candidates, not contracts, and
 its own contract is given here, so never fetch it with `engine::functions::info` first. If
 `<discovery_assist>` is present, follow it instead of searching. Only when

--- a/iii-directory/skills/SKILL.md
+++ b/iii-directory/skills/SKILL.md
@@ -43,7 +43,7 @@ never appear in `index` and `update`/`delete` refuse them.
 
 ## When to Use
 
-- You need functions for one to six unmet capabilities — `directory::search_functions`.
+- You need functions for a step's unmet capabilities (usually one to six, at most eighteen) — `directory::search_functions`.
 - You need to see which workers are installed — `directory::skills::index` (token-light; start here).
 - You need to read a worker's overview or a deeper doc it linked to — `directory::skills::get`.
 - You need to find a skill across the repo with filters — `directory::skills::list`.
@@ -67,7 +67,7 @@ never appear in `index` and `update`/`delete` refuse them.
 
 ## Functions
 
-- `directory::search_functions` — find compact installed and installable function candidates for one to six required capabilities.
+- `directory::search_functions` — find compact installed and installable function candidates for the required capabilities (usually one to six, at most eighteen per call).
 - `directory::skills::index` — token-light per-worker overview, one block per installed worker; truncates and tells you to call `list` when large.
 - `directory::skills::list` — enumerate every visible skill with id/title/type/description/bytes/modified_at; narrow with `search`, `prefix`, `type`, or `include_description`.
 - `directory::skills::get` — read one skill doc by its skill id; forgiving about short names, a trailing `.md`, an `iii://` prefix, and `SKILL.md` filenames. The response's `path` is the absolute on-disk file; its parent directory is the skill's base directory, where payload the body references by relative path (`scripts/`, `reference/`) lives.

--- a/iii-directory/skills/function-search.md
+++ b/iii-directory/skills/function-search.md
@@ -9,7 +9,7 @@ type: how-to
 
 # Function search
 
-A required list of one to six unmet external capabilities returns only compact
+A required list of unmet external capabilities (usually one to six, at most eighteen) returns only compact
 `function_id` + description candidates, grouped by worker. Choose the needed
 ids, then fetch their contracts in one batched `engine::functions::info` call.
 
@@ -17,15 +17,17 @@ ids, then fetch their contracts in one batched `engine::functions::info` call.
 
 - `directory::search_functions`: call once with
   `{ "capabilities": ["<unmet external capability>", "<another>"] }`. Provide
-  one to six short, non-overlapping capabilities derived from the goal and
-  current execution state, omitting work already satisfied. Include every
-  unmet external capability once in the same call. Write every capability in
+  short, non-overlapping capabilities derived from the goal and current
+  execution state, omitting work already satisfied. Include every unmet
+  external capability once in the same call — usually one to six, at most
+  eighteen; past that the result names what was not searched. Write every capability in
   English, translating non-English requests while preserving proper names,
   URLs, and function IDs. Exclude intrinsic reasoning,
   summarization, planning, and formatting; requests to summarize provided
   text or content are ignored. Each capability ranks independently and
-  candidates merge round-robin. The result contains at most six workers and
-  twelve compact candidates, never request schemas or a whole worker surface.
+  candidates merge round-robin in batches of six capabilities. Each batch
+  contributes at most twelve compact candidates across at most max(6, 2 ×
+  capabilities) workers, never request schemas or a whole worker surface.
   Choose the smallest needed id set and call `engine::functions::info` once with
   `{ "function_ids": [...] }` before using them. Repeat queries in one
   session omit candidates already delivered.

--- a/iii-directory/src/functions/search.rs
+++ b/iii-directory/src/functions/search.rs
@@ -29,7 +29,9 @@ use crate::surface::search_catalog as catalog;
 const CATALOG_TIMEOUT_MS: u64 = 5_000;
 /// Function ids per `functions::info` batch — the engine's documented max.
 const CATALOG_INFO_BATCH: usize = 32;
-/// Workers returned by one `directory::search_functions` call.
+/// Workers returned by one batch. A batch with more than three lanes may
+/// return two workers per lane instead, so every capability keeps its
+/// runner-up worker (see `select_preordered_ids`).
 const MAX_SEARCH_WORKERS: usize = 6;
 /// Candidates returned by one call — the ranked guards usually select a
 /// handful; this is the backstop.
@@ -679,11 +681,18 @@ fn production_minilm_assemble(
 }
 
 fn select_preordered_ids(rankings: Vec<Vec<(String, f64)>>) -> Vec<String> {
+    // Round-robin hands every lane two of the twelve slots. With six lanes
+    // the six leaders alone fill a six-worker cap and every runner-up in a
+    // new namespace is dropped, so the cap grows with the lane count.
+    let max_workers = MAX_SEARCH_WORKERS.max(2 * rankings.len());
     let rankings = rankings
         .into_iter()
         .map(|ranking| drop_trailing_namespaces(ranking, SEARCH_RANK_FLOOR))
         .collect::<Vec<_>>();
-    limit_search_workers(round_robin_rankings(&rankings, MAX_SEARCH_FUNCTIONS))
+    limit_search_workers(
+        round_robin_rankings(&rankings, MAX_SEARCH_FUNCTIONS),
+        max_workers,
+    )
 }
 
 fn search_queries(capabilities: &[String]) -> Vec<String> {
@@ -704,7 +713,7 @@ fn baggage_session_id() -> Option<String> {
     (!session_id.is_empty()).then_some(session_id)
 }
 
-fn limit_search_workers(selected: Vec<String>) -> Vec<String> {
+fn limit_search_workers(selected: Vec<String>, max_workers: usize) -> Vec<String> {
     let mut namespaces: Vec<String> = Vec::new();
     selected
         .into_iter()
@@ -715,7 +724,7 @@ fn limit_search_workers(selected: Vec<String>) -> Vec<String> {
             if namespaces.iter().any(|seen| seen == namespace) {
                 return true;
             }
-            if namespaces.len() == MAX_SEARCH_WORKERS {
+            if namespaces.len() == max_workers {
                 return false;
             }
             namespaces.push(namespace.to_string());
@@ -724,14 +733,11 @@ fn limit_search_workers(selected: Vec<String>) -> Vec<String> {
         .collect()
 }
 
-/// Group the selected function ids into compact candidates by worker,
-/// keeping at most `max_workers` workers. Ids missing from the catalog
-/// are skipped; within a worker the rank order is preserved — best first.
-fn assemble_workers(
-    selected: &[String],
-    tools: &[ToolSchema],
-    max_workers: usize,
-) -> Vec<SearchWorker> {
+/// Group the selected function ids into compact candidates by worker
+/// (`selected` is already worker-capped per batch). Ids missing from the
+/// catalog are skipped; within a worker the rank order is preserved — best
+/// first.
+fn assemble_workers(selected: &[String], tools: &[ToolSchema]) -> Vec<SearchWorker> {
     let mut workers: Vec<SearchWorker> = Vec::new();
     for function_id in selected {
         let Some(namespace) = function_namespace(function_id) else {
@@ -749,11 +755,10 @@ fn assemble_workers(
             .position(|worker| worker.namespace == namespace)
         {
             Some(index) => workers[index].functions.push(candidate),
-            None if workers.len() < max_workers => workers.push(SearchWorker {
+            None => workers.push(SearchWorker {
                 namespace: namespace.to_string(),
                 functions: vec![candidate],
             }),
-            None => {}
         }
     }
     workers
@@ -1172,7 +1177,7 @@ pub async fn search_functions(
         repeated = prior;
     }
     tracing::debug!(%fingerprint, batches, top_ids = ?selected, "function search selected");
-    let workers = assemble_workers(&selected, &tools, MAX_SEARCH_WORKERS * batches);
+    let workers = assemble_workers(&selected, &tools);
     let guidance = if workers.is_empty() && repeated.is_empty() {
         if installable.is_empty() {
             SEARCH_REFINE_GUIDANCE.to_string()
@@ -1637,7 +1642,7 @@ mod tests {
             }),
         }];
 
-        let workers = assemble_workers(&["github::pr::create".into()], &tools, MAX_SEARCH_WORKERS);
+        let workers = assemble_workers(&["github::pr::create".into()], &tools);
         let candidate = serde_json::to_value(&workers[0].functions[0]).unwrap();
 
         assert_eq!(
@@ -2713,11 +2718,39 @@ mod tests {
     }
 
     #[test]
+    fn six_lanes_keep_every_runner_up_worker() {
+        let rankings: Vec<Vec<(String, f64)>> = (0..6)
+            .map(|lane| {
+                vec![
+                    (format!("lead{lane}::run"), 1.0),
+                    (format!("second{lane}::run"), 0.9),
+                ]
+            })
+            .collect();
+
+        let selected = select_preordered_ids(rankings);
+
+        assert_eq!(selected.len(), 12, "{selected:?}");
+        assert!(selected.iter().any(|id| id == "second0::run"));
+    }
+
+    #[test]
+    fn one_lane_still_stops_at_six_workers() {
+        let ranking: Vec<(String, f64)> = (b'a'..=b'j')
+            .map(|letter| (format!("{}::run", char::from(letter)), 1.0))
+            .collect();
+
+        let selected = select_preordered_ids(vec![ranking]);
+
+        assert_eq!(selected.len(), MAX_SEARCH_WORKERS, "{selected:?}");
+    }
+
+    #[test]
     fn worker_cap_drops_candidates_before_session_delivery() {
         let ranked: Vec<String> = (b'a'..=b'g')
             .map(|letter| format!("{}::run", char::from(letter)))
             .collect();
-        let emitted = limit_search_workers(ranked);
+        let emitted = limit_search_workers(ranked, MAX_SEARCH_WORKERS);
         let mut registry = SessionRegistry::default();
 
         registry.split("session", "catalog", &emitted);

--- a/iii-directory/src/functions/search.rs
+++ b/iii-directory/src/functions/search.rs
@@ -87,8 +87,14 @@ const PRODUCTION_ADMISSION_COSINE: f64 = 0.30;
 /// On expiry the request serves the fused retrieval order; the blocking
 /// rerank task itself is not cancelled and finishes in the background.
 const PRODUCTION_RERANK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
-/// Capability-sized searches accepted by one request.
+/// Capability-sized searches per batch: each batch keeps its own candidate
+/// budget (`MAX_SEARCH_FUNCTIONS` / `MAX_SEARCH_WORKERS`), so every
+/// capability still receives about two candidates however many are sent.
 const MAX_SEARCH_QUERIES: usize = 6;
+/// Batches one request runs (sequentially — the reranker sits behind a
+/// mutex, so concurrent batches would only overlap their timeouts).
+/// Capabilities past the last batch are named in `guidance` instead.
+const MAX_SEARCH_BATCHES: usize = 3;
 /// Registry list queries per search: each capability, then informative
 /// terms one by one — the registry's pg_trgm similarity misses long
 /// natural-language queries that a single term ("email") hits. All
@@ -719,9 +725,13 @@ fn limit_search_workers(selected: Vec<String>) -> Vec<String> {
 }
 
 /// Group the selected function ids into compact candidates by worker,
-/// keeping at most `MAX_SEARCH_WORKERS` workers. Ids missing from the catalog
+/// keeping at most `max_workers` workers. Ids missing from the catalog
 /// are skipped; within a worker the rank order is preserved — best first.
-fn assemble_workers(selected: &[String], tools: &[ToolSchema]) -> Vec<SearchWorker> {
+fn assemble_workers(
+    selected: &[String],
+    tools: &[ToolSchema],
+    max_workers: usize,
+) -> Vec<SearchWorker> {
     let mut workers: Vec<SearchWorker> = Vec::new();
     for function_id in selected {
         let Some(namespace) = function_namespace(function_id) else {
@@ -739,7 +749,7 @@ fn assemble_workers(selected: &[String], tools: &[ToolSchema]) -> Vec<SearchWork
             .position(|worker| worker.namespace == namespace)
         {
             Some(index) => workers[index].functions.push(candidate),
-            None if workers.len() < MAX_SEARCH_WORKERS => workers.push(SearchWorker {
+            None if workers.len() < max_workers => workers.push(SearchWorker {
                 namespace: namespace.to_string(),
                 functions: vec![candidate],
             }),
@@ -1111,12 +1121,15 @@ pub async fn search_functions(
     if request.capabilities.is_empty() {
         return Err(Error::Handler("provide at least one capability".into()));
     }
-    // Over the cap: search the first MAX_SEARCH_QUERIES and name the rest in
+    // Over the batch budget: search what fits and name the rest in
     // `guidance` so the agent keeps this turn's candidates instead of a
     // rejected call.
-    let dropped = request
-        .capabilities
-        .split_off(request.capabilities.len().min(MAX_SEARCH_QUERIES));
+    let dropped = request.capabilities.split_off(
+        request
+            .capabilities
+            .len()
+            .min(MAX_SEARCH_QUERIES * MAX_SEARCH_BATCHES),
+    );
     if request
         .capabilities
         .iter()
@@ -1126,64 +1139,24 @@ pub async fn search_functions(
     }
     let started = Instant::now();
     let tools = deps.catalog.read().await.clone();
-    let search_queries = search_queries(&request.capabilities);
     let cfg = deps.config.load_full();
-    let mode = cfg.function_search_mode;
-    let lexical_started = Instant::now();
-    // ponytail: index rebuilt per call (~250 slim docs, sub-ms); cache by
-    // tool_fingerprint if search latency ever matters.
-    let corpus = canonical_tools(&tools);
-    let index = Bm25Index::build(&corpus);
-    let lexical = lexical_rankings(&index, &search_queries);
     let fingerprint = tool_fingerprint(&tools);
-    let lexical_top_ids: Vec<&str> = lexical
-        .iter()
-        .filter_map(|ranking| ranking.first().map(|(id, _)| id.as_str()))
-        .collect();
-    tracing::debug!(
-        ?mode,
-        %fingerprint,
-        elapsed_ms = lexical_started.elapsed().as_secs_f64() * 1000.0,
-        ?lexical_top_ids,
-        "lexical lane ranked"
-    );
-    let production_minilm =
-        mode == FunctionSearchMode::Hybrid && deps.semantic.is_production_minilm();
-    let production_outcome = if production_minilm {
-        let semantic_started = Instant::now();
-        let rankings = production_minilm_rankings(
-            &deps.semantic,
-            &fingerprint,
-            &tools,
-            &search_queries,
-            &lexical,
-        )
-        .await;
-        tracing::debug!(
-            ?mode,
-            available = rankings.is_some(),
-            complete = rankings.as_ref().is_some_and(|outcome| outcome.complete),
-            %fingerprint,
-            repository = deps.semantic.model_repository(),
-            revision = deps.semantic.model_revision(),
-            reranker_repository = deps.semantic.reranker_repository(),
-            reranker_revision = deps.semantic.reranker_revision(),
-            elapsed_ms = semantic_started.elapsed().as_secs_f64() * 1000.0,
-            "production MiniLM retrieval and reranking completed"
-        );
-        rankings
-    } else {
-        None
-    };
-    let production_rankings = production_outcome.map(|outcome| outcome.rankings);
-    let mut selected = match production_rankings {
-        Some(rankings) => select_preordered_ids(rankings),
-        None => select_preordered_ids(production_fallback_rankings(
-            &tools,
-            &search_queries,
-            &lexical,
-        )),
-    };
+    let mut selected: Vec<String> = Vec::new();
+    let mut installable: Vec<InstallableWorker> = Vec::new();
+    for batch in request.capabilities.chunks(MAX_SEARCH_QUERIES) {
+        let outcome = search_batch(deps, &cfg, &tools, &fingerprint, batch).await;
+        for function_id in outcome.selected {
+            if !selected.contains(&function_id) {
+                selected.push(function_id);
+            }
+        }
+        for worker in outcome.installable {
+            if !installable.iter().any(|known| known.name == worker.name) {
+                installable.push(worker);
+            }
+        }
+    }
+    let batches = request.capabilities.len().div_ceil(MAX_SEARCH_QUERIES);
     let session_id = baggage_session_id();
     // Repeat queries in one session skip candidates the session already
     // received (session identity from caller baggage; absent → full
@@ -1198,23 +1171,8 @@ pub async fn search_functions(
         selected = new;
         repeated = prior;
     }
-    tracing::debug!(?mode, %fingerprint, top_ids = ?selected, "function search selected");
-    let workers = assemble_workers(&selected, &tools);
-    // Installable section: every search also consults the public registry
-    // for NOT-installed workers whose functions match — behind the
-    // registry_search knob; every failure inside returns an empty section
-    // (fail-open).
-    let mut installable: Vec<InstallableWorker> = Vec::new();
-    if cfg.registry_search {
-        installable = registry_installable(
-            &cfg,
-            &deps.registry_cache,
-            production_minilm.then_some(&deps.semantic),
-            &tools,
-            &search_queries,
-        )
-        .await;
-    }
+    tracing::debug!(%fingerprint, batches, top_ids = ?selected, "function search selected");
+    let workers = assemble_workers(&selected, &tools, MAX_SEARCH_WORKERS * batches);
     let guidance = if workers.is_empty() && repeated.is_empty() {
         if installable.is_empty() {
             SEARCH_REFINE_GUIDANCE.to_string()
@@ -1239,8 +1197,9 @@ unchanged — reuse the earlier result): {}.",
         guidance
     } else {
         format!(
-            "{guidance} Only the first {MAX_SEARCH_QUERIES} capabilities were searched; \
+            "{guidance} Only the first {} capabilities were searched; \
 search again for: {}.",
+            MAX_SEARCH_QUERIES * MAX_SEARCH_BATCHES,
             dropped.join(", ")
         )
     };
@@ -1250,6 +1209,98 @@ search again for: {}.",
         installable,
         latency_ms: started.elapsed().as_secs_f64() * 1000.0,
     })
+}
+
+/// Candidates one batch of capabilities produced: selected function ids
+/// in rank order (already budgeted by `select_preordered_ids`) and the
+/// matching NOT-installed registry workers.
+struct BatchOutcome {
+    selected: Vec<String>,
+    installable: Vec<InstallableWorker>,
+}
+
+async fn search_batch(
+    deps: &Deps,
+    cfg: &SkillsConfig,
+    tools: &[ToolSchema],
+    fingerprint: &str,
+    capabilities: &[String],
+) -> BatchOutcome {
+    let search_queries = search_queries(capabilities);
+    let mode = cfg.function_search_mode;
+    let lexical_started = Instant::now();
+    // ponytail: index rebuilt per call (~250 slim docs, sub-ms); cache by
+    // tool_fingerprint if search latency ever matters.
+    let corpus = canonical_tools(tools);
+    let index = Bm25Index::build(&corpus);
+    let lexical = lexical_rankings(&index, &search_queries);
+    let lexical_top_ids: Vec<&str> = lexical
+        .iter()
+        .filter_map(|ranking| ranking.first().map(|(id, _)| id.as_str()))
+        .collect();
+    tracing::debug!(
+        ?mode,
+        %fingerprint,
+        elapsed_ms = lexical_started.elapsed().as_secs_f64() * 1000.0,
+        ?lexical_top_ids,
+        "lexical lane ranked"
+    );
+    let production_minilm =
+        mode == FunctionSearchMode::Hybrid && deps.semantic.is_production_minilm();
+    let production_outcome = if production_minilm {
+        let semantic_started = Instant::now();
+        let rankings = production_minilm_rankings(
+            &deps.semantic,
+            fingerprint,
+            tools,
+            &search_queries,
+            &lexical,
+        )
+        .await;
+        tracing::debug!(
+            ?mode,
+            available = rankings.is_some(),
+            complete = rankings.as_ref().is_some_and(|outcome| outcome.complete),
+            %fingerprint,
+            repository = deps.semantic.model_repository(),
+            revision = deps.semantic.model_revision(),
+            reranker_repository = deps.semantic.reranker_repository(),
+            reranker_revision = deps.semantic.reranker_revision(),
+            elapsed_ms = semantic_started.elapsed().as_secs_f64() * 1000.0,
+            "production MiniLM retrieval and reranking completed"
+        );
+        rankings
+    } else {
+        None
+    };
+    let production_rankings = production_outcome.map(|outcome| outcome.rankings);
+    let selected = match production_rankings {
+        Some(rankings) => select_preordered_ids(rankings),
+        None => select_preordered_ids(production_fallback_rankings(
+            tools,
+            &search_queries,
+            &lexical,
+        )),
+    };
+    // Installable section: every search also consults the public registry
+    // for NOT-installed workers whose functions match — behind the
+    // registry_search knob; every failure inside returns an empty section
+    // (fail-open).
+    let mut installable: Vec<InstallableWorker> = Vec::new();
+    if cfg.registry_search {
+        installable = registry_installable(
+            cfg,
+            &deps.registry_cache,
+            production_minilm.then_some(&deps.semantic),
+            tools,
+            &search_queries,
+        )
+        .await;
+    }
+    BatchOutcome {
+        selected,
+        installable,
+    }
 }
 
 fn listed_ids(value: &Value) -> Result<Vec<String>, String> {
@@ -1586,7 +1637,7 @@ mod tests {
             }),
         }];
 
-        let workers = assemble_workers(&["github::pr::create".into()], &tools);
+        let workers = assemble_workers(&["github::pr::create".into()], &tools, MAX_SEARCH_WORKERS);
         let candidate = serde_json::to_value(&workers[0].functions[0]).unwrap();
 
         assert_eq!(
@@ -2278,11 +2329,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn search_truncates_more_than_six_capabilities() {
-        let request: SearchFunctionsRequest = serde_json::from_value(json!({
-            "capabilities": ["one", "two", "three", "four", "five", "six", "seven", "eight"]
-        }))
-        .unwrap();
+    async fn search_truncates_beyond_the_batch_budget() {
+        let mut capabilities: Vec<String> = (1..=18).map(|n| format!("cap {n}")).collect();
+        capabilities.push("nineteen".into());
+        capabilities.push("twenty".into());
+        let request = SearchFunctionsRequest { capabilities };
 
         let response = search_functions(&search_deps(Vec::new()), request)
             .await
@@ -2290,8 +2341,25 @@ mod tests {
 
         assert!(
             response.guidance.contains(
-                "Only the first 6 capabilities were searched; search again for: seven, eight."
+                "Only the first 18 capabilities were searched; search again for: nineteen, twenty."
             ),
+            "{}",
+            response.guidance
+        );
+    }
+
+    #[tokio::test]
+    async fn search_batches_more_than_six_capabilities_without_a_note() {
+        let request = SearchFunctionsRequest {
+            capabilities: (1..=8).map(|n| format!("cap {n}")).collect(),
+        };
+
+        let response = search_functions(&search_deps(Vec::new()), request)
+            .await
+            .unwrap();
+
+        assert!(
+            !response.guidance.contains("were searched"),
             "{}",
             response.guidance
         );

--- a/iii-directory/src/functions/search.rs
+++ b/iii-directory/src/functions/search.rs
@@ -308,9 +308,9 @@ engine::functions::info call — never call an installable function before insta
 
 #[derive(Debug, Clone, serde::Deserialize, schemars::JsonSchema)]
 pub struct SearchFunctionsRequest {
-    /// One to six non-empty capability searches derived from the goal and
-    /// current execution state. For one search at each decision point, include all unmet
-    /// external capabilities once. Exclude intrinsic reasoning, summarization, planning, or
+    /// Non-empty capability searches derived from the goal and current execution state,
+    /// usually one to six and at most eighteen per call (searched in batches of six). For
+    /// one search at each decision point, include all unmet external capabilities once. Exclude intrinsic reasoning, summarization, planning, or
     /// formatting, and do not repeat needs already represented or satisfied. Requests to
     /// summarize provided text or content are ignored. Write every entry in English,
     /// translating non-English user requests while preserving proper names, URLs, and function

--- a/iii-directory/src/functions/search.rs
+++ b/iii-directory/src/functions/search.rs
@@ -1155,11 +1155,7 @@ pub async fn search_functions(
                 selected.push(function_id);
             }
         }
-        for worker in outcome.installable {
-            if !installable.iter().any(|known| known.name == worker.name) {
-                installable.push(worker);
-            }
-        }
+        merge_installable(&mut installable, outcome.installable);
     }
     let batches = request.capabilities.len().div_ceil(MAX_SEARCH_QUERIES);
     let session_id = baggage_session_id();
@@ -1214,6 +1210,28 @@ search again for: {}.",
         installable,
         latency_ms: started.elapsed().as_secs_f64() * 1000.0,
     })
+}
+
+/// Fold one batch's installable workers into the merged section: a worker
+/// two batches both surfaced keeps its first entry and gains the later
+/// batch's functions it did not already list.
+fn merge_installable(merged: &mut Vec<InstallableWorker>, batch: Vec<InstallableWorker>) {
+    for worker in batch {
+        match merged.iter_mut().find(|known| known.name == worker.name) {
+            Some(known) => {
+                for function in worker.functions {
+                    if !known
+                        .functions
+                        .iter()
+                        .any(|existing| existing.function_id == function.function_id)
+                    {
+                        known.functions.push(function);
+                    }
+                }
+            }
+            None => merged.push(worker),
+        }
+    }
 }
 
 /// Candidates one batch of capabilities produced: selected function ids
@@ -2715,6 +2733,34 @@ mod tests {
         let ids: Vec<&str> = ranked.iter().map(|tool| tool.name.as_str()).collect();
 
         assert_eq!(ids, ["browser::fetch"]);
+    }
+
+    #[test]
+    fn installable_workers_merge_functions_across_batches() {
+        let worker = |functions: &[&str]| InstallableWorker {
+            name: "email".into(),
+            version: "1.0.0".into(),
+            description: "Email worker".into(),
+            functions: functions
+                .iter()
+                .map(|id| FunctionCandidate {
+                    function_id: (*id).into(),
+                    description: String::new(),
+                })
+                .collect(),
+            install: install_call("email"),
+        };
+        let mut merged = vec![worker(&["email::send"])];
+
+        merge_installable(&mut merged, vec![worker(&["email::read", "email::send"])]);
+
+        assert_eq!(merged.len(), 1);
+        let ids: Vec<&str> = merged[0]
+            .functions
+            .iter()
+            .map(|f| f.function_id.as_str())
+            .collect();
+        assert_eq!(ids, ["email::send", "email::read"]);
     }
 
     #[test]

--- a/iii-directory/src/functions/search_relevance.rs
+++ b/iii-directory/src/functions/search_relevance.rs
@@ -545,6 +545,48 @@ async fn multiple_capabilities_return_every_need_in_one_call() {
 }
 
 #[tokio::test]
+async fn eight_capabilities_keep_per_capability_coverage_across_batches() {
+    let deps = fixture_deps();
+    let response = ask_capabilities(
+        &deps,
+        &[
+            "register javascript functions on the engine bus",
+            "read and write persistent state values",
+            "take a screenshot of the page",
+            "send an email",
+            "run a shell command",
+            "create a github pull request",
+            // second batch
+            "run a sql query against a database",
+            "extract the text of a pdf document",
+        ],
+    )
+    .await;
+    let ids = function_ids(&response);
+    for expected in [
+        "code-runner::register_function",
+        "state::set",
+        "browser::screenshot",
+        "github::pr::create",
+        "pdf::extract-text",
+    ] {
+        assert!(
+            ids.iter().any(|id| id.starts_with(expected)),
+            "missing {expected}; ids: {ids:?}"
+        );
+    }
+    let namespaces = workers(&response);
+    for expected in ["email", "shell", "database"] {
+        assert!(namespaces.contains(&expected), "workers: {namespaces:?}");
+    }
+    assert!(
+        !response.guidance.contains("were searched"),
+        "{}",
+        response.guidance
+    );
+}
+
+#[tokio::test]
 async fn todo_app_capabilities_resolve_in_one_call() {
     let deps = fixture_deps();
     let response = ask_capabilities(

--- a/iii-directory/src/hook.rs
+++ b/iii-directory/src/hook.rs
@@ -285,7 +285,7 @@ fn hint_block(functions_generation: u64, expose: ExposeKind) -> String {
     };
     format!(
         "<discovery_assist functions_generation={functions_generation}>\n\
-Before calling any task function whose ID has not already been verified in this conversation by a prior search result, contract lookup, or successful call, call directory::search_functions ONCE at this decision point instead of engine::functions::list. Never invent or call an unverified function ID. A clear capability need is not a verified function ID. This search call is fully specified here; do not look up its contract first. Include one to six short, non-overlapping `capabilities` derived from the goal and current execution state, covering all unmet external capabilities. Always write every `capabilities` entry in English, even when the user writes in another language; preserve proper names, URLs, and function IDs. Do not search for intrinsic reasoning, summarization, planning, or formatting, and do not repeat needs already represented in the conversation or already satisfied. Requests to summarize provided text or content are ignored. The result contains candidates, not contracts: choose the smallest candidate set the task needs, then BEFORE their first use call engine::functions::info ONCE with {{ \"function_ids\": [\"<selected id>\", \"<another selected id>\"] }}. A call marked pre-verified by a Harness runtime block or update is already verified; use its exact payload directly and do not search for it or fetch its contract. {call_instruction}\
+Before calling any task function whose ID has not already been verified in this conversation by a prior search result, contract lookup, or successful call, call directory::search_functions ONCE at this decision point instead of engine::functions::list. Never invent or call an unverified function ID. A clear capability need is not a verified function ID. This search call is fully specified here; do not look up its contract first. Include short, non-overlapping `capabilities` derived from the goal and current execution state, covering all unmet external capabilities in this ONE call — usually one to six, at most eighteen. Always write every `capabilities` entry in English, even when the user writes in another language; preserve proper names, URLs, and function IDs. Do not search for intrinsic reasoning, summarization, planning, or formatting, and do not repeat needs already represented in the conversation or already satisfied. Requests to summarize provided text or content are ignored. The result contains candidates, not contracts: choose the smallest candidate set the task needs, then BEFORE their first use call engine::functions::info ONCE with {{ \"function_ids\": [\"<selected id>\", \"<another selected id>\"] }}. A call marked pre-verified by a Harness runtime block or update is already verified; use its exact payload directly and do not search for it or fetch its contract. {call_instruction}\
 </discovery_assist>"
     )
 }
@@ -531,7 +531,7 @@ mod tests {
         assert!(!prompt.contains("\"query\""));
         assert!(prompt.contains("current execution state"));
         assert!(prompt.contains("all unmet external capabilities"));
-        assert!(prompt.contains("one to six short, non-overlapping `capabilities`"));
+        assert!(prompt.contains("usually one to six, at most eighteen"));
         assert!(!prompt.contains("For one capability, omit the field"));
         assert!(prompt.contains(
             "Do not search for intrinsic reasoning, summarization, planning, or formatting"

--- a/iii-directory/src/lib.rs
+++ b/iii-directory/src/lib.rs
@@ -6,7 +6,7 @@
 //! split into five surfaces (all MCP-agnostic):
 //!
 //!   * **Search** (`directory::search_functions`): compact installed and
-//!     installable function candidates for one to six capabilities.
+//!     installable function candidates for the requested capabilities.
 //!   * **Skills** (`directory::skills::*`): a filesystem-backed markdown
 //!     reader keyed by short skill ids
 //!     (slashed-path-relative-to-`skills_folder`).

--- a/iii-directory/src/surface.rs
+++ b/iii-directory/src/surface.rs
@@ -39,7 +39,7 @@ pub fn search_catalog() -> Vec<FunctionSpec> {
     vec![
         spec::<SearchFunctionsRequest, SearchFunctionsResponse>(
             "directory::search_functions",
-            "Search available functions for one to six external capabilities; returns compact function-id candidates grouped by worker.",
+            "Search available functions for the unmet external capabilities of a step (usually one to six, at most eighteen per call); returns compact function-id candidates grouped by worker.",
         ),
         spec::<PreGenerateHookRequest, PreGenerateHookResponse>(
             "directory::pre-generate",

--- a/iii-directory/tests/golden/schemas/directory.search_functions.json
+++ b/iii-directory/tests/golden/schemas/directory.search_functions.json
@@ -1,11 +1,11 @@
 {
-  "description": "Search available functions for one to six external capabilities; returns compact function-id candidates grouped by worker.",
+  "description": "Search available functions for the unmet external capabilities of a step (usually one to six, at most eighteen per call); returns compact function-id candidates grouped by worker.",
   "function_id": "directory::search_functions",
   "request_schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "properties": {
       "capabilities": {
-        "description": "One to six non-empty capability searches derived from the goal and current execution state. For one search at each decision point, include all unmet external capabilities once. Exclude intrinsic reasoning, summarization, planning, or formatting, and do not repeat needs already represented or satisfied. Requests to summarize provided text or content are ignored. Write every entry in English, translating non-English user requests while preserving proper names, URLs, and function IDs.",
+        "description": "Non-empty capability searches derived from the goal and current execution state, usually one to six and at most eighteen per call (searched in batches of six). For one search at each decision point, include all unmet external capabilities once. Exclude intrinsic reasoning, summarization, planning, or formatting, and do not repeat needs already represented or satisfied. Requests to summarize provided text or content are ignored. Write every entry in English, translating non-English user requests while preserving proper names, URLs, and function IDs.",
         "items": {
           "minLength": 1,
           "type": "string"


### PR DESCRIPTION
## Why

After #1110, `directory::search_functions` truncated anything past six capabilities and told the agent to search again, costing it a whole model turn. The directive also contradicted itself: "one to six" and "covering all unmet external capabilities" in the same sentence, so a step with eight real needs had no rule to follow.

## What

**Batching** (`search.rs`): each chunk of six capabilities runs the existing pipeline (BM25 + MiniLM + rerank + registry) with its own 12-function / 6-worker budget, so every capability still gets about two candidates however many are sent. Selected ids and installable workers merge across batches with dedupe; the session delivered-registry split runs once over the merged set. Up to 3 batches (18 capabilities); beyond that the #1110 truncation note remains.

**Lane-aware worker cap** (`select_preordered_ids`): round-robin hands each capability two of the twelve slots, but the flat six-worker cap meant that with six capabilities the six lane leaders filled it and every runner-up in a new namespace was dropped (a six-capability search returned ten functions and lost `code-runner::register_function` behind its twin `sandbox-code-runner::register_function`, tied reranker score). Cap is now `max(6, 2 × lanes)`; the redundant cap in `assemble_workers` is gone.

**Wording**: every agent-facing "one to six" became "usually one to six, at most eighteen" plus "all unmet capabilities in this ONE call": `harness/prompts/default.txt` and the bundled `iii.md` (byte-identical bodies, asserted by `bundled.rs`), `iii-minimal.md`, the pre-generate hint in `hook.rs`, the request-schema field and function descriptions plus goldens, and the `function-search` / `SKILL` skill docs (which also stated the old flat cap).

## Verification

- iii-directory: `cargo test --lib` 438 passed (2 batching unit tests, 2 worker-cap unit tests, 1 relevance test with 8 capabilities across the batch boundary), `search_schemas` golden green, clippy `--all-features --all-targets -D warnings` clean. harness: `cargo test --test prompts` green.
- Real MiniLM bundle over the 512-function fixture (debug, registry off): 1 cap 190 ms, 3 → 550 ms, 6 → 1.0 s / 12 fns / 8 workers (was 10 / 6), 8 → 1.3 s, 12 → 1.9 s / 24 fns / 14 workers, 18 → 2.9 s / 36 fns / 6 KB; every expected namespace present. Linear, ~150 ms per capability, no reranker timeout.
- Live stack (`harness::send`, `codex/gpt-5.5`, bundled `iii` profile): a discovery turn with eight needs produced ONE search with 8 capabilities, no truncation note, all eight mapped (2 steps, 19 s). An end-to-end turn (search → `compose::add pdf` → `compose::up {container:"pdf"}` → `pdf::extract-text` → `state::set` → `state::get`) completed with the expected answer code.

Not changed: `MAX_SEARCH_QUERIES` stays 6 per batch (the round-robin budget), `PRODUCTION_RERANK_DEPTH` and the reranker gap untouched.

https://claude.ai/code/session_01AqWfKxQWL7vozgm3byFVo2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Directory searches now support up to 18 capability requests per call, processed in batches of six.
  - Results preserve capability coverage, merge and deduplicate candidates, and combine functions from workers found across batches.
  - Search ranking now uses hybrid relevance ranking.
  - Guidance reports when requests exceed the supported capability limit.

- **Documentation**
  - Updated search descriptions and guidance for capability limits, batching, ranking, and worker-grouped results.

- **Tests**
  - Added coverage for multi-batch searches, capability coverage, truncation guidance, and scaled worker selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->