### PR TITLE
(MOT-4721) fix(session-manager): replay session files off the async thread

### DIFF
--- a/session-manager/src/functions/append.rs
+++ b/session-manager/src/functions/append.rs
@@ -46,15 +46,19 @@ const SLOW_APPEND: Duration = Duration::from_secs(1);
 pub async fn handle(deps: &Deps, req: AppendRequest) -> Result<AppendResponse, SessionError> {
     let session_id = req.session_id.clone();
     let started = Instant::now();
-    let (resp, events) = deps.service.append(req).await?;
+    // Timed before `?`: a store that took seconds to fail is the same
+    // signal as one that took seconds to succeed.
+    let result = deps.service.append(req).await;
     let elapsed = started.elapsed();
     if elapsed > SLOW_APPEND {
         tracing::warn!(
             session_id,
             elapsed_ms = elapsed.as_millis() as u64,
+            ok = result.is_ok(),
             "slow session::append"
         );
     }
+    let (resp, events) = result?;
     deps.sink.publish_all(&events).await;
     Ok(resp)
 }

--- a/session-manager/src/functions/append.rs
+++ b/session-manager/src/functions/append.rs
@@ -1,5 +1,7 @@
 //! `session::append` — append one entry, idempotent on `entry_id`.
 
+use std::time::{Duration, Instant};
+
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -36,8 +38,23 @@ pub struct AppendResponse {
     pub timestamp: i64,
 }
 
+/// Callers (the harness turn loop) time out an append at ~10s and fail the
+/// turn; log well before that so the slow store shows up in the worker's
+/// log next to the caller's timeout instead of only on the caller.
+const SLOW_APPEND: Duration = Duration::from_secs(1);
+
 pub async fn handle(deps: &Deps, req: AppendRequest) -> Result<AppendResponse, SessionError> {
+    let session_id = req.session_id.clone();
+    let started = Instant::now();
     let (resp, events) = deps.service.append(req).await?;
+    let elapsed = started.elapsed();
+    if elapsed > SLOW_APPEND {
+        tracing::warn!(
+            session_id,
+            elapsed_ms = elapsed.as_millis() as u64,
+            "slow session::append"
+        );
+    }
     deps.sink.publish_all(&events).await;
     Ok(resp)
 }

--- a/session-manager/src/store/fs.rs
+++ b/session-manager/src/store/fs.rs
@@ -126,9 +126,17 @@ pub fn decode_session_id(stem: &str) -> Option<String> {
     String::from_utf8(out).ok()
 }
 
+/// Test seam: runs on the blocking thread after a replay has read its file
+/// and before the result reaches the cache, so a test can park one replay
+/// while another caller gets there first.
+#[cfg(test)]
+type ReplayHook = std::sync::Arc<dyn Fn(&str) + Send + Sync>;
+
 pub struct FsStore {
     dir: PathBuf,
     cache: Mutex<HashMap<String, LoadedSession>>,
+    #[cfg(test)]
+    after_replay: Option<ReplayHook>,
 }
 
 impl FsStore {
@@ -140,6 +148,8 @@ impl FsStore {
         Ok(Self {
             dir,
             cache: Mutex::new(HashMap::new()),
+            #[cfg(test)]
+            after_replay: None,
         })
     }
 
@@ -202,9 +212,18 @@ impl FsStore {
         if !self.lock().contains_key(session_id) {
             let path = self.file_path(session_id);
             let id = session_id.to_string();
-            let loaded = tokio::task::spawn_blocking(move || Self::replay_file(&path, &id))
-                .await
-                .map_err(|e| StoreError(format!("replay {session_id}: {e}")))??;
+            #[cfg(test)]
+            let after_replay = self.after_replay.clone();
+            let loaded = tokio::task::spawn_blocking(move || {
+                let loaded = Self::replay_file(&path, &id);
+                #[cfg(test)]
+                if let Some(hook) = &after_replay {
+                    hook(&id);
+                }
+                loaded
+            })
+            .await
+            .map_err(|e| StoreError(format!("replay {session_id}: {e}")))??;
             // A concurrent caller may have replayed (and mutated) the same
             // session while we were off the lock; its state stays.
             self.lock().entry(session_id.to_string()).or_insert(loaded);
@@ -535,6 +554,8 @@ fn read_attachment_meta(path: &Path) -> Result<Option<AttachmentMeta>, StoreErro
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
+
     use crate::types::{AgentMessage, ContentBlock, SessionStatus};
 
     fn meta(session_id: &str, title: &str) -> SessionMeta {
@@ -737,6 +758,148 @@ mod tests {
         assert!(store.get_meta("nope").await.unwrap().is_none());
         assert!(store.list_entries("nope").await.unwrap().is_empty());
         assert!(store.get_active_leaf("nope").await.unwrap().is_none());
+    }
+
+    /// Write a session file directly: one meta line, then `entries`
+    /// message entries. Big enough that a cold replay takes real time.
+    fn seed_session_file(dir: &Path, session_id: &str, title: &str, entries: usize) {
+        let mut text = serde_json::to_string(&Record::Meta {
+            meta: meta(session_id, title),
+        })
+        .unwrap();
+        text.push('\n');
+        for i in 0..entries {
+            text.push_str(
+                &serde_json::to_string(&Record::Entry {
+                    entry: entry(&format!("e_seed_{i}"), None, "seed", 0),
+                })
+                .unwrap(),
+            );
+            text.push('\n');
+        }
+        let path = dir.join(format!("{}.jsonl", encode_session_id(session_id)));
+        std::fs::write(path, text).unwrap();
+    }
+
+    /// The replay runs off the lock, so two callers can miss the cache and
+    /// both replay the same session. Whoever inserts first wins; the other's
+    /// replay is dropped (`entry().or_insert`). A plain `insert` would let a
+    /// replay that read the file BEFORE the winner appended overwrite the
+    /// winner's state, losing that entry from the cache until a restart.
+    /// The seam parks the first replay between its read and its insert so
+    /// the interleaving is exact, not a matter of timing.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_replay_that_loses_the_race_does_not_clobber_the_winner() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::{mpsc, Arc};
+
+        let dir = tempfile::tempdir().unwrap();
+        seed_session_file(dir.path(), "s_1", "busy", 10);
+
+        let (parked_tx, parked_rx) = mpsc::channel::<()>();
+        let (release_tx, release_rx) = mpsc::channel::<()>();
+        let release_rx = Mutex::new(Some(release_rx));
+        let first = AtomicBool::new(true);
+        let mut store = FsStore::new(dir.path()).unwrap();
+        store.after_replay = Some(Arc::new(move |_id: &str| {
+            // Only the first replay parks; the winner's passes straight through.
+            if first.swap(false, Ordering::SeqCst) {
+                parked_tx.send(()).unwrap();
+                if let Some(rx) = release_rx.lock().unwrap().take() {
+                    rx.recv().unwrap();
+                }
+            }
+        }));
+        let store = Arc::new(store);
+
+        // The loser: reads the 10-entry file, then parks before inserting.
+        let loser = tokio::spawn({
+            let store = Arc::clone(&store);
+            async move { store.list_entries("s_1").await.unwrap().len() }
+        });
+        tokio::task::spawn_blocking(move || parked_rx.recv_timeout(Duration::from_secs(5)))
+            .await
+            .unwrap()
+            .expect("the first replay reached the seam");
+
+        // The winner: appends to disk, replays (its own entry included), and
+        // lands in the cache while the loser is still parked.
+        store
+            .put_entry("s_1", &entry("e_new", None, "new", 0))
+            .await
+            .unwrap();
+        assert!(store.get_entry("s_1", "e_new").await.unwrap().is_some());
+
+        release_tx.send(()).unwrap();
+        let seen_by_loser = loser.await.unwrap();
+
+        // The loser's stale replay must not have replaced the winner's state;
+        // its own read runs against the cache, so it sees the new entry too.
+        assert!(
+            store.get_entry("s_1", "e_new").await.unwrap().is_some(),
+            "a losing replay clobbered an entry appended while it ran"
+        );
+        assert_eq!(store.list_entries("s_1").await.unwrap().len(), 11);
+        assert_eq!(seen_by_loser, 11);
+    }
+
+    /// Cold loads of different sessions run side by side on the blocking
+    /// pool; each lands in the cache under its own key.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn many_cold_sessions_load_concurrently() {
+        let dir = tempfile::tempdir().unwrap();
+        const SESSIONS: usize = 32;
+        for i in 0..SESSIONS {
+            seed_session_file(dir.path(), &format!("s_{i}"), &format!("title {i}"), 50);
+        }
+
+        let store = std::sync::Arc::new(FsStore::new(dir.path()).unwrap());
+        let mut tasks = tokio::task::JoinSet::new();
+        for i in 0..SESSIONS {
+            let store = std::sync::Arc::clone(&store);
+            tasks.spawn(async move {
+                let id = format!("s_{i}");
+                let title = store.get_meta(&id).await.unwrap().unwrap().title;
+                let entries = store.list_entries(&id).await.unwrap().len();
+                (i, title, entries)
+            });
+        }
+        while let Some(joined) = tasks.join_next().await {
+            let (i, title, entries) = joined.unwrap();
+            assert_eq!(title, format!("title {i}"));
+            assert_eq!(entries, 50);
+        }
+        assert_eq!(store.lock().len(), SESSIONS);
+    }
+
+    /// A replay that fails (here: the session path is a directory, so the
+    /// read errors with something other than NotFound) surfaces as an error
+    /// and leaves nothing in the cache, so a later successful write is not
+    /// shadowed by a poisoned or empty cached state.
+    #[tokio::test]
+    async fn failed_replay_errors_and_is_not_cached() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = FsStore::new(dir.path()).unwrap();
+        let path = dir
+            .path()
+            .join(format!("{}.jsonl", encode_session_id("s_1")));
+        std::fs::create_dir(&path).unwrap();
+
+        let err = store.get_meta("s_1").await.unwrap_err();
+        assert!(err.to_string().contains("s_1"), "{err}");
+        assert!(store.list_entries("s_1").await.is_err());
+        assert!(
+            store.lock().is_empty(),
+            "a failed replay must not be cached"
+        );
+
+        // The operator fixes the disk; the next touch replays for real.
+        std::fs::remove_dir(&path).unwrap();
+        store.put_meta(&meta("s_1", "recovered")).await.unwrap();
+        assert_eq!(
+            store.get_meta("s_1").await.unwrap().unwrap().title,
+            "recovered"
+        );
     }
 
     fn attachment(session_id: &str, id: &str, name: &str, bytes: &[u8]) -> AttachmentMeta {

--- a/session-manager/src/store/fs.rs
+++ b/session-manager/src/store/fs.rs
@@ -204,12 +204,24 @@ impl FsStore {
     /// The replay runs on the blocking pool and outside the cache lock: a
     /// multi-MB transcript parsed on the async thread while holding the
     /// `std::Mutex` stalled every other session's append behind it.
+    ///
+    /// Because the replay is off the lock, a caller's replay can overlap
+    /// another caller's mutation of the same session. Two rules keep that
+    /// safe. Insert is `entry().or_insert`: whoever publishes first wins,
+    /// and a replay that read the file earlier is dropped rather than
+    /// overwriting state appended since. And cache entries are never
+    /// evicted: a deleted session keeps an empty entry until restart, so a
+    /// replay that read the file before the delete finds the entry taken
+    /// and cannot resurrect the deleted state (a per-session generation
+    /// check is the upgrade if the empty entries ever matter).
     async fn with_loaded<T>(
         &self,
         session_id: &str,
         f: impl FnOnce(&mut LoadedSession) -> T,
     ) -> Result<T, StoreError> {
-        if !self.lock().contains_key(session_id) {
+        let replayed = if self.lock().contains_key(session_id) {
+            None
+        } else {
             let path = self.file_path(session_id);
             let id = session_id.to_string();
             #[cfg(test)]
@@ -224,14 +236,15 @@ impl FsStore {
             })
             .await
             .map_err(|e| StoreError(format!("replay {session_id}: {e}")))??;
-            // A concurrent caller may have replayed (and mutated) the same
-            // session while we were off the lock; its state stays.
-            self.lock().entry(session_id.to_string()).or_insert(loaded);
-        }
+            Some(loaded)
+        };
         let mut cache = self.lock();
-        let loaded = cache
-            .get_mut(session_id)
-            .expect("session state inserted just above");
+        let loaded = match replayed {
+            Some(replayed) => cache.entry(session_id.to_string()).or_insert(replayed),
+            None => cache
+                .get_mut(session_id)
+                .expect("cache entries are never evicted"),
+        };
         Ok(f(loaded))
     }
 
@@ -351,9 +364,6 @@ impl SessionStore for FsStore {
                 s.clone()
             })
             .await?;
-        if snapshot.is_empty() {
-            self.lock().remove(session_id);
-        }
         self.persist_snapshot(session_id, &snapshot)
     }
 
@@ -399,9 +409,6 @@ impl SessionStore for FsStore {
                 s.clone()
             })
             .await?;
-        if snapshot.is_empty() {
-            self.lock().remove(session_id);
-        }
         self.persist_snapshot(session_id, &snapshot)
     }
 
@@ -425,9 +432,6 @@ impl SessionStore for FsStore {
                 s.clone()
             })
             .await?;
-        if snapshot.is_empty() {
-            self.lock().remove(session_id);
-        }
         self.persist_snapshot(session_id, &snapshot)
     }
 
@@ -841,6 +845,74 @@ mod tests {
         );
         assert_eq!(store.list_entries("s_1").await.unwrap().len(), 11);
         assert_eq!(seen_by_loser, 11);
+    }
+
+    /// A cold replay that read the file BEFORE a delete must not publish
+    /// that state afterwards. The delete leaves an empty cache entry behind
+    /// (entries are never evicted), so the late replay finds the slot taken
+    /// and its stale state is dropped; its callback runs on the emptied
+    /// session, exactly as if it had arrived after the delete.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_delete_that_overlaps_a_cold_replay_is_not_undone() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::{mpsc, Arc};
+
+        let dir = tempfile::tempdir().unwrap();
+        seed_session_file(dir.path(), "s_1", "doomed", 3);
+        let path = dir
+            .path()
+            .join(format!("{}.jsonl", encode_session_id("s_1")));
+
+        let (parked_tx, parked_rx) = mpsc::channel::<()>();
+        let (release_tx, release_rx) = mpsc::channel::<()>();
+        let release_rx = Mutex::new(Some(release_rx));
+        let first = AtomicBool::new(true);
+        let mut store = FsStore::new(dir.path()).unwrap();
+        store.after_replay = Some(Arc::new(move |_id: &str| {
+            if first.swap(false, Ordering::SeqCst) {
+                parked_tx.send(()).unwrap();
+                if let Some(rx) = release_rx.lock().unwrap().take() {
+                    rx.recv().unwrap();
+                }
+            }
+        }));
+        let store = Arc::new(store);
+
+        // The reader replays the live file, then parks before publishing.
+        let reader = tokio::spawn({
+            let store = Arc::clone(&store);
+            async move { store.get_meta("s_1").await.unwrap() }
+        });
+        tokio::task::spawn_blocking(move || parked_rx.recv_timeout(Duration::from_secs(5)))
+            .await
+            .unwrap()
+            .expect("the first replay reached the seam");
+
+        // The service's delete order runs to completion meanwhile.
+        store.delete_entries("s_1").await.unwrap();
+        store.delete_active_leaf("s_1").await.unwrap();
+        store.delete_meta("s_1").await.unwrap();
+        assert!(!path.exists());
+
+        release_tx.send(()).unwrap();
+        assert!(
+            reader.await.unwrap().is_none(),
+            "the reader's callback ran on the emptied session"
+        );
+        assert!(
+            store.get_meta("s_1").await.unwrap().is_none(),
+            "a late replay resurrected a deleted session"
+        );
+        assert!(store.list_entries("s_1").await.unwrap().is_empty());
+        assert!(!path.exists(), "a late replay must not bring the file back");
+
+        // The id is reusable: the next write starts a fresh file.
+        store.put_meta(&meta("s_1", "reborn")).await.unwrap();
+        assert_eq!(
+            store.get_meta("s_1").await.unwrap().unwrap().title,
+            "reborn"
+        );
+        assert!(path.exists());
     }
 
     /// Cold loads of different sessions run side by side on the blocking

--- a/session-manager/src/store/fs.rs
+++ b/session-manager/src/store/fs.rs
@@ -161,9 +161,8 @@ impl FsStore {
     /// Replay a session file into a [`LoadedSession`]. Missing file ->
     /// empty state. Malformed lines (incl. a truncated trailing line
     /// from a crash mid-append) are skipped with a warning.
-    fn replay_file(&self, session_id: &str) -> Result<LoadedSession, StoreError> {
-        let path = self.file_path(session_id);
-        let contents = match std::fs::read_to_string(&path) {
+    fn replay_file(path: &Path, session_id: &str) -> Result<LoadedSession, StoreError> {
+        let contents = match std::fs::read_to_string(path) {
             Ok(c) => c,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                 return Ok(LoadedSession::default())
@@ -191,16 +190,26 @@ impl FsStore {
 
     /// Run `f` against the loaded (cached) state of a session,
     /// replaying the file on first access.
-    fn with_loaded<T>(
+    ///
+    /// The replay runs on the blocking pool and outside the cache lock: a
+    /// multi-MB transcript parsed on the async thread while holding the
+    /// `std::Mutex` stalled every other session's append behind it.
+    async fn with_loaded<T>(
         &self,
         session_id: &str,
         f: impl FnOnce(&mut LoadedSession) -> T,
     ) -> Result<T, StoreError> {
-        let mut cache = self.lock();
-        if !cache.contains_key(session_id) {
-            let loaded = self.replay_file(session_id)?;
-            cache.insert(session_id.to_string(), loaded);
+        if !self.lock().contains_key(session_id) {
+            let path = self.file_path(session_id);
+            let id = session_id.to_string();
+            let loaded = tokio::task::spawn_blocking(move || Self::replay_file(&path, &id))
+                .await
+                .map_err(|e| StoreError(format!("replay {session_id}: {e}")))??;
+            // A concurrent caller may have replayed (and mutated) the same
+            // session while we were off the lock; its state stays.
+            self.lock().entry(session_id.to_string()).or_insert(loaded);
         }
+        let mut cache = self.lock();
         let loaded = cache
             .get_mut(session_id)
             .expect("session state inserted just above");
@@ -302,7 +311,7 @@ impl FsStore {
 #[async_trait]
 impl SessionStore for FsStore {
     async fn get_meta(&self, session_id: &str) -> Result<Option<SessionMeta>, StoreError> {
-        self.with_loaded(session_id, |s| s.meta.clone())
+        self.with_loaded(session_id, |s| s.meta.clone()).await
     }
 
     async fn put_meta(&self, meta: &SessionMeta) -> Result<(), StoreError> {
@@ -313,13 +322,16 @@ impl SessionStore for FsStore {
         let record = Record::Meta { meta: meta.clone() };
         self.append_record(&meta.session_id, &record)?;
         self.with_loaded(&meta.session_id, |s| s.meta = Some(meta.clone()))
+            .await
     }
 
     async fn delete_meta(&self, session_id: &str) -> Result<(), StoreError> {
-        let snapshot = self.with_loaded(session_id, |s| {
-            s.meta = None;
-            s.clone()
-        })?;
+        let snapshot = self
+            .with_loaded(session_id, |s| {
+                s.meta = None;
+                s.clone()
+            })
+            .await?;
         if snapshot.is_empty() {
             self.lock().remove(session_id);
         }
@@ -329,7 +341,7 @@ impl SessionStore for FsStore {
     async fn list_metas(&self) -> Result<Vec<SessionMeta>, StoreError> {
         let mut metas = Vec::new();
         for session_id in self.session_ids_on_disk()? {
-            if let Some(meta) = self.with_loaded(&session_id, |s| s.meta.clone())? {
+            if let Some(meta) = self.with_loaded(&session_id, |s| s.meta.clone()).await? {
                 metas.push(meta);
             }
         }
@@ -342,6 +354,7 @@ impl SessionStore for FsStore {
         entry_id: &str,
     ) -> Result<Option<SessionEntry>, StoreError> {
         self.with_loaded(session_id, |s| s.entries.get(entry_id).cloned())
+            .await
     }
 
     async fn put_entry(&self, session_id: &str, entry: &SessionEntry) -> Result<(), StoreError> {
@@ -352,17 +365,21 @@ impl SessionStore for FsStore {
         self.with_loaded(session_id, |s| {
             s.entries.insert(entry.id().to_string(), entry.clone());
         })
+        .await
     }
 
     async fn list_entries(&self, session_id: &str) -> Result<Vec<SessionEntry>, StoreError> {
         self.with_loaded(session_id, |s| s.entries.values().cloned().collect())
+            .await
     }
 
     async fn delete_entries(&self, session_id: &str) -> Result<(), StoreError> {
-        let snapshot = self.with_loaded(session_id, |s| {
-            s.entries.clear();
-            s.clone()
-        })?;
+        let snapshot = self
+            .with_loaded(session_id, |s| {
+                s.entries.clear();
+                s.clone()
+            })
+            .await?;
         if snapshot.is_empty() {
             self.lock().remove(session_id);
         }
@@ -370,7 +387,7 @@ impl SessionStore for FsStore {
     }
 
     async fn get_active_leaf(&self, session_id: &str) -> Result<Option<String>, StoreError> {
-        self.with_loaded(session_id, |s| s.leaf.clone())
+        self.with_loaded(session_id, |s| s.leaf.clone()).await
     }
 
     async fn set_active_leaf(&self, session_id: &str, entry_id: &str) -> Result<(), StoreError> {
@@ -379,13 +396,16 @@ impl SessionStore for FsStore {
         };
         self.append_record(session_id, &record)?;
         self.with_loaded(session_id, |s| s.leaf = Some(entry_id.to_string()))
+            .await
     }
 
     async fn delete_active_leaf(&self, session_id: &str) -> Result<(), StoreError> {
-        let snapshot = self.with_loaded(session_id, |s| {
-            s.leaf = None;
-            s.clone()
-        })?;
+        let snapshot = self
+            .with_loaded(session_id, |s| {
+                s.leaf = None;
+                s.clone()
+            })
+            .await?;
         if snapshot.is_empty() {
             self.lock().remove(session_id);
         }


### PR DESCRIPTION
## Why

During the Linkly agentic e2e run (MOT-4717), a long session's `.jsonl` grew to 10 MB / 10.7k records. `FsStore::with_loaded` replayed a cold session synchronously on the async runtime **while holding the cache `std::Mutex`**, so every other session's append queued behind that parse; the harness's 10 s `session::append` budget turned that into a failed turn (A4).

## What

- `with_loaded` is async: the replay runs under `tokio::task::spawn_blocking`, outside the lock. Insert is `entry().or_insert`, so a concurrent caller that replayed and mutated the same session meanwhile keeps its state.
- `session::append` logs `warn` (`session_id`, `elapsed_ms`) when the store takes > 1 s, so a slow append is visible in the worker's own log next to the caller's timeout.

## Deliberately not changed

Measured on the 10 MB session from the run:
- The per-append meta record is ~15% of the file (1.5 MB of 10.3 MB, 5.3k lines). Entries are the bulk; the replay is the cost, not the meta line.
- The event fan-out is `TriggerAction::Void`. The SDK's `trigger` just `send_message`s the frame and returns `Ok(Null)` without awaiting the engine, so it's already off the critical path. Bridge mode's `RemotePublisher` has its own timeout.

## Tests

- `cargo test`: unit 73/73. BDD: 149/159, the 10 failures (bridged-instance + engine-subscriber delivery scenarios against the live engine at `ws://127.0.0.1:49134`, plus their file-exists follow-ups) are **identical with and without this change** (diffed the panicked step set).
- `cargo clippy --all-targets` clean.
- Review follow-ups (CodeRabbit): cache entries are never evicted on delete, so a replay that read the file before a delete cannot resurrect the session (`a_delete_that_overlaps_a_cold_replay_is_not_undone`, deterministic via the same seam); `session::append` times a failed store call too. BDD `@pure`: 147/147.
- Store unit tests added for the new path: a deterministic two-caller race (first replay parked between read and insert via a `#[cfg(test)]` seam; fails with `insert`, passes with `or_insert`), 32 cold sessions loading concurrently, and a failed replay that errors without poisoning the cache. `cargo test --lib`: 76/76.

Part of MOT-4717 · closes MOT-4721

https://claude.ai/code/session_01PvtXK7JgHHNrG192afbRAk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session loading reliability when multiple requests access a session for the first time concurrently.
  - Prevented failed session loads from being retained, allowing subsequent attempts to retry successfully.
  - Improved responsiveness by allowing independent first-time session loads to proceed in parallel.
  - Prevented deleted sessions from being restored by an overlapping session load.

- **Monitoring**
  - Added warning logs for session updates that take longer than one second, including whether the update succeeded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->