### PR TITLE
fix(build): read CARGO_MANIFEST_DIR at runtime in build scripts

### DIFF
--- a/a2ui/build.rs
+++ b/a2ui/build.rs
@@ -19,7 +19,7 @@ fn main() {
         println!("cargo:rerun-if-changed={path}");
     }
 
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let ui_dir = manifest_dir.join("ui");
     let outputs = [ui_dir.join("dist/page.js"), ui_dir.join("dist/styles.css")];
     if outputs

--- a/browser/build.rs
+++ b/browser/build.rs
@@ -30,7 +30,7 @@ fn main() {
     println!("cargo:rerun-if-changed=../pnpm-lock.yaml");
     println!("cargo:rerun-if-changed=ui/tsconfig.json");
 
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let ui_dir = manifest_dir.join("ui");
     let dist_assets = [
         ui_dir.join("dist").join("page.js"),

--- a/canvas/build.rs
+++ b/canvas/build.rs
@@ -33,7 +33,7 @@ fn main() {
     println!("cargo:rerun-if-changed=../pnpm-lock.yaml");
     println!("cargo:rerun-if-changed=ui/tsconfig.json");
 
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let ui_dir = manifest_dir.join("ui");
     let dist_assets = [
         ui_dir.join("dist").join("page.js"),

--- a/code-runner/build.rs
+++ b/code-runner/build.rs
@@ -32,7 +32,7 @@ fn main() {
     println!("cargo:rerun-if-changed=../packages/console-ui");
     println!("cargo:rerun-if-changed=ui/tsconfig.json");
 
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let ui_dir = manifest_dir.join("ui");
     // Only the two console assets: unlike sandbox-code-runner, this worker
     // plants no `iii-sdk` bundle into a guest — its Node guest gets a

--- a/compose-ui/build.rs
+++ b/compose-ui/build.rs
@@ -26,7 +26,7 @@ fn main() {
     println!("cargo:rerun-if-changed=ui/tsconfig.json");
     println!("cargo:rerun-if-changed=../pnpm-lock.yaml");
 
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let ui_dir = manifest_dir.join("ui");
     let assets = [
         ui_dir.join("dist").join("page.js"),

--- a/computer/build.rs
+++ b/computer/build.rs
@@ -30,7 +30,7 @@ fn main() {
     println!("cargo:rerun-if-changed=../pnpm-lock.yaml");
     println!("cargo:rerun-if-changed=ui/tsconfig.json");
 
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let ui_dir = manifest_dir.join("ui");
     let dist_assets = [
         ui_dir.join("dist").join("page.js"),

--- a/context-manager/build.rs
+++ b/context-manager/build.rs
@@ -22,7 +22,7 @@ fn main() {
     println!("cargo:rerun-if-changed=ui/tsconfig.json");
     println!("cargo:rerun-if-env-changed=SKIP_UI_BUILD");
 
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let ui_dir = manifest_dir.join("ui");
     let dist_assets = [
         ui_dir.join("dist").join("page.js"),

--- a/cron/build.rs
+++ b/cron/build.rs
@@ -20,7 +20,7 @@ fn main() {
     println!("cargo:rerun-if-changed=../pnpm-lock.yaml");
     println!("cargo:rerun-if-changed=ui/tsconfig.json");
 
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let ui_dir = manifest_dir.join("ui");
     let dist_assets = [
         ui_dir.join("dist").join("page.js"),

--- a/database/build.rs
+++ b/database/build.rs
@@ -23,7 +23,7 @@ fn main() {
     println!("cargo:rerun-if-changed=../pnpm-lock.yaml");
     println!("cargo:rerun-if-changed=ui/tsconfig.json");
 
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let ui_dir = manifest_dir.join("ui");
     let dist_assets = [
         ui_dir.join("dist").join("page.js"),

--- a/editor/build.rs
+++ b/editor/build.rs
@@ -30,7 +30,7 @@ fn main() {
     println!("cargo:rerun-if-changed=../pnpm-lock.yaml");
     println!("cargo:rerun-if-changed=ui/tsconfig.json");
 
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let ui_dir = manifest_dir.join("ui");
     let dist_assets = [
         ui_dir.join("dist").join("page.js"),

--- a/eval/build.rs
+++ b/eval/build.rs
@@ -19,7 +19,7 @@ fn main() {
         println!("cargo:rerun-if-changed={path}");
     }
 
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let ui_dir = manifest_dir.join("ui");
     let assets = [ui_dir.join("dist/page.js"), ui_dir.join("dist/styles.css")];
     if assets

--- a/github/build.rs
+++ b/github/build.rs
@@ -26,7 +26,7 @@ fn main() {
     // re-runs this script (and refreshes the embedded assets accordingly).
     println!("cargo:rerun-if-env-changed=SKIP_UI_BUILD");
 
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let ui_dir = manifest_dir.join("ui");
     let dist_assets = [
         ui_dir.join("dist").join("page.js"),

--- a/harness/build.rs
+++ b/harness/build.rs
@@ -30,7 +30,7 @@ fn main() {
     println!("cargo:rerun-if-changed=../pnpm-lock.yaml");
     println!("cargo:rerun-if-changed=ui/tsconfig.json");
 
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let ui_dir = manifest_dir.join("ui");
     let dist_assets = [
         ui_dir.join("dist").join("page.js"),

--- a/iii-directory/build.rs
+++ b/iii-directory/build.rs
@@ -43,7 +43,7 @@ fn main() {
     println!("cargo:rerun-if-changed=../pnpm-lock.yaml");
     println!("cargo:rerun-if-changed=ui/tsconfig.json");
 
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let ui_dir = manifest_dir.join("ui");
     let dist_assets = [
         ui_dir.join("dist").join("page.js"),

--- a/llm-router/build.rs
+++ b/llm-router/build.rs
@@ -37,7 +37,7 @@ fn main() {
     println!("cargo:rerun-if-changed=../pnpm-lock.yaml");
     println!("cargo:rerun-if-changed=ui/tsconfig.json");
 
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let ui_dir = manifest_dir.join("ui");
     let dist_assets = [
         ui_dir.join("dist").join("page.js"),

--- a/memory/build.rs
+++ b/memory/build.rs
@@ -30,7 +30,7 @@ fn main() {
     println!("cargo:rerun-if-changed=../pnpm-lock.yaml");
     println!("cargo:rerun-if-changed=ui/tsconfig.json");
 
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let ui_dir = manifest_dir.join("ui");
     let dist_assets = [
         ui_dir.join("dist").join("page.js"),

--- a/pdf/build.rs
+++ b/pdf/build.rs
@@ -143,7 +143,7 @@ fn build_ui() {
     println!("cargo:rerun-if-changed=../pnpm-lock.yaml");
     println!("cargo:rerun-if-changed=ui/tsconfig.json");
 
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let ui_dir = manifest_dir.join("ui");
     let dist_assets = [
         ui_dir.join("dist").join("page.js"),

--- a/provider-openai-codex/build.rs
+++ b/provider-openai-codex/build.rs
@@ -23,7 +23,7 @@ fn main() {
     }
     println!("cargo:rerun-if-env-changed=SKIP_UI_BUILD");
 
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let ui_dir = manifest_dir.join("ui");
     let assets = [ui_dir.join("dist/page.js"), ui_dir.join("dist/styles.css")];
     if assets

--- a/sandbox-code-runner/build.rs
+++ b/sandbox-code-runner/build.rs
@@ -30,7 +30,7 @@ fn main() {
     println!("cargo:rerun-if-changed=../pnpm-lock.yaml");
     println!("cargo:rerun-if-changed=ui/tsconfig.json");
 
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let ui_dir = manifest_dir.join("ui");
     let dist_assets = [
         ui_dir.join("dist").join("page.js"),

--- a/security-scan/build.rs
+++ b/security-scan/build.rs
@@ -15,7 +15,7 @@ fn main() {
     println!("cargo:rerun-if-changed=ui/tsconfig.json");
     println!("cargo:rerun-if-changed=../pnpm-lock.yaml");
 
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let ui_dir = manifest_dir.join("ui");
     let assets = [
         ui_dir.join("dist").join("page.js"),

--- a/state/build.rs
+++ b/state/build.rs
@@ -30,7 +30,7 @@ fn main() {
     println!("cargo:rerun-if-changed=../pnpm-lock.yaml");
     println!("cargo:rerun-if-changed=ui/tsconfig.json");
 
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let ui_dir = manifest_dir.join("ui");
     let dist_assets = [
         ui_dir.join("dist").join("page.js"),

--- a/storage/build.rs
+++ b/storage/build.rs
@@ -12,7 +12,7 @@ fn main() {
     println!("cargo:rerun-if-changed=ui/tsconfig.json");
     println!("cargo:rerun-if-changed=../pnpm-lock.yaml");
 
-    let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let manifest_dir = std::path::PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let ui_dir = manifest_dir.join("ui");
     let assets = [ui_dir.join("dist/page.js"), ui_dir.join("dist/styles.css")];
     let sources = [

--- a/tailscale/build.rs
+++ b/tailscale/build.rs
@@ -19,7 +19,7 @@ fn main() {
         println!("cargo:rerun-if-changed={path}");
     }
 
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let ui_dir = manifest_dir.join("ui");
     let outputs = [ui_dir.join("dist/page.js"), ui_dir.join("dist/styles.css")];
 

--- a/voice/build.rs
+++ b/voice/build.rs
@@ -30,7 +30,7 @@ fn main() {
     println!("cargo:rerun-if-changed=../pnpm-lock.yaml");
     println!("cargo:rerun-if-changed=ui/tsconfig.json");
 
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let ui_dir = manifest_dir.join("ui");
     let dist_assets = [
         ui_dir.join("dist").join("page.js"),

--- a/web/build.rs
+++ b/web/build.rs
@@ -19,7 +19,7 @@ fn main() {
     println!("cargo:rerun-if-changed=../pnpm-lock.yaml");
     println!("cargo:rerun-if-changed=ui/tsconfig.json");
 
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let ui_dir = manifest_dir.join("ui");
     let assets = [ui_dir.join("dist/page.js"), ui_dir.join("dist/styles.css")];
     if assets

--- a/worktree/build.rs
+++ b/worktree/build.rs
@@ -30,7 +30,7 @@ fn main() {
     println!("cargo:rerun-if-changed=../pnpm-lock.yaml");
     println!("cargo:rerun-if-changed=ui/tsconfig.json");
 
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let ui_dir = manifest_dir.join("ui");
     let dist_assets = [
         ui_dir.join("dist").join("page.js"),


### PR DESCRIPTION
## Problem

`build.rs` in 26 workers resolves the crate directory with
`env!("CARGO_MANIFEST_DIR")`. That macro runs when the build-script binary is
compiled, so the absolute path is baked into the binary.

Cargo fingerprints a build script on its source and its dependencies. It does
not include the manifest path. So if a crate directory moves, is copied, or is
renamed while `target/` comes along, Cargo reuses the cached build-script
binary and the baked path points at a directory that is gone.

The build scripts pass that path to `Command::current_dir()`. The spawn fails
with `No such file or directory (os error 2)`, and the panic blames the
command instead of the directory:

```
thread 'main' panicked at build.rs:71:13:
failed to spawn `pnpm install` in /path/to/old-worktree/console/web:
No such file or directory (os error 2)
```

pnpm was on `PATH`. The directory was not there.

## Fix

Read the variable at runtime:

```rust
-let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
```

Cargo sets `CARGO_MANIFEST_DIR` for every build-script run. The value is the
same on a fresh build and correct on a moved one.

## Scope

26 files, 26 lines. Only `build.rs` files.

`env!` stays in `src/`, where `include_str!(concat!(env!("CARGO_MANIFEST_DIR"),
...))` needs a compile-time constant. Test helpers in `tests/support/` also
keep `env!`; test binaries rebuild with the crate.

## Verification

`cargo check` is clean on `console`, `storage`, `cron`, and `eval`.

Note: editing `build.rs` forces a recompile on its own, which clears a stale
baked path once. The runtime lookup is what stops it from coming back.

## Not included

`console/build.rs` and `shell/build.rs` carry the same pattern but those
crates are not on `main` yet. They are fixed on the branch that adds them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build and Compatibility**
  * Build processes now resolve project paths from the environment when running, improving flexibility across different build environments.
  * Existing UI asset checks, optional build skipping, and asset generation behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->