### PR TITLE
fix(computer): honor III_URL for deployment interface

### DIFF
--- a/computer/Cargo.toml
+++ b/computer/Cargo.toml
@@ -27,7 +27,7 @@ serde_yaml = "0.9"
 anyhow = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 schemars = "0.8"
 async-trait = "0.1"
 base64 = "0.22"

--- a/computer/src/main.rs
+++ b/computer/src/main.rs
@@ -26,7 +26,7 @@ struct Cli {
     /// configuration registration.
     #[arg(long)]
     config: Option<String>,
-    #[arg(long, default_value = "ws://127.0.0.1:49134")]
+    #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
     url: String,
     #[arg(long)]
     manifest: bool,
@@ -168,4 +168,26 @@ async fn main() -> Result<()> {
     sessions.stop_all().await;
     iii.shutdown_async().await;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Cli;
+    use clap::Parser;
+
+    #[test]
+    fn cli_reads_iii_url_from_environment() {
+        let previous = std::env::var_os("III_URL");
+        std::env::set_var("III_URL", "ws://127.0.0.1:49234");
+
+        let cli = Cli::try_parse_from(["computer"]).expect("parse computer CLI");
+
+        if let Some(value) = previous {
+            std::env::set_var("III_URL", value);
+        } else {
+            std::env::remove_var("III_URL");
+        }
+
+        assert_eq!(cli.url, "ws://127.0.0.1:49234");
+    }
 }


### PR DESCRIPTION
## Summary

Make the `computer` worker use the `III_URL` supplied by the deployment interface when `--url` is not passed. This lets the immutable-artifact check register `computer` with its temporary engine instead of falling back to port 49134.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`
- Regression test: `cli_reads_iii_url_from_environment`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The computer application can now read its connection URL from the `III_URL` environment variable.
  * The existing default connection URL remains available when no environment variable is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->