### PR TITLE
(MOT-4741) fix(provider-deepseek): current catalog (flash id, peak prices, effort vocabulary) and a native thinking-off switch

### DIFF
--- a/provider-deepseek/README.md
+++ b/provider-deepseek/README.md
@@ -34,15 +34,20 @@ models listing is always read from that endpoint's `/models` sibling.
   Bearer`; v1 performs no OAuth refresh.
 - **Catalog:** `GET /models` owns the id list; `src/curated.rs` supplies what
   the listing does not carry — display names, context windows, output
-  ceilings, and pricing (USD per MTok) from api-docs.deepseek.com. An id the
-  table does not know still lands in the catalog on conservative defaults
-  (64K context, 8K output, no pricing) rather than disappearing, so a model
-  DeepSeek ships tomorrow is routable today. The prices are DeepSeek's
-  regular rates, which is what is billed today, so reported cost is exact.
-  DeepSeek has announced a peak/off-peak policy charging 2x during
-  09:00–12:00 and 14:00–18:00 Beijing time but has not set an effective
-  date; if it lands, cost display becomes a floor during those windows,
-  since a time-of-day multiplier is not something the catalog can express.
+  ceilings, pricing (USD per MTok) and the `reasoning_effort` vocabulary
+  from api-docs.deepseek.com (snapshot 2026-09-10). The live ids are
+  `deepseek-flash` (DeepSeek-V4.1-Flash) and `deepseek-v4-pro`; the retired
+  `deepseek-v4-flash` names are still accepted by the API and get the Flash
+  row's metadata under their own id. An id the table does not know still
+  lands in the catalog on conservative defaults (64K context, 8K output, no
+  pricing) rather than disappearing, so a model DeepSeek ships tomorrow is
+  routable today. Prices are the **peak** rate — DeepSeek's list price;
+  off-peak (every hour outside 01:00–04:00 and 06:00–10:00 UTC, Monday to
+  Friday) is half of it, so reported cost is exact at peak and a 2x ceiling
+  off-peak — a time-of-day multiplier is not something the catalog can
+  express. DeepSeek retires V4 Pro on 2026-09-14 12:00 Beijing time: from
+  then `deepseek-v4-pro` requests are answered by V4.1 Flash and billed at
+  the Flash price until V4.1 Pro ships; the row stays while the id is listed.
 - **Liveness:** `ping` at least every 30s of upstream silence; a failed
   channel write (caller gone / `router::abort`) drops the SSE receiver and
   aborts the in-flight HTTP request. DeepSeek holds an overloaded request
@@ -64,13 +69,21 @@ models listing is always read from that endpoint's `/models` sibling.
   `thinking: {type: enabled}` plus the top-level `reasoning_effort` param —
   the router's five levels collapse onto DeepSeek's three-wide vocabulary as
   `minimal`/`low` → `low`, `medium`/`high` → `high`, `xhigh` → `max`
-  (`src/reasoning.rs`). With **no** level both params are omitted, so each
-  model runs its own documented default: the V4 family reasons at `high`
+  (`src/reasoning.rs`; the API would coerce a literal `xhigh` down to `high`,
+  so the mapping is done here). With **no** level both params are omitted, so
+  each model runs its own documented default: the V4 family reasons at `high`
   effort — an unconfigured console chat streams its chain of thought out of
   the box, with reasoning tokens billed as output — while a legacy
   non-thinking alias (`deepseek-chat`) keeps the behavior its name encodes.
-  `disabled` is never sent: the router has no off level to express, and a
-  synthetic off-by-default would blank the console's thinking pane.
+  **Off** is the one knob the ladder cannot express: pass
+  `provider_options: { deepseek: { thinking: "disabled" } }` on the send and
+  the request carries `thinking: {type: disabled}` with no `reasoning_effort`
+  (a `thinking_level` on the same send is reported as ignored). It is never
+  synthesised — an off-by-default would blank the console's thinking pane —
+  and any value other than `enabled`/`disabled` fails the turn instead of
+  silently running at full effort. Each documented catalog row advertises the
+  effort vocabulary as `reasoning_efforts` (`low`, `high`, `max`) so
+  `router::models::get` shows what a level lands on.
   Reasoning models stream their chain of thought as `reasoning_content`
   deltas, which the worker surfaces as `thinking` blocks (`src/sse.rs`), and
   `completion_tokens_details.reasoning_tokens` lands on `usage.reasoning`.

--- a/provider-deepseek/src/curated.rs
+++ b/provider-deepseek/src/curated.rs
@@ -5,10 +5,17 @@
 //! models DeepSeek documents, conservative defaults for anything else.
 //!
 //! Figures from api-docs.deepseek.com (quick_start/pricing,
-//! guides/thinking_mode, guides/json_mode), snapshot 2026-08. A stale row
-//! degrades cost display and limits, never routing correctness.
+//! guides/thinking_mode), snapshot 2026-09-10. The live ids are
+//! `deepseek-flash` (DeepSeek-V4.1-Flash) and `deepseek-v4-pro`
+//! (DeepSeek-V4-Pro-0813); `deepseek-v4-flash` is a retired alias the API
+//! still answers with Flash at the Flash price. DeepSeek has scheduled V4
+//! Pro's retirement for 2026-09-14 12:00 Beijing time, after which
+//! `deepseek-v4-pro` requests are answered by V4.1 Flash and billed at the
+//! Flash price until V4.1 Pro ships; the row stays until the id leaves
+//! `GET /models`. A stale row degrades cost display and limits, never routing
+//! correctness.
 use crate::PROVIDER_ID;
-use llm_router::types::model::{Model, Pricing};
+use llm_router::types::model::{Model, Pricing, ReasoningEffort};
 
 /// Context window and max output for unknown ids — an `api_url` override can
 /// point this provider at any OpenAI-compatible server. Deliberately the
@@ -17,13 +24,13 @@ use llm_router::types::model::{Model, Pricing};
 const UNKNOWN_CONTEXT_WINDOW: u64 = 65_536;
 const UNKNOWN_MAX_OUTPUT_TOKENS: u64 = 8_192;
 
-/// USD per MTok: (input on cache miss, input on cache hit, output).
-/// The regular list price, which is what is billed today. DeepSeek has
-/// announced — but not yet scheduled — a peak/off-peak policy charging 2x
-/// the regular price during 09:00–12:00 and 14:00–18:00 Beijing time
-/// ("the effective date will be subject to the official announcement").
-/// These rows stay the regular price when that lands; only a time-of-day
-/// multiplier the catalog has no way to express would need adding.
+/// USD per MTok: (input on cache miss, input on cache hit, output), at the
+/// PEAK rate — DeepSeek's list price. Off-peak is half of every figure and
+/// applies outside 01:00–04:00 and 06:00–10:00 UTC Monday–Friday
+/// (quick_start/pricing, note 3). The catalog has no time-of-day dimension,
+/// so the one figure published is the one that never under-reports a bill.
+// ponytail: peak price as the single figure; a time-of-day multiplier needs a
+// catalog extension.
 struct Row {
     id: &'static str,
     display: &'static str,
@@ -38,21 +45,49 @@ const ROWS: &[Row] = &[
         display: "DeepSeek V4 Pro",
         context_window: 1_000_000,
         max_output_tokens: 384_000,
-        price: (0.435, 0.003625, 0.87),
+        price: (1.32, 0.044, 3.96),
     },
     Row {
-        id: "deepseek-v4-flash",
-        display: "DeepSeek V4 Flash",
+        id: "deepseek-flash",
+        display: "DeepSeek V4.1 Flash",
         context_window: 1_000_000,
         max_output_tokens: 384_000,
-        price: (0.14, 0.0028, 0.28),
+        price: (0.30, 0.006, 1.20),
     },
 ];
+
+/// Legacy flash names the API still accepts but answers with V4.1 Flash at
+/// the Flash price (quick_start/pricing, note 1). Metadata follows the model
+/// that answers; the row keeps the id the caller used, because that is what
+/// routes.
+fn canonical(id: &str) -> &str {
+    match id {
+        "deepseek-v4-flash" | "deepseek-v4-flash-vision-exp" => "deepseek-flash",
+        other => other,
+    }
+}
+
+/// The wire vocabulary `reasoning_effort` takes, published so
+/// `router::models::get` shows what a `thinking_level` lands on
+/// (`reasoning::reasoning_effort_for`) instead of a bare `supports_thinking`.
+fn efforts() -> Vec<ReasoningEffort> {
+    [
+        ("low", "thinking_level minimal / low"),
+        ("high", "thinking_level medium / high; the API default"),
+        ("max", "thinking_level xhigh"),
+    ]
+    .into_iter()
+    .map(|(effort, description)| ReasoningEffort {
+        effort: effort.into(),
+        description: Some(description.into()),
+    })
+    .collect()
+}
 
 /// One live id → catalog Model: documented metadata when the id is known,
 /// conservative defaults otherwise.
 pub fn enrich(id: &str) -> Model {
-    match ROWS.iter().find(|r| r.id == id) {
+    match ROWS.iter().find(|r| r.id == canonical(id)) {
         Some(r) => {
             let (input, cached, output) = r.price;
             Model {
@@ -63,6 +98,12 @@ pub fn enrich(id: &str) -> Model {
                 // V4 model, and `reasoning_effort: max` is accepted by both.
                 supports_thinking: Some(true),
                 supports_xhigh: Some(true),
+                reasoning_efforts: Some(efforts()),
+                // Flash documents vision, but this provider's wire is text
+                // only (image blocks degrade to a marker — see
+                // `wire::messages`), so advertising it would route images
+                // into a turn that cannot carry them. Stays false until the
+                // wire grows content parts.
                 supports_vision: Some(false),
                 pricing: Some(Pricing {
                     input: Some(input),
@@ -123,20 +164,68 @@ mod tests {
         assert_eq!(m.supports_cache, Some(true));
         assert_eq!(m.supports_structured_output, Some(false));
         let p = m.pricing.unwrap();
-        assert_eq!(p.input, Some(0.435));
-        assert_eq!(p.cache_read, Some(0.003625));
-        assert_eq!(p.output, Some(0.87));
+        assert_eq!(p.input, Some(1.32));
+        assert_eq!(p.cache_read, Some(0.044));
+        assert_eq!(p.output, Some(3.96));
         assert!(p.cache_write.is_none());
+        let efforts: Vec<&str> = m
+            .reasoning_efforts
+            .as_ref()
+            .unwrap()
+            .iter()
+            .map(|e| e.effort.as_str())
+            .collect();
+        assert_eq!(efforts, ["low", "high", "max"]);
     }
 
     #[test]
-    fn flash_is_the_cheaper_row() {
-        let flash = enrich("deepseek-v4-flash").pricing.unwrap();
+    fn flash_is_the_live_id_and_the_cheaper_row() {
+        let m = enrich("deepseek-flash");
+        assert_eq!(m.display_name.as_deref(), Some("DeepSeek V4.1 Flash"));
+        assert_eq!(m.context_window, 1_000_000, "flash is not a 65K model");
+        assert_eq!(m.max_output_tokens, 384_000);
+        let flash = m.pricing.unwrap();
         let pro = enrich("deepseek-v4-pro").pricing.unwrap();
         assert!(flash.input < pro.input);
         assert!(flash.output < pro.output);
-        assert_eq!(flash.input, Some(0.14));
-        assert_eq!(flash.output, Some(0.28));
+        assert_eq!(flash.input, Some(0.30));
+        assert_eq!(flash.cache_read, Some(0.006));
+        assert_eq!(flash.output, Some(1.20));
+    }
+
+    #[test]
+    fn legacy_flash_aliases_get_flash_metadata_under_their_own_id() {
+        for alias in ["deepseek-v4-flash", "deepseek-v4-flash-vision-exp"] {
+            let m = enrich(alias);
+            assert_eq!(m.id, alias, "the caller's id is what routes");
+            assert_eq!(m.context_window, 1_000_000, "{alias} must not degrade");
+            assert_eq!(m.pricing, enrich("deepseek-flash").pricing);
+        }
+    }
+
+    #[test]
+    fn advertised_efforts_cover_every_level_the_mapper_emits() {
+        use crate::reasoning::reasoning_effort_for;
+        use llm_router::types::model::ThinkingLevel;
+        let advertised: Vec<String> = enrich("deepseek-v4-pro")
+            .reasoning_efforts
+            .unwrap()
+            .into_iter()
+            .map(|e| e.effort)
+            .collect();
+        for level in [
+            ThinkingLevel::Minimal,
+            ThinkingLevel::Low,
+            ThinkingLevel::Medium,
+            ThinkingLevel::High,
+            ThinkingLevel::Xhigh,
+        ] {
+            let effort = reasoning_effort_for(Some(level)).unwrap();
+            assert!(
+                advertised.iter().any(|a| a == effort),
+                "{level:?} → {effort} is not advertised in reasoning_efforts"
+            );
+        }
     }
 
     #[test]
@@ -148,6 +237,7 @@ mod tests {
         assert_eq!(m.max_output_tokens, 8_192);
         assert_eq!(m.supports_thinking, None);
         assert_eq!(m.supports_xhigh, None);
+        assert!(m.reasoning_efforts.is_none());
         assert!(m.pricing.is_none());
         // structured output and tools hold for the whole OpenAI-compatible
         // surface, known model or not.

--- a/provider-deepseek/src/discovery.rs
+++ b/provider-deepseek/src/discovery.rs
@@ -155,7 +155,7 @@ mod tests {
         let json = serde_json::json!({
             "object": "list",
             "data": [
-                { "id": "deepseek-v4-flash", "object": "model", "owned_by": "deepseek" },
+                { "id": "deepseek-flash", "object": "model", "owned_by": "deepseek" },
                 { "id": "deepseek-v4-pro", "object": "model", "owned_by": "deepseek" },
                 { "id": "", "object": "model" },
                 { "object": "model" },
@@ -163,9 +163,16 @@ mod tests {
         });
         let models = parse_live_models(&json);
         let ids: Vec<&str> = models.iter().map(|m| m.id.as_str()).collect();
-        assert_eq!(ids, ["deepseek-v4-flash", "deepseek-v4-pro"]);
+        assert_eq!(ids, ["deepseek-flash", "deepseek-v4-pro"]);
         assert_eq!(models[1].context_window, 1_000_000);
         assert_eq!(models[1].display_name.as_deref(), Some("DeepSeek V4 Pro"));
+        // The live id is `deepseek-flash`; a row keyed on the retired
+        // `deepseek-v4-flash` left flash on the 65K/8K unknown-model defaults.
+        assert_eq!(models[0].context_window, 1_000_000);
+        assert_eq!(
+            models[0].display_name.as_deref(),
+            Some("DeepSeek V4.1 Flash")
+        );
     }
 
     #[test]

--- a/provider-deepseek/src/reasoning.rs
+++ b/provider-deepseek/src/reasoning.rs
@@ -1,17 +1,24 @@
 //! thinking_level → DeepSeek's two reasoning knobs (api-docs.deepseek.com
-//! guides/thinking_mode, 2026-08):
-//!   - `thinking: { "type": "enabled" }` — sent only when a level was
-//!     requested. With no level the param is OMITTED so every model runs its
-//!     own default: the V4 family reasons at high effort — the chain of
-//!     thought streams into the console on an unconfigured chat — while a
-//!     legacy non-thinking alias (deepseek-chat) keeps the semantics its
-//!     name encodes. `"disabled"` is deliberately never sent: the router
-//!     has no off level to express, and a synthetic off-by-default blanked
-//!     the console's thinking pane on every chat that never picked a level.
-//!   - `reasoning_effort` — a top-level parameter (not nested in `thinking`),
-//!     taking `low` | `high` | `max`; also omitted with no level (API
-//!     default: high).
+//! guides/thinking_mode, 2026-09):
+//!   - `thinking: { "type": "enabled" | "disabled" }` — thinking is ON by
+//!     default on every V4 model. `"enabled"` rides only when a level was
+//!     requested; with no level the param is OMITTED so each model runs its
+//!     own default (V4: high effort — the chain of thought streams into the
+//!     console on an unconfigured chat) while a legacy non-thinking alias
+//!     (deepseek-chat) keeps the semantics its name encodes. `"disabled"` is
+//!     the one DeepSeek knob the router's five-level ladder cannot express:
+//!     it is sent only when the caller asks for it through this provider's
+//!     `provider_options.thinking` slice, never synthesised — an off-by-default
+//!     blanked the console's thinking pane on every chat that never picked a
+//!     level.
+//!   - `reasoning_effort` — a top-level parameter (not nested in `thinking`)
+//!     taking `low` | `high` | `max`; omitted with no level (API default:
+//!     high) and omitted when thinking is disabled (nothing to grade).
+//!     DeepSeek also accepts the router's own words and coerces server-side
+//!     (`minimal`→low, `medium`→high, `xhigh`→**high**), so the ladder is
+//!     mapped here, where `xhigh` gets `max`.
 use llm_router::types::model::ThinkingLevel;
+use serde_json::Value;
 
 /// Reasoning model detection: the catalog's `supports_thinking` flag wins;
 /// id-pattern fallback for models the catalog doesn't know. Every DeepSeek
@@ -25,11 +32,37 @@ pub fn is_reasoning_model(model: &str, catalog_supports_thinking: Option<bool>) 
     model.to_ascii_lowercase().starts_with("deepseek")
 }
 
-/// The `thinking.type` body value: `enabled` when a level was requested on a
-/// reasoning model; `None` (param omitted → the model's own default, which
-/// is thinking-on for the V4 family) otherwise.
-pub fn thinking_type(level: Option<ThinkingLevel>, reasoning: bool) -> Option<&'static str> {
-    (reasoning && level.is_some()).then_some("enabled")
+/// `provider_options.thinking`: the native on/off switch. `"disabled"` turns
+/// the chain of thought off entirely; `"enabled"` is accepted for symmetry.
+/// Anything else is a hard error — a misspelt off switch must not silently
+/// run at full effort (the codex provider takes the same line on its native
+/// `reasoning_effort`).
+pub fn native_thinking(provider_options: Option<&Value>) -> Result<Option<&'static str>, String> {
+    let Some(value) = provider_options.and_then(|options| options.get("thinking")) else {
+        return Ok(None);
+    };
+    match value.as_str().map(str::trim) {
+        Some("disabled") => Ok(Some("disabled")),
+        Some("enabled") => Ok(Some("enabled")),
+        _ => Err(format!(
+            "provider_options.thinking must be \"enabled\" or \"disabled\", got {value}"
+        )),
+    }
+}
+
+/// The `thinking.type` body value. A native switch wins outright; otherwise
+/// `enabled` when a level was requested on a reasoning model; `None` (param
+/// omitted → the model's own default, thinking-on for the V4 family)
+/// otherwise. Non-reasoning models never see the DeepSeek-specific param.
+pub fn thinking_type(
+    level: Option<ThinkingLevel>,
+    reasoning: bool,
+    native: Option<&'static str>,
+) -> Option<&'static str> {
+    if !reasoning {
+        return None;
+    }
+    native.or_else(|| level.is_some().then_some("enabled"))
 }
 
 /// The router's five levels collapse onto DeepSeek's three-wide ladder.
@@ -46,9 +79,35 @@ pub fn reasoning_effort_for(level: Option<ThinkingLevel>) -> Option<&'static str
     })
 }
 
+/// Both wire params, resolved together so the one rule that ties them —
+/// disabled thinking carries no effort — lives in one place.
+#[derive(Debug, PartialEq, Eq)]
+pub struct ReasoningParams {
+    pub thinking: Option<&'static str>,
+    pub reasoning_effort: Option<&'static str>,
+}
+
+pub fn resolve(
+    level: Option<ThinkingLevel>,
+    reasoning: bool,
+    native: Option<&'static str>,
+) -> ReasoningParams {
+    let thinking = thinking_type(level, reasoning, native);
+    let reasoning_effort = if reasoning && thinking != Some("disabled") {
+        reasoning_effort_for(level)
+    } else {
+        None
+    };
+    ReasoningParams {
+        thinking,
+        reasoning_effort,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn catalog_flag_wins_over_id_pattern() {
@@ -62,16 +121,84 @@ mod tests {
     #[test]
     fn thinking_param_rides_only_with_an_explicit_level() {
         assert_eq!(
-            thinking_type(Some(ThinkingLevel::High), true),
+            thinking_type(Some(ThinkingLevel::High), true, None),
             Some("enabled")
         );
         // No level → param omitted → the model's own default applies (V4:
         // enabled at high effort), so an unconfigured console chat still
-        // streams its chain of thought. `"disabled"` is never produced.
-        assert_eq!(thinking_type(None, true), None);
+        // streams its chain of thought. `"disabled"` is never synthesised.
+        assert_eq!(thinking_type(None, true, None), None);
         // non-reasoning models never see the DeepSeek-specific param
-        assert_eq!(thinking_type(Some(ThinkingLevel::High), false), None);
-        assert_eq!(thinking_type(None, false), None);
+        assert_eq!(thinking_type(Some(ThinkingLevel::High), false, None), None);
+        assert_eq!(thinking_type(None, false, None), None);
+    }
+
+    #[test]
+    fn native_switch_is_exact_or_an_error() {
+        assert_eq!(native_thinking(None), Ok(None));
+        assert_eq!(native_thinking(Some(&json!({}))), Ok(None));
+        assert_eq!(
+            native_thinking(Some(&json!({ "thinking": "disabled" }))),
+            Ok(Some("disabled"))
+        );
+        assert_eq!(
+            native_thinking(Some(&json!({ "thinking": " enabled " }))),
+            Ok(Some("enabled"))
+        );
+        // A typo on the off switch must fail the turn, not run at full effort.
+        for bad in [
+            json!({ "thinking": "off" }),
+            json!({ "thinking": false }),
+            json!({ "thinking": "" }),
+        ] {
+            let err = native_thinking(Some(&bad)).unwrap_err();
+            assert!(err.contains("\"enabled\" or \"disabled\""), "{err}");
+        }
+    }
+
+    #[test]
+    fn native_off_switch_wins_and_drops_the_effort() {
+        let off = ReasoningParams {
+            thinking: Some("disabled"),
+            reasoning_effort: None,
+        };
+        // off beats a requested level (the caller is warned upstream)
+        assert_eq!(
+            resolve(Some(ThinkingLevel::Xhigh), true, Some("disabled")),
+            off
+        );
+        assert_eq!(resolve(None, true, Some("disabled")), off);
+        // enabled without a level: thinking on, effort left to the API default
+        assert_eq!(
+            resolve(None, true, Some("enabled")),
+            ReasoningParams {
+                thinking: Some("enabled"),
+                reasoning_effort: None,
+            }
+        );
+        // the plain ladder is unchanged
+        assert_eq!(
+            resolve(Some(ThinkingLevel::High), true, None),
+            ReasoningParams {
+                thinking: Some("enabled"),
+                reasoning_effort: Some("high"),
+            }
+        );
+        assert_eq!(
+            resolve(None, true, None),
+            ReasoningParams {
+                thinking: None,
+                reasoning_effort: None,
+            }
+        );
+        // a non-reasoning model gets neither param, switch or not
+        assert_eq!(
+            resolve(Some(ThinkingLevel::High), false, Some("disabled")),
+            ReasoningParams {
+                thinking: None,
+                reasoning_effort: None,
+            }
+        );
     }
 
     #[test]

--- a/provider-deepseek/src/request.rs
+++ b/provider-deepseek/src/request.rs
@@ -14,8 +14,9 @@ pub struct BodyArgs {
     pub system_prompt: String,
     pub messages: Vec<AgentMessage>,
     pub tools: Vec<AgentFunction>,
-    /// Pre-resolved `thinking.type` ("enabled"); None omits the param so the
-    /// model's own default applies (V4: thinking on at high effort).
+    /// Pre-resolved `thinking.type` ("enabled" | "disabled"); None omits the
+    /// param so the model's own default applies (V4: thinking on at high
+    /// effort).
     pub thinking: Option<&'static str>,
     /// Pre-resolved effort string; None omits the param.
     pub reasoning_effort: Option<&'static str>,
@@ -154,6 +155,19 @@ mod tests {
         let body = build_body(&args());
         assert!(body.get("thinking").is_none());
         assert!(body.get("reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn disabled_thinking_rides_alone_without_an_effort() {
+        let mut a = args();
+        a.thinking = Some("disabled");
+        a.reasoning_effort = None;
+        let body = build_body(&a);
+        assert_eq!(body["thinking"]["type"], "disabled");
+        assert!(
+            body.get("reasoning_effort").is_none(),
+            "nothing to grade when thinking is off"
+        );
     }
 
     #[test]

--- a/provider-deepseek/src/stream_fn.rs
+++ b/provider-deepseek/src/stream_fn.rs
@@ -3,7 +3,7 @@
 //! the router-owned channel, terminal done/error last, then close.
 use crate::config::config_from_resolve;
 use crate::errors::classify_bus_error;
-use crate::reasoning::{is_reasoning_model, reasoning_effort_for, thinking_type};
+use crate::reasoning::{is_reasoning_model, native_thinking, resolve, ReasoningParams};
 use crate::request::{build_body, build_headers, BodyArgs};
 use crate::sse::synthetic_error_event;
 use crate::upstream::{spawn_upstream, UpstreamArgs};
@@ -136,12 +136,27 @@ async fn run_stream_call(
             "thinking_level ignored: {model} is not a reasoning model"
         ));
     }
-    let thinking = thinking_type(input.thinking_level, reasoning);
-    let reasoning_effort = if reasoning {
-        reasoning_effort_for(input.thinking_level)
-    } else {
-        None
+    // The native on/off switch is exact or nothing: a misspelt off switch
+    // must not silently run at full effort.
+    let native = match native_thinking(input.provider_options.as_ref()) {
+        Ok(native) => native,
+        Err(message) => {
+            let _ = send_event(
+                sink,
+                &synthetic_error_event(&message, &model, ErrorKind::Permanent),
+            );
+            return;
+        }
     };
+    if native == Some("disabled") && input.thinking_level.is_some() {
+        // Report-and-continue: off was asked for explicitly, so off wins.
+        warnings
+            .push("thinking_level ignored: provider_options.thinking is \"disabled\"".to_string());
+    }
+    let ReasoningParams {
+        thinking,
+        reasoning_effort,
+    } = resolve(input.thinking_level, reasoning, native);
 
     let body = build_body(&BodyArgs {
         model: cfg.model.clone(),

--- a/provider-deepseek/tests/integration.rs
+++ b/provider-deepseek/tests/integration.rs
@@ -212,7 +212,7 @@ const STUB_401: &str = "HTTP/1.1 401 Unauthorized\r\ncontent-type: application/j
 /// The `GET /models` payload, in DeepSeek's documented shape. Carries one id
 /// the local table knows and one it does not, so discovery is exercised on
 /// both paths.
-const STUB_MODELS: &str = "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\nconnection: close\r\n\r\n{\"object\":\"list\",\"data\":[{\"id\":\"deepseek-v4-pro\",\"object\":\"model\",\"owned_by\":\"deepseek\"},{\"id\":\"deepseek-v4-flash\",\"object\":\"model\",\"owned_by\":\"deepseek\"},{\"id\":\"deepseek-vNext\",\"object\":\"model\",\"owned_by\":\"deepseek\"}]}";
+const STUB_MODELS: &str = "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\nconnection: close\r\n\r\n{\"object\":\"list\",\"data\":[{\"id\":\"deepseek-v4-pro\",\"object\":\"model\",\"owned_by\":\"deepseek\"},{\"id\":\"deepseek-flash\",\"object\":\"model\",\"owned_by\":\"deepseek\"},{\"id\":\"deepseek-v4-flash\",\"object\":\"model\",\"owned_by\":\"deepseek\"},{\"id\":\"deepseek-vNext\",\"object\":\"model\",\"owned_by\":\"deepseek\"}]}";
 
 async fn stub_upstream(completions_response: &'static str) -> StubUpstream {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -497,7 +497,12 @@ async fn refresh_models_discovers_the_live_catalog() {
     // table does not know
     assert_eq!(
         ids,
-        ["deepseek-v4-pro", "deepseek-v4-flash", "deepseek-vNext"],
+        [
+            "deepseek-v4-pro",
+            "deepseek-flash",
+            "deepseek-v4-flash",
+            "deepseek-vNext"
+        ],
         "got {ids:?}"
     );
 
@@ -512,7 +517,25 @@ async fn refresh_models_discovers_the_live_catalog() {
     assert_eq!(pro["supports_structured_output"], false);
     assert_eq!(pro["supports_thinking"], true);
     assert_eq!(pro["supports_xhigh"], true);
-    assert_eq!(pro["pricing"]["input"], 0.435);
+    assert_eq!(
+        pro["pricing"]["input"], 1.32,
+        "peak list price, 2026-09 snapshot"
+    );
+
+    // the live flash id carries the Flash row — a row keyed on the retired
+    // `deepseek-v4-flash` left it on the 65K/8K unknown-model defaults — and
+    // the retired alias keeps its own id while borrowing that row's metadata
+    let flash = models.iter().find(|m| m["id"] == "deepseek-flash").unwrap();
+    assert_eq!(flash["display_name"], "DeepSeek V4.1 Flash");
+    assert_eq!(flash["context_window"], 1_000_000);
+    assert_eq!(flash["max_output_tokens"], 384_000);
+    assert_eq!(flash["pricing"]["input"], 0.30);
+    let alias = models
+        .iter()
+        .find(|m| m["id"] == "deepseek-v4-flash")
+        .unwrap();
+    assert_eq!(alias["context_window"], 1_000_000, "alias must not degrade");
+    assert_eq!(alias["pricing"], flash["pricing"]);
 
     // the unknown row survives on conservative defaults rather than vanishing
     let next = models.iter().find(|m| m["id"] == "deepseek-vNext").unwrap();


### PR DESCRIPTION
## Why

Run 6 of the Linkly e2e (DeepSeek, `thinking_level=minimal`) sent me into `provider-deepseek` expecting a broken thinking mapping. The mapping is fine — `Minimal|Low→low`, `Medium|High→high`, `Xhigh→max`, exactly what api-docs.deepseek.com/guides/thinking_mode documents — and MOT-4741 has been rewritten to say so. What the docs comparison *did* turn up is a stale catalog and a missing switch:

- **Flash was mis-cataloged.** Live `GET /models` returns `deepseek-flash`; the curated row was keyed on the retired `deepseek-v4-flash`, so V4.1 Flash (1M context, 384K output) fell through to the unknown-model defaults: 65K / 8K, no pricing. Anyone reading the catalog concluded flash could not hold an agentic session. It can.
- **Prices were the 2026-08 snapshot.** DeepSeek now bills peak/off-peak (off-peak = half; peak = 01–04 and 06–10 UTC Mon–Fri) and the list changed; every cost the router reported for DeepSeek was wrong in absolute terms.
- **Thinking could not be turned off.** DeepSeek has `thinking: {type: disabled}`; the router's ladder bottoms out at `minimal` = thinking *on* at low effort, and the provider never read `provider_options`.
- **The effort vocabulary was not introspectable.** `router::models::get` showed `supports_thinking: true` and nothing about what a level maps to.

## What changed (`provider-deepseek` only)

- `src/curated.rs` — row id `deepseek-v4-flash` → `deepseek-flash` ("DeepSeek V4.1 Flash"); retired flash names resolve to the Flash row under their own id; peak list prices (pro 1.32 / 0.044 / 3.96, flash 0.30 / 0.006 / 1.20 USD per MTok) with the off-peak rule and the 2026-09-14 V4 Pro retirement on the row; every documented row advertises `reasoning_efforts: [low, high, max]` with the `thinking_level` each covers. `supports_vision` stays `false` on flash on purpose: the wire is text-only, advertising it would route images into a turn that cannot carry them.
- `src/reasoning.rs` — `native_thinking(provider_options)` reads `thinking: "enabled" | "disabled"`; anything else is an error. `resolve()` produces both wire params with the one coupling rule in one place: disabled thinking carries no `reasoning_effort`.
- `src/stream_fn.rs` — the native switch wins over `thinking_level` (warning pushed when a level is dropped); an invalid value ends the turn as `permanent`, matching how `provider-openai-codex` treats its native `reasoning_effort`.
- `src/request.rs`, `src/discovery.rs` — doc + tests; the discovery fixture no longer encodes the retired id.
- `README.md` — Catalog and Reasoning sections.

## Behavior

| send | request to DeepSeek | before |
|---|---|---|
| no level | (both params omitted → API default: thinking on, high) | same |
| `thinking_level: minimal` | `thinking: enabled`, `reasoning_effort: low` | same |
| `thinking_level: xhigh` | `thinking: enabled`, `reasoning_effort: max` | same |
| `provider_options: {deepseek: {thinking: "disabled"}}` | `thinking: disabled`, no effort | ignored → thinking on |
| `…thinking: "disabled"` + a `thinking_level` | disabled; warning `thinking_level ignored` | level applied |
| `…thinking: "off"` | turn fails: `must be "enabled" or "disabled"` | ignored → full effort |
| `router::models::get deepseek-flash` | 1M / 384K, priced, `reasoning_efforts` | 65K / 8K, unpriced |

## Verification

- `cargo fmt --all -- --check` ✅ · `cargo clippy --all-targets --all-features --no-deps -- -D warnings` ✅ (type-checks the patched integration test) · `cargo test --lib --bins --test schemas`: **88 passed, 0 failed**.
- New/updated unit tests: exact switch parsing and rejection, off-wins-and-drops-effort, disabled body shape, flash live id, legacy aliases keep their id, and an invariant that every `thinking_level` the mapper emits is in the advertised `reasoning_efforts`.
- `tests/integration.rs`: pro price assertion updated (0.435 → 1.32); the `/models` stub now lists `deepseek-flash` and asserts it carries the Flash row while the retired `deepseek-v4-flash` alias keeps its id with the same metadata.
- **The engine-backed integration suite cannot run locally on any current engine** — pre-existing, not this PR: its bootstrap writes `iii-pubsub`/`iii-state` into the engine config and every current engine (0.23.1-rc.2 and rc.4 both tested) refuses with `UNSUPPORTED_CONFIG_WORKERS … move to worker-compose.yaml`. The self-skip only covers "no `iii` binary", so a present-but-incompatible engine fails all 5 tests at the 15s readiness assert. The untouched baseline fails identically (5/5, same line). 16 worker suites share the bootstrap; filed separately.

## Not in this PR

- The `ThinkingLevel` docstring in `llm-router` ("levels map via `Model::thinking_budgets`") is what sent me down the wrong path; this provider maps through an effort enum. One-line doc fix, separate crate.
- Vision on flash needs the wire to grow content parts.
- Time-of-day pricing needs a catalog dimension the `Pricing` type does not have; peak is published as the never-under-reports figure.

## Live verification (run-6 Linkly stack, this branch's binary swapped in via `path://`, engine 0.23.1-rc.4)

`router::models::list provider=deepseek` after the swap:

```
deepseek-flash   DeepSeek V4.1 Flash  ctx=1,000,000 out=384,000 in=$0.30 cache=$0.006 out=$1.20 efforts=[low, high, max]
deepseek-v4-pro  DeepSeek V4 Pro      ctx=1,000,000 out=384,000 in=$1.32 cache=$0.044 out=$3.96 efforts=[low, high, max]
```
(before: flash `65,536 / 8,192`, no pricing, no efforts.)

Same reasoning-heavy prompt (read a file, explain in 3 bullets), four fresh sessions, `deepseek-v4-pro`, numbers from `harness::metrics`:

| send | turns | output tokens | reasoning tokens | work | cost |
|---|---:|---:|---:|---:|---:|
| no options (control) | 5 | 1276 | 606 | 27.3s | $0.0178 |
| `provider_options: {deepseek: {thinking: "disabled"}}` | 3 | 486 | **none** | **12.1s** | $0.0089 |
| `thinking_level: high` + `thinking: "disabled"` | 3 | 460 | **none** (off wins) | 12.1s | $0.0088 |
| `thinking: "off"` | 1 | — | — | 3.0s | turn **failed**: `provider_options.thinking must be "enabled" or "disabled", got "off"` |

Trace evidence: the `provider::deepseek::stream` input for the disabled runs carries `provider_options: {"thinking":"disabled"}` (the provider's slice, forwarded by llm-router); the mixed run carries `thinking_level: "high"` alongside it. The invalid value surfaces to the caller verbatim in the turn's `result`.

Closes MOT-4741.

https://claude.ai/code/session_01PvtXK7JgHHNrG192afbRAk
