### PR TITLE
(MOT-4712) fix(console): serve on the next free port when the configured one is in use

### DIFF
--- a/console/src/main.rs
+++ b/console/src/main.rs
@@ -133,6 +133,15 @@ async fn main() -> Result<()> {
         }
     };
     cfg.http_port = runtime_config.http_port;
+    let free_port = server::free_port_from(cfg.http_port).await;
+    if free_port != cfg.http_port {
+        tracing::warn!(
+            configured = cfg.http_port,
+            chosen = free_port,
+            "configured console port is in use; serving on the next free port"
+        );
+        cfg.http_port = free_port;
+    }
 
     tracing::info!(
         http_port = cfg.http_port,

--- a/console/src/server.rs
+++ b/console/src/server.rs
@@ -284,6 +284,18 @@ pub fn bind_host() -> std::net::IpAddr {
         .unwrap_or(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST))
 }
 
+/// `preferred` when it is free, else the next free port above it. Another
+/// console (or anything else) already on the seed port must not keep this one
+/// from starting; the chosen port is what `local_addr` and the port cell report.
+pub async fn free_port_from(preferred: u16) -> u16 {
+    for port in preferred..=u16::MAX {
+        if bind_listener(port).await.is_ok() {
+            return port;
+        }
+    }
+    preferred
+}
+
 /// Bind `<bind_host>:<http_port>` without changing any live server state.
 /// Rebinds use this bind-new-before-stop-old step so a failed port change
 /// leaves the existing Console listener untouched.


### PR DESCRIPTION
## Summary
- Another console (or anything else) on the configured `http_port` stopped the worker with `binding TCP listener on 0.0.0.0:3113: Address already in use`.
- The port is now probed after the runtime configuration resolves and before the listener binds. When it is taken, the first free port above it is used.
- A warning names the configured and chosen ports. The port cell and the `console ready` line report the real port.

Needed for the `iii project init --learn-iii` tour (iii-hq/iii), which starts a second harness next to a running one. The harness template must pin a console release that contains this change.

## Test plan
- [x] `cargo check`, `cargo test --lib server`
- [ ] Start two consoles on the same host, confirm the second logs the warning and serves on 3114

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The console now detects when the configured HTTP port is unavailable and automatically selects the next available port.
  * Startup logs show both the configured port and the port ultimately used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->