### PR TITLE
feat: ade ui improvements

### DIFF
--- a/ade/web/src/components/chat/ChatView.tsx
+++ b/ade/web/src/components/chat/ChatView.tsx
@@ -64,6 +64,7 @@ import { createWorkspaceFileSearch } from '@/lib/file-search'
 import { formatStopReason } from '@/lib/format-stop-reason'
 import { requestPanelOpen } from '@/lib/panel-context'
 import { newMessageId } from '@/lib/session-id'
+import { isCallSettled } from '@/lib/sessions/entry-mapper'
 import {
   expandSlashInvocations,
   loadedSkillIds,
@@ -942,7 +943,7 @@ export function ChatView({
       if (event.kind === 'fcall-start') {
         const existing = event.functionTriggerId
           ? messagesRef.current.find(
-              (message) =>
+              (message): message is FunctionTriggerMessage =>
                 message.role === 'function-trigger' &&
                 message.functionTriggerId === event.functionTriggerId,
             )
@@ -962,6 +963,9 @@ export function ChatView({
           )
         }
         if (existing) {
+          // Delivered after the call already ran (unordered against the
+          // transcript's events): the prompt must not reopen.
+          if (isCallSettled(existing)) return
           onPatchMessage(conversation.id, existing.id, {
             pendingApproval: true,
             running: false,
@@ -988,7 +992,7 @@ export function ChatView({
       }
 
       const existing = messagesRef.current.find(
-        (message) =>
+        (message): message is FunctionTriggerMessage =>
           message.role === 'function-trigger' &&
           message.functionTriggerId === event.functionTriggerId,
       )
@@ -996,7 +1000,11 @@ export function ChatView({
       if (existing) {
         onPatchMessage(conversation.id, existing.id, {
           pendingApproval: false,
-          ...(event.running ? { running: true } : {}),
+          // A release delivered late, or twice, after the result landed
+          // would otherwise leave the card spinning until the turn ends.
+          ...(event.running && !isCallSettled(existing)
+            ? { running: true }
+            : {}),
         })
       }
     },
@@ -1809,11 +1817,18 @@ export function ChatView({
                     m.functionTriggerId === event.functionTriggerId,
                 )?.id
               if (clearedId) {
+                const cleared = messagesRef.current.find(
+                  (m): m is FunctionTriggerMessage =>
+                    m.id === clearedId && m.role === 'function-trigger',
+                )
                 onPatchMessage(conversationId, clearedId, {
                   pendingApproval: false,
                   // Allowed calls execute now; their result pairs in from
-                  // the transcript and flips running back off.
-                  ...(event.running ? { running: true } : {}),
+                  // the transcript and flips running back off. A release
+                  // that arrives after that result must not flip it on.
+                  ...(event.running && !(cleared && isCallSettled(cleared))
+                    ? { running: true }
+                    : {}),
                 })
               }
               break

--- a/ade/web/src/components/chat/MessageList.tsx
+++ b/ade/web/src/components/chat/MessageList.tsx
@@ -571,6 +571,10 @@ export function MessageList({
   const lastAnimationTimeRef = useRef<number | null>(null)
   const lastScrollTopRef = useRef(0)
   const lastTouchYRef = useRef<number | null>(null)
+  // A mouse button held on the list: a scrollbar drag or a selection
+  // auto-scroll is the one upward scroll that reaches handleScroll with no
+  // wheel, touch or key event of its own.
+  const mouseHeldRef = useRef(false)
   const tailStateRef = useRef<TailScrollState>('initializing')
   const [tailState, setTailState] = useState<TailScrollState>('initializing')
   // Any content image in the transcript opens in the viewer on click,
@@ -982,6 +986,7 @@ export function MessageList({
         tailStateRef.current,
         lastScrollTopRef.current,
         container,
+        mouseHeldRef.current,
       )
       if (nextState === 'paused') cancelTailAnimation()
       transitionTailState(nextState)
@@ -999,6 +1004,17 @@ export function MessageList({
     },
     [pauseTailFollow],
   )
+
+  const handleMouseDown = useCallback(() => {
+    mouseHeldRef.current = true
+    window.addEventListener(
+      'mouseup',
+      () => {
+        mouseHeldRef.current = false
+      },
+      { once: true },
+    )
+  }, [])
 
   const handleTouchStart = useCallback((event: TouchEvent<HTMLElement>) => {
     lastTouchYRef.current = event.touches[0]?.clientY ?? null
@@ -1044,6 +1060,10 @@ export function MessageList({
     }
 
     cancelTailAnimation()
+    // The scroll up to the card is this button's doing; the scroll handler
+    // no longer reads direction, so pause here. Landing on the tail (a card
+    // at the very end) re-arms following from the scroll event itself.
+    transitionTailState('paused')
     const containerRect = container.getBoundingClientRect()
     const approvalRect = approval.getBoundingClientRect()
     const centeredTop =
@@ -1068,6 +1088,7 @@ export function MessageList({
     cancelTailAnimation,
     handleJumpToLatest,
     newestPendingApprovalId,
+    transitionTailState,
     writeScrollTop,
   ])
 
@@ -1193,6 +1214,16 @@ export function MessageList({
         }}
         onKeyDown={(event) => {
           if (event.defaultPrevented) return
+          // The keys the browser scrolls a focused list up with.
+          if (
+            event.key === 'ArrowUp' ||
+            event.key === 'PageUp' ||
+            event.key === 'Home' ||
+            (event.key === ' ' && event.shiftKey)
+          ) {
+            pauseTailFollow()
+            return
+          }
           if (event.key !== 'Enter' && event.key !== ' ') return
           const zoom = imageZoomTarget(event.target)
           if (!zoom) return
@@ -1200,6 +1231,7 @@ export function MessageList({
           setZoomedImage(zoom)
         }}
         onWheel={handleWheel}
+        onMouseDown={handleMouseDown}
         onTouchStart={handleTouchStart}
         onTouchMove={handleTouchMove}
         onTouchEnd={clearTouchPosition}

--- a/ade/web/src/components/chat/tail-scroll.test.ts
+++ b/ade/web/src/components/chat/tail-scroll.test.ts
@@ -21,7 +21,23 @@ describe('tail scroll state', () => {
   it('pauses on any meaningful upward movement, even next to the bottom', () => {
     const metrics = { scrollTop: 399, scrollHeight: 500, clientHeight: 100 }
 
-    expect(tailStateAfterScroll('following', 400, metrics)).toBe('paused')
+    expect(tailStateAfterScroll('following', 400, metrics, true)).toBe('paused')
+  })
+
+  /* iOS WebKit reports scroll positions from its scrolling thread that can
+     lag a programmatic write, and a collapsing card above the fold moves
+     the offset too: both arrive as "scrolled up" with nobody touching the
+     screen. Without a gesture behind it, an upward scroll event is never a
+     reason to stop following. */
+  it('ignores an upward scroll event that no gesture started', () => {
+    const metrics = { scrollTop: 300, scrollHeight: 500, clientHeight: 100 }
+
+    expect(tailStateAfterScroll('following', 400, metrics, false)).toBe(
+      'following',
+    )
+    expect(tailStateAfterScroll('initializing', 400, metrics, false)).toBe(
+      'initializing',
+    )
   })
 
   it('keeps following when shrinking content clamps the viewport to its new tail', () => {
@@ -31,13 +47,15 @@ describe('tail scroll state', () => {
       clientHeight: 100,
     }
 
-    expect(tailStateAfterScroll('following', 400, clampedToNewTail)).toBe(
+    expect(tailStateAfterScroll('following', 400, clampedToNewTail, true)).toBe(
       'following',
     )
-    expect(tailStateAfterScroll('initializing', 400, clampedToNewTail)).toBe(
-      'initializing',
+    expect(
+      tailStateAfterScroll('initializing', 400, clampedToNewTail, true),
+    ).toBe('initializing')
+    expect(tailStateAfterScroll('paused', 400, clampedToNewTail, true)).toBe(
+      'paused',
     )
-    expect(tailStateAfterScroll('paused', 400, clampedToNewTail)).toBe('paused')
   })
 
   it('does not resume until the viewport reaches the actual tail', () => {
@@ -45,15 +63,15 @@ describe('tail scroll state', () => {
     const atTail = { ...away, scrollTop: 398 }
 
     expect(isAtTail(away)).toBe(false)
-    expect(tailStateAfterScroll('paused', 396, away)).toBe('paused')
+    expect(tailStateAfterScroll('paused', 396, away, false)).toBe('paused')
     expect(isAtTail(atTail)).toBe(true)
-    expect(tailStateAfterScroll('paused', 397, atTail)).toBe('following')
+    expect(tailStateAfterScroll('paused', 397, atTail, false)).toBe('following')
   })
 
   it('does not finish initialization from its own instant scroll event', () => {
     const atTail = { scrollTop: 400, scrollHeight: 500, clientHeight: 100 }
 
-    expect(tailStateAfterScroll('initializing', 400, atTail)).toBe(
+    expect(tailStateAfterScroll('initializing', 400, atTail, false)).toBe(
       'initializing',
     )
   })
@@ -62,7 +80,9 @@ describe('tail scroll state', () => {
     const metrics = { scrollTop: 400, scrollHeight: 900, clientHeight: 100 }
 
     expect(tailDistanceFromBottom(metrics)).toBe(400)
-    expect(tailStateAfterScroll('following', 400, metrics)).toBe('following')
+    expect(tailStateAfterScroll('following', 400, metrics, false)).toBe(
+      'following',
+    )
   })
 })
 

--- a/ade/web/src/components/chat/tail-scroll.ts
+++ b/ade/web/src/components/chat/tail-scroll.ts
@@ -40,15 +40,22 @@ export function didScrollUp(
 
 /**
  * Position alone cannot distinguish a programmatic downward follow from a
- * person's scroll. The caller records every programmatic write before its
- * scroll event arrives, so a real decrease is the one transition that pauses.
+ * person's scroll, and an upward move is no proof of a person either: a
+ * shrinking layout, a growing viewport and WebKit's asynchronous scroll
+ * position all emit scroll events that read as "up" with nobody touching
+ * anything. So a decrease pauses only while `gesture` says an input the
+ * caller saw start is driving the scroll (a held mouse button: scrollbar
+ * drag, selection auto-scroll); wheel, touch and keyboard pause straight
+ * from their own events. Re-arming needs no gesture: reaching the tail by
+ * any route resumes following.
  */
 export function tailStateAfterScroll(
   state: TailScrollState,
   previousScrollTop: number,
   metrics: TailScrollMetrics,
+  gesture: boolean,
 ): TailScrollState {
-  if (didScrollUp(previousScrollTop, metrics.scrollTop)) {
+  if (gesture && didScrollUp(previousScrollTop, metrics.scrollTop)) {
     // Shrinking content (or a taller viewport) clamps scrollTop downward and
     // emits a scroll event even though nobody scrolled. When a state that was
     // already following lands exactly on the new tail, preserve it. A real

--- a/ade/web/src/lib/sessions/entry-mapper.test.ts
+++ b/ade/web/src/lib/sessions/entry-mapper.test.ts
@@ -5,6 +5,7 @@ import {
   applyFcallPatch,
   clearTransientFlags,
   entrySegments,
+  isCallSettled,
   prependTranscript,
   splitReactionTask,
   transcriptToMessages,
@@ -1478,6 +1479,28 @@ describe('transcriptToMessages — running inference on hydration', () => {
       'sess-1',
     )
     expect((idle[0] as { running?: boolean }).running).toBeUndefined()
+  })
+})
+
+describe('isCallSettled', () => {
+  const row = (
+    extra: Partial<FunctionTriggerMessage>,
+  ): FunctionTriggerMessage => ({
+    id: 'e_a:1',
+    role: 'function-trigger',
+    functionId: 'shell::exec',
+    input: {},
+    functionTriggerId: 'fc-1',
+    createdAt: 1,
+    ...extra,
+  })
+
+  it('is settled once an output or its result entry is known', () => {
+    expect(isCallSettled(row({ running: true }))).toBe(false)
+    expect(isCallSettled(row({ output: 'ok' }))).toBe(true)
+    expect(isCallSettled(row({ resultEntryId: 'e_r1', unloaded: true }))).toBe(
+      true,
+    )
   })
 })
 

--- a/ade/web/src/lib/sessions/entry-mapper.ts
+++ b/ade/web/src/lib/sessions/entry-mapper.ts
@@ -960,6 +960,16 @@ export type FcallPatch = Partial<
 >
 
 /**
+ * A call whose result is on record. Approval triggers are delivered
+ * at-least-once with no order against the transcript's own events, so a
+ * pending or "released, now running" notice can land after the result
+ * did; a settled row must never be reopened or set spinning by one.
+ */
+export function isCallSettled(row: FunctionTriggerMessage): boolean {
+  return row.output !== undefined || row.resultEntryId !== undefined
+}
+
+/**
  * Patch the function-trigger row matching `functionTriggerId`. Returns the same
  * array when no row matched (caller may then append a fallback row).
  */

--- a/ide/ui/src/page/__tests__/diff-load.test.ts
+++ b/ide/ui/src/page/__tests__/diff-load.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { loadDiffContents, loadTurnDiff, preImageBody, turnFileFor } from '../diff-load'
+import { createTurnCache, loadDiffContents, loadTurnDiff, preImageBody, turnFileFor } from '../diff-load'
 import type { SessionTurn } from '../turns'
 
 function exec(overrides: Partial<{ exit_code: number; stdout: string; stderr: string }> = {}) {
@@ -168,5 +168,25 @@ describe('loadTurnDiff', () => {
     expect(await loadTurnDiff(host, '/r', 'zzz.ts', turn([]))).toMatchObject({ noBaseline: true })
     expect(await loadTurnDiff(host, '/r', 'a.ts', turn([record({ before: { truncated: true } })]))).toMatchObject({ noBaseline: true })
     expect(turnFileFor(turn([record({})]), '/r', 'a.ts')?.path).toBe('/r/a.ts')
+  })
+})
+
+describe('createTurnCache', () => {
+  it('shares one read per turn but asks again after a miss or a failure', async () => {
+    const turn: SessionTurn = { turn_id: 't1', started_at: 1, files: [] }
+    const answers: Array<() => unknown> = [
+      () => {
+        throw new Error('worker restarting')
+      },
+      () => ({ turn: null }),
+      () => ({ turn }),
+    ]
+    const { host, trigger } = hostWith({ 'shell::turns::get': () => answers.shift()?.() })
+    const cache = createTurnCache(host, 's1')
+    expect(await cache.get('t1')).toBeNull()
+    expect(await cache.get('t1')).toBeNull()
+    expect(await cache.get('t1')).toBe(turn)
+    expect(await cache.get('t1')).toBe(turn)
+    expect(trigger).toHaveBeenCalledTimes(3)
   })
 })

--- a/ide/ui/src/page/diff-load.ts
+++ b/ide/ui/src/page/diff-load.ts
@@ -281,8 +281,15 @@ export function createTurnCache(host: Host, sessionId: string | null | undefined
       if (!sessionId) return Promise.resolve(null)
       let pending = cache.get(turnId)
       if (!pending) {
-        pending = fetchSessionTurn(host, sessionId, turnId).catch(() => null)
-        cache.set(turnId, pending)
+        const read = fetchSessionTurn(host, sessionId, turnId).catch(() => null)
+        cache.set(turnId, read)
+        // A miss is not a fact to remember: the worker may be restarting,
+        // the read may have timed out, or the record may land with the
+        // next hook. Only a turn that was read is kept.
+        void read.then((turn) => {
+          if (turn === null && cache.get(turnId) === read) cache.delete(turnId)
+        })
+        pending = read
       }
       return pending
     },

--- a/ide/ui/src/page/index.tsx
+++ b/ide/ui/src/page/index.tsx
@@ -524,6 +524,21 @@ export function ShellExplorerPage({
     turnCache.clear()
     setDiskEpoch((value) => value + 1)
   }, [harnessTurn.completedAtMs, turnCache])
+  // A running turn keeps gaining files. The record a diff tab cached before
+  // a file landed says the turn never touched it, and a disk burst alone
+  // re-reads that same stale record; the polled list is what knows better.
+  const turnsShape = useMemo(
+    () =>
+      sessionTurns
+        .map((turn) => `${turn.turn_id}:${turn.ended_at ?? ''}:${turn.files.map((file) => `${file.path}${file.kind}`).join(',')}`)
+        .join('\n'),
+    [sessionTurns],
+  )
+  // biome-ignore lint/correctness/useExhaustiveDependencies: the list's shape is the trigger
+  useEffect(() => {
+    turnCache.clear()
+    setDiskEpoch((value) => value + 1)
+  }, [turnsShape, turnCache])
   const turnTitles = useMemo(
     () => new Map(sessionTurns.map((turn, index) => [turn.turn_id, turnTitle(turn, sessionTurns.length - index)] as const)),
     [sessionTurns],


### PR DESCRIPTION
- Fixed mobile auto scroll issue where sometimes it stops
- Fixed an edge-case issue where some functions were showing indefinitely as in progress requiring a browser refresh to update
- Fixing an issue where in some cases the diffs on the Timeline view don't always work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented completed approval requests from reopening or appearing to run again.
  - Improved chat scrolling so automatic layout changes, scrollbar dragging, text selection, and keyboard navigation don’t incorrectly interrupt following the latest messages.
  - Ensured approval-card navigation pauses automatic following consistently.
  - Refreshed diff views when files change during an active turn.
  - Corrected retry behavior when turn data is unavailable, while retaining successful results for reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->