### PR TITLE
(MOT-4758) feat(harness): a sub-agent continues its parent's agent profile

### DIFF
--- a/harness/README.md
+++ b/harness/README.md
@@ -295,8 +295,15 @@ resolution never reach a live session — start a new one to pick them up.
 resolved prompt (preloaded functions and skills included) is the child's whole identity, its model/effort slot in the same way
 (model precedence profile → explicit `model` → parent, without dragging the parent's
 provider onto a foreign model), and its name and icon become the display
-defaults. Which agent profile a spawn names is the prompt's decision — the profile
-body steers it, nothing gates it. Spawning
+defaults. A spawn that names NO profile continues the parent turn's: an agent
+running under a profile fans work out to itself, not to a stranger wearing the
+built-in identity, and the child re-resolves that same id so its own preloaded
+functions and skills arrive with it. `options.system_prompt` — the escape hatch
+for a child that genuinely needs a different identity — sheds the inherited
+profile instead of colliding with it, and a parentless spawn (console,
+workflow, CLI) has no parent turn to inherit from. Which agent profile a spawn
+names is the prompt's decision — the profile body steers it, nothing gates it.
+Spawning
 with `agent` into an already RUNNING session of the caller's own tree merges
 the task like any reuse and does not re-apply the profile.
 

--- a/harness/src/functions/spawn.rs
+++ b/harness/src/functions/spawn.rs
@@ -124,7 +124,9 @@ pub struct SpawnRequest {
     pub task: MessageInput,
     /// Directory agent profile id (`directory::agents::*`) supplying the
     /// child's prompt, skills, model, and display; refused with
-    /// `options.system_prompt`.
+    /// `options.system_prompt`. Omitted, an in-turn spawn continues the
+    /// parent turn's profile (name `options.system_prompt` for a child that
+    /// needs a different identity).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent: Option<String>,
     /// Display-only name/icon/color for the child session; never affects ids,

--- a/harness/src/subagent.rs
+++ b/harness/src/subagent.rs
@@ -233,6 +233,27 @@ struct ChildFunctions {
     dispatch_only: Vec<String>,
 }
 
+/// Which agent profile a child runs as: the one the spawn named, else the
+/// parent turn's. A spawn that names no profile continues the parent's
+/// identity — an agent running under a profile fans work out to itself, not
+/// to a stranger wearing the built-in identity. Like the inherited model this
+/// reaches only an IN-TURN spawn; a parentless one (console, workflow, CLI)
+/// has nothing to inherit from. A spawn that brings its own `system_prompt`
+/// inherits nothing: that prompt is the child's identity, and shedding the
+/// profile is what keeps the two from colliding.
+fn child_agent_id<'a>(
+    requested: Option<&'a str>,
+    parent_record: Option<&'a TurnRecord>,
+    names_own_prompt: bool,
+) -> Option<&'a str> {
+    requested.or_else(|| {
+        (!names_own_prompt)
+            .then(|| parent_record.and_then(|p| p.options.agent.as_ref()))
+            .flatten()
+            .map(|identity| identity.id.as_str())
+    })
+}
+
 /// Seed a child session + turn and enqueue its first step. When
 /// `parent_record` is set the policy is subset against it, `max_turns` is
 /// capped at the parent's remaining budget, and linkage metadata is recorded.
@@ -246,25 +267,41 @@ async fn seed_child(
 ) -> Result<ChildIds, HarnessError> {
     let session = deps.session().await;
 
-    // Resolve the agent profile (if named) before anything else fallible —
-    // an unknown id must not leave a session behind.
-    let agent = match req.agent.as_deref() {
-        Some(id) => {
-            if req
-                .options
-                .as_ref()
-                .is_some_and(|o| o.system_prompt.is_some())
-            {
-                return Err(HarnessError::InvalidRequest(
-                    "spawn `agent` supplies the child's system prompt; drop \
-                     `options.system_prompt` or drop `agent` (with `agent` set, \
-                     `system_prompt_strategy` is ignored: the profile's resolved \
-                     prompt is the child's whole identity)"
-                        .into(),
-                ));
-            }
-            Some(crate::agents::resolve(deps, cfg, id).await?)
-        }
+    let names_own_prompt = req
+        .options
+        .as_ref()
+        .is_some_and(|o| o.system_prompt.is_some());
+    if req.agent.is_some() && names_own_prompt {
+        return Err(HarnessError::InvalidRequest(
+            "spawn `agent` supplies the child's system prompt; drop \
+             `options.system_prompt` or drop `agent` (with `agent` set, \
+             `system_prompt_strategy` is ignored: the profile's resolved \
+             prompt is the child's whole identity)"
+                .into(),
+        ));
+    }
+    let agent_id = child_agent_id(req.agent.as_deref(), parent_record, names_own_prompt);
+    let inherited = agent_id.is_some() && req.agent.is_none();
+    // Resolve the agent profile (if any) before anything else fallible — an
+    // unknown id must not leave a session behind.
+    let agent = match agent_id {
+        Some(id) => Some(
+            crate::agents::resolve(deps, cfg, id)
+                .await
+                .map_err(|error| {
+                    if inherited {
+                        // The caller never named this profile; say where it came from
+                        // so the error is traceable to the parent's identity.
+                        HarnessError::InvalidRequest(format!(
+                            "sub-agent inherits the parent turn's agent profile `{id}`, which no \
+                     longer resolves: {error}. Name `agent` explicitly, or give the child \
+                     its own `options.system_prompt`."
+                        ))
+                    } else {
+                        error
+                    }
+                })?,
+        ),
         None => None,
     };
     let display = normalize_display(merged_display(req.display.as_ref(), agent.as_ref()).as_ref())?;
@@ -390,7 +427,8 @@ async fn seed_child(
                 .and_then(|o| o.filesystem_root.as_deref()),
             parent_record,
         )?,
-        // The child's OWN identity, never the parent's.
+        // The child's own resolved identity: the profile the spawn named, or
+        // the parent's when it named none.
         agent: agent.as_ref().map(|a| a.identity.clone()),
         max_validation_retries: req
             .options
@@ -784,6 +822,52 @@ mod tests {
             created_at: 1,
             updated_at: 1,
         }
+    }
+
+    fn under_profile(id: &str) -> TurnRecord {
+        let mut record = parent_record(None);
+        record.options.agent = Some(crate::types::turn::AgentIdentity {
+            id: id.into(),
+            name: Some("Linkly".into()),
+            icon: None,
+            color: None,
+        });
+        record
+    }
+
+    #[test]
+    fn a_child_runs_as_the_named_profile_else_the_parents() {
+        let parent = under_profile("linkly");
+        assert_eq!(
+            child_agent_id(None, Some(&parent), false),
+            Some("linkly"),
+            "an in-turn spawn naming no profile continues the parent's"
+        );
+        assert_eq!(
+            child_agent_id(Some("reviewer"), Some(&parent), false),
+            Some("reviewer"),
+            "an explicit profile wins over the parent's"
+        );
+        assert_eq!(
+            child_agent_id(None, Some(&parent), true),
+            None,
+            "a child with its own system prompt sheds the inherited profile"
+        );
+        assert_eq!(
+            child_agent_id(None, Some(&parent_record(None)), false),
+            None,
+            "a parent running the built-in identity passes nothing down"
+        );
+        assert_eq!(
+            child_agent_id(None, None, false),
+            None,
+            "a parentless spawn has nothing to inherit from"
+        );
+        assert_eq!(
+            child_agent_id(Some("reviewer"), None, false),
+            Some("reviewer"),
+            "a parentless spawn still honours an explicit profile"
+        );
     }
 
     #[test]

--- a/harness/tests/golden/schemas/harness.spawn.json
+++ b/harness/tests/golden/schemas/harness.spawn.json
@@ -286,7 +286,7 @@
     },
     "properties": {
       "agent": {
-        "description": "Directory agent profile id (`directory::agents::*`) supplying the child's prompt, skills, model, and display; refused with `options.system_prompt`.",
+        "description": "Directory agent profile id (`directory::agents::*`) supplying the child's prompt, skills, model, and display; refused with `options.system_prompt`. Omitted, an in-turn spawn continues the parent turn's profile (name `options.system_prompt` for a child that needs a different identity).",
         "type": [
           "string",
           "null"


### PR DESCRIPTION
A session created with `options.agent` runs as that directory profile, but the moment it fanned work out the identity was gone. `harness::spawn` resolved a profile only when the spawn payload named one, so every child of a profile-run turn came back as the built-in identity: no preloaded function contracts, no preloaded skills, no model/effort slot from the profile.

Measured on the Linkly agentic tutorial with a root session under the `linkly` profile, before this change:

| session | agent |
| --- | --- |
| root | linkly |
| ch1-core (sub-agent) | *(none)* |
| ch1-http (sub-agent) | *(none)* |

The profile body can ask the model to pass `agent` on every spawn, and that does work, but a prompt instruction is not a guarantee. The one thing the caller never meant was "fan out to a stranger".

A spawn that names no profile now continues the parent turn's, re-resolving the same id so the child's preloaded functions and skills arrive with it. It reaches only an in-turn spawn, exactly like the inherited model; a parentless spawn (console, workflow, CLI) still has nothing to inherit from. `options.system_prompt` keeps its meaning as the escape hatch: a child that brings its own prompt sheds the inherited profile rather than colliding with it, which is why the explicit-`agent`-plus-prompt refusal is unchanged. An inherited id that no longer resolves says where it came from, since the caller never named it.

The decision itself is a small pure function, so the six cases are a unit test rather than a live-only behaviour.

## Verification

`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and the full harness suite pass. The schema golden diff is the `agent` field description only.

Live, on a stack running this build: a turn under the `coder` profile spawning a child with no `agent` field produced a child session with `agent_profile.id = coder`. The same prompt on released harness 1.8.21 produced a child with no profile at all.

Closes MOT-4758.

https://claude.ai/code/session_01PvtXK7JgHHNrG192afbRAk


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - In-turn spawned agents now inherit the parent turn’s profile when no profile is specified.
  - Inherited profiles retain their preloaded functions and skills.
  - A custom system prompt can assign a spawned agent a different identity.
  - Parentless spawns do not inherit a profile.

- **Bug Fixes**
  - Improved error messages when an inherited profile cannot be resolved.

- **Documentation**
  - Updated spawn guidance and schema descriptions to explain profile inheritance and custom identities.

- **Tests**
  - Added coverage for profile inheritance behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->