### PR TITLE
test(provider-sarvam, provider-llamacpp): settle the three assertions left #[ignore]d by MOT-4743

### DIFF
--- a/provider-llamacpp/tests/integration.rs
+++ b/provider-llamacpp/tests/integration.rs
@@ -135,9 +135,12 @@ async fn boot_stack(engine_url: &str) -> (IIIClient, IIIClient) {
     // A real key exported on the host would ride the router's env-var
     // fallback into every resolve and defeat the no-credential assertions
     // below. The provider itself sends no Authorization header without a
-    // credential (request.rs); the leak is purely environmental, so strip
-    // the variable once, before anything in-process reads it.
-    std::env::remove_var("LLAMACPP_API_KEY");
+    // credential (request.rs); the leak is purely environmental. Strip the
+    // variable exactly once per process, before the first router or provider
+    // boots: every in-process read happens after this single mutation and
+    // no test ever sets the variable, so concurrent tests cannot race it.
+    static STRIP_HOST_KEY: std::sync::Once = std::sync::Once::new();
+    STRIP_HOST_KEY.call_once(|| std::env::remove_var("LLAMACPP_API_KEY"));
     let router_iii = register_worker(engine_url, test_init_options());
     register_router(router_iii.clone())
         .await

--- a/provider-llamacpp/tests/integration.rs
+++ b/provider-llamacpp/tests/integration.rs
@@ -132,6 +132,12 @@ async fn stub_upstream(chat_response: &'static str) -> StubUpstream {
 
 /// Boot router + provider on one engine; wait until the provider is listed.
 async fn boot_stack(engine_url: &str) -> (IIIClient, IIIClient) {
+    // A real key exported on the host would ride the router's env-var
+    // fallback into every resolve and defeat the no-credential assertions
+    // below. The provider itself sends no Authorization header without a
+    // credential (request.rs); the leak is purely environmental, so strip
+    // the variable once, before anything in-process reads it.
+    std::env::remove_var("LLAMACPP_API_KEY");
     let router_iii = register_worker(engine_url, test_init_options());
     register_router(router_iii.clone())
         .await
@@ -252,9 +258,6 @@ async fn refresh_and_wait(router_iii: &IIIClient, provider_iii: &IIIClient, expe
 
 #[tokio::test(flavor = "multi_thread")]
 async fn provider_registers_with_persisted_token_and_discovers_catalog_without_a_credential() {
-    // A real key exported on the host would leak into the in-process router's
-    // env-var fallback and defeat the no-credential assertions below.
-    std::env::remove_var("LLAMACPP_API_KEY");
     let engine = engine_or_skip!();
     let stub = stub_upstream(STUB_SSE).await;
     let (router_iii, provider_iii) = boot_stack(&engine.url).await;
@@ -308,7 +311,6 @@ async fn provider_registers_with_persisted_token_and_discovers_catalog_without_a
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "MOT-4744: the chat request carries an Authorization header with no credential configured; provider or test must change"]
 async fn chat_streams_end_to_end_with_no_credential_and_no_authorization_header() {
     let engine = engine_or_skip!();
     let stub = stub_upstream(STUB_SSE).await;

--- a/provider-sarvam/src/curated.rs
+++ b/provider-sarvam/src/curated.rs
@@ -119,6 +119,9 @@ fn to_chat_model(r: &Row) -> Model {
         supports_cache: None,
         supports_structured_output: Some(false),
         thinking_budgets: None,
+        // Sarvam prices in INR only (docs.sarvam.ai/api/getting-started/pricing)
+        // and `Pricing` is USD per MTok, so the rows stay unpriced on purpose:
+        // router::chat reports usage counts without a cost_usd.
         pricing: None,
         speech: None,
     }

--- a/provider-sarvam/tests/integration.rs
+++ b/provider-sarvam/tests/integration.rs
@@ -218,7 +218,6 @@ async fn provider_registers_with_persisted_token_and_credential_gated_catalog() 
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "MOT-4744: the Sarvam catalog publishes no pricing (curated.rs), so the router cannot fill cost_usd"]
 async fn chat_streams_end_to_end_with_cost_fill() {
     let engine = engine_or_skip!();
     let stub = stub_upstream(STUB_SSE).await;
@@ -244,9 +243,12 @@ async fn chat_streams_end_to_end_with_cost_fill() {
     assert_eq!(res["ok"], true, "chat response: {res}");
     assert_eq!(res["provider"], "sarvam");
     assert_eq!(res["stop_reason"], "end");
+    // Sarvam publishes its prices in INR only and the catalog's `Pricing` is
+    // USD per MTok, so the rows stay unpriced (curated.rs): the router forwards
+    // the usage counts and must not invent a cost_usd.
     assert!(
-        res["usage"]["cost_usd"].as_f64().is_some_and(|c| c > 0.0),
-        "cost filled: {res}"
+        res["usage"]["cost_usd"].is_null(),
+        "unpriced catalog must leave cost_usd empty: {res}"
     );
 
     let _ = tokio::time::timeout(Duration::from_secs(5), pump).await;
@@ -301,7 +303,6 @@ async fn upstream_401_surfaces_as_auth_expired_error_frame() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "MOT-4744: curated::models() mixes speech rows into a chat-modality listing; predates the router's modality filter"]
 async fn refresh_models_reconciles_curated_catalog() {
     let engine = engine_or_skip!();
     let stub = stub_upstream(STUB_SSE).await;
@@ -309,10 +310,40 @@ async fn refresh_models_reconciles_curated_catalog() {
     configure_stub_key(&router_iii, &stub.url).await;
     refresh_and_wait(&router_iii, &provider_iii, "sarvam-105b").await;
 
-    let list = call(
+    // The default listing is the chat modality: the speech rows (saaras:*,
+    // saarika:*, bulbul:*) are reached through router::transcribe / speak and
+    // only appear with `modality: "any"`.
+    let chat = call(
         &router_iii,
         "router::models::list",
         json!({ "provider": "sarvam" }),
+    )
+    .await
+    .unwrap();
+    let chat_ids: Vec<&str> = chat["models"]
+        .as_array()
+        .map(|a| a.iter().filter_map(|m| m["id"].as_str()).collect())
+        .unwrap_or_default();
+    let curated_chat: Vec<String> = provider_sarvam::curated::chat_models()
+        .into_iter()
+        .map(|m| m.id)
+        .collect();
+    for id in &curated_chat {
+        assert!(
+            chat_ids.contains(&id.as_str()),
+            "missing chat row {id}: {chat_ids:?}"
+        );
+    }
+    assert_eq!(
+        chat_ids.len(),
+        curated_chat.len(),
+        "speech rows in the chat listing: {chat_ids:?}"
+    );
+
+    let list = call(
+        &router_iii,
+        "router::models::list",
+        json!({ "provider": "sarvam", "modality": "any" }),
     )
     .await
     .unwrap();


### PR DESCRIPTION
Fixes MOT-4744.

## What

The first real run of the engine-backed suites (#1130, MOT-4743) left three assertions `#[ignore = "MOT-4744: …"]`. This settles each one and removes the attributes. None of them was a product bug:

| suite · test | what rotted | decision |
| --- | --- | --- |
| provider-sarvam · `chat_streams_end_to_end_with_cost_fill` | asserted `usage.cost_usd > 0`, but `curated.rs` carries `pricing: None` | **Unpriced by design.** Sarvam publishes prices in INR only ([docs.sarvam.ai pricing](https://docs.sarvam.ai/api/getting-started/pricing): Sarvam 105B ₹29.28 / ₹10.98 / ₹73.2 per 1M tokens) and the catalog `Pricing` is USD per MTok; a hand-converted USD number would drift with the exchange rate. The test now asserts `cost_usd` stays empty and `curated.rs` documents why next to `pricing: None`. |
| provider-sarvam · `refresh_models_reconciles_curated_catalog` | expected the speech rows in a `router::models::list` call that defaults to the chat modality | The default listing is checked against `curated::chat_models()` (chat only, no speech leakage) and the whole catalog with `modality: "any"`. |
| provider-llamacpp · `chat_streams_end_to_end_with_no_credential_and_no_authorization_header` | the captured chat request carried `authorization: Bearer …` with no credential configured | **Environmental, not a regression.** The header was a real `LLAMACPP_API_KEY` exported on the host, carried in by the router's env-var fallback (`registry/resolve.rs`); the provider sends no header without a credential (`request.rs` unit test). `boot_stack` now strips the variable for every test in the suite, where one sibling test used to do it for itself. |

## Verification

Against `iii 0.23.1-rc.4` (`III_ENGINE_BIN`) and the in-repo `state` worker (`III_STATE_BIN`), with `LLAMACPP_API_KEY` exported in the shell to reproduce the leak first:

- before: sarvam `0 passed; 2 failed` on the two ignored tests, llamacpp `0 passed; 1 failed` (header present)
- after: provider-sarvam integration 5/5 and provider-llamacpp integration 5/5, both with `--test-threads=1` and with the default parallelism; `cargo fmt --check`, `cargo clippy --locked --all-targets [--all-features] -- -D warnings`, sarvam `--lib` tests all clean

## Follow-up noticed on the Sarvam docs (not in this PR)

The docs now list `Sarvam 30B` and `Sarvam M` as deprecated and add hosted open-source rows (GLM 5.2/5.3, Gemma 4 31B, DeepSeek V4 Flash) plus `sarvam-105b-conversations`; `curated.rs` still ships `sarvam-30b` / `sarvam-m`. Catalog refresh is a separate ticket.

https://claude.ai/code/session_01PvtXK7JgHHNrG192afbRAk


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sarvam usage reporting no longer invents USD costs when pricing is available only in INR. Usage counts remain available while `cost_usd` is left blank.
  * Sarvam model listings now accurately distinguish chat models from speech models, with an option to view all supported modalities.
  * Chat streaming without an API key now works as expected without sending an authorization header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->