### PR TITLE
fix(harness): preserve the message contract for recovered tool results

### DIFF
--- a/harness/src/turn_loop.rs
+++ b/harness/src/turn_loop.rs
@@ -3086,6 +3086,7 @@ fn patch_orphaned_calls(messages: &mut Vec<Value>) -> usize {
                         "type": "text",
                         "text": "result elided from the assembled context (compaction); the call completed in an earlier turn — consult the transcript if its output matters",
                     }],
+                    "details": null,
                     "is_error": false,
                     "timestamp": AgentMessage::now_ms(),
                 }),
@@ -3987,6 +3988,9 @@ mod tests {
                 .and_then(serde_json::Value::as_str),
             Some("toolu_orphan")
         );
+        let result: crate::types::message::FunctionResultMessage =
+            serde_json::from_value(msgs[2].clone()).expect("valid function result");
+        assert!(result.details.is_null());
         assert_eq!(msgs.len(), 5);
         // Fully paired context is untouched.
         assert_eq!(super::patch_orphaned_calls(&mut msgs), 0);


### PR DESCRIPTION
Recovered tool calls could abort a turn with `bad ProviderStreamInput: data did not match any variant of untagged enum AgentMessage`. The synthetic result inserted for an orphaned call omitted the required `details` field.

Include `details: null` and extend the existing regression test to deserialize the synthetic result as `FunctionResultMessage`.

Validation: the focused regression test passed after updating the branch to current main. A local Registry planning execution using the corrected Harness completed through Console with a technically valid 100/100 result; that run had two separately recorded, recovered disk-quota errors.

Draft pending the required Linear ticket association: the Linear connector currently requires reauthentication. No ticket identifier has been invented and no `no-ticket` exemption has been applied.
