### PR TITLE
(MOT-4719) fix(shell): echo the binding's metadata on every shell::changed fire; skip ignored paths by default

### DIFF
--- a/shell/README.md
+++ b/shell/README.md
@@ -319,6 +319,17 @@ crate). A subscriber names the directory in its binding config:
 { "type": "shell::changed", "config": { "path": "/some/dir" } }
 ```
 
+Paths the root ignores — git-ignored inside a repository; `data/`,
+`config/`, `.iii/`, `node_modules/` and the root `.gitignore` outside one —
+are **not delivered** unless the binding also sets `include_ignored: true`.
+A watch on a project root would otherwise fire on the engine's own
+`data/observability` and `data/session-manager` writes, i.e. on the
+subscriber's own transcript. The workspace UI opts in to count them.
+
+Every fire carries the binding's registered `metadata` and `namespace`
+back to the bound function, the same way the engine's own trigger types
+do — the harness relies on it to match a wake to its `__binding`.
+
 Each registration starts one recursive watcher; unregistering (or the
 console GC'ing a closed tab's binding) tears it down. `config.path` goes
 through the same path policy as every `coder::*` call — jail containment

--- a/shell/skills/SKILL.md
+++ b/shell/skills/SKILL.md
@@ -125,8 +125,12 @@ effects, or an editor outside the engine. Payload:
 `path` relative to `root`, `dir` true for directories (skip those when
 opening files). Events coalesce per path in a short window
 (create + write = `created`; deletion supersedes), `.git` internals are
-filtered, and fan-out is fire-and-forget. Read content on demand via
-`coder::read-file` — the event deliberately carries none.
+filtered, and fan-out is fire-and-forget. Ignored paths (git-ignored, or
+`data/`, `config/`, `.iii/`, `node_modules/` outside a repository) are not
+delivered unless the binding sets `include_ignored: true` — a wake on a
+project root would otherwise fire on the engine's own data writes. Read
+content on demand via `coder::read-file` — the event deliberately carries
+none.
 
 ## Code files (`coder::*`)
 

--- a/shell/src/events.rs
+++ b/shell/src/events.rs
@@ -269,6 +269,64 @@ fn rel_to(root: &Path, path: &Path) -> Option<String> {
     Some(s.into_owned())
 }
 
+/// How one binding's events reach its function: the registration's stored
+/// `metadata` and `namespace`, echoed on every fire exactly like the engine
+/// does for its own trigger types, plus whether ignored paths are delivered.
+///
+/// The metadata is not optional plumbing. The harness binds every agent wake
+/// as `harness::trigger::deliver` with `metadata: { "__binding": <id> }` and
+/// DROPS any fire that arrives without it. Delivering the bare payload made
+/// every `shell::changed` wake in a live run expire "unfired" while this
+/// worker logged 34 000 successful deliveries (MOT-4719).
+#[derive(Debug, Clone, Default)]
+struct Delivery {
+    metadata: Option<Value>,
+    namespace: Option<String>,
+    /// Deliver paths the root ignores (git-ignored, or the built-in
+    /// engine-owned set outside a repository). Off by default: a wake armed on
+    /// a project root would otherwise fire on the engine's own
+    /// `data/observability` and `data/session-manager` writes — the
+    /// subscriber's own transcript. The workspace UI opts in to count them.
+    include_ignored: bool,
+}
+
+impl Delivery {
+    fn from_config(config: &TriggerConfig) -> Self {
+        Self {
+            metadata: config.metadata.clone(),
+            namespace: config.namespace.clone(),
+            include_ignored: config
+                .config
+                .get("include_ignored")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+        }
+    }
+
+    /// The fire for one event: the bound function, the event, `Void` routing
+    /// (fire-and-forget), and the binding's metadata/namespace passed through.
+    fn request(
+        &self,
+        function_id: &str,
+        payload: Value,
+    ) -> iii_sdk::protocol::TriggerRequestWithMetadata {
+        let mut request: iii_sdk::protocol::TriggerRequestWithMetadata = TriggerRequest {
+            function_id: function_id.to_string(),
+            payload,
+            action: Some(TriggerAction::Void),
+            timeout_ms: None,
+        }
+        .into();
+        if let Some(metadata) = &self.metadata {
+            request = request.metadata(metadata.clone());
+        }
+        if let Some(namespace) = &self.namespace {
+            request = request.namespace(namespace.clone());
+        }
+        request
+    }
+}
+
 /// Consume raw watcher events, coalesce per path, fan out to the bound
 /// function. Owns the watcher: aborting this task tears the watch down.
 async fn pump(
@@ -277,6 +335,7 @@ async fn pump(
     root: PathBuf,
     _watcher: notify::RecommendedWatcher,
     mut rx: tokio::sync::mpsc::Receiver<notify::Event>,
+    delivery: Delivery,
 ) {
     let root_str = root.to_string_lossy().into_owned();
     loop {
@@ -327,6 +386,14 @@ async fn pump(
             };
             let dir = kind != "deleted" && root.join(&path).is_dir();
             let ignored = ignored_paths.contains(&path);
+            if ignored && !delivery.include_ignored {
+                tracing::debug!(
+                    function_id = %function_id,
+                    path = %path,
+                    "shell::changed skipped an ignored path (bind with include_ignored: true to receive it)"
+                );
+                continue;
+            }
             let event = ChangedEvent {
                 path,
                 kind: kind.to_string(),
@@ -344,16 +411,9 @@ async fn pump(
             // "slow subscriber never delays anything" violation.
             let iii = iii.clone();
             let function_id = function_id.clone();
+            let request = delivery.request(&function_id, payload);
             tokio::spawn(async move {
-                if let Err(e) = iii
-                    .trigger(TriggerRequest {
-                        function_id: function_id.clone(),
-                        payload,
-                        action: Some(TriggerAction::Void),
-                        timeout_ms: None,
-                    })
-                    .await
-                {
+                if let Err(e) = iii.trigger(request).await {
                     tracing::warn!(function_id = %function_id, error = %e, "shell::changed fan-out failed");
                 } else {
                     tracing::info!(
@@ -394,12 +454,14 @@ impl TriggerHandler for ChangedTriggerHandler {
             root = %root.display(),
             "watch registered"
         );
+        let delivery = Delivery::from_config(&config);
         let task = tokio::spawn(pump(
             self.iii.clone(),
             config.function_id,
             root,
             watcher,
             rx,
+            delivery,
         ));
         // Poison recovery: the map is plain data — a panic elsewhere must
         // not silently drop this registration (the entry's Drop aborts
@@ -428,7 +490,9 @@ pub fn register_changed_trigger(iii: &IIIClient, resolver: ResolverCell) {
         CHANGED,
         "Fires when anything under the watched directory changes, whoever changed \
          it — bind with config: { path } naming the directory (jail-checked like \
-         every coder::* path).",
+         every coder::* path). Ignored paths (git-ignored; outside a repository \
+         data/, config/, .iii/, node_modules/) are skipped unless config also sets \
+         include_ignored: true.",
         ChangedTriggerHandler {
             iii: iii.clone(),
             watches: Arc::new(Mutex::new(HashMap::new())),
@@ -635,6 +699,42 @@ mod tests {
         );
         assert!(rel_to(root, Path::new("/srv/app")).is_none());
         assert!(rel_to(root, Path::new("/elsewhere/b.rs")).is_none());
+    }
+
+    /// Prevents: the wake that never fires — the harness binds
+    /// `harness::trigger::deliver` with `metadata: { "__binding": id }` and
+    /// drops a fire without it; the pump used to send the bare payload
+    /// (MOT-4719, 34k deliveries logged here, 0 fires counted there).
+    #[test]
+    fn deliveries_echo_the_binding_metadata_and_namespace() {
+        let config = TriggerConfig {
+            id: "b1".into(),
+            function_id: "harness::trigger::deliver".into(),
+            config: json!({ "path": "/tmp/x" }),
+            metadata: Some(json!({ "__binding": "sub_abc" })),
+            namespace: Some("project".into()),
+        };
+        let delivery = Delivery::from_config(&config);
+        assert!(!delivery.include_ignored, "ignored paths are opt-in");
+        let request = delivery.request("harness::trigger::deliver", json!({ "path": "a.rs" }));
+        let debug = format!("{request:?}");
+        assert!(debug.contains("__binding"), "{debug}");
+        assert!(debug.contains("sub_abc"), "{debug}");
+        assert!(debug.contains("project"), "{debug}");
+        assert!(debug.contains("Void"), "{debug}");
+
+        // A legacy binding without metadata still fires, without inventing any.
+        let bare = Delivery::from_config(&TriggerConfig {
+            id: "b2".into(),
+            function_id: "probe::on_change".into(),
+            config: json!({ "path": "/tmp/x", "include_ignored": true }),
+            metadata: None,
+            namespace: None,
+        });
+        assert!(bare.include_ignored);
+        let debug = format!("{:?}", bare.request("probe::on_change", json!({})));
+        assert!(debug.contains("metadata: None"), "{debug}");
+        assert!(debug.contains("namespace: None"), "{debug}");
     }
 
     fn resolver_rooted_at(root: &Path) -> PathResolver {

--- a/shell/ui/src/page/live.ts
+++ b/shell/ui/src/page/live.ts
@@ -59,7 +59,10 @@ export function useWorkspaceChanges(
     const offTrigger = host.iii.registerTrigger({
       type: 'shell::changed',
       function_id: `${functionId}::${host.iii.browserId}`,
-      config: { path: root },
+      // The workspace view counts ignored churn (build output, engine data)
+      // instead of hiding it, so it opts in; every other subscriber gets
+      // only the changes that matter by default.
+      config: { path: root, include_ignored: true },
     })
     return () => {
       offTrigger()


### PR DESCRIPTION
## Why

In the Linkly agentic e2e (MOT-4717) every `shell::changed` wake the agent armed expired with `0 fires` — five chapters, ≈15 min idle. The shell log for the same run has **34 141** `shell::changed delivered` lines to `harness::trigger::deliver`, including the exact fragment files the agent was waiting for. The harness dropped all of them: `harness::trigger::deliver: fire without a `__binding` key; dropping`.

## Root cause

`events.rs::pump` fanned events out with a bare `TriggerRequest` — no `metadata`, no `namespace`. `TriggerConfig` hands the provider the binding's stored `metadata` (`{ "__binding": id }` for harness wakes) precisely so it can be echoed on every fire; state, queue and cron already do `request.metadata(m)`. The two hypotheses in the issue (jail refusal, create-tmp→rename coalescing) were wrong: the watcher and the write path were fine.

## What

- `Delivery::from_config` keeps the registration's `metadata` and `namespace`; every fire goes out as `TriggerRequestWithMetadata` with both attached. Unit test asserts the `__binding` and namespace ride along and that a legacy binding without metadata invents none.
- Ignored paths are skipped unless the binding sets `include_ignored: true`. With metadata fixed, a wake on the project root would otherwise have fired on the engine's own `data/observability` / `data/session-manager` writes — the subscriber's own transcript. The workspace UI (`ui/src/page/live.ts`), which counts ignored churn, opts in. README, SKILL and the trigger-type description document the knob.

## Verification

- `cargo test` (all shell suites), `cargo clippy -D warnings`, `cargo fmt`.
- Live, this build swapped in for `shell 0.12.5` in the Linkly agentic stack (harness = MOT-4718 build): agent armed a `shell::changed` wake on `link/src` → `coder::create-file` under it → the session woke 8 s later with `[notification] probe wake: {"kind":"modified","path":"wake-probe.txt",...}` and answered; harness log shows **0** `__binding` drops. A probe watch on the project root without `include_ignored` did not fire for a write under `data/`, and fired once for a write under `link/src`.

Linear: MOT-4719 (parent MOT-4717)

https://claude.ai/code/session_01PvtXK7JgHHNrG192afbRAk


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - File-change triggers now include the binding’s registered metadata and namespace with every event.
  - Added an `include_ignored` option to receive changes for ignored files and engine-managed paths.

- **Bug Fixes**
  - Project-root watchers no longer react to internal engine data changes by default.
  - The workspace live view opts in to include ignored-path events when monitoring changes.

- **Documentation**
  - Updated shell trigger documentation to describe ignored-path filtering and event context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->