### PR TITLE
fix(ade): bind to all IPv4 interfaces by default

### DIFF
--- a/ade/README.md
+++ b/ade/README.md
@@ -208,12 +208,14 @@ The local `config.yaml` is a first-registration seed and a fallback for direct
 runs where the configuration worker is unavailable:
 
 ```yaml
+http_host: 0.0.0.0    # HTTP bind address (default: all IPv4 interfaces)
 http_port: 3113       # initial port seed for the UI + /ws (default: 3113)
 injectable_ui: true   # kill switch for runtime-injected worker UI (default: true)
 ```
 
 | Key | Default | Description |
 |---|---|---|
+| `http_host` | `0.0.0.0` | HTTP bind address; set `127.0.0.1` for local access only. Applied at startup |
 | `http_port` | `3113` | Initial TCP port seed for `/`, `/assets/*`, and `/ws`; the stored `console.http_port` wins thereafter |
 | `injectable_ui` | `true` | When `false`, skips the `console:script` / `console:style` / `console:assets` trigger types, the `/ui` + `/vendor` routes, and the SPA loader (`console::ui-manifest` answers `disabled: true`) |
 
@@ -227,6 +229,7 @@ Console restart; the local `injectable_ui` kill switch remains startup-only.
 |---|---|---|
 | `--config <path>` | `./config.yaml` | Path to the first-registration YAML seed/fallback |
 | `--url <ws://…>` | `ws://127.0.0.1:49134` | iii engine WebSocket URL (`DEFAULT_ENGINE_URL` in [`src/config.rs`](src/config.rs)) |
+| `--http-host <address>` | from seed | Overrides the YAML bind address; applied at startup |
 | `--http-port <port>` | from seed | Overrides the YAML port seed; an existing configuration-worker value still wins |
 | `--manifest` | — | Print the publish manifest as JSON and exit (used by the registry pipeline) |
 

--- a/ade/config.yaml
+++ b/ade/config.yaml
@@ -1,6 +1,6 @@
 # First-registration seed/fallback. After registration, the `console`
 # configuration worker entry is authoritative and port edits apply live.
 http_port: 3113
-# Interface the listener binds. Loopback by default; set 0.0.0.0 to expose the
-# console (and its engine WebSocket proxy) on every interface. Boot-time only.
-http_host: 127.0.0.1
+# Interface the listener binds. All IPv4 interfaces by default; set 127.0.0.1
+# to limit the console and its engine WebSocket proxy to local access. Boot-time only.
+http_host: 0.0.0.0

--- a/ade/src/config.rs
+++ b/ade/src/config.rs
@@ -32,7 +32,7 @@ pub struct ConsoleConfig {
 }
 
 fn default_http_host() -> String {
-    "127.0.0.1".to_string()
+    "0.0.0.0".to_string()
 }
 
 fn default_http_port() -> u16 {

--- a/ade/src/config.rs
+++ b/ade/src/config.rs
@@ -1,7 +1,9 @@
 //! Local seed/fallback configuration for the `console` worker.
 //!
-//! The YAML config file exposes two operator-facing knobs:
+//! The YAML config file exposes three operator-facing knobs:
 //!
+//! - `http_host` — HTTP bind address. Defaults to `0.0.0.0` (all IPv4
+//!   interfaces); set `127.0.0.1` for local access only. Boot-time only.
 //! - `http_port` — first-registration seed/fallback for the TCP port serving
 //!   `/`, `/assets/*`, and `/ws`. Defaults to `3113`; after registration the
 //!   central `console.http_port` value is authoritative and hot-reloads.
@@ -20,9 +22,9 @@ pub const DEFAULT_ENGINE_URL: &str = "ws://127.0.0.1:49134";
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct ConsoleConfig {
-    /// Interface the HTTP listener binds. Loopback by default: the console
-    /// proxies the engine WebSocket and serves worker UIs, so exposing it on
-    /// every interface is an opt-in (`0.0.0.0`), like `http` and `rbac-proxy`.
+    /// Interface the HTTP listener binds. Defaults to all IPv4 interfaces
+    /// (`0.0.0.0`); set `127.0.0.1` to limit the console and its engine
+    /// WebSocket proxy to local access.
     #[serde(default = "default_http_host")]
     pub http_host: String,
     #[serde(default = "default_http_port")]
@@ -66,15 +68,15 @@ mod tests {
     #[test]
     fn defaults_from_empty_yaml() {
         let cfg: ConsoleConfig = serde_yaml::from_str("{}").unwrap();
-        assert_eq!(cfg.http_host, "127.0.0.1");
+        assert_eq!(cfg.http_host, "0.0.0.0");
         assert_eq!(cfg.http_port, 3113);
         assert!(cfg.injectable_ui);
     }
 
     #[test]
-    fn http_host_is_an_explicit_opt_in_to_all_interfaces() {
-        let cfg: ConsoleConfig = serde_yaml::from_str("http_host: 0.0.0.0\n").unwrap();
-        assert_eq!(cfg.http_host, "0.0.0.0");
+    fn custom_yaml_overrides_http_host() {
+        let cfg: ConsoleConfig = serde_yaml::from_str("http_host: 127.0.0.1\n").unwrap();
+        assert_eq!(cfg.http_host, "127.0.0.1");
     }
 
     #[test]
@@ -93,6 +95,7 @@ mod tests {
     fn impl_default_matches_yaml_defaults() {
         let from_empty: ConsoleConfig = serde_yaml::from_str("{}").unwrap();
         let from_default = ConsoleConfig::default();
+        assert_eq!(from_empty.http_host, from_default.http_host);
         assert_eq!(from_empty.http_port, from_default.http_port);
     }
 

--- a/ade/src/main.rs
+++ b/ade/src/main.rs
@@ -40,8 +40,8 @@ struct Cli {
     #[arg(long)]
     http_port: Option<u16>,
 
-    /// Interface to bind (`127.0.0.1` by default; `0.0.0.0` exposes the console
-    /// and its engine WebSocket proxy on every interface). Overrides
+    /// Interface to bind (`0.0.0.0` by default; `127.0.0.1` limits the console
+    /// and its engine WebSocket proxy to local access). Overrides
     /// `http_host` from the seed file. Boot-time only: it does not hot-reload.
     #[arg(long)]
     http_host: Option<String>,

--- a/ade/src/server.rs
+++ b/ade/src/server.rs
@@ -1,10 +1,9 @@
 //! HTTP server: routes `/`, `/assets/*`, `/ws` (WebSocket proxy), and —
 //! when injectable UI is enabled — `/ui`, `/ui/*`, and `/vendor/*`.
 //!
-//! Binds `<http_host>:<http_port>` — loopback unless the operator opts into
-//! `0.0.0.0` (`http_host` in the seed config or `--http-host`), the same
-//! default as the `http` and `rbac-proxy` workers. Front it with a reverse
-//! proxy when exposing it beyond the host.
+//! Binds `<http_host>:<http_port>` — `0.0.0.0` by default. Set `http_host`
+//! in the seed config or `--http-host` to select an interface. Front it
+//! with a reverse proxy when exposing it beyond the host.
 
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -265,9 +264,7 @@ pub async fn start(http_port: u16, state: AppState) -> anyhow::Result<ServerHand
 }
 
 /// The interface every listener binds. Set once at boot from `http_host`
-/// (config seed or `--http-host`); loopback until then. The console used to
-/// bind `0.0.0.0` unconditionally, exposing the engine WebSocket proxy on every
-/// interface by default while `http` and `rbac-proxy` stay on loopback.
+/// (config seed or `--http-host`); loopback until then.
 static BIND_HOST: std::sync::OnceLock<std::net::IpAddr> = std::sync::OnceLock::new();
 
 /// Pin the bind interface for this process. A second call is ignored: the


### PR DESCRIPTION
ADE now binds its HTTP server to `0.0.0.0` by default, so the UI and engine WebSocket proxy are reachable through network and container interfaces. Set `http_host: 127.0.0.1` or `--http-host 127.0.0.1` to limit access to the local host.

Align the sample configuration, CLI help, and documentation with this default. Fix the CI test that still expected `127.0.0.1`, verify an explicit host override, and check that YAML defaults match `ConsoleConfig::default()`.

Validation from `ade/`, using the existing frontend bundles (`SKIP_WEB_BUILD=1 SKIP_UI_BUILD=1` for Clippy and tests):

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features` — 96 tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The console and engine WebSocket proxy now bind to all IPv4 interfaces (`0.0.0.0`) by default.
  - Local-only access remains available by setting the host to `127.0.0.1`.
  - Added support for serving installable PWA assets and engine UI files.

- **Documentation**
  - Updated configuration examples and reference documentation to describe the new default, host override, and `--http-host` command-line option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->