### PR TITLE
(MOT-4613) fix(ci): keep the harness integration cache key stable across runner images

### DIFF
--- a/.github/scripts/tests/test_rust_ci_workflows.py
+++ b/.github/scripts/tests/test_rust_ci_workflows.py
@@ -183,6 +183,28 @@ def test_harness_integration_downloads_latest_rc_engine_without_building_it() ->
     assert "database -> target" in stack_cache["with"]["workspaces"]
 
 
+def test_harness_integration_cache_key_ignores_preinstalled_toolchains() -> None:
+    # rust-cache hashes every installed toolchain into its key. The trusted
+    # main build (larger-runner image) and PR builds (ubuntu-latest) ship
+    # different preinstalled stables, so the extras must go before the key
+    # is computed or PRs never restore the cache main publishes.
+    integration = workflow("_harness-integration.yml")
+    steps = integration["jobs"]["build"]["steps"]
+    names = [step.get("name") or step.get("uses") for step in steps]
+    toolchain = next(
+        index for index, step in enumerate(steps)
+        if str(step.get("uses", "")).startswith("dtolnay/rust-toolchain@")
+    )
+    prune = names.index("Keep only the pinned Rust toolchain")
+    restore = names.index("Restore integration Rust cache")
+    assert toolchain < prune < restore
+
+    run = named_step(steps, "Keep only the pinned Rust toolchain")["run"]
+    assert "rustup show active-toolchain" in run
+    assert "rustup toolchain uninstall" in run
+    assert "rustup toolchain list --quiet" in run
+
+
 def test_slow_rust_builds_upload_cargo_timing_reports() -> None:
     integration = workflow("_harness-integration.yml")
     integration_steps = integration["jobs"]["build"]["steps"]

--- a/.github/workflows/_harness-integration.yml
+++ b/.github/workflows/_harness-integration.yml
@@ -76,6 +76,21 @@ jobs:
           toolchain: 1.97.1
           components: ${{ inputs.coverage && 'llvm-tools' || '' }}
 
+      # rust-cache hashes every installed toolchain into its key, and the
+      # larger-runner image ships a different preinstalled stable than
+      # ubuntu-latest. Leaving those extras in place gave the trusted main
+      # build and the PR builds different keys, so PRs never restored the
+      # cache main published. Keep only the pinned toolchain before the key
+      # is computed.
+      - name: Keep only the pinned Rust toolchain
+        run: |
+          set -euo pipefail
+          active="$(rustup show active-toolchain | awk '{print $1}')"
+          rustup toolchain list --quiet \
+            | { grep -vxF "$active" || true; } \
+            | xargs -r -n1 rustup toolchain uninstall
+          rustup toolchain list
+
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           version: 11.13.1

--- a/docs/architecture/testing-and-ci.md
+++ b/docs/architecture/testing-and-ci.md
@@ -139,6 +139,15 @@ runs there while the stack builds. Callers can override `runner` for the build
 or `execution-runner` for the other jobs without changing this dependency
 graph.
 
+The stack build keys its `rust-cache` entry on every installed toolchain, and
+the larger-runner image ships a different preinstalled stable than
+`ubuntu-latest`. The build therefore uninstalls every toolchain except the
+pinned one before restoring the cache, so the entry the trusted `main` push
+publishes from `workers-ci-linux-8core` is the one PR builds on
+`ubuntu-latest` restore. Both pools must stay on this contract; a build that
+logs `No cache found.` on a PR while `main` is publishing means the keys have
+drifted again.
+
 Use
 [`harness-integration-benchmark.yml`](../../.github/workflows/harness-integration-benchmark.yml)
 to compare `ubuntu-latest` with `workers-ci-linux-8core` for the single build


### PR DESCRIPTION
Refs MOT-4613

## Problem

PRs that touch the harness take 20–22 min because `harness-integration / build harness stack` compiles the whole stack cold (~15.5 min on `ubuntu-latest`). The `rust-cache` step always logs `No cache found.`.

Two things stacked up:

1. Since #1054 the trusted `main` push builds the stack on `workers-ci-linux-8core`, but the `workers-ci-hosted` runner group had no repository selected. Every `main` build since 2026-09-02 sat queued until the next push cancelled it (34/34), so the cache was never published. Fixed today in the org settings by adding `iii-hq/workers` to the group; run 34547139615 then built in 8.7 min and published `v0-rust-harness-integration-Linux-x64-718c915e-f53c2289`.
2. That entry still cannot be restored by PRs. `rust-cache` hashes every installed toolchain (`rustup toolchain list`) into the key, and the larger-runner image ships stable 1.98.0 while `ubuntu-latest` ships 1.98.1. PR builds compute `...-7f7ca0a9-...`, and the restore key only falls back within the same environment hash.

## Change

- `_harness-integration.yml`: before `Restore integration Rust cache`, uninstall every toolchain except the pinned one so both pools compute the same environment hash.
- Regression test pinning the step's position and contents.
- `docs/architecture/testing-and-ci.md`: record the contract and the symptom to watch for.

## Validation

- `python3 -m pytest .github/scripts/tests/ -q` → 273 passed, 3 subtests passed
- `actionlint -config-file .github/actionlint.yaml`
- `git diff --check`

After merge, the first `main` push publishes a key both pools share; the next harness PR should show `Restored from cache key` and a build around 9–11 min instead of 15–18.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Rust toolchain handling in CI builds so cached dependencies can be restored consistently across build environments.

* **Documentation**
  * Documented the Rust cache key requirements and troubleshooting guidance for harness integration builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->