### PR TITLE
feat(release): compile public worker identities from catalog metadata

### DIFF
--- a/.deploy/workers.yaml
+++ b/.deploy/workers.yaml
@@ -396,6 +396,7 @@ workers:
         outputs:
         - dist
     publish: true
+    previous_names: [console]
   context-manager:
     source:
       path: context-manager
@@ -1855,6 +1856,7 @@ workers:
         outputs:
         - dist
     publish: true
+    previous_names: [shell]
   fixture-shell-harness:
     source:
       path: shell/tests/e2e/workers/harness

--- a/.github/contracts/deployment-descriptor.schema.json
+++ b/.github/contracts/deployment-descriptor.schema.json
@@ -32,6 +32,21 @@
     "registry_projection_sha256": {"$ref": "#/$defs/sha256"},
     "compiler_digest": {"$ref": "#/$defs/sha256"},
     "descriptor_sha256": {"$ref": "#/$defs/sha256"},
+    "previous_names": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "pattern": "^[a-z0-9][a-z0-9_-]*$"}
+    },
+    "previous_source_paths": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$)).+$"
+      }
+    },
     "source": {
       "type": "object",
       "additionalProperties": false,

--- a/.github/scripts/_lib.py
+++ b/.github/scripts/_lib.py
@@ -486,10 +486,11 @@ def read_worker_catalog(path: Path | None = None) -> dict[str, WorkerSpec]:
             raise ValueError(f"{catalog_path}: workers.{catalog_id} must be a mapping")
         raw = dict(value)
         expected_sections = {"source", "artifact", "publish"}
+        optional_sections = {"previous_names", "previous_source_paths"}
         legacy = {"language", "deploy", "manifest", "bin", "scripts", "interface_smoke", "registry_interface"} & set(raw)
         if legacy:
             raise ValueError(f"{catalog_path}: workers.{catalog_id} uses legacy fields: {sorted(legacy)}")
-        unknown_sections = set(raw) - expected_sections
+        unknown_sections = set(raw) - expected_sections - optional_sections
         missing_sections = expected_sections - set(raw)
         if unknown_sections or missing_sections:
             raise ValueError(

--- a/.github/scripts/deployment_compiler.py
+++ b/.github/scripts/deployment_compiler.py
@@ -27,6 +27,7 @@ DEPLOY_KIND = {
     "image": "oci-image",
 }
 DEPLOYMENT_SECTIONS = {"source", "artifact", "publish"}
+DEPLOYMENT_HISTORY = {"previous_names", "previous_source_paths"}
 SECRET_KEYS = {
     "api_key",
     "access_key",
@@ -159,17 +160,50 @@ def validate_public_defaults(value: Any, field: str) -> None:
             fail(f"{field}: secret defaults cannot be released")
 
 
-def normalize_dependencies(value: Any, field: str) -> list[dict[str, str]]:
+def normalize_dependencies(
+    value: Any, field: str, public_names: dict[str, str] | None = None
+) -> list[dict[str, str]]:
     if value is None:
         return []
     if not isinstance(value, dict):
         fail(f"{field} must be a mapping")
     rows: list[dict[str, str]] = []
+    seen: set[str] = set()
     for name, version in value.items():
         if not isinstance(name, str) or not name or not isinstance(version, str):
             fail(f"{field} must map worker names to semver strings")
+        name = (public_names or {}).get(name, name)
+        if name in seen:
+            fail(f"{field} contains multiple names for public worker {name!r}")
+        seen.add(name)
         rows.append({"name": name, "version": version})
     return sorted(rows, key=lambda row: (row["name"], row["version"]))
+
+
+def previous_names(value: Any, current: str, field: str) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list) or any(
+        not isinstance(name, str) or not WORKER_RE.fullmatch(name) for name in value
+    ):
+        fail(f"{field} must be an array of valid worker names")
+    if current in value or len(set(value)) != len(value):
+        fail(f"{field} must be unique and must not contain the current name")
+    return value
+
+
+def previous_source_paths(value: Any, field: str) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list) or any(
+        not isinstance(path, str)
+        or not path
+        or Path(path).is_absolute()
+        or ".." in Path(path).parts
+        for path in value
+    ):
+        fail(f"{field} must be an array of safe relative paths")
+    return value
 
 
 def normalize_tags(value: Any, field: str) -> list[str]:
@@ -222,7 +256,7 @@ def normalize_runtime(
     else:
         result["interface_config"] = None
     if kind == "rust-binary":
-        result["exec"] = [str(manifest.get("bin") or worker)]
+        result["exec"] = [str(manifest["name"])]
     elif kind in {"javascript-bundle", "python-bundle"}:
         start = scripts.get("start")
         if not isinstance(start, str) or not start.strip():
@@ -408,13 +442,22 @@ def build_units(worker: str, artifact: dict[str, Any]) -> list[dict[str, Any]]:
     return [{"id": f"{worker}-bundle", "kind": kind}]
 
 
-def compile_worker(root: Path, worker: str, value: Any, source_sha: str, compiler_sha: str) -> dict[str, Any]:
+def compile_worker(
+    root: Path,
+    worker: str,
+    value: Any,
+    source_sha: str,
+    compiler_sha: str,
+    public_names: dict[str, str] | None = None,
+) -> dict[str, Any]:
     if not WORKER_RE.fullmatch(worker) or not isinstance(value, dict):
         fail(f"invalid release worker entry {worker!r}")
-    if set(value) != DEPLOYMENT_SECTIONS:
+    missing = DEPLOYMENT_SECTIONS - set(value)
+    unknown = set(value) - DEPLOYMENT_SECTIONS - DEPLOYMENT_HISTORY
+    if missing or unknown:
         fail(
-            f"workers.{worker} must contain exactly {sorted(DEPLOYMENT_SECTIONS)}; "
-            f"got {sorted(value) if isinstance(value, dict) else type(value).__name__}"
+            f"workers.{worker} sections differ; missing={sorted(missing)} "
+            f"unknown={sorted(unknown)}"
         )
     source = value["source"]
     if not isinstance(source, dict) or set(source) != {"path", "package_manifest"}:
@@ -428,8 +471,13 @@ def compile_worker(root: Path, worker: str, value: Any, source_sha: str, compile
     manifest = read_yaml(public_path)
     if not isinstance(manifest, dict):
         fail(f"{public_path}: expected a mapping")
-    if manifest.get("name") != worker:
-        fail(f"{public_path}: name must be {worker!r}")
+    public_name = manifest.get("name")
+    if not isinstance(public_name, str) or not WORKER_RE.fullmatch(public_name):
+        fail(f"{public_path}: name must be a valid worker name")
+    aliases = previous_names(value.get("previous_names"), public_name, f"{worker}.previous_names")
+    old_paths = previous_source_paths(
+        value.get("previous_source_paths"), f"{worker}.previous_source_paths"
+    )
     if manifest.get("manifest") != manifest_name:
         fail(f"{public_path}: manifest must match the private package_manifest")
     if "interface_smoke" in manifest:
@@ -447,12 +495,14 @@ def compile_worker(root: Path, worker: str, value: Any, source_sha: str, compile
     artifact = validate_artifact(root, worker, worker_dir, value["artifact"], manifest)
     package_manifest_version = read_version(package_manifest)
     projection = {
-        "worker_name": worker,
+        "worker_name": public_name,
         "type": manifest["deploy"],
         "description": str(manifest.get("description") or ""),
         "license": str(manifest.get("license") or ""),
         "tags": normalize_tags(manifest.get("tags"), f"{worker}.tags"),
-        "dependencies": normalize_dependencies(manifest.get("dependencies"), f"{worker}.dependencies"),
+        "dependencies": normalize_dependencies(
+            manifest.get("dependencies"), f"{worker}.dependencies", public_names
+        ),
         "config": normalize_config(worker_dir, manifest),
         "experimental": bool(manifest.get("experimental", False)),
         "readme": (worker_dir / "README.md").read_text(encoding="utf-8")
@@ -478,6 +528,10 @@ def compile_worker(root: Path, worker: str, value: Any, source_sha: str, compile
         "build_units": build_units(worker, artifact),
         "registry_projection": projection,
     }
+    if aliases:
+        descriptor["previous_names"] = aliases
+    if old_paths:
+        descriptor["previous_source_paths"] = old_paths
     descriptor["descriptor_sha256"] = json_sha256(descriptor)
     return descriptor
 
@@ -504,11 +558,41 @@ def compile_index(args: argparse.Namespace) -> int:
     output = args.output_dir.resolve()
     if output.exists() and any(output.iterdir()):
         fail(f"{output}: output directory must be absent or empty")
+    publishable = {
+        worker: value
+        for worker, value in document["workers"].items()
+        if not isinstance(value, dict) or value.get("publish") is not False
+    }
+    public_names: dict[str, str] = {}
+    for worker, value in sorted(publishable.items()):
+        if not WORKER_RE.fullmatch(worker) or not isinstance(value, dict):
+            fail(f"invalid release worker entry {worker!r}")
+        source = value.get("source")
+        if not isinstance(source, dict):
+            fail(f"workers.{worker}.source must be a mapping")
+        worker_dir = safe_relative(
+            root, source.get("path"), f"workers.{worker}.source.path", directory=True
+        )
+        manifest = read_yaml(worker_dir / "iii.worker.yaml")
+        if not isinstance(manifest, dict):
+            fail(f"{worker_dir}/iii.worker.yaml: expected a mapping")
+        public_name = manifest.get("name")
+        if not isinstance(public_name, str) or not WORKER_RE.fullmatch(public_name):
+            fail(f"{worker_dir}/iii.worker.yaml: name must be a valid worker name")
+        for name in [
+            public_name,
+            *previous_names(value.get("previous_names"), public_name, f"{worker}.previous_names"),
+        ]:
+            owner = public_names.get(name)
+            if owner is not None:
+                fail(f"public worker name {name!r} is declared by both {owner!r} and {worker!r}")
+            public_names[name] = public_name
+
     descriptors: dict[str, dict[str, Any]] = {}
-    for worker, value in sorted(document["workers"].items()):
-        if isinstance(value, dict) and value.get("publish") is False:
-            continue
-        descriptors[worker] = compile_worker(root, worker, value, args.source_sha, digest)
+    for worker, value in sorted(publishable.items()):
+        descriptors[worker] = compile_worker(
+            root, worker, value, args.source_sha, digest, public_names
+        )
     entries: dict[str, dict[str, Any]] = {}
     for worker, descriptor in descriptors.items():
         relative = f"descriptors/{worker}.json"

--- a/.github/scripts/deployment_train.py
+++ b/.github/scripts/deployment_train.py
@@ -61,10 +61,12 @@ def verify_descriptor(descriptor: object) -> dict[str, object]:
         "descriptor_sha256", "source", "artifact", "runtime",
         "interface_capture", "publish", "build_units", "registry_projection",
     }
-    if set(descriptor) != required:
+    optional = {"previous_names", "previous_source_paths"}
+    if not required.issubset(descriptor) or set(descriptor) - required - optional:
         raise SystemExit(
             "deployment descriptor fields differ from compiler contract: "
-            f"missing={sorted(required - set(descriptor))} unknown={sorted(set(descriptor) - required)}"
+            f"missing={sorted(required - set(descriptor))} "
+            f"unknown={sorted(set(descriptor) - required - optional)}"
         )
     if descriptor["contract"] != "deployment-descriptor":
         raise SystemExit("deployment descriptor contract mismatch")
@@ -79,6 +81,10 @@ def verify_descriptor(descriptor: object) -> dict[str, object]:
         raise SystemExit("deployment descriptor interface_capture must be required or skipped")
     if not isinstance(descriptor["build_units"], list) or not descriptor["build_units"]:
         raise SystemExit("deployment descriptor build_units must be non-empty")
+    for field in optional & set(descriptor):
+        value = descriptor[field]
+        if not isinstance(value, list) or not value or any(not isinstance(item, str) or not item for item in value):
+            raise SystemExit(f"deployment descriptor {field} must be a non-empty string array")
     return descriptor
 
 
@@ -489,17 +495,19 @@ def build(args: argparse.Namespace) -> int:
             command.append("--locked")
         run(*command)
         binary = str(artifact["binary"])
+        archive_binary = str(descriptor["registry_projection"]["worker_name"])
         is_windows = target.endswith("-pc-windows-msvc")
         binary_filename = f"{binary}.exe" if is_windows else binary
+        archive_binary_filename = f"{archive_binary}.exe" if is_windows else archive_binary
         binary_path = source_dir / "target" / target / "release" / binary_filename
         if not binary_path.is_file():
             raise SystemExit(f"built binary not found at {binary_path}")
         if is_windows:
             archive = args.out / f"{binary}-{target}.zip"
-            normalized_zip([(binary_path, binary_filename)], archive)
+            normalized_zip([(binary_path, archive_binary_filename)], archive)
         else:
             archive = args.out / f"{binary}-{target}.tar.gz"
-            normalized_tar([(binary_path, binary)], archive)
+            normalized_tar([(binary_path, archive_binary)], archive)
         role = "binary"
     elif kind in {"javascript-bundle", "python-bundle"}:
         workspace_root = Path(str(artifact["workspace_root"]))

--- a/.github/scripts/tests/test_build_manifest.py
+++ b/.github/scripts/tests/test_build_manifest.py
@@ -222,6 +222,28 @@ def test_release_control_can_build_the_registry_payload_from_the_manifest_alone(
     assert payload["functions"][0]["name"] == "smoke::run"
 
 
+def test_build_handoff_keeps_the_selector_and_binary_while_publishing_the_public_name(tmp_path: Path) -> None:
+    selected = descriptor("shell", "rust-binary")
+    selected["artifact"]["binary"] = "shell"
+    selected["runtime"]["exec"] = ["ide"]
+    selected["registry_projection"]["worker_name"] = "ide"
+    selected["previous_names"] = ["shell"]
+    seal(selected)
+    files = {
+        name: (unit.replace("web-", "shell-"), role)
+        for name, (unit, role) in RUST_FILES.items()
+    }
+    root = prepared_release(tmp_path, selected, files)
+
+    manifest = written(write_args(root, receipt(root, "shell"), "shell"))
+
+    assert manifest["worker"] == "shell"
+    assert manifest["descriptor"]["worker"] == "shell"
+    assert manifest["descriptor"]["registry_projection"]["worker_name"] == "ide"
+    assert manifest["descriptor"]["artifact"]["binary"] == "shell"
+    assert manifest["descriptor"]["runtime"]["exec"] == ["ide"]
+
+
 def test_bundle_manifest_exposes_archive_url_and_sha256(tmp_path: Path) -> None:
     root = prepared_release(
         tmp_path, descriptor("smoke", "javascript-bundle"),

--- a/.github/scripts/tests/test_deployment_compiler.py
+++ b/.github/scripts/tests/test_deployment_compiler.py
@@ -1,3 +1,4 @@
+import argparse
 import json
 from pathlib import Path
 
@@ -7,6 +8,71 @@ import deployment_compiler
 
 
 ROOT = Path(__file__).resolve().parents[3]
+
+
+def write_worker(
+    root: Path,
+    selector: str,
+    *,
+    name: str,
+    source_path: str | None = None,
+    previous_names: list[str] | None = None,
+    previous_source_paths: list[str] | None = None,
+    dependencies: dict[str, str] | None = None,
+) -> dict:
+    source_path = source_path or selector
+    worker_dir = root / source_path
+    worker_dir.mkdir(parents=True)
+    (worker_dir / "Cargo.toml").write_text(
+        f'[package]\nname = "{selector}"\nversion = "1.0.0"\n', encoding="utf-8"
+    )
+    manifest = {
+        "iii": "v1",
+        "name": name,
+        "language": "rust",
+        "deploy": "binary",
+        "manifest": "Cargo.toml",
+        "bin": f"{selector}-bin",
+        "description": selector,
+        "license": "Apache-2.0",
+    }
+    if dependencies is not None:
+        manifest["dependencies"] = dependencies
+    (worker_dir / "iii.worker.yaml").write_text(json.dumps(manifest), encoding="utf-8")
+    spec = {
+        "source": {"path": source_path, "package_manifest": "Cargo.toml"},
+        "artifact": {
+            "kind": "rust-binary",
+            "toolchain": {"name": "rust", "version": "1.97.1"},
+            "binary": f"{selector}-bin",
+            "targets": ["x86_64-pc-windows-msvc"],
+        },
+        "publish": True,
+    }
+    if previous_names is not None:
+        spec["previous_names"] = previous_names
+    if previous_source_paths is not None:
+        spec["previous_source_paths"] = previous_source_paths
+    return spec
+
+
+def compile_temp_index(root: Path, workers: dict[str, dict]) -> dict:
+    deploy = root / ".deploy"
+    deploy.mkdir()
+    (deploy / "workers.yaml").write_text(json.dumps({"workers": workers}), encoding="utf-8")
+    output = root / "compiled"
+    deployment_compiler.compile_index(argparse.Namespace(
+        root=root,
+        deployment_spec=Path(".deploy/workers.yaml"),
+        source_sha="a" * 40,
+        compiler_repository="iii-hq/workers",
+        schema=ROOT / ".github/contracts/deployment-descriptor.schema.json",
+        output_dir=output,
+    ))
+    return {
+        path.stem: json.loads(path.read_text(encoding="utf-8"))
+        for path in (output / "descriptors").glob("*.json")
+    }
 
 
 def test_canonical_numbers_match_json_stringify_representation():
@@ -52,6 +118,129 @@ def test_compiler_derives_registry_interface_capture_policy_for_every_worker():
         "sha256": deployment_compiler.file_sha256(ROOT / "database" / "config.collect.yaml"),
     }
     assert descriptors["web"]["runtime"]["interface_config"] is None
+    assert descriptors["web"]["worker"] == "web"
+    assert descriptors["web"]["registry_projection"]["worker_name"] == "web"
+    assert "previous_names" not in descriptors["web"]
+    assert "previous_source_paths" not in descriptors["web"]
+    assert descriptors["shell"]["runtime"]["exec"] == ["ide"]
+    assert descriptors["console"]["runtime"]["exec"] == ["ade"]
+
+
+def test_compiler_separates_build_selector_from_public_identity_and_normalizes_aliases(tmp_path: Path):
+    workers = {
+        "consumer-selector": write_worker(
+            tmp_path,
+            "consumer-selector",
+            name="consumer",
+            dependencies={"oldest": "1.x"},
+        ),
+        "stable-selector": write_worker(
+            tmp_path,
+            "stable-selector",
+            name="canonical",
+            source_path="workers/current-location",
+            previous_names=["oldest", "middle"],
+            previous_source_paths=["workers/oldest", "workers/middle"],
+        ),
+    }
+
+    descriptors = compile_temp_index(tmp_path, workers)
+    target = descriptors["stable-selector"]
+
+    assert target["worker"] == "stable-selector"
+    assert target["registry_projection"]["worker_name"] == "canonical"
+    assert target["previous_names"] == ["oldest", "middle"]
+    assert target["previous_source_paths"] == ["workers/oldest", "workers/middle"]
+    assert target["source"]["path"] == "workers/current-location"
+    assert target["artifact"]["binary"] == "stable-selector-bin"
+    assert target["runtime"]["exec"] == ["canonical"]
+    assert target["registry_projection_sha256"] == deployment_compiler.json_sha256(
+        target["registry_projection"]
+    )
+    assert descriptors["consumer-selector"]["registry_projection"]["dependencies"] == [
+        {"name": "canonical", "version": "1.x"}
+    ]
+
+
+def test_empty_private_identity_history_is_omitted(tmp_path: Path):
+    workers = {
+        "selector": write_worker(
+            tmp_path,
+            "selector",
+            name="public-name",
+            previous_names=[],
+            previous_source_paths=[],
+        )
+    }
+
+    descriptor = compile_temp_index(tmp_path, workers)["selector"]
+
+    assert "previous_names" not in descriptor
+    assert "previous_source_paths" not in descriptor
+
+
+@pytest.mark.parametrize(
+    ("second_name", "second_aliases"),
+    [("alpha", None), ("shared", None), ("beta", ["shared"])],
+)
+def test_compile_index_rejects_duplicate_or_ambiguous_public_names(
+    tmp_path: Path, second_name: str, second_aliases: list[str] | None
+):
+    workers = {
+        "one": write_worker(tmp_path, "one", name="alpha", previous_names=["shared"]),
+        "two": write_worker(tmp_path, "two", name=second_name, previous_names=second_aliases),
+    }
+
+    with pytest.raises(ValueError, match="declared by both"):
+        compile_temp_index(tmp_path, workers)
+
+
+@pytest.mark.parametrize("aliases", [["current"], ["old", "old"]])
+def test_previous_names_are_unique_and_exclude_current(tmp_path: Path, aliases: list[str]):
+    workers = {
+        "selector": write_worker(
+            tmp_path, "selector", name="current", previous_names=aliases
+        )
+    }
+
+    with pytest.raises(ValueError, match="unique and must not contain"):
+        compile_temp_index(tmp_path, workers)
+
+
+@pytest.mark.parametrize("aliases", [False, "", {}, [1]])
+def test_previous_names_reject_non_array_values(tmp_path: Path, aliases):
+    workers = {
+        "selector": write_worker(
+            tmp_path, "selector", name="current", previous_names=aliases
+        )
+    }
+
+    with pytest.raises(ValueError, match="array of valid worker names"):
+        compile_temp_index(tmp_path, workers)
+
+
+@pytest.mark.parametrize("path", ["../old", "/old"])
+def test_previous_source_paths_must_be_safe_but_need_not_exist(tmp_path: Path, path: str):
+    workers = {
+        "selector": write_worker(
+            tmp_path, "selector", name="current", previous_source_paths=[path]
+        )
+    }
+
+    with pytest.raises(ValueError, match="safe relative paths"):
+        compile_temp_index(tmp_path, workers)
+
+
+@pytest.mark.parametrize("paths", [False, "", {}, [1]])
+def test_previous_source_paths_reject_non_array_values(tmp_path: Path, paths):
+    workers = {
+        "selector": write_worker(
+            tmp_path, "selector", name="current", previous_source_paths=paths
+        )
+    }
+
+    with pytest.raises(ValueError, match="array of safe relative paths"):
+        compile_temp_index(tmp_path, workers)
 
 
 def test_descriptor_schema_requires_explicit_interface_capture_policy():

--- a/.github/scripts/tests/test_deployment_interface.py
+++ b/.github/scripts/tests/test_deployment_interface.py
@@ -100,7 +100,7 @@ def test_required_rust_capture_stages_only_prepared_bytes_with_absolute_paths(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     selected = {
-        "worker": "smoke",
+        "worker": "shell",
         "source_sha": "a" * 40,
         "descriptor_sha256": "b" * 64,
         "interface_capture": "required",
@@ -110,12 +110,12 @@ def test_required_rust_capture_stages_only_prepared_bytes_with_absolute_paths(
         },
         "artifact": {
             "kind": "rust-binary",
-            "binary": "smoke",
+            "binary": "shell",
             "targets": ["x86_64-unknown-linux-gnu"],
             "toolchain": {"name": "rust", "version": "1.97.1"},
         },
         "runtime": {
-            "exec": ["smoke", "--capture-interface"],
+            "exec": ["ide", "--capture-interface"],
             "environment": {},
             "resources": {},
         },
@@ -128,7 +128,7 @@ def test_required_rust_capture_stages_only_prepared_bytes_with_absolute_paths(
     descriptor, prepared = write_archive_prepared_inputs(
         tmp_path,
         selected=selected,
-        member_name="smoke",
+        member_name="ide",
         member_bytes=b"prepared executable",
         unit="rust-x86_64-unknown-linux-gnu",
         role="binary",
@@ -151,6 +151,7 @@ def test_required_rust_capture_stages_only_prepared_bytes_with_absolute_paths(
     assert runtime.is_absolute()
     assert executable.is_absolute()
     assert executable.is_relative_to(runtime)
+    assert executable.name == "ide"
     assert stage["command"][1:] == ["--capture-interface"]
     assert executable.read_bytes() == b"prepared executable"
     assert not (tmp_path / "source-must-not-be-read").exists()

--- a/.github/scripts/tests/test_deployment_train.py
+++ b/.github/scripts/tests/test_deployment_train.py
@@ -269,6 +269,67 @@ def test_rust_build_uses_deterministic_target_native_archive(
             assert extracted is not None and extracted.read() == binary.read_bytes()
 
 
+@pytest.mark.parametrize(
+    ("target", "archive_name", "source_name", "member_name"),
+    [
+        ("x86_64-unknown-linux-gnu", "shell-x86_64-unknown-linux-gnu.tar.gz", "shell", "ide"),
+        ("x86_64-pc-windows-msvc", "shell-x86_64-pc-windows-msvc.zip", "shell.exe", "ide.exe"),
+    ],
+)
+def test_renamed_rust_worker_packages_the_public_executable_name(
+    tmp_path: Path,
+    monkeypatch,
+    target: str,
+    archive_name: str,
+    source_name: str,
+    member_name: str,
+) -> None:
+    source_sha = "a" * 40
+    worker_dir = tmp_path / "shell"
+    worker_dir.mkdir()
+    (worker_dir / "Cargo.toml").write_text(
+        "[package]\nname='shell'\nversion='0.1.0'\n", encoding="utf-8"
+    )
+    binary = worker_dir / "target" / target / "release" / source_name
+    binary.parent.mkdir(parents=True)
+    binary.write_bytes(b"shell executable\n")
+    binary.chmod(0o755)
+    selected = rust_descriptor("shell", source_sha, [target])
+    selected["registry_projection"]["worker_name"] = "ide"
+    selected["runtime"]["exec"] = ["ide"]
+    seal_descriptor(selected)
+    descriptor_path = tmp_path / "deployment-descriptor.json"
+    descriptor_path.write_text(json.dumps(selected), encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        deployment_train.subprocess, "check_output", lambda *args, **kwargs: source_sha + "\n"
+    )
+    monkeypatch.setattr(deployment_train, "run", lambda *args, **kwargs: None)
+
+    output = tmp_path / "output"
+    build(argparse.Namespace(
+        descriptor=descriptor_path, unit=f"shell-{target}", out=output
+    ))
+
+    archive_path = output / archive_name
+    assert archive_path.is_file()
+    checksum = output / (
+        archive_name.removesuffix(".tar.gz").removesuffix(".zip") + ".sha256"
+    )
+    assert checksum.read_text(encoding="utf-8") == (
+        f"{deployment_train.sha256(archive_path)}  {archive_name}\n"
+    )
+    if archive_name.endswith(".zip"):
+        with zipfile.ZipFile(archive_path) as archive:
+            assert archive.namelist() == [member_name]
+            assert archive.read(member_name) == binary.read_bytes()
+    else:
+        with tarfile.open(archive_path, mode="r:gz") as archive:
+            assert archive.getnames() == [member_name]
+            extracted = archive.extractfile(member_name)
+            assert extracted is not None and extracted.read() == binary.read_bytes()
+
+
 def test_javascript_bundle_preserves_compiler_owned_include_path(tmp_path: Path, monkeypatch) -> None:
     source_sha = "a" * 40
     source = tmp_path / "worker"
@@ -466,5 +527,3 @@ def _init_release_repo(tmp_path: Path, tags: list[str]) -> str:
     return subprocess.check_output(
         ["git", "rev-parse", "HEAD"], cwd=tmp_path, text=True, env=GIT_HERMETIC_ENV
     ).strip()
-
-

--- a/.github/scripts/tests/test_worker_compose.py
+++ b/.github/scripts/tests/test_worker_compose.py
@@ -16,7 +16,10 @@ def test_catalog_has_only_release_build_contract_and_explicit_bundle_files():
     workers = _lib.read_worker_catalog(CATALOG)
     legacy = {"language", "deploy", "manifest", "bin", "scripts", "interface_smoke", "registry_interface", "name"}
     for worker_id, worker in workers.items():
-        assert set(worker.raw) == {"source", "artifact", "publish"}
+        assert {"source", "artifact", "publish"}.issubset(worker.raw)
+        assert set(worker.raw) <= {
+            "source", "artifact", "publish", "previous_names", "previous_source_paths"
+        }
         assert not legacy.intersection(worker.raw), worker_id
         for include in worker.artifact.get("include", []):
             assert (worker.path / include).is_file() or include.startswith("dist/"), (

--- a/.github/scripts/validate_worker.py
+++ b/.github/scripts/validate_worker.py
@@ -14,8 +14,6 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import _lib  # noqa: E402
 
 
-BINARY_NAME_EXCEPTIONS = frozenset({"acp"})
-
 BUNDLE_PRESET_IMAGES = frozenset({
     "docker.io/iiidev/python:latest",
     "docker.io/iiidev/node:latest",
@@ -33,8 +31,6 @@ def validate_public_manifest(worker: str, spec: _lib.WorkerSpec, hard) -> None:
     for key in ("name", "language", "deploy", "manifest"):
         if not manifest.raw.get(key):
             hard(f"{worker}/iii.worker.yaml is missing key: {key}")
-    if manifest.name != worker:
-        hard(f"{worker}/iii.worker.yaml name={manifest.name!r} does not match folder")
     if manifest.language not in {"rust", "node", "python", "javascript"}:
         hard(f"{worker}/iii.worker.yaml has unsupported language={manifest.language!r}")
     if manifest.deploy not in {"binary", "image", "bundle"}:
@@ -77,9 +73,9 @@ def validate_public_manifest(worker: str, spec: _lib.WorkerSpec, hard) -> None:
         hard(f"{worker}/iii.worker.yaml tags must be non-empty when Registry interface publication is enabled")
 
     if manifest.deploy == "binary":
-        executable = manifest.bin or manifest.name
-        if executable != worker and worker not in BINARY_NAME_EXCEPTIONS:
-            hard(f"{worker}/iii.worker.yaml bin={executable!r} must match the worker ID")
+        executable = manifest.bin or worker
+        if executable != (spec.binary or worker):
+            hard(f"{worker}/iii.worker.yaml bin={executable!r} differs from artifact.binary")
     if manifest.deploy == "bundle":
         scripts = manifest.raw.get("scripts") or {}
         if not isinstance(scripts, dict):
@@ -131,9 +127,6 @@ def main(argv: list[str] | None = None) -> int:
         validate_public_manifest(worker, spec, hard)
         if not spec.publish:
             hard(f"{worker}: first-party CI workers must set publish=true")
-        expected_path = pathlib.Path(worker).resolve()
-        if spec.path != expected_path:
-            hard(f"{worker}: source.path must be {worker!r}, got {spec.source.get('path')!r}")
         readme = spec.path / "README.md"
         if not readme.exists():
             soft(f"{worker}/README.md is missing")
@@ -148,13 +141,6 @@ def main(argv: list[str] | None = None) -> int:
         elif spec.validation.get("interface") == "required" and not tags:
             hard(f"{worker}/iii.worker.yaml tags must be non-empty when the PR interface smoke is enabled")
 
-        if spec.artifact_kind == "rust-binary":
-            executable = spec.binary or worker
-            if executable != worker and worker not in BINARY_NAME_EXCEPTIONS:
-                hard(
-                    f"{worker}: artifact.binary={executable!r} must match the worker ID "
-                    "because Registry extraction addresses the worker by ID"
-                )
         if spec.manifest:
             manifest_path = spec.path / spec.manifest
             if not manifest_path.is_file():
@@ -167,7 +153,7 @@ def main(argv: list[str] | None = None) -> int:
                     current_version = None
                 try:
                     base_blob = subprocess.check_output(
-                        ["git", "show", f"{args.base_ref}:{worker}/{spec.manifest}"],
+                        ["git", "show", f"{args.base_ref}:{spec.source['path']}/{spec.manifest}"],
                         text=True,
                         stderr=subprocess.DEVNULL,
                     )

--- a/console/iii.worker.yaml
+++ b/console/iii.worker.yaml
@@ -1,5 +1,5 @@
 iii: v1
-name: console
+name: ade
 language: rust
 deploy: binary
 manifest: Cargo.toml

--- a/docs/architecture/iii-worker-yaml.md
+++ b/docs/architecture/iii-worker-yaml.md
@@ -10,7 +10,7 @@ descriptor; Release Control and post-prepare workflows never read it.
 | Field | Type | Purpose |
 |---|---|---|
 | `iii` | `v1` | Schema version |
-| `name` | string | Folder name; git tag prefix; registry id |
+| `name` | string | Public Registry identity |
 | `language` | enum | `rust` \| `javascript` \| `node` \| `python` — routes CI language job |
 | `deploy` | enum | `binary` \| `image` \| `bundle` — routes release build + publish |
 | `manifest` | path | Version source: `Cargo.toml`, `package.json`, `pyproject.toml` |
@@ -27,6 +27,39 @@ When `targets` is omitted, all six default Unix triples are built: macOS
 x86_64/aarch64, Linux x86_64 gnu/musl, aarch64 gnu, and armv7 gnueabihf.
 The authoritative release matrix lives in `.deploy/workers.yaml`; when this
 public field is present the compiler requires the two lists to match.
+
+## Identity changes
+
+The mapping key in `.deploy/workers.yaml` is the stable build selector used by
+workflows, descriptor filenames, and artifacts. It may differ from the public
+`name` in `iii.worker.yaml`; the compiler preserves it as `descriptor.worker`
+and publishes `name` as `descriptor.registry_projection.worker_name`. Binary
+archives retain their existing external asset filenames but store the
+executable entry under this public name (plus `.exe` for Windows), which is the
+basename the iii installer extracts.
+
+When changing the public name, add every former public name to the private
+catalog entry's `previous_names`, ordered oldest first. This list is append-only
+and must keep the complete history across later renames so Release Control can
+retain the same oldest lease scope. When moving the source directory, add each
+explicit old repository-relative directory to private `previous_source_paths`.
+Empty histories may be absent or `[]`; the compiler omits empty history fields
+from unchanged descriptors. These release-only fields do not belong in
+`iii.worker.yaml`.
+
+```yaml
+workers:
+  stable-build-selector:
+    source: {path: workers/current-dir, package_manifest: Cargo.toml}
+    artifact:
+      kind: rust-binary
+      binary: worker-bin
+      toolchain: {name: rust, version: 1.97.1}
+      targets: [x86_64-pc-windows-msvc]
+    publish: true
+    previous_names: [oldest-name, middle-name]
+    previous_source_paths: [workers/oldest-dir, workers/middle-dir]
+```
 
 ## Opt-outs and runtime
 

--- a/docs/architecture/worker-compose.md
+++ b/docs/architecture/worker-compose.md
@@ -50,9 +50,11 @@ workers:
     publish: true
 ```
 
-Each entry contains exactly `source`, `artifact`, `validation`, and `publish`.
-The worker identity is the mapping key. The selected package-manifest version
-is metadata; Release Control selects the exact deployment target version.
+Each entry contains `source`, `artifact`, and `publish`, plus optional
+`previous_names` and `previous_source_paths` identity history. The mapping key
+is the stable build selector; the public Registry identity comes from
+`iii.worker.yaml` and may differ. The selected package-manifest version is
+metadata; Release Control selects the exact deployment target version.
 
 Public runtime and Registry metadata remain in `<worker>/iii.worker.yaml`:
 identity, deploy kind, package manifest, binary name, description, license,

--- a/docs/sops/binary-worker.md
+++ b/docs/sops/binary-worker.md
@@ -44,9 +44,12 @@ workers:
     publish: true
 ```
 
-The slug, folder, Cargo package, binary, runtime executable and registered
-worker identity should match unless an existing package has an explicitly
-tested exception.
+The selector, folder, Cargo package, binary and public worker identity normally
+match. When a public identity changes, `artifact.binary` still names the source
+executable, while the compiler sets `runtime.exec` and the executable entry
+inside release archives to the public `iii.worker.yaml` name. Archive and
+checksum filenames remain based on the source binary so immutable asset naming
+does not change.
 
 ## Crate shape
 

--- a/docs/sops/release.md
+++ b/docs/sops/release.md
@@ -17,6 +17,16 @@ artifact contains `deployment-descriptor-index.json` and exact
 source SHA, compiler commit/digest, artifact and descriptor digest before
 planning.
 
+## Identity-change rollout order
+
+Identity changes are compiler-first. Merge the Workers compiler/catalog change,
+then publish and verify the `main` descriptor checkpoint exposes the new public
+names and complete aliases (for this transition, `shell` → `ide` and `console`
+→ `ade`). Deploy the corresponding Release Control change only after that
+checkpoint exists. Release Control without the matching descriptor contract
+fails closed on identity mismatch during the transition; do not add a static
+rename map or deploy Release Control first.
+
 ## What a build does
 
 [`build.yml`](../../.github/workflows/build.yml) runs for one worker and one

--- a/shell/iii.worker.yaml
+++ b/shell/iii.worker.yaml
@@ -1,5 +1,5 @@
 iii: v1
-name: shell
+name: ide
 language: rust
 deploy: binary
 manifest: Cargo.toml


### PR DESCRIPTION
Release builds currently require the build selector, source directory and Registry name to match, forcing Release Control to carry worker-specific rename rules.

The descriptor now uses the public manifest name for Registry publication while preserving the private catalog's build selector, source path and source binary. Optional `previous_names` and `previous_source_paths` live in `.deploy/workers.yaml`; the compiler validates aliases and canonicalizes dependencies before computing digests.

The `shell` and `console` build selectors publish as `ide` and `ade`, with their previous names explicitly declared. The public runtime manifest gains no new metadata fields.

Rust archives contain the executable under the public name expected by the installer, and `runtime.exec` matches that entry for interface capture. Source binary, archive and checksum filenames remain unchanged; Windows entries preserve `.exe`.

Companion: https://github.com/iii-hq/release-control/pull/189. Publish and verify this Workers main checkpoint first (public names `ide`/`ade`, historical names `shell`/`console`), then deploy the descriptor-aware Release Control consumer. The previous consumer rejects the new contract during this transition.

Draft: the required MOT tracking ticket has not been assigned.

Validation:

- 292 script tests and 3 subtests passing, including renamed tar/zip payloads and interface staging.
- 73 descriptors compiled and validated against JSON Schema and the build consumer.
- The same 73 generated descriptors loaded successfully in the companion Release Control consumer, with digest and canonical dependency validation.
- Shell and Console worker validators and whitespace checks passing.
