### PR TITLE
feat: adding astra compatibility

### DIFF
--- a/provider-claude-code/README.md
+++ b/provider-claude-code/README.md
@@ -37,15 +37,17 @@ This worker is a **dumb token consumer** — login and refresh live out-of-band:
    `{ type: "oauth", access_token, refresh_token?, expires_at?(seconds),
    provider_extra: { subscription_type?, scopes? }, refresh_fn:
    "oauth::claude-code::refresh" }`.
-2. **Local dev fallback:** when no vault is running, the worker reads
-   `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.credentials.json` directly (read-only —
-   the `claude` CLI owns that file's refresh, including rotating the refresh
-   token). The file's `claudeAiOauth.expiresAt` is epoch **milliseconds**;
-   it is stored as seconds in the vault shape. Requires host access to that
-   path, so it does not apply to sandboxed/microVM-managed workers, and **macOS
-   is not covered** (Claude Code stores credentials in the Keychain there, not a
-   file). On boot the worker also does a one-time, read-only import of that file
-   into the vault when the vault is present but empty (never written back).
+2. **Local dev fallback:** when no vault is running, the worker reads the
+   `claude` CLI's own credential (read-only — the CLI owns its refresh,
+   including rotating the refresh token): `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.credentials.json`
+   and, on macOS, the "Claude Code-credentials" login Keychain item (via
+   `security find-generic-password`), taking whichever expires later — the
+   macOS CLI stops updating the file once it uses the Keychain. The
+   `claudeAiOauth.expiresAt` is epoch **milliseconds**; it is stored as seconds
+   in the vault shape. Requires host access to those stores, so it does not
+   apply to sandboxed/microVM-managed workers. On boot the worker also does a
+   one-time, read-only import of that credential into the vault when the vault
+   is present but empty (never written back).
 
 API-key credentials are rejected — they belong on `provider-anthropic` under
 provider id `anthropic`.
@@ -86,7 +88,7 @@ or `III_URL`), `--manifest` (print the registry manifest and exit), `--config`
 (accepted but ignored — this worker has no file-based config).
 
 ```bash
-# ensure `claude` has signed in so ~/.claude/.credentials.json exists (dev)
+# ensure `claude` has signed in (dev): ~/.claude/.credentials.json or, on macOS, the Keychain
 cargo run -- --url ws://127.0.0.1:49134
 ```
 
@@ -104,10 +106,10 @@ Regenerate the wire-schema goldens with `UPDATE_GOLDENS=1 cargo test`.
 
 | Symptom | Cause | Fix |
 | --- | --- | --- |
-| `not configured: sign in with Claude Code …` | no vault credential and no readable `~/.claude/.credentials.json` | run the `oauth-claude-code` sign-in, or `claude` (login) so `~/.claude/.credentials.json` exists; on macOS the Keychain store is not read |
-| local fallback is used on each request | `auth-credentials` vault not running | start the vault for shared/refreshing credentials, or keep relying on the local `~/.claude/.credentials.json` fallback |
+| `not configured: sign in with Claude Code …` | no vault credential and no local `claude` credential (`~/.claude/.credentials.json`, or the Keychain on macOS) | run the `oauth-claude-code` sign-in, or `claude` (login) |
+| local fallback is used on each request | `auth-credentials` vault not running | start the vault for shared/refreshing credentials, or keep relying on the local `claude` credential fallback |
 | `requires a Claude Pro/Max OAuth login … API keys belong on provider-anthropic` | credential is an API key | this provider is OAuth-only; use `provider-anthropic` for keys |
-| `auth_expired` on every request | the local `.credentials.json` token expired and no refresh worker is registered | run `claude` once to refresh the file, or register the `oauth-claude-code` refresh flow |
+| `auth_expired` on every request | the local `claude` token expired and no refresh worker is registered | run `claude` once to refresh it, or register the `oauth-claude-code` refresh flow |
 | catalog shows only the curated fallback models | `GET /v1/models` rejected the OAuth bearer, or the models endpoint is unreachable | expected — the subscription token may not be accepted on `/v1/models`; streaming still works, and the live list returns once the endpoint accepts the token |
 | upstream 401 despite a valid token | the request no longer resembles Claude Code | keep the identity system block first and the `anthropic-beta: oauth-2025-04-20` header; a future backend change may require a `user-agent` compat header |
 | model routes ambiguously | a `claude-code/*` id collided with another provider | keep ids namespaced; or pin `provider: "claude-code"` |

--- a/provider-claude-code/src/auth.rs
+++ b/provider-claude-code/src/auth.rs
@@ -10,8 +10,9 @@
 //! milliseconds**, so there is no JWT decode here — expiry is read straight
 //! from the file/credential (converted to seconds to match the vault shape).
 //!
-//! macOS stores these credentials in the Keychain rather than a file; that
-//! path is out of scope here (the file fallback simply reports NotConfigured).
+//! macOS keeps the live credential in the login Keychain ("Claude Code-
+//! credentials") and leaves any `.credentials.json` stale, so the dev fallback
+//! reads both stores and takes whichever expires later.
 use crate::{router_client, PROVIDER_ID};
 use iii_sdk::IIIClient;
 use serde_json::{json, Value};
@@ -86,23 +87,71 @@ fn credential_from_credentials_json(root: &Value) -> Option<Value> {
     Some(cred)
 }
 
-/// Read a credential straight from `~/.claude/.credentials.json` (DEV FALLBACK
-/// for when no auth-credentials vault is running). Read-only — the `claude` CLI
-/// owns the file's refresh; this provider never writes it. Returns None if the
-/// file is absent/unreadable (e.g. macOS Keychain-only, or a sandboxed home),
-/// not JSON, or missing the `claudeAiOauth` block.
-pub fn read_claude_home_credential() -> Option<Value> {
+fn read_file_credential() -> Option<Value> {
     let path = claude_credentials_path()?;
     let contents = std::fs::read_to_string(&path).ok()?;
     let root: Value = serde_json::from_str(&contents).ok()?;
     credential_from_credentials_json(&root)
 }
 
+/// macOS: the `claude` CLI stores the same JSON as `.credentials.json` as the
+/// password of the "Claude Code-credentials" login Keychain item.
+#[cfg(target_os = "macos")]
+fn read_keychain_credential() -> Option<Value> {
+    let out = std::process::Command::new("security")
+        .args([
+            "find-generic-password",
+            "-s",
+            "Claude Code-credentials",
+            "-w",
+        ])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let root: Value = serde_json::from_slice(&out.stdout).ok()?;
+    credential_from_credentials_json(&root)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn read_keychain_credential() -> Option<Value> {
+    None
+}
+
+const FILE_SOURCE: &str = "~/.claude/.credentials.json";
+const KEYCHAIN_SOURCE: &str = "macOS Keychain";
+
+/// The candidate that expires last (ties go to the later entry). On macOS the
+/// file is usually a stale leftover next to a live Keychain item.
+fn freshest(candidates: Vec<(Value, &'static str)>) -> Option<(Value, &'static str)> {
+    candidates
+        .into_iter()
+        .max_by_key(|(cred, _)| credential_expires_at(cred))
+}
+
+/// Read the `claude` CLI's own credential (DEV FALLBACK for when no
+/// auth-credentials vault is running) from `~/.claude/.credentials.json` or the
+/// macOS Keychain, whichever expires later, with its source label. Read-only —
+/// the CLI owns refresh; this provider never writes either store. None when
+/// neither store holds a `claudeAiOauth` block (e.g. a sandboxed home).
+pub fn read_claude_home_credential() -> Option<(Value, &'static str)> {
+    freshest(
+        [
+            read_file_credential().map(|c| (c, FILE_SOURCE)),
+            read_keychain_credential().map(|c| (c, KEYCHAIN_SOURCE)),
+        ]
+        .into_iter()
+        .flatten()
+        .collect(),
+    )
+}
+
 /// Fetch a usable credential for either streaming or model discovery.
 ///
 /// The vault is authoritative when present. A near-expiry vault token triggers
 /// the vault-owned refresh. Local development falls back to the Claude Code
-/// CLI's read-only `.credentials.json` when no vault credential is available.
+/// CLI's own read-only credential store when no vault credential is available.
 pub async fn fetch_fresh_credential(iii: &IIIClient) -> Option<Value> {
     if let Some(cred) = router_client::get_token_if_available(iii, PROVIDER_ID)
         .await
@@ -123,19 +172,18 @@ pub async fn fetch_fresh_credential(iii: &IIIClient) -> Option<Value> {
         }
         return Some(cred);
     }
-    if let Some(cred) = read_claude_home_credential() {
+    if let Some((cred, source)) = read_claude_home_credential() {
         eprintln!(
-            "[provider-claude-code] no auth-credentials vault — using local \
-             ~/.claude/.credentials.json (dev fallback)"
+            "[provider-claude-code] no auth-credentials vault — using local {source} (dev fallback)"
         );
         return Some(cred);
     }
     None
 }
 
-/// One-time, best-effort READ-ONLY import of `~/.claude/.credentials.json` into
-/// the vault — only when the vault has no credential yet (so a fresher, rotated
-/// vault token is never downgraded). Never writes back to the file.
+/// One-time, best-effort READ-ONLY import of the `claude` CLI's local credential
+/// into the vault — only when the vault has no credential yet (so a fresher,
+/// rotated vault token is never downgraded). Never writes back to the CLI store.
 pub async fn import_claude_home_if_absent(iii: &IIIClient) {
     if !router_client::auth_get_token_available(iii).await {
         return;
@@ -147,30 +195,12 @@ pub async fn import_claude_home_if_absent(iii: &IIIClient) {
     ) {
         return;
     }
-    let Some(path) = claude_credentials_path() else {
-        return;
-    };
-    let Ok(contents) = std::fs::read_to_string(&path) else {
-        return; // no file / unreadable (macOS Keychain, sandboxed home) — silent, expected
-    };
-    let Ok(root) = serde_json::from_str::<Value>(&contents) else {
-        eprintln!(
-            "[provider-claude-code] {} is not valid JSON — skipping import",
-            path.display()
-        );
-        return;
-    };
-    let Some(cred) = credential_from_credentials_json(&root) else {
-        eprintln!(
-            "[provider-claude-code] {} has no claudeAiOauth credential — skipping import",
-            path.display()
-        );
-        return;
+    let Some((cred, source)) = read_claude_home_credential() else {
+        return; // not signed in locally / sandboxed home — silent, expected
     };
     match router_client::set_token_if_available(iii, PROVIDER_ID, cred).await {
         Ok(true) => println!(
-            "[provider-claude-code] imported Claude Code OAuth credential from {} into the vault",
-            path.display()
+            "[provider-claude-code] imported Claude Code OAuth credential from {source} into the vault"
         ),
         Ok(false) => {}
         Err(e) => eprintln!("[provider-claude-code] vault import failed ({e})"),
@@ -216,6 +246,19 @@ mod tests {
             &json!({ "claudeAiOauth": { "accessToken": "   " } })
         )
         .is_none());
+    }
+
+    #[test]
+    fn freshest_local_credential_wins() {
+        let stale = (json!({ "access_token": "old", "expires_at": 100 }), "file");
+        let live = (
+            json!({ "access_token": "new", "expires_at": 200 }),
+            "keychain",
+        );
+        let (cred, source) = freshest(vec![live, stale]).unwrap();
+        assert_eq!(cred["access_token"], "new");
+        assert_eq!(source, "keychain");
+        assert!(freshest(vec![]).is_none());
     }
 
     #[test]

--- a/provider-openai-codex/src/request.rs
+++ b/provider-openai-codex/src/request.rs
@@ -11,8 +11,12 @@ use serde_json::{json, Value};
 /// Codex client version whose Responses contract this worker mirrors.
 ///
 /// The ChatGPT backend uses this header to gate newly released models. Omitting
-/// it makes supported models such as GPT-5.6 Luna fail as "Model not found".
-pub(crate) const CODEX_COMPAT_VERSION: &str = "0.144.1";
+/// it makes supported models such as GPT-5.6 Luna fail as "Model not found",
+/// and the `/models` catalog drops models the version is too old for (e.g.
+/// `gpt-6-astra` needs >= 0.153.0). Bump to the installed `codex --version`
+/// when the CLI lists a model this provider does not; the configuration UI
+/// shows the current value.
+pub(crate) const CODEX_COMPAT_VERSION: &str = "0.153.4";
 
 const SUMMARY_UNSUPPORTED_MODEL: &str = "gpt-5.3-codex-spark";
 

--- a/provider-openai-codex/src/ui.rs
+++ b/provider-openai-codex/src/ui.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use crate::request::CODEX_COMPAT_VERSION;
 use iii_console_ui::ConsoleUi;
 use iii_sdk::IIIClient;
 
@@ -11,9 +12,16 @@ pub const STYLES_PATH: &str = "provider-openai-codex/styles.css";
 const PAGE_JS: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/ui/dist/page.js"));
 const STYLES_CSS: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/ui/dist/styles.css"));
 
+/// Placeholder in `ui/page.tsx`; the form shows which Codex CLI this worker mirrors.
+const COMPAT_VERSION_PLACEHOLDER: &str = "__CODEX_COMPAT_VERSION__";
+
+fn page_js() -> String {
+    PAGE_JS.replace(COMPAT_VERSION_PLACEHOLDER, CODEX_COMPAT_VERSION)
+}
+
 fn console_ui() -> ConsoleUi {
     ConsoleUi::new("provider-openai-codex")
-        .script(PAGE_PATH, PAGE_JS)
+        .script(PAGE_PATH, page_js())
         .style(STYLES_PATH, STYLES_CSS)
 }
 
@@ -34,6 +42,14 @@ mod tests {
     fn embedded_page_registers_the_provider_form() {
         assert!(PAGE_JS.contains("providerConfigForms"));
         assert!(PAGE_JS.contains("codex login"));
+    }
+
+    #[test]
+    fn embedded_page_shows_the_compat_version() {
+        assert!(PAGE_JS.contains(COMPAT_VERSION_PLACEHOLDER));
+        let js = page_js();
+        assert!(js.contains(CODEX_COMPAT_VERSION));
+        assert!(!js.contains(COMPAT_VERSION_PLACEHOLDER));
     }
 
     #[test]

--- a/provider-openai-codex/ui/page.tsx
+++ b/provider-openai-codex/ui/page.tsx
@@ -5,6 +5,9 @@ import {
 } from '@iii-dev/console-ui'
 import { useState } from 'react'
 
+/** Replaced by the worker at serve time with its `CODEX_COMPAT_VERSION`. */
+const COMPAT_VERSION = '__CODEX_COMPAT_VERSION__'
+
 function messageOf(error: unknown): string {
   return error instanceof Error ? error.message : 'Could not connect to Codex.'
 }
@@ -51,6 +54,12 @@ function CodexProviderForm({
         <p>
           This provider uses your ChatGPT subscription. Do not enter an API key
           here; API keys belong to the OpenAI provider.
+        </p>
+        <p>
+          Mirrors Codex CLI <code>{COMPAT_VERSION}</code>. ChatGPT hides
+          newer models from older clients, so a model your <code>codex</code>{' '}
+          CLI offers but this list lacks means this provider needs a version
+          bump.
         </p>
         <ol>
           <li>Open a terminal on the machine running the provider.</li>

--- a/provider-openai-codex/ui/styles.css
+++ b/provider-openai-codex/ui/styles.css
@@ -31,6 +31,10 @@
   margin: 0;
 }
 
+[data-iii-ui='provider-openai-codex'] .codex-provider-card p + p {
+  margin-top: 8px;
+}
+
 [data-iii-ui='provider-openai-codex'] .codex-provider-card ol {
   margin: 12px 0;
   padding-left: 22px;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * macOS users can now authenticate through Claude Code credentials stored in Keychain or the local credential file, with the latest-expiring credential selected automatically.
  * OpenAI Codex compatibility now supports newer models through an updated compatibility version.
  * The Codex provider interface now explains compatibility behavior and when an update may be needed.

* **Bug Fixes**
  * Improved local Claude credential import and fallback handling.

* **Style**
  * Added clearer spacing between explanatory paragraphs in the Codex provider form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->