### PR TITLE
(MOT-4740) fix(harness): metrics answers the session id a caller already holds

### DIFF
--- a/harness/src/functions/metrics.rs
+++ b/harness/src/functions/metrics.rs
@@ -19,6 +19,10 @@ use super::session_tree::{self, SessionTreeNodeV1};
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct SessionMetricsRequestV1 {
+    /// Any session in the tree. `session_id` is accepted as an alias, and a
+    /// child id is walked up to its root, so the id that addresses
+    /// `harness::status` addresses the tree here too.
+    #[serde(alias = "session_id")]
     pub root_session_id: String,
 }
 
@@ -42,17 +46,35 @@ pub struct SessionUsageTotalsV1 {
     pub turns: u64,
     pub function_calls: u64,
     pub function_call_errors: u64,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Summed over every generation that reported it. `null` means at least
+    /// one generation did not report the counter (a provider that omits it, or
+    /// a turn that failed before usage came back) — never a measured zero, so
+    /// the key is always present and a reader can tell the two apart.
     pub input_tokens: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Summed over every generation that reported it. `null` means at least
+    /// one generation did not report the counter (a provider that omits it, or
+    /// a turn that failed before usage came back) — never a measured zero, so
+    /// the key is always present and a reader can tell the two apart.
     pub output_tokens: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Summed over every generation that reported it. `null` means at least
+    /// one generation did not report the counter (a provider that omits it, or
+    /// a turn that failed before usage came back) — never a measured zero, so
+    /// the key is always present and a reader can tell the two apart.
     pub cache_read_tokens: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Summed over every generation that reported it. `null` means at least
+    /// one generation did not report the counter (a provider that omits it, or
+    /// a turn that failed before usage came back) — never a measured zero, so
+    /// the key is always present and a reader can tell the two apart.
     pub cache_write_tokens: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Summed over every generation that reported it. `null` means at least
+    /// one generation did not report the counter (a provider that omits it, or
+    /// a turn that failed before usage came back) — never a measured zero, so
+    /// the key is always present and a reader can tell the two apart.
     pub reasoning_tokens: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Summed over every generation that reported it. `null` means at least
+    /// one generation did not report the counter (a provider that omits it, or
+    /// a turn that failed before usage came back) — never a measured zero, so
+    /// the key is always present and a reader can tell the two apart.
     pub cost_usd: Option<f64>,
 }
 
@@ -66,17 +88,35 @@ pub struct SessionUsageV1 {
     pub turns: u64,
     pub function_calls: u64,
     pub function_call_errors: u64,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Summed over every generation that reported it. `null` means at least
+    /// one generation did not report the counter (a provider that omits it, or
+    /// a turn that failed before usage came back) — never a measured zero, so
+    /// the key is always present and a reader can tell the two apart.
     pub input_tokens: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Summed over every generation that reported it. `null` means at least
+    /// one generation did not report the counter (a provider that omits it, or
+    /// a turn that failed before usage came back) — never a measured zero, so
+    /// the key is always present and a reader can tell the two apart.
     pub output_tokens: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Summed over every generation that reported it. `null` means at least
+    /// one generation did not report the counter (a provider that omits it, or
+    /// a turn that failed before usage came back) — never a measured zero, so
+    /// the key is always present and a reader can tell the two apart.
     pub cache_read_tokens: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Summed over every generation that reported it. `null` means at least
+    /// one generation did not report the counter (a provider that omits it, or
+    /// a turn that failed before usage came back) — never a measured zero, so
+    /// the key is always present and a reader can tell the two apart.
     pub cache_write_tokens: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Summed over every generation that reported it. `null` means at least
+    /// one generation did not report the counter (a provider that omits it, or
+    /// a turn that failed before usage came back) — never a measured zero, so
+    /// the key is always present and a reader can tell the two apart.
     pub reasoning_tokens: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Summed over every generation that reported it. `null` means at least
+    /// one generation did not report the counter (a provider that omits it, or
+    /// a turn that failed before usage came back) — never a measured zero, so
+    /// the key is always present and a reader can tell the two apart.
     pub cost_usd: Option<f64>,
     /// The session's latest per-generation context snapshot (categories,
     /// budget, usage) — absent for sessions that have not generated since
@@ -131,7 +171,8 @@ pub async fn handle(
     deps: &Deps,
     req: SessionMetricsRequestV1,
 ) -> Result<SessionMetricsResponseV1, HarnessError> {
-    let tree = session_tree::collect(deps, &req.root_session_id).await?;
+    let root_session_id = resolve_root(deps, &req.root_session_id).await?;
+    let tree = session_tree::collect(deps, &root_session_id).await?;
     let session = deps.session().await;
     let cfg = deps.cfg().await;
     let mut complete = tree.complete;
@@ -194,18 +235,52 @@ pub async fn handle(
     // comparatively expensive and does not help the watchdog decide whether
     // work advanced, so collect it only for the final complete response.
     let traces = if complete {
-        collect_trace_metrics(deps, &tree.sessions, &req.root_session_id).await
+        collect_trace_metrics(deps, &tree.sessions, &root_session_id).await
     } else {
         None
     };
 
     Ok(SessionMetricsResponseV1 {
-        root_session_id: req.root_session_id,
+        root_session_id,
         complete,
         totals: total.finish_totals(tree.sessions.len() as u64),
         by_session,
         traces,
     })
+}
+
+/// Walk `session_id` up to the root of its tree. Every other `harness::*`
+/// function takes the session a caller is holding, so this one accepts it too
+/// and reports the whole tree that session belongs to rather than refusing the
+/// id. A root (or an orphan) walks zero steps.
+async fn resolve_root(deps: &Deps, session_id: &str) -> Result<String, HarnessError> {
+    /// Deeper than any legitimate sub-agent chain; a cycle in the durable
+    /// metadata must end as an error, never as an unbounded walk.
+    const MAX_ANCESTORS: usize = 64;
+    let session = deps.session().await;
+    let mut current = session_id.to_string();
+    let mut seen = BTreeSet::from([current.clone()]);
+    for _ in 0..MAX_ANCESTORS {
+        let Some(metadata) = session.metadata_of(&current).await? else {
+            return Ok(current);
+        };
+        let Some(parent) = metadata
+            .get("parent_session_id")
+            .and_then(serde_json::Value::as_str)
+            .filter(|parent| !parent.is_empty())
+        else {
+            return Ok(current);
+        };
+        if !seen.insert(parent.to_string()) {
+            return Err(HarnessError::InvalidRequest(format!(
+                "session `{session_id}` has a cyclic parent chain at `{parent}`;                  pass the root session id"
+            )));
+        }
+        current = parent.to_string();
+    }
+    Err(HarnessError::InvalidRequest(format!(
+        "session `{session_id}` has more than {MAX_ANCESTORS} ancestors;          pass the root session id"
+    )))
 }
 
 fn terminal_status(status: Option<crate::types::turn::TurnStatus>) -> bool {
@@ -523,6 +598,41 @@ mod tests {
         assert_eq!(totals.turns, 2);
         assert_eq!(totals.input_tokens, None);
         assert_eq!(totals.output_tokens, Some(2));
+    }
+
+    #[test]
+    fn the_request_takes_either_session_id_spelling() {
+        for payload in [
+            json!({"root_session_id": "s_root"}),
+            json!({"session_id": "s_root"}),
+        ] {
+            let req: SessionMetricsRequestV1 = serde_json::from_value(payload.clone()).unwrap();
+            assert_eq!(req.root_session_id, "s_root", "{payload}");
+        }
+    }
+
+    #[test]
+    fn unreported_usage_stays_a_present_null_never_a_measured_zero() {
+        let mut usage = UsageAccumulator::default();
+        usage.observe(&message(json!({
+            "role": "assistant",
+            "content": [],
+            "stop_reason": "end",
+            "usage": {"input": 7},
+            "model": "model",
+            "provider": "provider",
+            "timestamp": 1
+        })));
+        let wire =
+            serde_json::to_value(usage.finish_session(&session("s_root", None, 0), None)).unwrap();
+        assert_eq!(wire["input_tokens"], json!(7));
+        for unreported in ["output_tokens", "reasoning_tokens", "cost_usd"] {
+            assert!(
+                wire.get(unreported).is_some_and(serde_json::Value::is_null),
+                "{unreported} must be present and null, got {:?}",
+                wire.get(unreported)
+            );
+        }
     }
 
     #[test]

--- a/harness/src/functions/mod.rs
+++ b/harness/src/functions/mod.rs
@@ -79,8 +79,10 @@ pub const SESSION_TREE_DESC: &str =
 
 pub const METRICS_ID: &str = "harness::metrics";
 pub const METRICS_DESC: &str =
-    "Aggregate durable model usage, function outcomes, and available trace/span observability. \
-     `complete` is true only after every session in the durable tree has reached a terminal turn.";
+    "Aggregate durable model usage, function outcomes, and available trace/span observability \
+     for the session tree `root_session_id` belongs to (`session_id` is accepted as an alias, \
+     and a sub-agent id is resolved to its root). `complete` is true only after every session \
+     in the durable tree has reached a terminal turn.";
 
 pub const TEARDOWN_ID: &str = "harness::teardown";
 pub const TEARDOWN_DESC: &str =

--- a/harness/tests/golden/schemas/harness.metrics.json
+++ b/harness/tests/golden/schemas/harness.metrics.json
@@ -4,6 +4,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "properties": {
       "root_session_id": {
+        "description": "Any session in the tree. `session_id` is accepted as an alias, and a child id is walked up to its root, so the id that addresses `harness::status` addresses the tree here too.",
         "type": "string"
       }
     },
@@ -217,6 +218,7 @@
         "additionalProperties": false,
         "properties": {
           "cache_read_tokens": {
+            "description": "Summed over every generation that reported it. `null` means at least one generation did not report the counter (a provider that omits it, or a turn that failed before usage came back) — never a measured zero, so the key is always present and a reader can tell the two apart.",
             "format": "uint64",
             "minimum": 0.0,
             "type": [
@@ -225,6 +227,7 @@
             ]
           },
           "cache_write_tokens": {
+            "description": "Summed over every generation that reported it. `null` means at least one generation did not report the counter (a provider that omits it, or a turn that failed before usage came back) — never a measured zero, so the key is always present and a reader can tell the two apart.",
             "format": "uint64",
             "minimum": 0.0,
             "type": [
@@ -233,6 +236,7 @@
             ]
           },
           "cost_usd": {
+            "description": "Summed over every generation that reported it. `null` means at least one generation did not report the counter (a provider that omits it, or a turn that failed before usage came back) — never a measured zero, so the key is always present and a reader can tell the two apart.",
             "format": "double",
             "type": [
               "number",
@@ -250,6 +254,7 @@
             "type": "integer"
           },
           "input_tokens": {
+            "description": "Summed over every generation that reported it. `null` means at least one generation did not report the counter (a provider that omits it, or a turn that failed before usage came back) — never a measured zero, so the key is always present and a reader can tell the two apart.",
             "format": "uint64",
             "minimum": 0.0,
             "type": [
@@ -258,6 +263,7 @@
             ]
           },
           "output_tokens": {
+            "description": "Summed over every generation that reported it. `null` means at least one generation did not report the counter (a provider that omits it, or a turn that failed before usage came back) — never a measured zero, so the key is always present and a reader can tell the two apart.",
             "format": "uint64",
             "minimum": 0.0,
             "type": [
@@ -266,6 +272,7 @@
             ]
           },
           "reasoning_tokens": {
+            "description": "Summed over every generation that reported it. `null` means at least one generation did not report the counter (a provider that omits it, or a turn that failed before usage came back) — never a measured zero, so the key is always present and a reader can tell the two apart.",
             "format": "uint64",
             "minimum": 0.0,
             "type": [
@@ -296,6 +303,7 @@
         "additionalProperties": false,
         "properties": {
           "cache_read_tokens": {
+            "description": "Summed over every generation that reported it. `null` means at least one generation did not report the counter (a provider that omits it, or a turn that failed before usage came back) — never a measured zero, so the key is always present and a reader can tell the two apart.",
             "format": "uint64",
             "minimum": 0.0,
             "type": [
@@ -304,6 +312,7 @@
             ]
           },
           "cache_write_tokens": {
+            "description": "Summed over every generation that reported it. `null` means at least one generation did not report the counter (a provider that omits it, or a turn that failed before usage came back) — never a measured zero, so the key is always present and a reader can tell the two apart.",
             "format": "uint64",
             "minimum": 0.0,
             "type": [
@@ -323,6 +332,7 @@
             "description": "The session's latest per-generation context snapshot (categories, budget, usage) — absent for sessions that have not generated since snapshots landed."
           },
           "cost_usd": {
+            "description": "Summed over every generation that reported it. `null` means at least one generation did not report the counter (a provider that omits it, or a turn that failed before usage came back) — never a measured zero, so the key is always present and a reader can tell the two apart.",
             "format": "double",
             "type": [
               "number",
@@ -345,6 +355,7 @@
             "type": "integer"
           },
           "input_tokens": {
+            "description": "Summed over every generation that reported it. `null` means at least one generation did not report the counter (a provider that omits it, or a turn that failed before usage came back) — never a measured zero, so the key is always present and a reader can tell the two apart.",
             "format": "uint64",
             "minimum": 0.0,
             "type": [
@@ -353,6 +364,7 @@
             ]
           },
           "output_tokens": {
+            "description": "Summed over every generation that reported it. `null` means at least one generation did not report the counter (a provider that omits it, or a turn that failed before usage came back) — never a measured zero, so the key is always present and a reader can tell the two apart.",
             "format": "uint64",
             "minimum": 0.0,
             "type": [
@@ -367,6 +379,7 @@
             ]
           },
           "reasoning_tokens": {
+            "description": "Summed over every generation that reported it. `null` means at least one generation did not report the counter (a provider that omits it, or a turn that failed before usage came back) — never a measured zero, so the key is always present and a reader can tell the two apart.",
             "format": "uint64",
             "minimum": 0.0,
             "type": [


### PR DESCRIPTION
`harness::metrics` was the one `harness::*` function that refused `session_id`. Every other one takes it, so the natural call came back as a raw serde error with eleven frames of iii-sdk stack instead of a parameter message:

```
$ iii trigger harness::metrics --json '{"session_id":"s_…"}'
Error: { "code": "invocation_failed",
         "message": "serialization error: missing field `root_session_id`",
         "stacktrace": "   0: <iii_sdk::iii::IIIClient>::handle_invoke_function… (11 frames)" }
```

The request now accepts `session_id` as an alias and walks a sub-agent id up to its root, so any session in the tree addresses the tree. The walk is bounded and refuses a cyclic parent chain rather than looping. The function description says which id it wants, where `engine::functions::list` shows it.

The usage counters are also no longer dropped from the wire when they are unknown. `None` there never meant zero: it means at least one generation did not report that counter, which is exactly the case a reader most wants to see (thinking off, or a turn that failed before usage came back). Emitting `0` would have claimed a measurement nobody made, so the keys are always present and carry `null` instead. A reader can index them without a KeyError and still tell "unreported" from "measured zero".

Deliberately not here: reshaping the SDK's deserialization-failure surface into a short `invalid_params` error. That is the same shape as A7 and belongs in `iii-sdk`, where every worker gets it at once.

## Verification

`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and the full harness suite (488 unit + goldens) pass; two new unit tests cover the alias and the present-null contract. The schema golden diff is descriptions only, no structural change.

Live, against a stack running this build:

| call | result |
| --- | --- |
| `{"session_id": "<root>"}` | `root_session_id` = root, 2 sessions |
| `{"session_id": "<child>"}` | same root, same 2 sessions |
| `by_session[].cache_write_tokens` | present as `null`, not absent |

Closes MOT-4740.

https://claude.ai/code/session_01PvtXK7JgHHNrG192afbRAk


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Session metrics requests now accept `session_id` as an alternative to `root_session_id`.
  - Sub-session requests resolve to the root session when aggregating metrics.
  - Session hierarchy traversal safely handles cycles and enforces nesting limits.

- **Changes**
  - Metrics responses consistently include token and cost counters; unavailable values appear as `null`.
  - Metrics schemas now require counter fields while permitting null values.
  - Documentation clarifies session-tree scope and null counter meanings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->